### PR TITLE
ci: add Go CodeQL workflow

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -15,11 +15,12 @@ counterpart or enforces a Go release constraint that does not exist in Python.
 | `release.yml` | `release.yml` | GitHub binary assets and GHCR replace PyPI; release verification and documentation deployment keep the same gates. |
 | `release-verify.yml` | `release-verify.yml` | Verification exercises published Go archives and image digests instead of Python distributions. |
 
-Two Go-specific workflows extend, rather than replace, that Python topology:
+Three Go-specific workflows extend, rather than replace, that Python topology:
 
 | Go workflow | Purpose |
 | --- | --- |
 | `migration-gates.yml` | Reusable PR assurance called by `master.yml`: frozen Python Oracle regeneration, Python↔Go interoperability, HTTP differential, race/fuzz, live OceanBase, host adapters, evaluation, and four-platform standard/Full builds. |
+| `codeql.yml` | Go CodeQL analysis on pull requests, pushes to `main`, a weekly schedule, and manual dispatch. Pull request runs check out the exact submitted head commit before the explicit Go build. |
 | `provider-smoke.yml` | Explicitly dispatched, credentialed, bounded real-provider verification; never required on an ordinary pull request. |
 
 The committed `test/conformance/testdata/python-v0.0.2` baseline remains immutable. Pull requests execute the pinned

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,66 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  schedule:
+    - cron: "24 3 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+
+concurrency:
+  group: codeql-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  GOTOOLCHAIN: local
+
+jobs:
+  analyze:
+    name: Analyze Go
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - name: Check out pull request head
+        if: github.event_name == 'pull_request'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+
+      - name: Check out repository
+        if: github.event_name != 'pull_request'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - name: Verify checked-out commit
+        env:
+          EXPECTED_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: test "$(git rev-parse HEAD)" = "$EXPECTED_SHA"
+
+      - name: Set up Go
+        uses: ./.github/actions/setup-go-env
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4
+        with:
+          languages: go
+          build-mode: manual
+
+      - name: Build for CodeQL
+        run: CGO_ENABLED=1 go build -tags sqlite_fts5 ./...
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4
+        with:
+          category: "/language:go"
+          ref: ${{ github.event_name == 'pull_request' && format('refs/pull/{0}/head', github.event.pull_request.number) || github.ref }}
+          sha: ${{ github.event.pull_request.head.sha || github.sha }}

--- a/tools/release/workflow_test.go
+++ b/tools/release/workflow_test.go
@@ -37,6 +37,7 @@ func TestContinuousIntegrationPreservesPythonTopologyAndGoAssurance(t *testing.T
 		"release.yml":         true,
 	}
 	goAssurance := map[string]bool{
+		"codeql.yml":          true,
 		"migration-gates.yml": true,
 		"provider-smoke.yml":  true,
 	}
@@ -71,6 +72,13 @@ func TestContinuousIntegrationPreservesPythonTopologyAndGoAssurance(t *testing.T
 			"Run Python to Go to Python compatibility tests", "Run the frozen Python versus Go HTTP differential",
 			"OceanBase live compatibility", "Standard (", "Full build tags (",
 			"Host adapters", "Evaluation control plane and console",
+		},
+		"codeql.yml": {
+			"name: CodeQL", "pull_request:", "push:", "branches: [main]", "schedule:", "workflow_dispatch:",
+			"security-events: write", "persist-credentials: false",
+			"github/codeql-action/init@", "build-mode: manual",
+			"CGO_ENABLED=1 go build -tags sqlite_fts5 ./...",
+			"github/codeql-action/analyze@",
 		},
 		"provider-smoke.yml": {
 			"name: Provider smoke", "workflow_dispatch:", "environment: provider-smoke",


### PR DESCRIPTION
## Summary

Closes #9.

This PR adds the narrow WP0-B Go CodeQL quality gate requested in #9:

- adds a dedicated `.github/workflows/codeql.yml`,
- runs CodeQL on `pull_request`, `push` to `main`, a weekly schedule, and `workflow_dispatch`,
- keeps workflow permissions limited to `contents: read` and `security-events: write`,
- pins all third-party actions to immutable commit SHAs,
- checks out the exact pull request head commit before analysis,
- uses CodeQL manual build mode with the repository's standard Linux SQLite build path,
- documents the new workflow in `.github/workflows/README.md`.

## Scope boundaries

Out of scope for this PR:

- dependency-review / govulncheck / Dependabot,
- branch protection or repository settings,
- generated `api/v1` files,
- broader CI refactors.

## Validation

Validated on `remote-dev` Linux using a clean LF-safe archive of the branch plus the final two-file diff:

```bash
git diff --check
go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/codeql.yml
make fmt-check
make check-generated
make vet
make test
CGO_ENABLED=1 go build -tags sqlite_fts5 ./...
make test-sqlite
git status --short
```

Fork smoke evidence:

- Pull request smoke: https://github.com/xiaobaicai66695/powercontext-go/pull/1
- CodeQL pull_request run: https://github.com/xiaobaicai66695/powercontext-go/actions/runs/33099112035
- `CodeQL / Analyze Go` completed successfully, including the explicit `Build for CodeQL` step.
- `Code scanning results / CodeQL` reported no new alerts in the changed code.

Notes from the smoke run:

- The fork smoke PR also triggered the pre-existing `CI` workflow.
- Those `CI` failures are separate from this new CodeQL workflow and match known #3 baseline failures or transient module proxy download failures.
- The CodeQL workflow itself completed successfully on the pull_request event.