### PR TITLE
Fix possible fix(deps): 4 vulnerable dependencies in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,101 +28,101 @@ require (
 	go.opentelemetry.io/otel/metric v1.44.0
 	go.opentelemetry.io/otel/sdk v1.44.0
 	go.opentelemetry.io/otel/trace v1.44.0
-	golang.org/x/mod v0.38.0
+	golang.org/x/mod v0.40.0
 	golang.org/x/text v0.41.0
 	google.golang.org/genai v1.65.0
 )
 
 require (
-	cloud.google.com/go v0.116.0 // indirect
-	cloud.google.com/go/auth v0.9.3 // indirect
-	cloud.google.com/go/compute/metadata v0.9.0 // indirect
-	filippo.io/edwards25519 v1.2.0 // indirect
-	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.18 // indirect
-	github.com/aws/aws-sdk-go-v2/credentials v1.19.36 // indirect
-	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.37 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.37 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.37 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.38 // indirect
-	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.17 // indirect
-	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.37 // indirect
-	github.com/aws/aws-sdk-go-v2/service/signin v1.5.6 // indirect
-	github.com/aws/aws-sdk-go-v2/service/sso v1.33.6 // indirect
-	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.38.6 // indirect
-	github.com/aws/aws-sdk-go-v2/service/sts v1.45.6 // indirect
-	github.com/bahlo/generic-list-go v0.2.0 // indirect
-	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/buger/jsonparser v1.1.2 // indirect
-	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
-	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/daulet/tokenizers v1.26.0 // indirect
-	github.com/dlclark/regexp2 v1.12.0 // indirect
-	github.com/dustin/go-humanize v1.0.1 // indirect
-	github.com/fatih/color v1.19.0 // indirect
-	github.com/go-errors/errors v1.5.1 // indirect
-	github.com/go-faster/yaml v0.4.6 // indirect
-	github.com/go-logr/logr v1.4.3 // indirect
-	github.com/go-logr/stdr v1.2.2 // indirect
-	github.com/gofrs/flock v0.13.0 // indirect
-	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
-	github.com/gomlx/exceptions v0.0.3 // indirect
-	github.com/gomlx/go-huggingface v0.3.5-0.20260327162928-af20e4f3e7b5 // indirect
-	github.com/gomlx/go-xla v0.2.2 // indirect
-	github.com/gomlx/gomlx v0.27.2 // indirect
-	github.com/gomlx/onnx-gomlx v0.4.2-0.20260327164137-4e2832549fc1 // indirect
-	github.com/google/go-cmp v0.7.0 // indirect
-	github.com/google/jsonschema-go v0.4.3 // indirect
-	github.com/google/s2a-go v0.1.8 // indirect
-	github.com/googleapis/enterprise-certificate-proxy v0.3.4 // indirect
-	github.com/gorilla/websocket v1.5.3 // indirect
-	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
-	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/invopop/jsonschema v0.14.0 // indirect
-	github.com/knights-analytics/ortgenai v0.2.0 // indirect
-	github.com/mattn/go-colorable v0.1.14 // indirect
-	github.com/mattn/go-isatty v0.0.22 // indirect
-	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/pb33f/ordered-map/v2 v2.3.1 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
-	github.com/prometheus/common v0.70.1 // indirect
-	github.com/prometheus/procfs v0.21.1 // indirect
-	github.com/segmentio/asm v1.2.1 // indirect
-	github.com/segmentio/encoding v0.5.4 // indirect
-	github.com/shopspring/decimal v1.4.0 // indirect
-	github.com/spf13/pflag v1.0.9 // indirect
-	github.com/standard-webhooks/standard-webhooks/libraries v0.0.1 // indirect
-	github.com/tidwall/gjson v1.19.0 // indirect
-	github.com/tidwall/match v1.1.1 // indirect
-	github.com/tidwall/pretty v1.2.1 // indirect
-	github.com/tidwall/sjson v1.2.5 // indirect
-	github.com/viant/afs v1.30.0 // indirect
-	github.com/x448/float16 v0.8.4 // indirect
-	github.com/yalue/onnxruntime_go v1.27.0 // indirect
-	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
-	github.com/yuin/goldmark v1.8.2 // indirect
-	go.opencensus.io v0.24.0 // indirect
-	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.44.0 // indirect
-	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
-	go.uber.org/multierr v1.11.0 // indirect
-	go.uber.org/zap v1.28.0 // indirect
-	go.yaml.in/yaml/v4 v4.0.0-rc.2 // indirect
-	golang.org/x/crypto v0.54.0 // indirect
-	golang.org/x/exp v0.0.0-20260312153236-7ab1446f8b90 // indirect
-	golang.org/x/image v0.38.0 // indirect
-	golang.org/x/net v0.57.0 // indirect
-	golang.org/x/oauth2 v0.36.0 // indirect
-	golang.org/x/sync v0.22.0 // indirect
-	golang.org/x/sys v0.47.0 // indirect
-	golang.org/x/term v0.45.0 // indirect
-	golang.org/x/tools v0.48.0 // indirect
-	google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa // indirect
-	google.golang.org/grpc v1.81.1 // indirect
-	google.golang.org/protobuf v1.36.11 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
-	k8s.io/klog/v2 v2.140.0 // indirect
+cloud.google.com/go v0.116.0 // indirect
+cloud.google.com/go/auth v0.9.3 // indirect
+cloud.google.com/go/compute/metadata v0.9.0 // indirect
+filippo.io/edwards25519 v1.2.0 // indirect
+github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.18 // indirect
+github.com/aws/aws-sdk-go-v2/credentials v1.19.36 // indirect
+github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.37 // indirect
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.37 // indirect
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.37 // indirect
+github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.38 // indirect
+github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.17 // indirect
+github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.37 // indirect
+github.com/aws/aws-sdk-go-v2/service/signin v1.5.6 // indirect
+github.com/aws/aws-sdk-go-v2/service/sso v1.33.6 // indirect
+github.com/aws/aws-sdk-go-v2/service/ssooidc v1.38.6 // indirect
+github.com/aws/aws-sdk-go-v2/service/sts v1.45.6 // indirect
+github.com/bahlo/generic-list-go v0.2.0 // indirect
+github.com/beorn7/perks v1.0.1 // indirect
+github.com/buger/jsonparser v1.1.2 // indirect
+github.com/cenkalti/backoff/v5 v5.0.3 // indirect
+github.com/cespare/xxhash/v2 v2.3.0 // indirect
+github.com/daulet/tokenizers v1.26.0 // indirect
+github.com/dlclark/regexp2 v1.12.0 // indirect
+github.com/dustin/go-humanize v1.0.1 // indirect
+github.com/fatih/color v1.19.0 // indirect
+github.com/go-errors/errors v1.5.1 // indirect
+github.com/go-faster/yaml v0.4.6 // indirect
+github.com/go-logr/logr v1.4.3 // indirect
+github.com/go-logr/stdr v1.2.2 // indirect
+github.com/gofrs/flock v0.13.0 // indirect
+github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
+github.com/gomlx/exceptions v0.0.3 // indirect
+github.com/gomlx/go-huggingface v0.3.5-0.20260327162928-af20e4f3e7b5 // indirect
+github.com/gomlx/go-xla v0.2.2 // indirect
+github.com/gomlx/gomlx v0.27.2 // indirect
+github.com/gomlx/onnx-gomlx v0.4.2-0.20260327164137-4e2832549fc1 // indirect
+github.com/google/go-cmp v0.7.0 // indirect
+github.com/google/jsonschema-go v0.4.3 // indirect
+github.com/google/s2a-go v0.1.8 // indirect
+github.com/googleapis/enterprise-certificate-proxy v0.3.4 // indirect
+github.com/gorilla/websocket v1.5.3 // indirect
+github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
+github.com/inconshreveable/mousetrap v1.1.0 // indirect
+github.com/invopop/jsonschema v0.14.0 // indirect
+github.com/knights-analytics/ortgenai v0.2.0 // indirect
+github.com/mattn/go-colorable v0.1.14 // indirect
+github.com/mattn/go-isatty v0.0.22 // indirect
+github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+github.com/pb33f/ordered-map/v2 v2.3.1 // indirect
+github.com/pkg/errors v0.9.1 // indirect
+github.com/prometheus/client_model v0.6.2 // indirect
+github.com/prometheus/common v0.70.1 // indirect
+github.com/prometheus/procfs v0.21.1 // indirect
+github.com/segmentio/asm v1.2.1 // indirect
+github.com/segmentio/encoding v0.5.4 // indirect
+github.com/shopspring/decimal v1.4.0 // indirect
+github.com/spf13/pflag v1.0.9 // indirect
+github.com/standard-webhooks/standard-webhooks/libraries v0.0.1 // indirect
+github.com/tidwall/gjson v1.19.0 // indirect
+github.com/tidwall/match v1.1.1 // indirect
+github.com/tidwall/pretty v1.2.1 // indirect
+github.com/tidwall/sjson v1.2.5 // indirect
+github.com/viant/afs v1.30.0 // indirect
+github.com/x448/float16 v0.8.4 // indirect
+github.com/yalue/onnxruntime_go v1.27.0 // indirect
+github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
+github.com/yuin/goldmark v1.8.2 // indirect
+go.opencensus.io v0.24.0 // indirect
+go.opentelemetry.io/auto/sdk v1.2.1 // indirect
+go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.44.0 // indirect
+go.opentelemetry.io/proto/otlp v1.10.0 // indirect
+go.uber.org/multierr v1.11.0 // indirect
+go.uber.org/zap v1.28.0 // indirect
+go.yaml.in/yaml/v4 v4.0.0-rc.2 // indirect
+golang.org/x/crypto v0.54.0 // indirect
+golang.org/x/exp v0.0.0-20260312153236-7ab1446f8b90 // indirect
+golang.org/x/image v0.43.0 // indirect
+golang.org/x/net v0.57.0 // indirect
+golang.org/x/oauth2 v0.36.0 // indirect
+golang.org/x/sync v0.22.0 // indirect
+golang.org/x/sys v0.47.0 // indirect
+golang.org/x/term v0.45.0 // indirect
+golang.org/x/tools v0.48.0 // indirect
+google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa // indirect
+google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa // indirect
+google.golang.org/grpc v1.82.1 // indirect
+google.golang.org/protobuf v1.36.11 // indirect
+gopkg.in/yaml.v2 v2.4.0 // indirect
+k8s.io/klog/v2 v2.140.0 // indirect
 )
 
 tool github.com/ogen-go/ogen/cmd/ogen


### PR DESCRIPTION
Proposing a fix for something flagged in `go.mod`. It is around line 1.

The project uses golang.org/x/image v0.38.0, which contains a TIFF decoder vulnerability (CVE-2026-46602). The decoder fails to limit tile sizes in tiled TIFF images, allowing an attacker to craft a malicious image that triggers unbounded memory allocation, leading to denial‑of‑service. This is classified as HIGH severity due to the potential for resource exhaustion in any component that processes TIFF files.

Updated vulnerable dependencies to latest safe versions per security advisory.

For reference: rule `CVE-2026-46602`. Rated high.

Take or leave whichever parts are useful. If this is not the right approach, closing is fine.

---
*Found with automated scanning ([RedGem](https://code.redgem.net)) and reviewed before opening. If it is not useful, closing it is completely fine.*
