### PR TITLE
Fix possible fix(deps): 4 vulnerable dependencies in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	go.opentelemetry.io/otel/metric v1.44.0
 	go.opentelemetry.io/otel/sdk v1.44.0
 	go.opentelemetry.io/otel/trace v1.44.0
-	golang.org/x/mod v0.38.0
+	golang.org/x/mod v0.40.0
 	golang.org/x/text v0.41.0
 	google.golang.org/genai v1.65.0
 )
@@ -110,7 +110,7 @@ require (
 	go.yaml.in/yaml/v4 v4.0.0-rc.2 // indirect
 	golang.org/x/crypto v0.54.0 // indirect
 	golang.org/x/exp v0.0.0-20260312153236-7ab1446f8b90 // indirect
-	golang.org/x/image v0.38.0 // indirect
+	golang.org/x/image v0.43.0 // indirect
 	golang.org/x/net v0.57.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sync v0.22.0 // indirect
@@ -119,7 +119,7 @@ require (
 	golang.org/x/tools v0.48.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa // indirect
-	google.golang.org/grpc v1.81.1 // indirect
+	google.golang.org/grpc v1.82.1 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect


### PR DESCRIPTION
Proposing a fix for something flagged in `go.mod`. It is around line 1.

The project uses golang.org/x/image v0.38.0, which contains a TIFF decoder vulnerability (CVE-2026-46602). The decoder fails to limit tile sizes in tiled TIFF images, allowing an attacker to craft a malicious image that triggers unbounded memory allocation, leading to denial‑of‑service. This is classified as HIGH severity due to the potential for resource exhaustion in any component that processes TIFF files.

Update vulnerable dependencies: golang.org/x/image to v0.43.0, golang.org/x/mod to v0.40.0, and google.golang.org/grpc to v1.82.1.

For reference: rule `CVE-2026-46602`. Rated high.

Take or leave whichever parts are useful. If this is not the right approach, closing is fine.

---
*Found with automated scanning ([RedGem](https://code.redgem.net)) and reviewed before opening. If it is not useful, closing it is completely fine.*
