### PR TITLE
chore: establish pinned lint foundation

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -6,7 +6,7 @@ counterpart or enforces a Go release constraint that does not exist in Python.
 
 | Python workflow | Go workflow | Deliberate adaptation |
 | --- | --- | --- |
-| `master.yml` | `master.yml` | Go module, formatting, vet, generated transport contracts, Go tests, and the same Pi package replace Python lock, prek, and interpreter tests. |
+| `master.yml` | `master.yml` | Pinned lint and formatting, Go module verification, vet, generated transport contracts, Go tests, and the same Pi package replace Python lock, prek, and interpreter tests. |
 | `e2e-harness.yml` | `e2e-harness.yml` | The same validate/SQLite/OceanBase/evidence lifecycle drives the Go process and live OceanBase acceptance tests. |
 | `license-check.yml` | `license-check.yml` | Both call SkyWalking Eyes 0.8.0 directly. `make license-check` and `make license-fix` remain local entry points. |
 | `deploy-docs.yml` | `deploy-docs.yml` | Both build locked Zensical documentation and deploy GitHub Pages. |

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -11,6 +11,22 @@ permissions:
   contents: read
 
 jobs:
+  lint:
+    name: lint
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    env:
+      GOTOOLCHAIN: local
+    steps:
+      - name: Check out
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Set up the environment
+        uses: ./.github/actions/setup-go-env
+
+      - name: Run the pinned lint policy
+        run: make lint
+
   quality:
     runs-on: ubuntu-latest
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /dist/
 /coverage/
 /site/
+/.tools/
 .powercontext-e2e/
 *.coverprofile
 *.test

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,7 +14,31 @@
 
 version: "2"
 
-# Keep this file intentionally minimal until a golangci-lint release is pinned
-# by CI and the release toolchain.
 run:
   timeout: 5m
+  modules-download-mode: readonly
+
+linters:
+  default: none
+  enable:
+    - bodyclose
+    - durationcheck
+    - ineffassign
+    - wastedassign
+    - whitespace
+  exclusions:
+    generated: strict
+
+formatters:
+  enable:
+    - gofmt
+    - gofumpt
+    - goimports
+  settings:
+    gofumpt:
+      module-path: github.com/ob-labs/powercontext-go
+    goimports:
+      local-prefixes:
+        - github.com/ob-labs/powercontext-go
+  exclusions:
+    generated: strict

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -31,12 +31,9 @@ linters:
 
 formatters:
   enable:
-    - gofmt
     - gofumpt
     - goimports
   settings:
-    gofumpt:
-      module-path: github.com/ob-labs/powercontext-go
     goimports:
       local-prefixes:
         - github.com/ob-labs/powercontext-go

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,3 +130,7 @@ source / artifact / trigger / inference
   raw database bytes that contain the producing SQLite version and physical
   page-layout metadata. Keep committed fixture hashes pinned separately, and
   verify both semantic regeneration and cross-runtime read/write compatibility.
+- When `go install module@version` provisions a repository-local tool, run the
+  install with the project-selected `go env GOVERSION` as the minimum
+  `GOTOOLCHAIN`. Verify from an older bootstrap Go release that the installed
+  binary can process the module's declared Go version.

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 GO ?= go
-GOFMT ?= $(GO) tool gofmt
+GOFMT ?= gofmt
 GOCACHE ?=
 GOMODCACHE ?=
 PNPM ?= pnpm

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ TOOLS_BIN := $(CURDIR)/.tools/bin
 GOLANGCI_LINT_VERSION := v2.13.1
 GOLANGCI_LINT := $(TOOLS_BIN)/golangci-lint$(shell $(GO) env GOEXE)
 GOLANGCI_LINT_STAMP := $(TOOLS_BIN)/.golangci-lint-$(GOLANGCI_LINT_VERSION)
+PROJECT_GO_TOOLCHAIN = $(shell $(GO) env GOVERSION)
 
 STANDARD_TAGS := sqlite_fts5
 FULL_TAGS := sqlite_fts5,local_embeddings,ORT
@@ -25,7 +26,8 @@ LDFLAGS := -s -w -X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.dat
 
 $(GOLANGCI_LINT): Makefile
 	@mkdir -p "$(TOOLS_BIN)"
-	GOBIN="$(TOOLS_BIN)" $(GO) install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
+	GOTOOLCHAIN="$(PROJECT_GO_TOOLCHAIN)+auto" GOBIN="$(TOOLS_BIN)" \
+		$(GO) install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
 
 $(GOLANGCI_LINT_STAMP): $(GOLANGCI_LINT)
 	@$(RM) $(TOOLS_BIN)/.golangci-lint-*

--- a/Makefile
+++ b/Makefile
@@ -23,9 +23,11 @@ LDFLAGS := -s -w -X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.dat
 	harness-compose-acceptance harness-compose-down build build-full smoke smoke-full check \
 	package-standard package-full clean
 
-$(GOLANGCI_LINT_STAMP):
+$(GOLANGCI_LINT): Makefile
 	@mkdir -p "$(TOOLS_BIN)"
 	GOBIN="$(TOOLS_BIN)" $(GO) install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
+
+$(GOLANGCI_LINT_STAMP): $(GOLANGCI_LINT)
 	@$(RM) $(TOOLS_BIN)/.golangci-lint-*
 	@touch "$@"
 

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,14 @@
 GO ?= go
-GOFMT ?= gofmt
 GOCACHE ?=
 GOMODCACHE ?=
 PNPM ?= pnpm
 UV ?= uv
 LICENSE_EYE ?= $(GO) run github.com/apache/skywalking-eyes/cmd/license-eye@v0.8.0
+
+TOOLS_BIN := $(CURDIR)/.tools/bin
+GOLANGCI_LINT_VERSION := v2.13.1
+GOLANGCI_LINT := $(TOOLS_BIN)/golangci-lint$(shell $(GO) env GOEXE)
+GOLANGCI_LINT_STAMP := $(TOOLS_BIN)/.golangci-lint-$(GOLANGCI_LINT_VERSION)
 
 STANDARD_TAGS := sqlite_fts5
 FULL_TAGS := sqlite_fts5,local_embeddings,ORT
@@ -13,11 +17,26 @@ COMMIT ?= $(shell git rev-parse HEAD 2>/dev/null || printf unknown)
 BUILD_DATE ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
 LDFLAGS := -s -w -X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.date=$(BUILD_DATE)
 
-.PHONY: generate check-generated module-check contract-test license-check license-fix fmt fmt-check vet \
+.PHONY: lint-tools lint lint-fix generate check-generated module-check contract-test license-check license-fix fmt fmt-check vet \
 	test unit-test e2e-test test-sqlite test-race test-full test-oceanbase-live real-provider-test \
 	pi-test docs-sync docs-test docs-build harness-sync harness-check harness-compose-check \
 	harness-compose-acceptance harness-compose-down build build-full smoke smoke-full check \
 	package-standard package-full clean
+
+$(GOLANGCI_LINT_STAMP):
+	@mkdir -p "$(TOOLS_BIN)"
+	GOBIN="$(TOOLS_BIN)" $(GO) install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
+	@$(RM) $(TOOLS_BIN)/.golangci-lint-*
+	@touch "$@"
+
+lint-tools: $(GOLANGCI_LINT_STAMP)
+
+lint: lint-tools
+	"$(GOLANGCI_LINT)" run
+
+lint-fix: lint-tools
+	"$(GOLANGCI_LINT)" fmt
+	"$(GOLANGCI_LINT)" run --fix
 
 generate:
 	$(GO) generate ./openapi
@@ -44,12 +63,11 @@ license-fix:
 	$(LICENSE_EYE) -c .licenserc.yaml header fix
 	$(LICENSE_EYE) -c .licenserc.yaml header check
 
-fmt:
-	$(GOFMT) -w $$(find . -name '*.go' -not -path './vendor/*')
+fmt: lint-tools
+	"$(GOLANGCI_LINT)" fmt
 
-fmt-check:
-	@files="$$(gofmt -l $$(find . -name '*.go' -not -path './vendor/*'))"; \
-	if [ -n "$$files" ]; then printf '%s\n' "$$files"; exit 1; fi
+fmt-check: lint-tools
+	"$(GOLANGCI_LINT)" fmt --diff
 
 vet:
 	$(GO) vet ./...

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 GO ?= go
+GOFMT ?= $(GO) tool gofmt
 GOCACHE ?=
 GOMODCACHE ?=
 PNPM ?= pnpm
@@ -7,9 +8,12 @@ LICENSE_EYE ?= $(GO) run github.com/apache/skywalking-eyes/cmd/license-eye@v0.8.
 
 TOOLS_BIN := $(CURDIR)/.tools/bin
 GOLANGCI_LINT_VERSION := v2.13.1
+GOLANGCI_LINT_VERSION_TEXT := $(patsubst v%,%,$(GOLANGCI_LINT_VERSION))
 GOLANGCI_LINT := $(TOOLS_BIN)/golangci-lint$(shell $(GO) env GOEXE)
-GOLANGCI_LINT_STAMP := $(TOOLS_BIN)/.golangci-lint-$(GOLANGCI_LINT_VERSION)
 PROJECT_GO_TOOLCHAIN = $(shell $(GO) env GOVERSION)
+GOLANGCI_LINT_STAMP = $(TOOLS_BIN)/.golangci-lint-$(GOLANGCI_LINT_VERSION)-$(PROJECT_GO_TOOLCHAIN)
+
+.DEFAULT_GOAL := generate
 
 STANDARD_TAGS := sqlite_fts5
 FULL_TAGS := sqlite_fts5,local_embeddings,ORT
@@ -24,12 +28,13 @@ LDFLAGS := -s -w -X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.dat
 	harness-compose-acceptance harness-compose-down build build-full smoke smoke-full check \
 	package-standard package-full clean
 
-$(GOLANGCI_LINT): Makefile
+$(GOLANGCI_LINT): Makefile go.mod
 	@mkdir -p "$(TOOLS_BIN)"
 	GOTOOLCHAIN="$(PROJECT_GO_TOOLCHAIN)+auto" GOBIN="$(TOOLS_BIN)" \
 		$(GO) install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
 
 $(GOLANGCI_LINT_STAMP): $(GOLANGCI_LINT)
+	@"$(GOLANGCI_LINT)" --version | grep -q "version $(GOLANGCI_LINT_VERSION_TEXT) "
 	@$(RM) $(TOOLS_BIN)/.golangci-lint-*
 	@touch "$@"
 
@@ -68,9 +73,11 @@ license-fix:
 	$(LICENSE_EYE) -c .licenserc.yaml header check
 
 fmt: lint-tools
+	$(GOFMT) -w $$(find . -name '*.go' -not -path './vendor/*')
 	"$(GOLANGCI_LINT)" fmt
 
 fmt-check: lint-tools
+	@$(GOFMT) -l $$(find . -name '*.go' -not -path './vendor/*') >/dev/null
 	"$(GOLANGCI_LINT)" fmt --diff
 
 vet:

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ The standard build uses CGO and statically embeds the same sqlite-vec 0.1.9
 
 ```sh
 make check
+make lint
 make contract-test
 make unit-test
 make e2e-test
@@ -76,6 +77,7 @@ SQLite remains the zero-dependency default.
 Useful verification targets:
 
 ```sh
+make lint-fix
 make license-check
 make pi-test
 make docs-test
@@ -84,6 +86,10 @@ make test-full TOKENIZERS_LIB_DIR=/path/to/tokenizers/lib
 POWERCONTEXT_TEST_OCEANBASE_URL='mysql+aoceanbase://root%40tenant:password@127.0.0.1:2881/powercontext?charset=utf8mb4' \
   make test-oceanbase-live
 ```
+
+The lint targets install the pinned `golangci-lint` release under
+`.tools/bin`; its embedded gofmt, gofumpt, and goimports versions are therefore
+the same locally and in CI. No mutable global linter installation is used.
 
 If a newly added source file is missing the standard Apache-2.0 header, repair
 all eligible files and immediately recheck them with one command:

--- a/README.md
+++ b/README.md
@@ -88,8 +88,8 @@ POWERCONTEXT_TEST_OCEANBASE_URL='mysql+aoceanbase://root%40tenant:password@127.0
 ```
 
 The lint targets install the pinned `golangci-lint` release under
-`.tools/bin`; its embedded gofmt, gofumpt, and goimports versions are therefore
-the same locally and in CI. No mutable global linter installation is used.
+`.tools/bin`; its embedded gofumpt and goimports versions are therefore the same
+locally and in CI. No mutable global linter installation is used.
 
 If a newly added source file is missing the standard Apache-2.0 header, repair
 all eligible files and immediately recheck them with one command:

--- a/artifact/experience/model.go
+++ b/artifact/experience/model.go
@@ -63,8 +63,10 @@ func (c Content) Action() string    { return c.action }
 func (c Content) Outcome() string   { return c.outcome }
 func (c Content) Lesson() string    { return c.lesson }
 
-type Experience = artifact.Artifact[Content]
-type Draft = artifact.Draft[Content]
+type (
+	Experience = artifact.Artifact[Content]
+	Draft      = artifact.Draft[Content]
+)
 
 func NewDraft(content Content, sources []source.Ref, artifacts []artifact.Ref) (Draft, error) {
 	return artifact.NewDraft(Family, content, sources, artifacts)

--- a/artifact/handoff/citation.go
+++ b/artifact/handoff/citation.go
@@ -40,6 +40,7 @@ func (c SourceCitation) Validate() error {
 	_, err := source.NewRef(c.ref.Type(), c.ref.ID())
 	return err
 }
+
 func (c SourceCitation) citationKey() string {
 	return "source\x00" + c.ref.Type() + "\x00" + c.ref.ID()
 }
@@ -79,6 +80,7 @@ func (c MemoryCitation) Validate() error {
 	_, err := memory.ValidateIdentifier(c.citation.EntryVersionID)
 	return err
 }
+
 func (c MemoryCitation) citationKey() string {
 	return "memory\x00" + c.citation.MemoryRef.String() + "\x00" + c.citation.EntryID + "\x00" + c.citation.EntryVersionID
 }

--- a/artifact/handoff/generation.go
+++ b/artifact/handoff/generation.go
@@ -200,9 +200,11 @@ func (o GenerationOutput) Disposition() Disposition     { return o.disposition }
 func (o GenerationOutput) NextAction() *GenerationStatement {
 	return cloneGenerationStatement(o.nextAction)
 }
+
 func (o GenerationOutput) Omissions() []GenerationOmission {
 	return cloneGenerationOmissions(o.omissions)
 }
+
 func (o GenerationOutput) Validate() error {
 	if o.disposition != Continuable && o.disposition != Blocked && o.disposition != Complete {
 		return fmt.Errorf("invalid Handoff generation disposition %q", o.disposition)

--- a/artifact/handoff/model.go
+++ b/artifact/handoff/model.go
@@ -76,8 +76,10 @@ const (
 	MemoryCitationKind   CitationKind = "memory"
 )
 
-type Handoff = artifact.Artifact[Content]
-type ArtifactDraft = artifact.Draft[Content]
+type (
+	Handoff       = artifact.Artifact[Content]
+	ArtifactDraft = artifact.Draft[Content]
+)
 
 func NewArtifactDraft(content Content, sources []source.Ref, artifacts []artifact.Ref) (ArtifactDraft, error) {
 	if err := content.Validate(); err != nil {

--- a/artifact/handoff/request.go
+++ b/artifact/handoff/request.go
@@ -74,6 +74,7 @@ func (a Activate) Clone() Activate {
 	a.evidence = slices.Clone(a.evidence)
 	return a
 }
+
 func (a Activate) Validate() error {
 	if _, err := source.NewRef(a.boundarySource.Type(), a.boundarySource.ID()); err != nil {
 		return err
@@ -99,6 +100,7 @@ func (a Activate) Validate() error {
 	}
 	return nil
 }
+
 func (a Activate) ActionEvidence() []Citation {
 	boundary := SourceCitation{ref: a.boundarySource}
 	result := []Citation{boundary}

--- a/artifact/handoff/resolution.go
+++ b/artifact/handoff/resolution.go
@@ -94,6 +94,7 @@ func (c EvidenceCheck) Claim() Claim                    { return c.claim }
 func (c EvidenceCheck) StateIndex() *int                { return cloneInt(c.stateIndex) }
 func (c EvidenceCheck) Status() EvidenceStatus          { return c.status }
 func (c EvidenceCheck) UnavailableEvidence() []Citation { return slices.Clone(c.unavailableEvidence) }
+
 func (c EvidenceCheck) Validate() error {
 	if c.claim != StateClaim && c.claim != NextActionClaim {
 		return fmt.Errorf("invalid Handoff evidence claim %q", c.claim)

--- a/artifact/memory/canonical.go
+++ b/artifact/memory/canonical.go
@@ -24,10 +24,11 @@ import (
 	"unicode"
 	"unicode/utf8"
 
+	"golang.org/x/text/unicode/norm"
+
 	"github.com/ob-labs/powercontext-go/artifact"
 	internaljcs "github.com/ob-labs/powercontext-go/internal/jcs"
 	"github.com/ob-labs/powercontext-go/source"
-	"golang.org/x/text/unicode/norm"
 )
 
 var lowerHex64 = regexp.MustCompile(`^[0-9a-f]{64}$`)

--- a/artifact/memory/model.go
+++ b/artifact/memory/model.go
@@ -190,8 +190,10 @@ func (c Content) Changes() []Change {
 	return result
 }
 
-type Memory = artifact.Artifact[Content]
-type Draft = artifact.Draft[Content]
+type (
+	Memory = artifact.Artifact[Content]
+	Draft  = artifact.Draft[Content]
+)
 
 func NewDraft(content Content, sources []source.Ref, artifacts []artifact.Ref) (Draft, error) {
 	return artifact.NewDraft(Family, content, sources, artifacts)

--- a/artifact/memory/service.go
+++ b/artifact/memory/service.go
@@ -65,8 +65,10 @@ type ArtifactResolver interface {
 	Get(context.Context, artifact.Snapshot) (artifact.Snapshot, error)
 }
 
-type IDFactory func(string) (string, error)
-type Clock func() time.Time
+type (
+	IDFactory func(string) (string, error)
+	Clock     func() time.Time
+)
 
 type ServiceOptions struct {
 	CandidatePipeline    CandidatePipeline

--- a/artifact/memory/service_plan.go
+++ b/artifact/memory/service_plan.go
@@ -199,7 +199,7 @@ func (s *Service) prepareCommit(
 	evidence operationEvidence,
 	currentEntries []EntryVersion,
 ) (*Commit, error) {
-	memoryID := ""
+	var memoryID string
 	nextRevision := int64(1)
 	manifest := make(map[string]ManifestEntry)
 	if base == nil {

--- a/artifact/model_test.go
+++ b/artifact/model_test.go
@@ -60,9 +60,11 @@ type memoryCatalog struct{}
 func (memoryCatalog) Get(_ context.Context, value artifact.Artifact[string]) (artifact.Artifact[string], error) {
 	return value, nil
 }
+
 func (memoryCatalog) Latest(_ context.Context, value artifact.Artifact[string]) (artifact.Artifact[string], error) {
 	return value, nil
 }
+
 func (memoryCatalog) Revisions(_ context.Context, value artifact.Artifact[string]) ([]artifact.Artifact[string], error) {
 	return []artifact.Artifact[string]{value}, nil
 }
@@ -72,6 +74,7 @@ type memoryStore struct{}
 func (memoryStore) Add(_ context.Context, draft artifact.Draft[string]) (artifact.Artifact[string], error) {
 	return artifact.New("new", 1, draft)
 }
+
 func (memoryStore) Revise(_ context.Context, current artifact.Artifact[string], draft artifact.Draft[string]) (artifact.Artifact[string], error) {
 	return artifact.New(current.ID(), current.Revision()+1, draft)
 }

--- a/artifact/skill/external.go
+++ b/artifact/skill/external.go
@@ -99,10 +99,12 @@ func NewRegistration(
 		maximum int
 	}{
 		{"external_skill_id", externalSkillID, artifactIDLimit},
-		{"provider", provider, 128}, {"agent_kind", agentKind, 128},
+		{"provider", provider, 128},
+		{"agent_kind", agentKind, 128},
 		{"host_id", hostID, MaxExternalHostIDLength},
 		{"locator", locator, MaxExternalLocatorLength},
-		{"name", name, MaxNameLength}, {"description", description, MaxDescriptionLength},
+		{"name", name, MaxNameLength},
+		{"description", description, MaxDescriptionLength},
 	} {
 		if err := externalText(value.label, value.text, value.maximum); err != nil {
 			return Registration{}, err

--- a/artifact/skill/external_provider.go
+++ b/artifact/skill/external_provider.go
@@ -188,6 +188,7 @@ func (p *CodexProvider) ProviderNames() []string { return []string{string(CodexA
 func (p *CodexProvider) Scan(ctx context.Context) (ProviderScan, error) {
 	return p.provider.Scan(ctx)
 }
+
 func (p *CodexProvider) Resolve(ctx context.Context, registration Registration) (Resolution, error) {
 	return p.provider.Resolve(ctx, registration)
 }

--- a/artifact/skill/model.go
+++ b/artifact/skill/model.go
@@ -67,8 +67,10 @@ func (c Content) Description() string  { return c.description }
 func (c Content) Instructions() string { return c.instructions }
 func (c Content) Validation() []string { return slices.Clone(c.validation) }
 
-type Skill = artifact.Artifact[Content]
-type Draft = artifact.Draft[Content]
+type (
+	Skill = artifact.Artifact[Content]
+	Draft = artifact.Draft[Content]
+)
 
 func NewDraft(content Content, sources []source.Ref, artifacts []artifact.Ref) (Draft, error) {
 	return artifact.NewDraft(Family, content, sources, artifacts)

--- a/artifact/skill/snapshot_source.go
+++ b/artifact/skill/snapshot_source.go
@@ -47,6 +47,7 @@ func (s SnapshotSource) SourceName() string { return s.name }
 func (SnapshotSource) SourceMaterialization() source.Materialization {
 	return source.Captured
 }
+
 func (SnapshotSource) SourceDescription() (string, bool) {
 	return "Exact external Skill snapshot captured by an explicit managed import or fork.", true
 }
@@ -68,6 +69,7 @@ func (SnapshotSourceAdapter) Resolve(_ context.Context, value SnapshotCapture) (
 		name: "ext_skill_" + hex.EncodeToString(digest[:]), snapshot: value.Snapshot, mode: value.Mode,
 	}, nil
 }
+
 func (SnapshotSourceAdapter) Read(_ context.Context, value SnapshotSource) (SnapshotCapture, error) {
 	return SnapshotCapture{Snapshot: value.snapshot, Mode: value.mode}, nil
 }

--- a/client/client.go
+++ b/client/client.go
@@ -26,12 +26,13 @@ import (
 	"strings"
 	"time"
 
-	v1 "github.com/ob-labs/powercontext-go/api/v1"
-	requesttrace "github.com/ob-labs/powercontext-go/internal/observability/tracing"
 	"github.com/ogen-go/ogen/ogenerrors"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
+
+	v1 "github.com/ob-labs/powercontext-go/api/v1"
+	requesttrace "github.com/ob-labs/powercontext-go/internal/observability/tracing"
 )
 
 const DefaultTimeout = 10 * time.Second
@@ -348,7 +349,7 @@ func AsServerError(response any) (*ServerError, bool) {
 	if value, ok := response.(*ServerError); ok && value != nil {
 		return value, true
 	}
-	status := 0
+	var status int
 	switch response.(type) {
 	case *v1.UnauthorizedHeaders:
 		status = http.StatusUnauthorized

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -28,9 +28,10 @@ import (
 	"time"
 
 	"github.com/go-faster/jx"
-	v1 "github.com/ob-labs/powercontext-go/api/v1"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	v1 "github.com/ob-labs/powercontext-go/api/v1"
 )
 
 const capabilitiesJSON = `{"source_types":[],"artifact_families":[],"memory_extraction":false,"experience_generation":false,"managed_skill_generation":false,"external_skill_registry":false,"handoff_generation":false,"search_modes":[],"context_versions":[]}`

--- a/inference/tracing_test.go
+++ b/inference/tracing_test.go
@@ -19,10 +19,11 @@ import (
 	"strings"
 	"testing"
 
-	servertracing "github.com/ob-labs/powercontext-go/internal/observability/tracing"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"go.opentelemetry.io/otel/trace"
+
+	servertracing "github.com/ob-labs/powercontext-go/internal/observability/tracing"
 )
 
 func TestInferenceSpanRecordsNoModelContent(t *testing.T) {

--- a/internal/cli/artifact_commands.go
+++ b/internal/cli/artifact_commands.go
@@ -21,11 +21,12 @@ import (
 	"io/fs"
 	"path/filepath"
 
+	"github.com/spf13/cobra"
+
 	v1 "github.com/ob-labs/powercontext-go/api/v1"
 	"github.com/ob-labs/powercontext-go/artifact"
 	artifactskill "github.com/ob-labs/powercontext-go/artifact/skill"
 	pcclient "github.com/ob-labs/powercontext-go/client"
-	"github.com/spf13/cobra"
 )
 
 func newExperienceCommand(state *commandState) *cobra.Command {

--- a/internal/cli/candidate_commands.go
+++ b/internal/cli/candidate_commands.go
@@ -22,9 +22,10 @@ import (
 	"os"
 	"unicode/utf8"
 
+	"github.com/spf13/cobra"
+
 	v1 "github.com/ob-labs/powercontext-go/api/v1"
 	pcclient "github.com/ob-labs/powercontext-go/client"
-	"github.com/spf13/cobra"
 )
 
 func newCandidateCommand(state *commandState) *cobra.Command {

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -28,8 +28,9 @@ import (
 	"time"
 	"unicode/utf8"
 
-	v1 "github.com/ob-labs/powercontext-go/api/v1"
 	"github.com/spf13/cobra"
+
+	v1 "github.com/ob-labs/powercontext-go/api/v1"
 )
 
 type diagnostic struct {
@@ -204,6 +205,7 @@ func decodeDiagnosticJSON(payload []byte, target any) error {
 	}
 	return nil
 }
+
 func writeDiagnostics(state *commandState, values map[string]diagnostic) error {
 	if state.json {
 		return writeJSON(state.stdout, map[string]any{

--- a/internal/cli/external_skill_commands.go
+++ b/internal/cli/external_skill_commands.go
@@ -18,9 +18,10 @@ import (
 	"context"
 	"errors"
 
+	"github.com/spf13/cobra"
+
 	v1 "github.com/ob-labs/powercontext-go/api/v1"
 	pcclient "github.com/ob-labs/powercontext-go/client"
-	"github.com/spf13/cobra"
 )
 
 func newExternalSkillCommand(state *commandState) *cobra.Command {

--- a/internal/cli/integration_codex.go
+++ b/internal/cli/integration_codex.go
@@ -91,6 +91,7 @@ func newSetupCodexCommand(state *commandState) *cobra.Command {
 	command.Flags().StringVar(&ref, "ref", defaultMarketplaceRef, "Git ref used for a remote marketplace source.")
 	return command
 }
+
 func runCodexDiagnostics(ctx context.Context, commands systemCommandExecutor) map[string]diagnostic {
 	executable, err := commands.LookPath("codex")
 	if err != nil {
@@ -126,6 +127,7 @@ func runCodexDiagnostics(ctx context.Context, commands systemCommandExecutor) ma
 	}
 	return map[string]diagnostic{"codex": {OK: true, Status: "ok", Detail: executable}, "plugin": plugin}
 }
+
 func normalizeMarketplaceSource(source string) (string, bool, error) {
 	if strings.HasPrefix(source, ".") || strings.HasPrefix(source, "/") || strings.HasPrefix(source, "~") ||
 		(len(source) >= 2 && source[1] == ':') {

--- a/internal/cli/integration_dsh.go
+++ b/internal/cli/integration_dsh.go
@@ -73,6 +73,7 @@ func newSetupDSHCommand(state *commandState) *cobra.Command {
 	command.Flags().StringVar(&ref, "ref", defaultMarketplaceRef, "Git ref used for a remote source.")
 	return command
 }
+
 func runDSHDiagnostics(ctx context.Context, commands systemCommandExecutor) map[string]diagnostic {
 	executable, err := dshExecutable(commands, runtime.GOOS)
 	if err != nil {
@@ -101,6 +102,7 @@ func runDSHDiagnostics(ctx context.Context, commands systemCommandExecutor) map[
 	}
 	return map[string]diagnostic{"dsh": {OK: true, Status: "ok", Detail: executable}, "plugin": plugin}
 }
+
 func dshExecutable(commands systemCommandExecutor, goos string) (string, error) {
 	if goos == "windows" {
 		if executable, err := commands.LookPath("dsh.cmd"); err == nil {
@@ -115,17 +117,11 @@ func resolveDSHPlugin(
 	commands systemCommandExecutor,
 	source, ref, dataDirectory string,
 ) (string, error) {
-	_, local, err := normalizeMarketplaceSource(source)
+	root, local, err := normalizeMarketplaceSource(source)
 	if err != nil {
 		return "", err
 	}
-	root := source
-	if local {
-		root, _, err = normalizeMarketplaceSource(source)
-		if err != nil {
-			return "", err
-		}
-	} else {
+	if !local {
 		if ref == "" || ref == "." || ref == ".." || strings.ContainsRune(ref, '\x00') {
 			return "", errors.New("invalid DeepSeek Harness ref")
 		}

--- a/internal/cli/python_contract_test.go
+++ b/internal/cli/python_contract_test.go
@@ -42,8 +42,11 @@ const pendingCandidateJSON = `{
 
 func TestCLIHelpAndInstalledRoleCommands(t *testing.T) {
 	for _, arguments := range [][]string{
-		{"-h"}, {"--help"}, {"experience", "--help"},
-		{"skill", "--help"}, {"external-skill", "--help"},
+		{"-h"},
+		{"--help"},
+		{"experience", "--help"},
+		{"skill", "--help"},
+		{"external-skill", "--help"},
 	} {
 		stdout, _, err := executeContractCLI(t, nil, arguments...)
 		if err != nil {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -29,9 +29,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/spf13/cobra"
+
 	v1 "github.com/ob-labs/powercontext-go/api/v1"
 	pcclient "github.com/ob-labs/powercontext-go/client"
-	"github.com/spf13/cobra"
 )
 
 const (

--- a/internal/cli/server_command.go
+++ b/internal/cli/server_command.go
@@ -24,9 +24,10 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/spf13/cobra"
+
 	serverlogging "github.com/ob-labs/powercontext-go/internal/observability/logging"
 	"github.com/ob-labs/powercontext-go/server"
-	"github.com/spf13/cobra"
 )
 
 type serverCommandRunner func(context.Context, *commandState, server.ProcessConfig) error

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -18,8 +18,9 @@ import (
 	"errors"
 	"os"
 
-	"github.com/ob-labs/powercontext-go/server"
 	"github.com/spf13/cobra"
+
+	"github.com/ob-labs/powercontext-go/server"
 )
 
 const (
@@ -42,6 +43,7 @@ func newSetupCommand(state *commandState) *cobra.Command {
 	)
 	return command
 }
+
 func prepareDataDirectory() (string, error) {
 	directory, err := server.PowerContextDataDir()
 	if err != nil {

--- a/internal/cli/system_commands.go
+++ b/internal/cli/system_commands.go
@@ -18,9 +18,10 @@ import (
 	"context"
 	"errors"
 
+	"github.com/spf13/cobra"
+
 	v1 "github.com/ob-labs/powercontext-go/api/v1"
 	pcclient "github.com/ob-labs/powercontext-go/client"
-	"github.com/spf13/cobra"
 )
 
 func newCapabilitiesCommand(state *commandState) *cobra.Command {

--- a/internal/endpoint/handoff_report.go
+++ b/internal/endpoint/handoff_report.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/go-faster/jx"
+
 	v1 "github.com/ob-labs/powercontext-go/api/v1"
 	"github.com/ob-labs/powercontext-go/internal/handoffreport"
 	"github.com/ob-labs/powercontext-go/internal/runtime"

--- a/internal/endpoint/memory.go
+++ b/internal/endpoint/memory.go
@@ -343,5 +343,7 @@ func decodeMetadata(value v1.OptNilCaptureContentSourceRequestMetadata) (map[str
 	return result, nil
 }
 
-var _ SourceOperations = (*runtime.SourceApplication)(nil)
-var _ MemoryOperations = (*runtime.MemoryApplication)(nil)
+var (
+	_ SourceOperations = (*runtime.SourceApplication)(nil)
+	_ MemoryOperations = (*runtime.MemoryApplication)(nil)
+)

--- a/internal/endpoint/system.go
+++ b/internal/endpoint/system.go
@@ -21,8 +21,10 @@ import (
 	"github.com/ob-labs/powercontext-go/internal/runtime"
 )
 
-type CapabilityProvider func(context.Context) (runtime.Capabilities, error)
-type ReadinessProvider func(context.Context) (runtime.Readiness, error)
+type (
+	CapabilityProvider func(context.Context) (runtime.Capabilities, error)
+	ReadinessProvider  func(context.Context) (runtime.Readiness, error)
+)
 
 type HandlerOptions struct {
 	Capabilities  CapabilityProvider

--- a/internal/handoffreport/activity.go
+++ b/internal/handoffreport/activity.go
@@ -46,9 +46,11 @@ func (v ActivityAgent) Validate() error {
 	}
 	return nil
 }
+
 func (v ActivityAgent) MarshalJSON() ([]byte, error) {
 	return json.Marshal(map[string]any{"provider": v.provider, "label": v.label})
 }
+
 func (v *ActivityAgent) UnmarshalJSON(data []byte) error {
 	var dto struct {
 		Provider *string `json:"provider"`
@@ -87,9 +89,11 @@ func (v ActivityVCSContext) Validate() error {
 	}
 	return nil
 }
+
 func (v ActivityVCSContext) MarshalJSON() ([]byte, error) {
 	return json.Marshal(map[string]any{"branch": v.branch, "head_revision": v.headRevision})
 }
+
 func (v *ActivityVCSContext) UnmarshalJSON(data []byte) error {
 	var dto struct {
 		Branch       *string `json:"branch"`
@@ -244,6 +248,7 @@ func (v ActivityEvent) Validate() error {
 	})
 	return err
 }
+
 func (v ActivityEvent) EffectivePeriodTime() *time.Time {
 	switch v.timeBasis {
 	case TimeSourceReported:
@@ -255,6 +260,7 @@ func (v ActivityEvent) EffectivePeriodTime() *time.Time {
 		return nil
 	}
 }
+
 func (v ActivityEvent) MarshalJSON() ([]byte, error) {
 	if err := v.Validate(); err != nil {
 		return nil, err

--- a/internal/handoffreport/canonical.go
+++ b/internal/handoffreport/canonical.go
@@ -77,6 +77,7 @@ func SelectionEnvelope(report Report) (map[string]any, error) {
 	}
 	return map[string]any{"schema": "powercontext.handoff-report-selection.v1", "project_id": report.project.ProjectID(), "project_revision": report.project.Version(), "normalized_filters": report.normalizedFilters, "normalized_period": report.normalizedPeriod, "selection_consistency": "optimistic_stable", "activity_cursor": report.activityCursor, "baseline_selection": baseline, "end_selection": end, "activity_selection": activity}, nil
 }
+
 func SelectionDigest(report Report) (string, error) {
 	value, err := SelectionEnvelope(report)
 	if err != nil {
@@ -84,6 +85,7 @@ func SelectionDigest(report Report) (string, error) {
 	}
 	return digest(value)
 }
+
 func ReportDigest(report Report) (string, error) {
 	value, err := report.object(false, true)
 	if err != nil {
@@ -91,6 +93,7 @@ func ReportDigest(report Report) (string, error) {
 	}
 	return digest(value)
 }
+
 func FinalizeDigests(report Report) (Report, error) {
 	if err := report.Validate(); err != nil {
 		return Report{}, err
@@ -110,6 +113,7 @@ func FinalizeDigests(report Report) (Report, error) {
 	}
 	return report, nil
 }
+
 func digest(value any) (string, error) {
 	encoded, err := CanonicalJSONBytes(value)
 	if err != nil {
@@ -216,6 +220,7 @@ func normalizeCanonical(value any) (any, error) {
 		return nil, &CanonicalizationError{Code: "unsupported-type", Detail: reflected.Type().String()}
 	}
 }
+
 func stringsContainsFloat(value string) bool {
 	for _, marker := range []string{".", "e", "E"} {
 		if slices.Contains([]byte(value), marker[0]) {
@@ -224,12 +229,14 @@ func stringsContainsFloat(value string) bool {
 	}
 	return false
 }
+
 func canonicalTimePtr(value *time.Time) any {
 	if value == nil {
 		return nil
 	}
 	return UTCText(*value)
 }
+
 func cloneJSONMap(value map[string]any) map[string]any {
 	if value == nil {
 		return nil

--- a/internal/handoffreport/catalog.go
+++ b/internal/handoffreport/catalog.go
@@ -36,6 +36,7 @@ func NewExternalReference(kind ExternalReferenceKind, provider, externalID strin
 	}
 	return value, nil
 }
+
 func (v ExternalReference) Validate() error {
 	if !validExternalKind(v.kind) {
 		return fieldError("kind", "has an unsupported value")
@@ -58,9 +59,11 @@ func (v ExternalReference) URL() *string                { return cloneString(v.u
 func (v ExternalReference) key() string {
 	return string(v.kind) + "\x00" + v.provider + "\x00" + v.externalID + "\x00" + optionalKey(v.url)
 }
+
 func (v ExternalReference) MarshalJSON() ([]byte, error) {
 	return json.Marshal(map[string]any{"kind": v.kind, "provider": v.provider, "external_id": v.externalID, "url": v.url})
 }
+
 func (v *ExternalReference) UnmarshalJSON(data []byte) error {
 	var dto struct {
 		Kind       ExternalReferenceKind `json:"kind"`
@@ -119,6 +122,7 @@ func (v RepositoryRef) Subpath() *string             { return cloneString(v.subp
 func (v RepositoryRef) MarshalJSON() ([]byte, error) {
 	return json.Marshal(map[string]any{"provider": v.provider, "repository_id": v.repositoryID, "normalized_remote": v.normalizedRemote, "subpath": v.subpath})
 }
+
 func (v *RepositoryRef) UnmarshalJSON(data []byte) error {
 	var dto struct {
 		Provider         RepositoryProvider `json:"provider"`
@@ -155,6 +159,7 @@ func NewProjectDescriptor(projectID, projectKey, title string, description *stri
 	}
 	return value, nil
 }
+
 func (v ProjectDescriptor) Validate() error {
 	for _, item := range []struct {
 		name, value string
@@ -196,6 +201,7 @@ func (v ProjectDescriptor) Schema() string             { return ProjectSchemaVer
 func (v ProjectDescriptor) MarshalJSON() ([]byte, error) {
 	return json.Marshal(map[string]any{"schema": ProjectSchemaVersion, "project_id": v.projectID, "project_key": v.projectKey, "title": v.title, "description": v.description, "default_locale": v.defaultLocale, "timezone": v.timezone, "catalog_state": v.catalogState, "version": v.version})
 }
+
 func (v *ProjectDescriptor) UnmarshalJSON(data []byte) error {
 	var dto struct {
 		Schema        string       `json:"schema"`
@@ -246,6 +252,7 @@ func NewWorkstreamDescriptor(scopeID, projectID string, key *string, title strin
 	}
 	return value, nil
 }
+
 func (v WorkstreamDescriptor) Validate() error {
 	if err := requireText("scope_id", v.scopeID, MaxScopeIDLength); err != nil {
 		return err
@@ -309,6 +316,7 @@ func (v WorkstreamDescriptor) Schema() string                    { return Workst
 func (v WorkstreamDescriptor) MarshalJSON() ([]byte, error) {
 	return json.Marshal(map[string]any{"schema": WorkstreamSchemaVersion, "scope_id": v.scopeID, "project_id": v.projectID, "key": v.key, "title": v.title, "kind": v.kind, "catalog_state": v.catalogState, "external_refs": v.externalRefs, "labels": v.labels, "version": v.version})
 }
+
 func (v *WorkstreamDescriptor) UnmarshalJSON(data []byte) error {
 	var dto struct {
 		Schema       string              `json:"schema"`

--- a/internal/handoffreport/models.go
+++ b/internal/handoffreport/models.go
@@ -24,9 +24,10 @@ import (
 	"time"
 	"unicode/utf8"
 
-	"github.com/ob-labs/powercontext-go/artifact"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/unicode/norm"
+
+	"github.com/ob-labs/powercontext-go/artifact"
 )
 
 const (
@@ -162,7 +163,9 @@ type ActivityPage struct {
 
 func NormalizeSortText(value string) string { return cases.Fold().String(norm.NFC.String(value)) }
 func UTCText(value time.Time) string        { return value.UTC().Format("2006-01-02T15:04:05.000000Z") }
-func TimestampText(value time.Time) string  { return value.Format("2006-01-02T15:04:05.000000Z07:00") }
+
+func TimestampText(value time.Time) string { return value.Format("2006-01-02T15:04:05.000000Z07:00") }
+
 func JSONTimestampText(value time.Time) string {
 	value = value.Truncate(time.Microsecond)
 	layout := "2006-01-02T15:04:05"
@@ -263,6 +266,7 @@ func normalizeRepositoryRemote(value *string) (*string, error) {
 	result := strings.ToLower(parsed.Scheme) + "://" + host + "/" + strings.Join(parts, "/")
 	return &result, nil
 }
+
 func normalizeRepositorySubpath(value *string) (*string, error) {
 	if value == nil {
 		return nil, nil
@@ -295,24 +299,29 @@ func requireText(field, value string, max int) error {
 	}
 	return nil
 }
+
 func requireOptionalText(field string, value *string, max int) error {
 	if value == nil {
 		return nil
 	}
 	return requireText(field, *value, max)
 }
+
 func fieldError(field, detail string) error {
 	return &CatalogArgumentError{Field: field, Detail: detail}
 }
+
 func invalidActivity(field, detail string) error {
 	return &InvalidActivityEventError{Field: field, Detail: detail}
 }
+
 func activityField(err error) error {
 	if e, ok := err.(*CatalogArgumentError); ok {
 		return invalidActivity(e.Field, e.Detail)
 	}
 	return err
 }
+
 func cloneString(value *string) *string {
 	if value == nil {
 		return nil
@@ -320,6 +329,7 @@ func cloneString(value *string) *string {
 	copy := *value
 	return &copy
 }
+
 func cloneTime(value *time.Time) *time.Time {
 	if value == nil {
 		return nil
@@ -327,6 +337,7 @@ func cloneTime(value *time.Time) *time.Time {
 	copy := *value
 	return &copy
 }
+
 func cloneExternal(value *ExternalReference) *ExternalReference {
 	if value == nil {
 		return nil
@@ -335,6 +346,7 @@ func cloneExternal(value *ExternalReference) *ExternalReference {
 	copy.url = cloneString(value.url)
 	return &copy
 }
+
 func cloneAgent(value *ActivityAgent) *ActivityAgent {
 	if value == nil {
 		return nil
@@ -344,6 +356,7 @@ func cloneAgent(value *ActivityAgent) *ActivityAgent {
 	copy.label = cloneString(value.label)
 	return &copy
 }
+
 func cloneVCS(value *ActivityVCSContext) *ActivityVCSContext {
 	if value == nil {
 		return nil
@@ -353,6 +366,7 @@ func cloneVCS(value *ActivityVCSContext) *ActivityVCSContext {
 	copy.headRevision = cloneString(value.headRevision)
 	return &copy
 }
+
 func cloneArtifactRef(value *artifact.Ref) *artifact.Ref {
 	if value == nil {
 		return nil
@@ -360,41 +374,50 @@ func cloneArtifactRef(value *artifact.Ref) *artifact.Ref {
 	copy := *value
 	return &copy
 }
+
 func optionalKey(value *string) string {
 	if value == nil {
 		return "\x00"
 	}
 	return *value
 }
+
 func timeTextPtr(value *time.Time) any {
 	if value == nil {
 		return nil
 	}
 	return TimestampText(*value)
 }
+
 func artifactRefMap(value *artifact.Ref) any {
 	if value == nil {
 		return nil
 	}
 	return map[string]any{"family": value.Family(), "artifact_id": value.ID(), "revision": value.Revision()}
 }
+
 func decodeStrict(data []byte, value any) error {
 	decoder := json.NewDecoder(strings.NewReader(string(data)))
 	decoder.DisallowUnknownFields()
 	return decoder.Decode(value)
 }
+
 func validExternalKind(v ExternalReferenceKind) bool {
 	return slices.Contains([]ExternalReferenceKind{ExternalIssue, ExternalTask, ExternalPullRequest, ExternalBranch, ExternalFeature, ExternalRelease, ExternalProgram, ExternalOther}, v)
 }
+
 func validRepositoryProvider(v RepositoryProvider) bool {
 	return slices.Contains([]RepositoryProvider{RepositoryGitHub, RepositoryGitLab, RepositoryLocal, RepositoryOther}, v)
 }
+
 func validWorkstreamKind(v WorkstreamKind) bool {
 	return slices.Contains([]WorkstreamKind{WorkstreamFeature, WorkstreamBug, WorkstreamRefactor, WorkstreamOperations, WorkstreamResearch, WorkstreamOther}, v)
 }
+
 func validActivitySource(v ActivitySource) bool {
 	return slices.Contains([]ActivitySource{ActivityHandoffObservation, ActivityGitCommit, ActivityGitWorktree, ActivityCodingSession, ActivityOther}, v)
 }
+
 func validTimeBasis(v TimeBasis) bool {
 	return slices.Contains([]TimeBasis{TimeSourceReported, TimeHostObserved, TimeFirstSeen, TimeCurrentOnly, TimeUnknown}, v)
 }

--- a/internal/handoffreport/rendering.go
+++ b/internal/handoffreport/rendering.go
@@ -245,6 +245,7 @@ func renderAgent(value *ActivityAgent, labels map[string]string) string {
 	}
 	return strings.Join(values, " / ")
 }
+
 func renderVCS(value *ActivityVCSContext, labels map[string]string) string {
 	if value == nil {
 		return labels["none"]
@@ -258,12 +259,14 @@ func renderVCS(value *ActivityVCSContext, labels map[string]string) string {
 	}
 	return strings.Join(values, " / ")
 }
+
 func optionalReference(value *ExternalReference, labels map[string]string) string {
 	if value == nil {
 		return labels["none"]
 	}
 	return renderReference(*value)
 }
+
 func renderReference(value ExternalReference) string {
 	values := []string{codeSpan(string(value.Kind())), codeSpan(value.Provider()), codeSpan(value.ExternalID())}
 	if target := value.URL(); target != nil {
@@ -271,18 +274,21 @@ func renderReference(value ExternalReference) string {
 	}
 	return strings.Join(values, " / ")
 }
+
 func optionalText(value *string, labels map[string]string) string {
 	if value == nil {
 		return labels["none"]
 	}
 	return markdownText(*value)
 }
+
 func optionalCode(value *string, labels map[string]string) string {
 	if value == nil {
 		return labels["none"]
 	}
 	return codeSpan(*value)
 }
+
 func optionalTimestamp(value *time.Time, labels map[string]string) string {
 	if value == nil {
 		return labels["none"]
@@ -315,6 +321,7 @@ func collapseLines(value string) string {
 	}
 	return builder.String()
 }
+
 func markdownText(value string) string {
 	value = pythonHTMLEscape(collapseLines(value))
 	var builder strings.Builder
@@ -326,6 +333,7 @@ func markdownText(value string) string {
 	}
 	return builder.String()
 }
+
 func codeSpan(value string) string {
 	value = pythonHTMLEscape(collapseLines(value))
 	maxRun, current := 0, 0
@@ -345,10 +353,12 @@ func codeSpan(value string) string {
 	}
 	return delimiter + value + delimiter
 }
+
 func pythonHTMLEscape(value string) string {
 	escaped := html.EscapeString(value)
 	return strings.ReplaceAll(escaped, "&#39;", "&#x27;")
 }
+
 func yamlString(value string) string {
 	encoded, err := marshalUnescaped(value)
 	if err != nil {
@@ -356,6 +366,7 @@ func yamlString(value string) string {
 	}
 	return string(encoded)
 }
+
 func pythonISOTime(value time.Time) string {
 	_, offset := value.Zone()
 	sign := "+"
@@ -370,6 +381,7 @@ func pythonISOTime(value time.Time) string {
 	}
 	return fmt.Sprintf("%s%s%02d:%02d", base, sign, hours, minutes)
 }
+
 func orNone(value, fallback string) string {
 	if value == "" {
 		return fallback

--- a/internal/handoffreport/report.go
+++ b/internal/handoffreport/report.go
@@ -53,10 +53,12 @@ const (
 	ActivityUnavailable   ActivityCoverageStatus = "unavailable"
 )
 
-type WorkStatus string
-type ActivityStatus string
-type ReportingStatus string
-type HandoffActivityRelation string
+type (
+	WorkStatus              string
+	ActivityStatus          string
+	ReportingStatus         string
+	HandoffActivityRelation string
+)
 
 const (
 	WorkContinuable WorkStatus = "continuable"
@@ -210,6 +212,7 @@ func (v Report) PeriodComparison() *PeriodComparison {
 	copy := *v.periodComparison
 	return &copy
 }
+
 func (v Report) BaselineSelection() ([]SelectionEntry, bool) {
 	return slices.Clone(v.baselineSelection), v.baselinePresent
 }

--- a/internal/handoffreport/report_workstream.go
+++ b/internal/handoffreport/report_workstream.go
@@ -45,6 +45,7 @@ type WorkstreamReport struct {
 func (v WorkstreamReport) Workstream() WorkstreamDescriptor { return v.workstream }
 func (v WorkstreamReport) Continuity() work.Continuity      { return v.continuity }
 func (v WorkstreamReport) HandoffRef() *artifact.Ref        { return cloneArtifactRef(v.handoffRef) }
+
 func (v WorkstreamReport) Content() *handoff.Content {
 	if v.content == nil {
 		return nil
@@ -57,6 +58,7 @@ func (v WorkstreamReport) HandoffHistoryTruncated() bool { return v.handoffHisto
 func (v WorkstreamReport) HandoffHistory() []HandoffRevisionSummary {
 	return slices.Clone(v.handoffHistory)
 }
+
 func (v WorkstreamReport) EvidenceChecks() ([]handoff.EvidenceCheck, bool) {
 	if !v.evidenceChecked {
 		return nil, false

--- a/internal/handoffreport/selection_model.go
+++ b/internal/handoffreport/selection_model.go
@@ -34,6 +34,7 @@ func NewSelectionEntry(scopeID string, revision int, status SelectionStatus, ref
 	}
 	return value, nil
 }
+
 func (v SelectionEntry) Validate() error {
 	if err := requireText("scope_id", v.scopeID, MaxScopeIDLength); err != nil {
 		return err

--- a/internal/handoffreport/selection_test.go
+++ b/internal/handoffreport/selection_test.go
@@ -172,12 +172,15 @@ func (r *selectionReader) Latest(_ context.Context, scope string) (handoff.Hando
 	}
 	return *values[index], true, nil
 }
+
 func (*selectionReader) Get(context.Context, string, artifact.Ref) (handoff.Handoff, error) {
 	panic("unexpected exact read")
 }
+
 func (*selectionReader) Revisions(context.Context, string) ([]handoff.Handoff, error) {
 	panic("unexpected revisions read")
 }
+
 func (*selectionReader) CheckEvidence(context.Context, string, artifact.Ref) ([]handoff.EvidenceCheck, error) {
 	panic("unexpected evidence read")
 }
@@ -190,16 +193,20 @@ type selectionBackend struct {
 func (*selectionBackend) Create(context.Context, string, handoff.ArtifactDraft) (handoff.Handoff, error) {
 	panic("unexpected create")
 }
+
 func (*selectionBackend) Revise(context.Context, handoff.Handoff, handoff.ArtifactDraft) (handoff.Handoff, error) {
 	panic("unexpected revise")
 }
+
 func (b *selectionBackend) Get(_ context.Context, ref artifact.Ref) (handoff.Handoff, error) {
 	b.references = append(b.references, ref)
 	return b.value, nil
 }
+
 func (b *selectionBackend) Latest(context.Context, string) (handoff.Handoff, bool, error) {
 	return b.value, true, nil
 }
+
 func (b *selectionBackend) Revisions(context.Context, string) ([]handoff.Handoff, error) {
 	return []handoff.Handoff{b.value}, nil
 }
@@ -209,6 +216,7 @@ type selectionResolver struct{}
 func (selectionResolver) Resolve(context.Context, handoff.Citation) (handoff.Evidence, error) {
 	panic("unexpected resolve")
 }
+
 func (selectionResolver) Validate(context.Context, handoff.Citation) error {
 	panic("unexpected validation")
 }

--- a/internal/handoffreport/service.go
+++ b/internal/handoffreport/service.go
@@ -366,6 +366,7 @@ func groupActivities(events []ActivityEvent, workstreams []WorkstreamDescriptor)
 	}
 	return grouped, unassigned
 }
+
 func reportingStatus(omissions []handoff.Omission, checks []handoff.EvidenceCheck, checked, unavailable bool) ReportingStatus {
 	if unavailable {
 		return ReportingEvidenceMissing
@@ -382,6 +383,7 @@ func reportingStatus(omissions []handoff.Omission, checks []handoff.EvidenceChec
 	}
 	return ReportingReported
 }
+
 func activityStatus(events []ActivityEvent) ActivityStatus {
 	if len(events) == 0 {
 		return ActivityNone
@@ -393,6 +395,7 @@ func activityStatus(events []ActivityEvent) ActivityStatus {
 	}
 	return ActivityCurrentOnly
 }
+
 func deriveCoverage(items []WorkstreamReport, unassigned []ActivityEvent, status ActivityCoverageStatus) Coverage {
 	result := Coverage{TotalIncludedWorkstreams: len(items), CatalogMatchedWorkstreams: len(items), SelectedWorkstreams: len(items), UnassignedActivityCount: len(unassigned), UnassignedActivityEvents: len(unassigned), ActivityCoverage: status}
 	for _, item := range items {
@@ -427,6 +430,7 @@ func deriveCoverage(items []WorkstreamReport, unassigned []ActivityEvent, status
 	}
 	return result
 }
+
 func deriveSummary(items []WorkstreamReport) Summary {
 	var result Summary
 	for _, item := range items {
@@ -443,6 +447,7 @@ func deriveSummary(items []WorkstreamReport) Summary {
 	}
 	return result
 }
+
 func cloneComparison(value *PeriodComparison) *PeriodComparison {
 	if value == nil {
 		return nil

--- a/internal/handoffreport/service_test.go
+++ b/internal/handoffreport/service_test.go
@@ -300,6 +300,7 @@ func (r *reportReader) Latest(_ context.Context, scope string) (handoff.Handoff,
 	}
 	return *value, true, nil
 }
+
 func (r *reportReader) Get(_ context.Context, scope string, ref artifact.Ref) (handoff.Handoff, error) {
 	r.exactReads++
 	value := r.values[scope]
@@ -308,6 +309,7 @@ func (r *reportReader) Get(_ context.Context, scope string, ref artifact.Ref) (h
 	}
 	return *value, nil
 }
+
 func (r *reportReader) Revisions(_ context.Context, scope string) ([]handoff.Handoff, error) {
 	if values, ok := r.histories[scope]; ok {
 		return append([]handoff.Handoff(nil), values...), nil
@@ -318,6 +320,7 @@ func (r *reportReader) Revisions(_ context.Context, scope string) ([]handoff.Han
 	}
 	return []handoff.Handoff{*value}, nil
 }
+
 func (r *reportReader) CheckEvidence(context.Context, string, artifact.Ref) ([]handoff.EvidenceCheck, error) {
 	r.evidenceReads++
 	if r.evidenceUnavailable {
@@ -338,12 +341,15 @@ func (r *alternatingReader) Latest(context.Context, string) (handoff.Handoff, bo
 	}
 	return r.two, true, nil
 }
+
 func (*alternatingReader) Get(context.Context, string, artifact.Ref) (handoff.Handoff, error) {
 	panic("unexpected exact read")
 }
+
 func (*alternatingReader) Revisions(context.Context, string) ([]handoff.Handoff, error) {
 	return nil, nil
 }
+
 func (*alternatingReader) CheckEvidence(context.Context, string, artifact.Ref) ([]handoff.EvidenceCheck, error) {
 	return nil, nil
 }
@@ -356,6 +362,7 @@ func domainProject(t *testing.T) handoffreport.ProjectDescriptor {
 	}
 	return value
 }
+
 func domainWorkstream(t *testing.T, scope string) handoffreport.WorkstreamDescriptor {
 	t.Helper()
 	value, err := handoffreport.NewWorkstreamDescriptor(scope, "prj-1", nil, "Report", handoffreport.WorkstreamFeature, handoffreport.CatalogIncluded, nil, nil, 1)
@@ -364,6 +371,7 @@ func domainWorkstream(t *testing.T, scope string) handoffreport.WorkstreamDescri
 	}
 	return value
 }
+
 func domainActivity(t *testing.T, id, scope string, occurred time.Time) handoffreport.ActivityEvent {
 	t.Helper()
 	value, err := handoffreport.NewActivityEvent(handoffreport.ActivityEventInput{EventID: id, ProjectID: "prj-1", ScopeID: &scope, Source: handoffreport.ActivityCodingSession, SourceEventID: "source-" + id, OccurredAt: &occurred, ObservedAt: occurred.Add(time.Hour).UTC(), TimeBasis: handoffreport.TimeSourceReported})
@@ -372,6 +380,7 @@ func domainActivity(t *testing.T, id, scope string, occurred time.Time) handoffr
 	}
 	return value
 }
+
 func reportHandoff(t *testing.T, revision int64) handoff.Handoff {
 	return reportHandoffRevision(t, revision, "Implement the report.", "Add the API.")
 }

--- a/internal/handoffreport/workspace.go
+++ b/internal/handoffreport/workspace.go
@@ -54,6 +54,7 @@ func (v WorkspaceBinding) Version() int                 { return v.version }
 func (v WorkspaceBinding) MarshalJSON() ([]byte, error) {
 	return json.Marshal(map[string]any{"schema": "powercontext.workspace-binding.v1", "workspace_instance_id": v.workspaceInstanceID, "project_id": v.projectID, "repository_ref": v.repositoryRef, "state": v.state, "confirmed_at": JSONTimestampText(v.confirmedAt), "version": v.version})
 }
+
 func (v *WorkspaceBinding) UnmarshalJSON(data []byte) error {
 	var dto struct {
 		Schema      string                `json:"schema"`

--- a/internal/httpapi/aliases.go
+++ b/internal/httpapi/aliases.go
@@ -18,7 +18,9 @@ import "github.com/ogen-go/ogen/middleware"
 
 // These aliases keep the request-ID middleware signature readable without
 // introducing a transport abstraction parallel to ogen.
-type Request = middleware.Request
-type Response = middleware.Response
-type Next = middleware.Next
-type Middleware = middleware.Middleware
+type (
+	Request    = middleware.Request
+	Response   = middleware.Response
+	Next       = middleware.Next
+	Middleware = middleware.Middleware
+)

--- a/internal/httpapi/errors.go
+++ b/internal/httpapi/errors.go
@@ -23,9 +23,10 @@ import (
 	"strconv"
 	"strings"
 
-	v1 "github.com/ob-labs/powercontext-go/api/v1"
 	"github.com/ogen-go/ogen/ogenerrors"
 	"github.com/ogen-go/ogen/validate"
+
+	v1 "github.com/ob-labs/powercontext-go/api/v1"
 )
 
 var (

--- a/internal/httpapi/middleware.go
+++ b/internal/httpapi/middleware.go
@@ -32,9 +32,10 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"go.opentelemetry.io/otel/propagation"
+
 	serverlogging "github.com/ob-labs/powercontext-go/internal/observability/logging"
 	requesttrace "github.com/ob-labs/powercontext-go/internal/observability/tracing"
-	"go.opentelemetry.io/otel/propagation"
 )
 
 // ValidateJSONUnicode rejects malformed UTF-8 and unpaired JSON surrogate

--- a/internal/httpapi/middleware_test.go
+++ b/internal/httpapi/middleware_test.go
@@ -25,8 +25,9 @@ import (
 	"testing"
 	"unicode/utf8"
 
-	v1 "github.com/ob-labs/powercontext-go/api/v1"
 	"go.opentelemetry.io/otel/trace"
+
+	v1 "github.com/ob-labs/powercontext-go/api/v1"
 )
 
 func TestValidJSONUnicodeDistinguishesSurrogateEscapes(t *testing.T) {

--- a/internal/httpapi/request.go
+++ b/internal/httpapi/request.go
@@ -19,8 +19,9 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 
-	requesttrace "github.com/ob-labs/powercontext-go/internal/observability/tracing"
 	"go.opentelemetry.io/otel/trace"
+
+	requesttrace "github.com/ob-labs/powercontext-go/internal/observability/tracing"
 )
 
 const (

--- a/internal/httpapi/tracing.go
+++ b/internal/httpapi/tracing.go
@@ -18,9 +18,10 @@ import (
 	"context"
 	"errors"
 
+	"go.opentelemetry.io/otel/trace"
+
 	v1 "github.com/ob-labs/powercontext-go/api/v1"
 	requesttrace "github.com/ob-labs/powercontext-go/internal/observability/tracing"
-	"go.opentelemetry.io/otel/trace"
 )
 
 // TraceApplication records the decoded application operation as a child of

--- a/internal/mcpapi/handoff_picker.go
+++ b/internal/mcpapi/handoff_picker.go
@@ -22,9 +22,10 @@ import (
 	"unicode/utf8"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"golang.org/x/text/cases"
+
 	v1 "github.com/ob-labs/powercontext-go/api/v1"
 	"github.com/ob-labs/powercontext-go/internal/endpoint"
-	"golang.org/x/text/cases"
 )
 
 const (

--- a/internal/mcpapi/handoff_picker_test.go
+++ b/internal/mcpapi/handoff_picker_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+
 	v1 "github.com/ob-labs/powercontext-go/api/v1"
 )
 

--- a/internal/mcpapi/logging.go
+++ b/internal/mcpapi/logging.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+
 	serverlogging "github.com/ob-labs/powercontext-go/internal/observability/logging"
 )
 

--- a/internal/mcpapi/server.go
+++ b/internal/mcpapi/server.go
@@ -29,11 +29,12 @@ import (
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"go.opentelemetry.io/otel/trace"
+
 	v1 "github.com/ob-labs/powercontext-go/api/v1"
 	"github.com/ob-labs/powercontext-go/internal/endpoint"
 	serverlogging "github.com/ob-labs/powercontext-go/internal/observability/logging"
 	requesttrace "github.com/ob-labs/powercontext-go/internal/observability/tracing"
-	"go.opentelemetry.io/otel/trace"
 )
 
 const (

--- a/internal/mcpapi/server_test.go
+++ b/internal/mcpapi/server_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+
 	v1 "github.com/ob-labs/powercontext-go/api/v1"
 	"github.com/ob-labs/powercontext-go/internal/endpoint"
 	requesttrace "github.com/ob-labs/powercontext-go/internal/observability/tracing"

--- a/internal/modelprovider/anthropic.go
+++ b/internal/modelprovider/anthropic.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/anthropics/anthropic-sdk-go/option"
+
 	"github.com/ob-labs/powercontext-go/inference"
 )
 

--- a/internal/modelprovider/bedrock.go
+++ b/internal/modelprovider/bedrock.go
@@ -33,6 +33,7 @@ import (
 	bedrocktypes "github.com/aws/aws-sdk-go-v2/service/bedrockruntime/types"
 	"github.com/aws/smithy-go/auth/bearer"
 	smithyhttp "github.com/aws/smithy-go/transport/http"
+
 	"github.com/ob-labs/powercontext-go/inference"
 )
 

--- a/internal/modelprovider/bedrock_mantle.go
+++ b/internal/modelprovider/bedrock_mantle.go
@@ -21,10 +21,11 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/ob-labs/powercontext-go/inference"
 	openai "github.com/openai/openai-go/v3"
 	openaiBedrock "github.com/openai/openai-go/v3/bedrock"
 	"github.com/openai/openai-go/v3/option"
+
+	"github.com/ob-labs/powercontext-go/inference"
 )
 
 type BedrockMantleConfig struct {

--- a/internal/modelprovider/cohere.go
+++ b/internal/modelprovider/cohere.go
@@ -25,6 +25,7 @@ import (
 	cohere "github.com/cohere-ai/cohere-go/v2"
 	"github.com/cohere-ai/cohere-go/v2/core"
 	coherev2 "github.com/cohere-ai/cohere-go/v2/v2"
+
 	"github.com/ob-labs/powercontext-go/inference"
 )
 

--- a/internal/modelprovider/google.go
+++ b/internal/modelprovider/google.go
@@ -20,8 +20,9 @@ import (
 	"net/http"
 	"slices"
 
-	"github.com/ob-labs/powercontext-go/inference"
 	"google.golang.org/genai"
+
+	"github.com/ob-labs/powercontext-go/inference"
 )
 
 type GoogleBackend uint8

--- a/internal/modelprovider/openai.go
+++ b/internal/modelprovider/openai.go
@@ -22,11 +22,12 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/ob-labs/powercontext-go/inference"
 	openai "github.com/openai/openai-go/v3"
 	"github.com/openai/openai-go/v3/option"
 	"github.com/openai/openai-go/v3/responses"
 	"github.com/openai/openai-go/v3/shared"
+
+	"github.com/ob-labs/powercontext-go/inference"
 )
 
 const openAIResponsesIdentity = "openai-responses"

--- a/internal/modelprovider/provider_b_test.go
+++ b/internal/modelprovider/provider_b_test.go
@@ -26,8 +26,9 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime"
 	bedrocktypes "github.com/aws/aws-sdk-go-v2/service/bedrockruntime/types"
-	"github.com/ob-labs/powercontext-go/inference"
 	"google.golang.org/genai"
+
+	"github.com/ob-labs/powercontext-go/inference"
 )
 
 func TestHTTPChatProviderWireProfiles(t *testing.T) {

--- a/internal/modelprovider/sentence_transformers_ort.go
+++ b/internal/modelprovider/sentence_transformers_ort.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/knights-analytics/hugot"
 	"github.com/knights-analytics/hugot/options"
+
 	"github.com/ob-labs/powercontext-go/inference"
 )
 

--- a/internal/observability/logging/logger.go
+++ b/internal/observability/logging/logger.go
@@ -28,8 +28,9 @@ import (
 	"sync"
 	"time"
 
-	requesttrace "github.com/ob-labs/powercontext-go/internal/observability/tracing"
 	"go.opentelemetry.io/otel/trace"
+
+	requesttrace "github.com/ob-labs/powercontext-go/internal/observability/tracing"
 )
 
 type Format string

--- a/internal/observability/logging/logger_test.go
+++ b/internal/observability/logging/logger_test.go
@@ -23,8 +23,9 @@ import (
 	"testing"
 	"time"
 
-	requesttrace "github.com/ob-labs/powercontext-go/internal/observability/tracing"
 	"go.opentelemetry.io/otel/trace"
+
+	requesttrace "github.com/ob-labs/powercontext-go/internal/observability/tracing"
 )
 
 func TestJSONLoggerEmitsOnlyOperationalFields(t *testing.T) {

--- a/internal/observability/metrics/server.go
+++ b/internal/observability/metrics/server.go
@@ -21,10 +21,11 @@ import (
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
-	v1 "github.com/ob-labs/powercontext-go/api/v1"
 	"github.com/ogen-go/ogen/middleware"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+
+	v1 "github.com/ob-labs/powercontext-go/api/v1"
 )
 
 // Server owns an isolated Prometheus registry for one PowerContext process.

--- a/internal/observability/tracing/server.go
+++ b/internal/observability/tracing/server.go
@@ -30,7 +30,7 @@ import (
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	"go.opentelemetry.io/otel/semconv/v1.41.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.41.0"
 	"go.opentelemetry.io/otel/trace"
 )
 

--- a/internal/runtime/external_skill_application_test.go
+++ b/internal/runtime/external_skill_application_test.go
@@ -101,6 +101,7 @@ func (externalApplicationProvider) ProviderNames() []string { return []string{"c
 func (p externalApplicationProvider) Scan(context.Context) (skill.ProviderScan, error) {
 	return skill.NewProviderScan([]skill.Registration{p.registration}, 0)
 }
+
 func (p externalApplicationProvider) Resolve(context.Context, skill.Registration) (skill.Resolution, error) {
 	return skill.Resolution{
 		Registration: p.registration, Status: skill.Available, Entrypoint: "/bounded/SKILL.md",
@@ -115,6 +116,7 @@ func (s *externalApplicationStore) Replace(
 	s.registrations = slices.Clone(registrations)
 	return slices.Clone(registrations), nil
 }
+
 func (s *externalApplicationStore) Get(_ context.Context, id string) (skill.Registration, error) {
 	for _, registration := range s.registrations {
 		if registration.ExternalSkillID() == id {
@@ -123,6 +125,7 @@ func (s *externalApplicationStore) Get(_ context.Context, id string) (skill.Regi
 	}
 	return skill.Registration{}, &skill.ExternalNotFoundError{ExternalSkillID: id}
 }
+
 func (s *externalApplicationStore) List(context.Context) ([]skill.Registration, error) {
 	return slices.Clone(s.registrations), nil
 }

--- a/internal/runtime/handoff_report_application.go
+++ b/internal/runtime/handoff_report_application.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+
 	"github.com/ob-labs/powercontext-go/artifact"
 	"github.com/ob-labs/powercontext-go/artifact/handoff"
 	"github.com/ob-labs/powercontext-go/internal/handoffreport"
@@ -212,6 +213,7 @@ func (a *HandoffReportApplication) CreateProject(ctx context.Context, input Crea
 	})
 	return result, err
 }
+
 func (a *HandoffReportApplication) GetProject(ctx context.Context, id string) (handoffreport.ProjectDescriptor, error) {
 	var result handoffreport.ProjectDescriptor
 	err := a.runtime.Operation(ctx, func(ctx context.Context) error {
@@ -221,6 +223,7 @@ func (a *HandoffReportApplication) GetProject(ctx context.Context, id string) (h
 	})
 	return result, err
 }
+
 func (a *HandoffReportApplication) UpdateProject(ctx context.Context, value handoffreport.ProjectDescriptor, expected int) (handoffreport.ProjectDescriptor, error) {
 	var result handoffreport.ProjectDescriptor
 	err := a.runtime.Operation(ctx, func(ctx context.Context) error {
@@ -230,6 +233,7 @@ func (a *HandoffReportApplication) UpdateProject(ctx context.Context, value hand
 	})
 	return result, err
 }
+
 func (a *HandoffReportApplication) ListProjects(ctx context.Context, cursor *string, limit int, archived bool) (handoffreport.Page[handoffreport.ProjectDescriptor], error) {
 	var result handoffreport.Page[handoffreport.ProjectDescriptor]
 	err := a.runtime.Operation(ctx, func(ctx context.Context) error {
@@ -239,6 +243,7 @@ func (a *HandoffReportApplication) ListProjects(ctx context.Context, cursor *str
 	})
 	return result, err
 }
+
 func (a *HandoffReportApplication) RegisterWorkstream(ctx context.Context, input RegisterHandoffReportWorkstream) (handoffreport.WorkstreamDescriptor, error) {
 	var result handoffreport.WorkstreamDescriptor
 	err := a.runtime.Operation(ctx, func(ctx context.Context) error {
@@ -255,6 +260,7 @@ func (a *HandoffReportApplication) RegisterWorkstream(ctx context.Context, input
 	})
 	return result, err
 }
+
 func (a *HandoffReportApplication) UpdateWorkstream(ctx context.Context, value handoffreport.WorkstreamDescriptor, expected int) (handoffreport.WorkstreamDescriptor, error) {
 	var result handoffreport.WorkstreamDescriptor
 	err := a.runtime.Operation(ctx, func(ctx context.Context) error {
@@ -264,6 +270,7 @@ func (a *HandoffReportApplication) UpdateWorkstream(ctx context.Context, value h
 	})
 	return result, err
 }
+
 func (a *HandoffReportApplication) ListWorkstreams(ctx context.Context, project string, cursor *string, limit int, archived bool) (handoffreport.Page[handoffreport.WorkstreamDescriptor], error) {
 	var result handoffreport.Page[handoffreport.WorkstreamDescriptor]
 	err := a.runtime.Operation(ctx, func(ctx context.Context) error {
@@ -290,6 +297,7 @@ func (a *HandoffReportApplication) RecordActivity(ctx context.Context, input Rec
 	})
 	return result, err
 }
+
 func (a *HandoffReportApplication) ListActivities(ctx context.Context, query HandoffReportActivityList) (handoffreport.ActivityPage, error) {
 	var result handoffreport.ActivityPage
 	err := a.runtime.Operation(ctx, func(ctx context.Context) error {
@@ -299,6 +307,7 @@ func (a *HandoffReportApplication) ListActivities(ctx context.Context, query Han
 	})
 	return result, err
 }
+
 func (a *HandoffReportApplication) PurgeActivities(ctx context.Context, project string, before time.Time) (int64, error) {
 	var result int64
 	err := a.runtime.Operation(ctx, func(ctx context.Context) error {
@@ -308,6 +317,7 @@ func (a *HandoffReportApplication) PurgeActivities(ctx context.Context, project 
 	})
 	return result, err
 }
+
 func (a *HandoffReportApplication) GetWorkspaceBinding(ctx context.Context, id string) (handoffreport.WorkspaceBinding, error) {
 	var result handoffreport.WorkspaceBinding
 	err := a.runtime.Operation(ctx, func(ctx context.Context) error {
@@ -317,6 +327,7 @@ func (a *HandoffReportApplication) GetWorkspaceBinding(ctx context.Context, id s
 	})
 	return result, err
 }
+
 func (a *HandoffReportApplication) AttachWorkspaceBinding(ctx context.Context, id, project string, repository handoffreport.RepositoryRef, expected *int) (handoffreport.WorkspaceBinding, error) {
 	var result handoffreport.WorkspaceBinding
 	err := a.runtime.Operation(ctx, func(ctx context.Context) error {
@@ -326,6 +337,7 @@ func (a *HandoffReportApplication) AttachWorkspaceBinding(ctx context.Context, i
 	})
 	return result, err
 }
+
 func (a *HandoffReportApplication) DetachWorkspaceBinding(ctx context.Context, id string, expected int) (handoffreport.WorkspaceBinding, error) {
 	var result handoffreport.WorkspaceBinding
 	err := a.runtime.Operation(ctx, func(ctx context.Context) error {
@@ -421,6 +433,7 @@ func NewHandoffReportReader(services HandoffServiceFactory) (*HandoffReportReade
 	}
 	return &HandoffReportReader{services: services}, nil
 }
+
 func (r *HandoffReportReader) service(scope string) (*handoff.Service, error) {
 	service, err := r.services(scope)
 	if err != nil {
@@ -431,6 +444,7 @@ func (r *HandoffReportReader) service(scope string) (*handoff.Service, error) {
 	}
 	return service, nil
 }
+
 func (r *HandoffReportReader) Latest(ctx context.Context, scope string) (handoff.Handoff, bool, error) {
 	service, err := r.service(scope)
 	if err != nil {
@@ -438,6 +452,7 @@ func (r *HandoffReportReader) Latest(ctx context.Context, scope string) (handoff
 	}
 	return service.Latest(ctx)
 }
+
 func (r *HandoffReportReader) Get(ctx context.Context, scope string, ref artifact.Ref) (handoff.Handoff, error) {
 	service, err := r.service(scope)
 	if err != nil {
@@ -445,6 +460,7 @@ func (r *HandoffReportReader) Get(ctx context.Context, scope string, ref artifac
 	}
 	return service.Revision(ctx, ref)
 }
+
 func (r *HandoffReportReader) Revisions(ctx context.Context, scope string) ([]handoff.Handoff, error) {
 	service, err := r.service(scope)
 	if err != nil {
@@ -452,6 +468,7 @@ func (r *HandoffReportReader) Revisions(ctx context.Context, scope string) ([]ha
 	}
 	return service.Revisions(ctx)
 }
+
 func (*HandoffReportReader) CheckEvidence(context.Context, string, artifact.Ref) ([]handoff.EvidenceCheck, error) {
 	return nil, &handoffreport.EvidenceCheckUnavailableError{}
 }

--- a/internal/runtime/scope_cache.go
+++ b/internal/runtime/scope_cache.go
@@ -23,8 +23,10 @@ import (
 
 const DefaultScopeCacheSize = 128
 
-type ScopeCacheObserver func(cached, active int)
-type ScopeEvictor func(scopeID string)
+type (
+	ScopeCacheObserver func(cached, active int)
+	ScopeEvictor       func(scopeID string)
+)
 
 type RuntimeOptions struct {
 	ScopeCacheSize int

--- a/internal/runtime/work_application.go
+++ b/internal/runtime/work_application.go
@@ -247,7 +247,7 @@ func (a *WorkApplication) capture(ctx context.Context, scope string, kind work.K
 	if err != nil {
 		return work.SourceReceipt{}, err
 	}
-	schema := ""
+	var schema string
 	switch value := record.(type) {
 	case work.Contract:
 		schema = value.Schema()

--- a/internal/scheduler/pickle.go
+++ b/internal/scheduler/pickle.go
@@ -33,14 +33,19 @@ type InvalidJobStateError struct{ Detail string }
 
 func (e *InvalidJobStateError) Error() string { return "invalid APScheduler job state: " + e.Detail }
 
-type pickleTuple []any
-type pickleGlobal struct{ module, name string }
-type pickleObject struct {
-	class pickleGlobal
-	state map[string]any
-}
-type pickleTimedelta struct{ days, seconds, microseconds int64 }
-type pickleUTC struct{}
+type (
+	pickleTuple  []any
+	pickleGlobal struct{ module, name string }
+	pickleObject struct {
+		class pickleGlobal
+		state map[string]any
+	}
+)
+
+type (
+	pickleTimedelta struct{ days, seconds, microseconds int64 }
+	pickleUTC       struct{}
+)
 
 type pickleParser struct {
 	data     []byte
@@ -540,9 +545,11 @@ func (d pickleTimedelta) duration() (time.Duration, error) {
 	}
 	return time.Duration(micros) * time.Microsecond, nil
 }
+
 func allowedGlobal(value pickleGlobal) bool {
 	return value == (pickleGlobal{"apscheduler.triggers.interval", "IntervalTrigger"}) || value == (pickleGlobal{"datetime", "timezone"}) || value == (pickleGlobal{"datetime", "timedelta"}) || value == (pickleGlobal{"datetime", "datetime"})
 }
+
 func exactKeys(value map[string]any, keys []string) bool {
 	if len(value) != len(keys) {
 		return false

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -460,6 +460,7 @@ func claimOwner(path string) error {
 	liveOwners.paths[path] = struct{}{}
 	return nil
 }
+
 func releaseOwner(path string) {
 	liveOwners.Lock()
 	delete(liveOwners.paths, path)
@@ -480,6 +481,7 @@ func storedFloat(value any) (float64, bool) {
 	}
 	return result, !math.IsNaN(result) && !math.IsInf(result, 0)
 }
+
 func storedBlob(value any) ([]byte, bool) {
 	switch typed := value.(type) {
 	case []byte:

--- a/internal/sqlstore/artifact_create_conflict_test.go
+++ b/internal/sqlstore/artifact_create_conflict_test.go
@@ -23,6 +23,7 @@ import (
 
 	mysql "github.com/go-sql-driver/mysql"
 	"github.com/mattn/go-sqlite3"
+
 	"github.com/ob-labs/powercontext-go/artifact"
 	"github.com/ob-labs/powercontext-go/artifact/experience"
 )

--- a/internal/sqlstore/artifacts.go
+++ b/internal/sqlstore/artifacts.go
@@ -23,6 +23,7 @@ import (
 
 	mysql "github.com/go-sql-driver/mysql"
 	"github.com/mattn/go-sqlite3"
+
 	"github.com/ob-labs/powercontext-go/artifact"
 	"github.com/ob-labs/powercontext-go/source"
 )

--- a/internal/sqlstore/database.go
+++ b/internal/sqlstore/database.go
@@ -30,6 +30,7 @@ import (
 
 	mysql "github.com/go-sql-driver/mysql"
 	"github.com/mattn/go-sqlite3"
+
 	embeddedseekdb "github.com/ob-labs/powercontext-go/internal/sqlstore/seekdb"
 	"github.com/ob-labs/powercontext-go/internal/sqlstore/sqlitevec"
 )

--- a/internal/sqlstore/experience_index.go
+++ b/internal/sqlstore/experience_index.go
@@ -37,6 +37,7 @@ func (NoExperienceIndex) Initialize(context.Context, DBTX) error { return nil }
 func (NoExperienceIndex) Replace(context.Context, DBTX, string, experience.Experience) error {
 	return nil
 }
+
 func (NoExperienceIndex) Search(
 	context.Context,
 	DBTX,

--- a/internal/sqlstore/handoff_report.go
+++ b/internal/sqlstore/handoff_report.go
@@ -59,11 +59,13 @@ func (s *HandoffReportStore) CreateProject(ctx context.Context, value handoffrep
 	})
 	return result, err
 }
+
 func (s *HandoffReportStore) GetProject(ctx context.Context, projectID string) (handoffreport.ProjectDescriptor, error) {
 	var result handoffreport.ProjectDescriptor
 	err := s.database.Transaction(ctx, func(tx DBTX) error { var err error; result, err = s.getProject(ctx, tx, projectID); return err })
 	return result, err
 }
+
 func (s *HandoffReportStore) UpdateProject(ctx context.Context, value handoffreport.ProjectDescriptor, expected int, effectiveAt time.Time) (handoffreport.ProjectDescriptor, error) {
 	var result handoffreport.ProjectDescriptor
 	err := s.database.Transaction(ctx, func(tx DBTX) error {
@@ -73,6 +75,7 @@ func (s *HandoffReportStore) UpdateProject(ctx context.Context, value handoffrep
 	})
 	return result, err
 }
+
 func (s *HandoffReportStore) ListProjects(ctx context.Context, cursor *string, limit int, includeArchived bool) (handoffreport.Page[handoffreport.ProjectDescriptor], error) {
 	var result handoffreport.Page[handoffreport.ProjectDescriptor]
 	err := s.database.Transaction(ctx, func(tx DBTX) error {
@@ -82,6 +85,7 @@ func (s *HandoffReportStore) ListProjects(ctx context.Context, cursor *string, l
 	})
 	return result, err
 }
+
 func (s *HandoffReportStore) RegisterWorkstream(ctx context.Context, value handoffreport.WorkstreamDescriptor, effectiveAt time.Time) (handoffreport.WorkstreamDescriptor, error) {
 	var result handoffreport.WorkstreamDescriptor
 	err := s.database.Transaction(ctx, func(tx DBTX) error {
@@ -91,6 +95,7 @@ func (s *HandoffReportStore) RegisterWorkstream(ctx context.Context, value hando
 	})
 	return result, err
 }
+
 func (s *HandoffReportStore) UpdateWorkstream(ctx context.Context, value handoffreport.WorkstreamDescriptor, expected int, effectiveAt time.Time) (handoffreport.WorkstreamDescriptor, error) {
 	var result handoffreport.WorkstreamDescriptor
 	err := s.database.Transaction(ctx, func(tx DBTX) error {
@@ -100,6 +105,7 @@ func (s *HandoffReportStore) UpdateWorkstream(ctx context.Context, value handoff
 	})
 	return result, err
 }
+
 func (s *HandoffReportStore) ListWorkstreams(ctx context.Context, projectID string, cursor *string, limit int, includeArchived bool) (handoffreport.Page[handoffreport.WorkstreamDescriptor], error) {
 	var result handoffreport.Page[handoffreport.WorkstreamDescriptor]
 	err := s.database.Transaction(ctx, func(tx DBTX) error {
@@ -140,6 +146,7 @@ func (s *HandoffReportStore) createProject(ctx context.Context, tx DBTX, value h
 	}
 	return value, nil
 }
+
 func (s *HandoffReportStore) getProject(ctx context.Context, tx DBTX, projectID string) (handoffreport.ProjectDescriptor, error) {
 	if err := reportIdentifier("project_id", projectID, handoffreport.MaxReportIDLength); err != nil {
 		return handoffreport.ProjectDescriptor{}, err
@@ -171,6 +178,7 @@ func (s *HandoffReportStore) findProject(ctx context.Context, tx DBTX, id string
 	row.payload, err = reportPayload(payload)
 	return row, err
 }
+
 func decodeProjectRow(row projectRow) (handoffreport.ProjectDescriptor, error) {
 	var value handoffreport.ProjectDescriptor
 	if err := unmarshalJSON(row.payload, &value); err != nil {
@@ -181,6 +189,7 @@ func decodeProjectRow(row projectRow) (handoffreport.ProjectDescriptor, error) {
 	}
 	return value, nil
 }
+
 func (s *HandoffReportStore) updateProject(ctx context.Context, tx DBTX, value handoffreport.ProjectDescriptor, expected int, effectiveAt time.Time) (handoffreport.ProjectDescriptor, error) {
 	if expected < 1 {
 		return handoffreport.ProjectDescriptor{}, catalogArg("expected_version", "must be a positive integer")
@@ -289,6 +298,7 @@ func (s *HandoffReportStore) findWorkstream(ctx context.Context, tx DBTX, scope 
 	row.payload, err = reportPayload(payload)
 	return row, err
 }
+
 func decodeWorkstreamRow(row workstreamRow) (handoffreport.WorkstreamDescriptor, error) {
 	var value handoffreport.WorkstreamDescriptor
 	if err := unmarshalJSON(row.payload, &value); err != nil {
@@ -300,6 +310,7 @@ func decodeWorkstreamRow(row workstreamRow) (handoffreport.WorkstreamDescriptor,
 	}
 	return value, nil
 }
+
 func (s *HandoffReportStore) createWorkstream(ctx context.Context, tx DBTX, value handoffreport.WorkstreamDescriptor, effectiveAt time.Time) (handoffreport.WorkstreamDescriptor, error) {
 	if value.Version() != 1 {
 		return handoffreport.WorkstreamDescriptor{}, catalogArg("version", "a new Workstream must start at version 1")
@@ -340,6 +351,7 @@ func (s *HandoffReportStore) createWorkstream(ctx context.Context, tx DBTX, valu
 	}
 	return value, nil
 }
+
 func (s *HandoffReportStore) updateWorkstream(ctx context.Context, tx DBTX, value handoffreport.WorkstreamDescriptor, expected int, effectiveAt time.Time) (handoffreport.WorkstreamDescriptor, error) {
 	if expected < 1 {
 		return handoffreport.WorkstreamDescriptor{}, catalogArg("expected_version", "must be a positive integer")
@@ -388,6 +400,7 @@ func (s *HandoffReportStore) updateWorkstream(ctx context.Context, tx DBTX, valu
 	}
 	return value, nil
 }
+
 func (s *HandoffReportStore) listWorkstreams(ctx context.Context, tx DBTX, projectID string, cursor *string, limit int, includeArchived bool) (handoffreport.Page[handoffreport.WorkstreamDescriptor], error) {
 	if err := reportIdentifier("project_id", projectID, handoffreport.MaxReportIDLength); err != nil {
 		return handoffreport.Page[handoffreport.WorkstreamDescriptor]{}, err
@@ -449,6 +462,7 @@ func reportIdentifier(field, value string, maximum int) error {
 	}
 	return nil
 }
+
 func pageArguments(cursor *string, limit, maximum int) error {
 	if cursor != nil {
 		if err := reportIdentifier("cursor", *cursor, maximum); err != nil {
@@ -460,6 +474,7 @@ func pageArguments(cursor *string, limit, maximum int) error {
 	}
 	return nil
 }
+
 func catalogArg(field, detail string) error {
 	return &handoffreport.CatalogArgumentError{Field: field, Detail: detail}
 }
@@ -470,12 +485,15 @@ func reportNullableString(value *string) any {
 	}
 	return *value
 }
+
 func projectConflict(id string, expected, current *int, detail string) error {
 	return &handoffreport.ProjectConflictError{ProjectID: id, ExpectedVersion: expected, CurrentVersion: current, Detail: detail}
 }
+
 func workstreamConflict(id string, expected, current *int, detail string) error {
 	return &handoffreport.WorkstreamConflictError{ScopeID: id, ExpectedVersion: expected, CurrentVersion: current, Detail: detail}
 }
+
 func reportPayload(value any) ([]byte, error) {
 	switch typed := value.(type) {
 	case string:
@@ -486,6 +504,7 @@ func reportPayload(value any) ([]byte, error) {
 		return nil, &InvalidStoredColumnError{Column: "payload", Expected: "text"}
 	}
 }
+
 func semanticActivityPayload(payload []byte) ([]byte, error) {
 	var value map[string]any
 	if err := unmarshalJSON(payload, &value); err != nil {
@@ -495,6 +514,7 @@ func semanticActivityPayload(payload []byte) ([]byte, error) {
 	delete(value, "observed_at")
 	return marshalJSON(value)
 }
+
 func duplicateStrings(values []handoffreport.ActivitySource) []handoffreport.ActivitySource {
 	if values == nil {
 		return nil

--- a/internal/sqlstore/handoff_report_activity.go
+++ b/internal/sqlstore/handoff_report_activity.go
@@ -213,6 +213,7 @@ func scanActivity(scanner rowScanner) (activityRow, error) {
 	row.payload, err = reportPayload(payload)
 	return row, err
 }
+
 func decodeActivityRow(row activityRow) (handoffreport.StoredActivity, error) {
 	if row.cursor < 1 {
 		return handoffreport.StoredActivity{}, invalidStoredActivity("cursor", "must be a positive integer")
@@ -233,6 +234,7 @@ func decodeActivityRow(row activityRow) (handoffreport.StoredActivity, error) {
 	}
 	return handoffreport.StoredActivity{Event: event, Cursor: row.cursor}, nil
 }
+
 func idempotentActivity(row activityRow, candidate []byte) (handoffreport.StoredActivity, error) {
 	existingSemantic, err := semanticActivityPayload(row.payload)
 	if err != nil {

--- a/internal/sqlstore/handoff_report_test.go
+++ b/internal/sqlstore/handoff_report_test.go
@@ -363,6 +363,7 @@ func reportProject(t *testing.T, id, key string, version int, state handoffrepor
 	}
 	return value
 }
+
 func reportWorkstream(t *testing.T, scope, project string, version int, state handoffreport.CatalogState) handoffreport.WorkstreamDescriptor {
 	t.Helper()
 	value, err := handoffreport.NewWorkstreamDescriptor(scope, project, nil, "Workstream", handoffreport.WorkstreamFeature, state, nil, nil, version)
@@ -371,6 +372,7 @@ func reportWorkstream(t *testing.T, scope, project string, version int, state ha
 	}
 	return value
 }
+
 func reportActivity(t *testing.T, id, project, sourceID string, observed, occurred time.Time, title *string) handoffreport.ActivityEvent {
 	t.Helper()
 	value, err := handoffreport.NewActivityEvent(handoffreport.ActivityEventInput{EventID: id, ProjectID: project, Source: handoffreport.ActivityGitCommit, SourceEventID: sourceID, OccurredAt: &occurred, ObservedAt: observed.UTC(), TimeBasis: handoffreport.TimeSourceReported, Title: title})
@@ -379,6 +381,7 @@ func reportActivity(t *testing.T, id, project, sourceID string, observed, occurr
 	}
 	return value
 }
+
 func reportTime(day int) time.Time {
 	return time.Date(2026, time.August, day, 10, 0, 0, 123456000, time.UTC)
 }

--- a/internal/sqlstore/handoff_report_workspace.go
+++ b/internal/sqlstore/handoff_report_workspace.go
@@ -32,6 +32,7 @@ func (s *HandoffReportStore) GetWorkspaceBinding(ctx context.Context, workspaceI
 	})
 	return result, err
 }
+
 func (s *HandoffReportStore) AttachWorkspaceBinding(ctx context.Context, workspaceID, projectID string, repository handoffreport.RepositoryRef, expected *int, confirmedAt time.Time) (handoffreport.WorkspaceBinding, error) {
 	var result handoffreport.WorkspaceBinding
 	err := s.database.Transaction(ctx, func(tx DBTX) error {
@@ -44,6 +45,7 @@ func (s *HandoffReportStore) AttachWorkspaceBinding(ctx context.Context, workspa
 	})
 	return result, err
 }
+
 func (s *HandoffReportStore) DetachWorkspaceBinding(ctx context.Context, workspaceID string, expected int) (handoffreport.WorkspaceBinding, error) {
 	var result handoffreport.WorkspaceBinding
 	err := s.database.Transaction(ctx, func(tx DBTX) error {
@@ -74,6 +76,7 @@ func (s *HandoffReportStore) findWorkspace(ctx context.Context, tx DBTX, id stri
 	row.payload, err = reportPayload(payload)
 	return row, err
 }
+
 func decodeWorkspaceRow(row workspaceRow) (handoffreport.WorkspaceBinding, error) {
 	var value handoffreport.WorkspaceBinding
 	if err := unmarshalJSON(row.payload, &value); err != nil {
@@ -84,6 +87,7 @@ func decodeWorkspaceRow(row workspaceRow) (handoffreport.WorkspaceBinding, error
 	}
 	return value, nil
 }
+
 func (s *HandoffReportStore) getWorkspaceBinding(ctx context.Context, tx DBTX, id string, confirmedOnly bool) (handoffreport.WorkspaceBinding, error) {
 	if err := reportIdentifier("workspace_instance_id", id, handoffreport.MaxWorkspaceInstanceIDLength); err != nil {
 		return handoffreport.WorkspaceBinding{}, err
@@ -104,6 +108,7 @@ func (s *HandoffReportStore) getWorkspaceBinding(ctx context.Context, tx DBTX, i
 	}
 	return value, nil
 }
+
 func (s *HandoffReportStore) attachWorkspaceBinding(ctx context.Context, tx DBTX, id, projectID string, repository handoffreport.RepositoryRef, expected *int, confirmedAt time.Time) (handoffreport.WorkspaceBinding, error) {
 	if err := reportIdentifier("workspace_instance_id", id, handoffreport.MaxWorkspaceInstanceIDLength); err != nil {
 		return handoffreport.WorkspaceBinding{}, err
@@ -163,6 +168,7 @@ func (s *HandoffReportStore) attachWorkspaceBinding(ctx context.Context, tx DBTX
 	}
 	return value, nil
 }
+
 func (s *HandoffReportStore) detachWorkspaceBinding(ctx context.Context, tx DBTX, id string, expected int) (handoffreport.WorkspaceBinding, error) {
 	if expected < 1 {
 		return handoffreport.WorkspaceBinding{}, catalogArg("expected_version", "must be a positive integer")
@@ -199,6 +205,7 @@ func (s *HandoffReportStore) detachWorkspaceBinding(ctx context.Context, tx DBTX
 	}
 	return detached, nil
 }
+
 func workspaceConflict(id string, expected, current *int, detail string) error {
 	return &handoffreport.WorkspaceBindingConflictError{WorkspaceInstanceID: id, ExpectedVersion: expected, CurrentVersion: current, Detail: detail}
 }

--- a/internal/sqlstore/memory_index.go
+++ b/internal/sqlstore/memory_index.go
@@ -163,9 +163,11 @@ func (NoMemoryIndex) Capabilities() memory.Capabilities { return memory.Capabili
 func (NoMemoryIndex) Initialize(context.Context, DBTX) error {
 	return nil
 }
+
 func (NoMemoryIndex) Replace(context.Context, DBTX, string, artifact.Ref, []memory.Projection) error {
 	return nil
 }
+
 func (NoMemoryIndex) Search(
 	context.Context,
 	DBTX,
@@ -174,6 +176,7 @@ func (NoMemoryIndex) Search(
 ) (memory.SearchChannels, error) {
 	return memory.SearchChannels{}, &memory.CapabilityNotSupportedError{Capability: "fts"}
 }
+
 func (NoMemoryIndex) VectorComplete(
 	context.Context,
 	DBTX,
@@ -183,6 +186,7 @@ func (NoMemoryIndex) VectorComplete(
 ) (bool, error) {
 	return false, nil
 }
+
 func (NoMemoryIndex) Hydrate(
 	_ context.Context,
 	_ DBTX,

--- a/internal/sqlstore/memory_test.go
+++ b/internal/sqlstore/memory_test.go
@@ -195,9 +195,11 @@ func initialMemoryCommit(t *testing.T, artifactID string) memory.Commit {
 type failingMemoryIndex struct{ failure error }
 
 func (f failingMemoryIndex) Capabilities() memory.Capabilities { return memory.Capabilities{FTS: true} }
+
 func (f failingMemoryIndex) Initialize(context.Context, sqlstore.DBTX) error {
 	return nil
 }
+
 func (f failingMemoryIndex) Replace(
 	context.Context,
 	sqlstore.DBTX,
@@ -207,6 +209,7 @@ func (f failingMemoryIndex) Replace(
 ) error {
 	return f.failure
 }
+
 func (f failingMemoryIndex) Search(
 	context.Context,
 	sqlstore.DBTX,
@@ -215,6 +218,7 @@ func (f failingMemoryIndex) Search(
 ) (memory.SearchChannels, error) {
 	return memory.SearchChannels{}, f.failure
 }
+
 func (f failingMemoryIndex) VectorComplete(
 	context.Context,
 	sqlstore.DBTX,
@@ -224,6 +228,7 @@ func (f failingMemoryIndex) VectorComplete(
 ) (bool, error) {
 	return false, f.failure
 }
+
 func (f failingMemoryIndex) Hydrate(
 	_ context.Context,
 	_ sqlstore.DBTX,

--- a/internal/sqlstore/review_test.go
+++ b/internal/sqlstore/review_test.go
@@ -295,6 +295,7 @@ func (f failingExperienceIndex) Replace(
 ) error {
 	return f.failure
 }
+
 func (f failingExperienceIndex) Search(
 	context.Context,
 	sqlstore.DBTX,

--- a/internal/sqlstore/schema.go
+++ b/internal/sqlstore/schema.go
@@ -21,8 +21,10 @@ import (
 	"strings"
 )
 
-var cursorIdentifierPattern = regexp.MustCompile(`\bcursor\b`)
-var varcharIdentityPattern = regexp.MustCompile(`\bVARCHAR\(([0-9]+)\)`)
+var (
+	cursorIdentifierPattern = regexp.MustCompile(`\bcursor\b`)
+	varcharIdentityPattern  = regexp.MustCompile(`\bVARCHAR\(([0-9]+)\)`)
+)
 
 // quoteCursorIdentifier preserves the frozen column name while making SQL
 // valid on OceanBase, where CURSOR is reserved. Backtick identifiers are also

--- a/internal/sqlstore/sqlite_memory_vector_test.go
+++ b/internal/sqlstore/sqlite_memory_vector_test.go
@@ -186,10 +186,14 @@ func TestSQLiteVec0ReplaceHydrateAndSearch(t *testing.T) {
 	}
 	const scopeID = "scope"
 	entries := []memory.EntryVersion{
-		{MemoryArtifactID: memoryRef.ID(), EntryID: "entry-a", EntryVersionID: "version-a", Version: 1,
-			Kind: "fact", Text: "nearest", EntryContentHash: strings.Repeat("a", 64), CreatedInRevision: 1},
-		{MemoryArtifactID: memoryRef.ID(), EntryID: "entry-b", EntryVersionID: "version-b", Version: 1,
-			Kind: "fact", Text: "farther", EntryContentHash: strings.Repeat("b", 64), CreatedInRevision: 1},
+		{
+			MemoryArtifactID: memoryRef.ID(), EntryID: "entry-a", EntryVersionID: "version-a", Version: 1,
+			Kind: "fact", Text: "nearest", EntryContentHash: strings.Repeat("a", 64), CreatedInRevision: 1,
+		},
+		{
+			MemoryArtifactID: memoryRef.ID(), EntryID: "entry-b", EntryVersionID: "version-b", Version: 1,
+			Kind: "fact", Text: "farther", EntryContentHash: strings.Repeat("b", 64), CreatedInRevision: 1,
+		},
 	}
 	vectors := [][]float64{{1, 0, 0}, {0, 1, 0}}
 	projections := make([]memory.Projection, len(entries))

--- a/internal/stats/model.go
+++ b/internal/stats/model.go
@@ -170,8 +170,9 @@ type Inventory struct {
 	memory     MemoryEntryInventory
 }
 
-func (v Inventory) Sources() SourceInventory            { return v.sources }
-func (v Inventory) Artifacts() ArtifactInventory        { return cloneArtifactInventory(v.artifacts) }
+func (v Inventory) Sources() SourceInventory     { return v.sources }
+func (v Inventory) Artifacts() ArtifactInventory { return cloneArtifactInventory(v.artifacts) }
+
 func (v Inventory) Candidates() CandidateInventory      { return cloneCandidateInventory(v.candidates) }
 func (v Inventory) MemoryEntries() MemoryEntryInventory { return cloneMemoryInventory(v.memory) }
 
@@ -286,7 +287,8 @@ func (v RecallTokenMeasurement) Estimator() inference.TokenEstimatorProfile { re
 func (v RecallTokenMeasurement) Ready() bool                                { return v.ready }
 func (v RecallTokenMeasurement) Comparable() bool                           { return v.comparable }
 func (v RecallTokenMeasurement) BaselineTokens() int64                      { return v.baselineTokens }
-func (v RecallTokenMeasurement) RecalledTokens() int64                      { return v.recalledTokens }
+
+func (v RecallTokenMeasurement) RecalledTokens() int64 { return v.recalledTokens }
 
 type RecallTokenValue struct {
 	preparations, readyPreparations, comparablePreparations int64
@@ -351,14 +353,17 @@ func cloneInt64(value *int64) *int64 {
 	copy := *value
 	return &copy
 }
+
 func cloneUsageValue(v ModelUsageValue) ModelUsageValue {
 	v.inputTokens, v.outputTokens = cloneInt64(v.inputTokens), cloneInt64(v.outputTokens)
 	return v
 }
+
 func cloneModelUsage(v ModelUsage) ModelUsage {
 	v.generation, v.embedding = cloneUsageValue(v.generation), cloneUsageValue(v.embedding)
 	return v
 }
+
 func clonePurposeBreakdowns(values []PurposeBreakdown) []PurposeBreakdown {
 	result := make([]PurposeBreakdown, len(values))
 	for i, value := range values {
@@ -367,6 +372,7 @@ func clonePurposeBreakdowns(values []PurposeBreakdown) []PurposeBreakdown {
 	}
 	return result
 }
+
 func cloneUsageDays(values []ModelUsageDay) []ModelUsageDay {
 	result := make([]ModelUsageDay, len(values))
 	for i, value := range values {
@@ -376,30 +382,36 @@ func cloneUsageDays(values []ModelUsageDay) []ModelUsageDay {
 	}
 	return result
 }
+
 func cloneArtifactInventory(v ArtifactInventory) ArtifactInventory {
 	v.byFamily = slices.Clone(v.byFamily)
 	return v
 }
+
 func cloneCandidateInventory(v CandidateInventory) CandidateInventory {
 	v.byFamily = slices.Clone(v.byFamily)
 	return v
 }
+
 func cloneMemoryInventory(v MemoryEntryInventory) MemoryEntryInventory {
 	v.byKind = slices.Clone(v.byKind)
 	return v
 }
+
 func cloneInventory(v Inventory) Inventory {
 	v.artifacts = cloneArtifactInventory(v.artifacts)
 	v.candidates = cloneCandidateInventory(v.candidates)
 	v.memory = cloneMemoryInventory(v.memory)
 	return v
 }
+
 func cloneUsage(v Usage) Usage {
 	v.totals = cloneModelUsage(v.totals)
 	v.byPurpose = clonePurposeBreakdowns(v.byPurpose)
 	v.daily = cloneUsageDays(v.daily)
 	return v
 }
+
 func cloneRecall(v Recall) Recall {
 	if v.estimator != nil {
 		profile := *v.estimator

--- a/internal/work/receipt.go
+++ b/internal/work/receipt.go
@@ -66,6 +66,7 @@ func (c ReceiverChecks) Authorization() ReadinessCheckStatus { return c.authoriz
 func (c ReceiverChecks) AllConfirmed() bool {
 	return c.liveState == LiveStateConfirmed && c.capability == ReadinessConfirmed && c.authorization == ReadinessConfirmed
 }
+
 func (c ReceiverChecks) Validate() error {
 	if c.liveState != LiveStateConfirmed && c.liveState != LiveStateMismatch && c.liveState != LiveStateNotChecked {
 		return &InvalidError{Field: "receiver_checks.live_state", Detail: "has an unsupported value"}

--- a/openapi/python_contract_test.go
+++ b/openapi/python_contract_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 
 	"github.com/ghodss/yaml"
+
 	v1 "github.com/ob-labs/powercontext-go/api/v1"
 )
 

--- a/server/application.go
+++ b/server/application.go
@@ -21,6 +21,8 @@ import (
 	"net/http"
 	"sync"
 
+	"go.opentelemetry.io/otel/trace"
+
 	v1 "github.com/ob-labs/powercontext-go/api/v1"
 	"github.com/ob-labs/powercontext-go/artifact/skill"
 	"github.com/ob-labs/powercontext-go/internal/endpoint"
@@ -28,7 +30,6 @@ import (
 	servermetrics "github.com/ob-labs/powercontext-go/internal/observability/metrics"
 	pcruntime "github.com/ob-labs/powercontext-go/internal/runtime"
 	"github.com/ob-labs/powercontext-go/internal/webui"
-	"go.opentelemetry.io/otel/trace"
 )
 
 // Application is one fully assembled Runtime and its shared endpoint adapter.

--- a/server/application_foundation.go
+++ b/server/application_foundation.go
@@ -19,11 +19,12 @@ import (
 	"errors"
 	"time"
 
+	"go.opentelemetry.io/otel/trace"
+
 	servermetrics "github.com/ob-labs/powercontext-go/internal/observability/metrics"
 	servertracing "github.com/ob-labs/powercontext-go/internal/observability/tracing"
 	pcruntime "github.com/ob-labs/powercontext-go/internal/runtime"
 	"github.com/ob-labs/powercontext-go/internal/sqlstore"
-	"go.opentelemetry.io/otel/trace"
 )
 
 type applicationFoundation struct {

--- a/server/application_readiness_test.go
+++ b/server/application_readiness_test.go
@@ -28,13 +28,14 @@ import (
 	"testing"
 	"time"
 
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace/noop"
+
 	"github.com/ob-labs/powercontext-go/inference"
 	"github.com/ob-labs/powercontext-go/internal/endpoint"
 	servermetrics "github.com/ob-labs/powercontext-go/internal/observability/metrics"
 	"github.com/ob-labs/powercontext-go/internal/runtime"
-	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	"go.opentelemetry.io/otel/sdk/trace/tracetest"
-	"go.opentelemetry.io/otel/trace/noop"
 )
 
 func TestConfiguredReadinessIncludesRuntimeAndConfiguredInference(t *testing.T) {

--- a/server/application_support.go
+++ b/server/application_support.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+
 	"github.com/ob-labs/powercontext-go/artifact/experience"
 	"github.com/ob-labs/powercontext-go/artifact/memory"
 	"github.com/ob-labs/powercontext-go/artifact/skill"

--- a/server/application_test.go
+++ b/server/application_test.go
@@ -33,6 +33,7 @@ import (
 	"time"
 
 	_ "github.com/mattn/go-sqlite3"
+
 	v1 "github.com/ob-labs/powercontext-go/api/v1"
 	"github.com/ob-labs/powercontext-go/artifact"
 	"github.com/ob-labs/powercontext-go/artifact/experience"

--- a/server/config.go
+++ b/server/config.go
@@ -99,8 +99,10 @@ type LoggingConfig struct {
 	Access bool
 }
 
-type MetricsConfig struct{ Enabled bool }
-type TracingConfig struct{ Enabled bool }
+type (
+	MetricsConfig struct{ Enabled bool }
+	TracingConfig struct{ Enabled bool }
+)
 
 type RuntimeConfig struct {
 	ScopeCacheSize               int

--- a/server/config_env.go
+++ b/server/config_env.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/caarlos0/env/v11"
+
 	"github.com/ob-labs/powercontext-go/artifact/memory"
 )
 

--- a/server/dependencies.go
+++ b/server/dependencies.go
@@ -20,6 +20,8 @@ import (
 	"net/http"
 	"time"
 
+	"go.opentelemetry.io/otel/trace"
+
 	"github.com/ob-labs/powercontext-go/artifact/experience"
 	"github.com/ob-labs/powercontext-go/artifact/handoff"
 	"github.com/ob-labs/powercontext-go/artifact/memory"
@@ -27,7 +29,6 @@ import (
 	"github.com/ob-labs/powercontext-go/inference"
 	"github.com/ob-labs/powercontext-go/internal/modelprovider"
 	pcruntime "github.com/ob-labs/powercontext-go/internal/runtime"
-	"go.opentelemetry.io/otel/trace"
 )
 
 // Dependencies are deliberate extension points for deterministic tests and

--- a/server/http.go
+++ b/server/http.go
@@ -24,6 +24,9 @@ import (
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/trace"
+
 	v1 "github.com/ob-labs/powercontext-go/api/v1"
 	"github.com/ob-labs/powercontext-go/internal/endpoint"
 	"github.com/ob-labs/powercontext-go/internal/httpapi"
@@ -32,8 +35,6 @@ import (
 	servermetrics "github.com/ob-labs/powercontext-go/internal/observability/metrics"
 	requesttrace "github.com/ob-labs/powercontext-go/internal/observability/tracing"
 	"github.com/ob-labs/powercontext-go/internal/webui"
-	"go.opentelemetry.io/otel/metric"
-	"go.opentelemetry.io/otel/trace"
 )
 
 type HTTPOptions struct {

--- a/server/http_test.go
+++ b/server/http_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+
 	v1 "github.com/ob-labs/powercontext-go/api/v1"
 	"github.com/ob-labs/powercontext-go/artifact/memory"
 	"github.com/ob-labs/powercontext-go/internal/endpoint"

--- a/server/logging_test.go
+++ b/server/logging_test.go
@@ -27,12 +27,13 @@ import (
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
 	"github.com/ob-labs/powercontext-go/internal/endpoint"
 	serverlogging "github.com/ob-labs/powercontext-go/internal/observability/logging"
 	requesttrace "github.com/ob-labs/powercontext-go/internal/observability/tracing"
 	"github.com/ob-labs/powercontext-go/internal/runtime"
-	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 )
 
 func TestHTTPAccessLogCorrelatesWithIngressSpanAndSkipsInfrastructure(t *testing.T) {

--- a/server/runtime_tracing.go
+++ b/server/runtime_tracing.go
@@ -17,9 +17,10 @@ package server
 import (
 	"context"
 
+	"go.opentelemetry.io/otel/trace"
+
 	requesttrace "github.com/ob-labs/powercontext-go/internal/observability/tracing"
 	pcruntime "github.com/ob-labs/powercontext-go/internal/runtime"
-	"go.opentelemetry.io/otel/trace"
 )
 
 type runtimeStageTracing struct{ provider trace.TracerProvider }

--- a/server/runtime_tracing_test.go
+++ b/server/runtime_tracing_test.go
@@ -19,9 +19,10 @@ import (
 	"strings"
 	"testing"
 
-	pcruntime "github.com/ob-labs/powercontext-go/internal/runtime"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	pcruntime "github.com/ob-labs/powercontext-go/internal/runtime"
 )
 
 func TestRuntimeStageSpansInheritApplicationContextWithoutRawScope(t *testing.T) {

--- a/server/tracing_test.go
+++ b/server/tracing_test.go
@@ -20,11 +20,12 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ob-labs/powercontext-go/internal/endpoint"
 	"go.opentelemetry.io/otel/attribute"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"go.opentelemetry.io/otel/trace"
+
+	"github.com/ob-labs/powercontext-go/internal/endpoint"
 )
 
 func TestHTTPAndApplicationSpansPreserveW3CParentWithoutSensitiveAttributes(t *testing.T) {

--- a/source/catalog_test.go
+++ b/source/catalog_test.go
@@ -46,6 +46,7 @@ func (adapter) Name() string { return "capture" }
 func (a adapter) Resolve(_ context.Context, value input) (capturedSource, error) {
 	return capturedSource{name: value.name}, nil
 }
+
 func (adapter) Read(_ context.Context, value capturedSource) (string, error) {
 	return "read:" + value.name, nil
 }
@@ -65,6 +66,7 @@ func (b *backend) Get(_ context.Context, value source.Value) (source.Value, erro
 	}
 	return nil, &source.NotFoundError{Source: value}
 }
+
 func (b *backend) List(context.Context) ([]source.Value, error) {
 	return append([]source.Value(nil), b.values...), nil
 }

--- a/source/content.go
+++ b/source/content.go
@@ -63,6 +63,7 @@ func (s ContentSource) SourceName() string { return s.name }
 func (s ContentSource) SourceMaterialization() Materialization {
 	return s.materialization
 }
+
 func (s ContentSource) SourceDescription() (string, bool) {
 	if s.description == nil {
 		return "", false
@@ -117,6 +118,7 @@ func (ContentAdapter) Resolve(_ context.Context, value ContentCapture) (ContentS
 		metadata:        metadata,
 	}, nil
 }
+
 func (ContentAdapter) Read(_ context.Context, value ContentSource) (ContentCapture, error) {
 	return NewContentCapture(value.name, value.content, value.metadata)
 }

--- a/test/e2e/oceanbase_live_test.go
+++ b/test/e2e/oceanbase_live_test.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	mysql "github.com/go-sql-driver/mysql"
+
 	"github.com/ob-labs/powercontext-go/internal/handoffreport"
 	"github.com/ob-labs/powercontext-go/internal/sqlstore"
 	"github.com/ob-labs/powercontext-go/source"

--- a/tools/locomo/operations.go
+++ b/tools/locomo/operations.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/go-faster/jx"
+
 	v1 "github.com/ob-labs/powercontext-go/api/v1"
 	"github.com/ob-labs/powercontext-go/artifact"
 	"github.com/ob-labs/powercontext-go/artifact/memory"

--- a/tools/process-smoke/main.go
+++ b/tools/process-smoke/main.go
@@ -39,6 +39,7 @@ import (
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+
 	v1 "github.com/ob-labs/powercontext-go/api/v1"
 	pcclient "github.com/ob-labs/powercontext-go/client"
 )

--- a/tools/release/makefile_test.go
+++ b/tools/release/makefile_test.go
@@ -41,9 +41,22 @@ func TestBareMakeKeepsGenerateAsDefaultGoal(t *testing.T) {
 	if err != nil {
 		t.Fatalf("make dry-run failed: %v\n%s", err, output)
 	}
-	if first := strings.SplitN(string(output), "\n", 2)[0]; !strings.Contains(first, "generate ./openapi") {
+	if first := firstGeneratedCommand(string(output)); !strings.Contains(first, "generate ./openapi") {
 		t.Fatalf("bare make first command = %q, want generate default goal", first)
 	}
+}
+
+func firstGeneratedCommand(output string) string {
+	for _, line := range strings.Split(output, "\n") {
+		if strings.HasPrefix(line, "make") && (strings.Contains(line, "Entering directory") ||
+			strings.Contains(line, "Leaving directory")) {
+			continue
+		}
+		if strings.TrimSpace(line) != "" {
+			return line
+		}
+	}
+	return ""
 }
 
 func TestLintToolInstallUsesProjectSelectedGoVersion(t *testing.T) {

--- a/tools/release/makefile_test.go
+++ b/tools/release/makefile_test.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestLintToolInstallUsesProjectSelectedGoVersion(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the repository Makefile requires a POSIX shell")
+	}
+
+	repository := filepath.Clean(filepath.Join("..", ".."))
+	temporary := t.TempDir()
+	toolsBin := filepath.Join(temporary, "bin")
+	toolchainRecord := filepath.Join(temporary, "toolchain.txt")
+	fakeGo := filepath.Join(temporary, "go")
+	const fakeGoScript = `#!/bin/sh
+set -eu
+
+case "${1:-} ${2:-}" in
+  "env GOEXE")
+    exit 0
+    ;;
+  "env GOVERSION")
+    printf 'go1.27.0\n'
+    exit 0
+    ;;
+esac
+
+if [ "${1:-}" != "install" ]; then
+  printf 'unexpected go command: %s\n' "$*" >&2
+  exit 64
+fi
+
+printf '%s\n' "${GOTOOLCHAIN:-}" > "$TOOLCHAIN_RECORD"
+mkdir -p "$GOBIN"
+cat > "$GOBIN/golangci-lint" <<'EOF'
+#!/bin/sh
+exit 0
+EOF
+chmod +x "$GOBIN/golangci-lint"
+`
+	if err := os.WriteFile(fakeGo, []byte(fakeGoScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	command := exec.Command("make", "lint-tools", "GO="+fakeGo, "TOOLS_BIN="+toolsBin)
+	command.Dir = repository
+	command.Env = append(os.Environ(), "GOTOOLCHAIN=auto", "TOOLCHAIN_RECORD="+toolchainRecord)
+	if output, err := command.CombinedOutput(); err != nil {
+		t.Fatalf("make lint-tools failed: %v\n%s", err, output)
+	}
+
+	payload, err := os.ReadFile(toolchainRecord)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := strings.TrimSpace(string(payload)), "go1.27.0+auto"; got != want {
+		t.Fatalf("lint tool install GOTOOLCHAIN = %q, want %q", got, want)
+	}
+}

--- a/tools/release/makefile_test.go
+++ b/tools/release/makefile_test.go
@@ -19,9 +19,32 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 )
+
+func TestBareMakeKeepsGenerateAsDefaultGoal(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the repository Makefile requires a POSIX shell")
+	}
+
+	repository := filepath.Clean(filepath.Join("..", ".."))
+	fakeGo := filepath.Join(t.TempDir(), "go")
+	if err := os.WriteFile(fakeGo, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	command := exec.CommandContext(t.Context(), "make", "--dry-run", "GO="+fakeGo)
+	command.Dir = repository
+	output, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("make dry-run failed: %v\n%s", err, output)
+	}
+	if first := strings.SplitN(string(output), "\n", 2)[0]; !strings.Contains(first, "generate ./openapi") {
+		t.Fatalf("bare make first command = %q, want generate default goal", first)
+	}
+}
 
 func TestLintToolInstallUsesProjectSelectedGoVersion(t *testing.T) {
 	if runtime.GOOS == "windows" {
@@ -55,6 +78,9 @@ printf '%s\n' "${GOTOOLCHAIN:-}" > "$TOOLCHAIN_RECORD"
 mkdir -p "$GOBIN"
 cat > "$GOBIN/golangci-lint" <<'EOF'
 #!/bin/sh
+if [ "${1:-}" = "--version" ]; then
+  printf 'golangci-lint has version 2.13.1 built with go1.27.0\n'
+fi
 exit 0
 EOF
 chmod +x "$GOBIN/golangci-lint"
@@ -63,7 +89,7 @@ chmod +x "$GOBIN/golangci-lint"
 		t.Fatal(err)
 	}
 
-	command := exec.Command("make", "lint-tools", "GO="+fakeGo, "TOOLS_BIN="+toolsBin)
+	command := exec.CommandContext(t.Context(), "make", "lint-tools", "GO="+fakeGo, "TOOLS_BIN="+toolsBin)
 	command.Dir = repository
 	command.Env = append(os.Environ(), "GOTOOLCHAIN=auto", "TOOLCHAIN_RECORD="+toolchainRecord)
 	if output, err := command.CombinedOutput(); err != nil {
@@ -76,5 +102,202 @@ chmod +x "$GOBIN/golangci-lint"
 	}
 	if got, want := strings.TrimSpace(string(payload)), "go1.27.0+auto"; got != want {
 		t.Fatalf("lint tool install GOTOOLCHAIN = %q, want %q", got, want)
+	}
+}
+
+func TestLintToolReinstallsWhenGoModSelectsNewGoVersion(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the repository Makefile requires a POSIX shell")
+	}
+
+	repository := filepath.Clean(filepath.Join("..", ".."))
+	temporary := t.TempDir()
+	toolsBin := filepath.Join(temporary, "bin")
+	installCount := filepath.Join(temporary, "install-count.txt")
+	fakeGo := filepath.Join(temporary, "go")
+	const fakeGoScript = `#!/bin/sh
+set -eu
+
+case "${1:-} ${2:-}" in
+  "env GOEXE")
+    exit 0
+    ;;
+  "env GOVERSION")
+    printf 'go1.27.0\n'
+    exit 0
+    ;;
+esac
+
+if [ "${1:-}" != "install" ]; then
+  printf 'unexpected go command: %s\n' "$*" >&2
+  exit 64
+fi
+
+count=0
+if [ -f "$INSTALL_COUNT" ]; then
+  count="$(cat "$INSTALL_COUNT")"
+fi
+count=$((count + 1))
+printf '%s\n' "$count" > "$INSTALL_COUNT"
+mkdir -p "$GOBIN"
+cat > "$GOBIN/golangci-lint" <<'EOF'
+#!/bin/sh
+if [ "${1:-}" = "--version" ]; then
+  printf 'golangci-lint has version 2.13.1 built with go1.27.0\n'
+fi
+exit 0
+EOF
+chmod +x "$GOBIN/golangci-lint"
+`
+	if err := os.WriteFile(fakeGo, []byte(fakeGoScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, arguments := range [][]string{
+		{"lint-tools", "GO=" + fakeGo, "TOOLS_BIN=" + toolsBin},
+		{"lint-tools", "-W", "go.mod", "GO=" + fakeGo, "TOOLS_BIN=" + toolsBin},
+	} {
+		command := exec.CommandContext(t.Context(), "make", arguments...)
+		command.Dir = repository
+		command.Env = append(os.Environ(), "GOTOOLCHAIN=auto", "INSTALL_COUNT="+installCount)
+		if output, err := command.CombinedOutput(); err != nil {
+			t.Fatalf("make %s failed: %v\n%s", strings.Join(arguments, " "), err, output)
+		}
+	}
+
+	payload, err := os.ReadFile(installCount)
+	if err != nil {
+		t.Fatal(err)
+	}
+	count, err := strconv.Atoi(strings.TrimSpace(string(payload)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 2 {
+		t.Fatalf("lint tool install count = %d, want 2 after go.mod changes", count)
+	}
+}
+
+func TestLintToolRejectsWrongCachedBinaryVersion(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the repository Makefile requires a POSIX shell")
+	}
+
+	repository := filepath.Clean(filepath.Join("..", ".."))
+	temporary := t.TempDir()
+	toolsBin := filepath.Join(temporary, "bin")
+	if err := os.MkdirAll(toolsBin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	linter := filepath.Join(toolsBin, "golangci-lint")
+	const linterScript = `#!/bin/sh
+if [ "${1:-}" = "--version" ]; then
+  printf 'golangci-lint has version 2.12.0 built with go1.27.0\n'
+fi
+exit 0
+`
+	if err := os.WriteFile(linter, []byte(linterScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	fakeGo := filepath.Join(temporary, "go")
+	const fakeGoScript = `#!/bin/sh
+set -eu
+
+case "${1:-} ${2:-}" in
+  "env GOEXE")
+    exit 0
+    ;;
+  "env GOVERSION")
+    printf 'go1.27.0\n'
+    exit 0
+    ;;
+esac
+
+printf 'unexpected go command: %s\n' "$*" >&2
+exit 64
+`
+	if err := os.WriteFile(fakeGo, []byte(fakeGoScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	command := exec.CommandContext(t.Context(), "make", "lint-tools", "GO="+fakeGo, "TOOLS_BIN="+toolsBin)
+	command.Dir = repository
+	output, err := command.CombinedOutput()
+	if err == nil {
+		t.Fatalf("make lint-tools accepted a wrong cached golangci-lint version:\n%s", output)
+	}
+	if _, err := os.Stat(filepath.Join(toolsBin, ".golangci-lint-v2.13.1-go1.27.0")); !os.IsNotExist(err) {
+		t.Fatalf("lint-tools created a stamp for the wrong cached binary version: %v", err)
+	}
+}
+
+func TestFmtFailsWhenGoSyntaxIsInvalid(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the repository Makefile requires a POSIX shell")
+	}
+
+	repository := filepath.Clean(filepath.Join("..", ".."))
+	temporary := t.TempDir()
+	makefile, err := os.ReadFile(filepath.Join(repository, "Makefile"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(temporary, "Makefile"), makefile, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(temporary, "go.mod"), []byte("module example.com/malformed\n\ngo 1.27.0\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(temporary, "malformed.go"), []byte("package invalid\n\nfunc broken( {\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	toolsBin := filepath.Join(temporary, ".tools", "bin")
+	if err := os.MkdirAll(toolsBin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	linter := filepath.Join(toolsBin, "golangci-lint")
+	const linterScript = `#!/bin/sh
+if [ "${1:-}" = "--version" ]; then
+  printf 'golangci-lint has version 2.13.1 built with go1.27.0\n'
+fi
+exit 0
+`
+	if err := os.WriteFile(linter, []byte(linterScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(toolsBin, ".golangci-lint-v2.13.1-go1.27.0"), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	fakeGo := filepath.Join(temporary, "go")
+	const fakeGoScript = `#!/bin/sh
+set -eu
+
+case "${1:-} ${2:-}" in
+  "env GOEXE")
+    exit 0
+    ;;
+  "env GOVERSION")
+    printf 'go1.27.0\n'
+    exit 0
+    ;;
+esac
+
+printf 'unexpected go command: %s\n' "$*" >&2
+exit 64
+`
+	if err := os.WriteFile(fakeGo, []byte(fakeGoScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	command := exec.CommandContext(t.Context(), "make", "fmt", "GO="+fakeGo, "GOFMT=gofmt", "TOOLS_BIN="+toolsBin)
+	command.Dir = temporary
+	output, err := command.CombinedOutput()
+	if err == nil {
+		t.Fatalf("make fmt unexpectedly succeeded with malformed Go source:\n%s", output)
+	}
+	if !strings.Contains(string(output), "malformed.go") {
+		t.Fatalf("make fmt failed for the wrong reason, output did not mention malformed.go:\n%s", output)
 	}
 }


### PR DESCRIPTION
## Summary

- pin `golangci-lint` v2.13.1 in a repository-local `.tools/bin` directory
- use the pinned formatter set for gofmt, gofumpt v0.11.0, and goimports from `golang.org/x/tools` v0.49.0
- add `make lint`, `make lint-fix`, and a stable `lint` CI job with `GOTOOLCHAIN=local` and an explicit timeout
- adopt the first zero-debt high-signal linter set: bodyclose, durationcheck, ineffassign, wastedassign, and whitespace
- migrate existing hand-written Go sources to the required formatter policy

## Dependency

PR #17 has merged. This PR now targets `main` directly.

Refs #3

## Scope and measured debt

The formatter migration changes hand-written Go files mechanically: import grouping, declaration spacing, and composite literal layout. Generated files are excluded using the strict standard Go generated-file marker.

The first full scan measured additional existing high-signal debt that remains deliberately outside this PR so each gate stays reviewable:

- errcheck: 33 findings
- govet shadow: 50 findings
- misspell: 7 findings
- staticcheck: 24 findings
- unused: 6 findings

No broad directory exclusion, new-only mode, or issue-count baseline hides those findings. They will be enabled only in follow-up repair slices that first clear the corresponding debt.

## Behavioral changes

Four lint findings required small behavior-preserving repairs:

- reuse the first normalized DSH source path instead of assigning and reparsing it
- replace three immediately overwritten zero-value assignments with explicit declarations

Changed test files contain formatter-only import, whitespace, or composite-literal layout changes; no test inputs, assertions, mocks, fixtures, or execution paths changed.

## Validation

Validated on exact Head `27b448d702bf064851e62da7b0c842146a8e60ce` with Linux Go 1.27:

- `go test ./...`
- `make lint` (`0 issues`)
- `make check`
- `make check-generated`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/master.yml`
- `git diff --check HEAD^`

The pinned linter binary reports:

- `github.com/golangci/golangci-lint/v2` v2.13.1
- `mvdan.cc/gofumpt` v0.11.0
- `golang.org/x/tools` v0.49.0

## Compatibility

No public API, wire contract, persistence format, generated contract, or lifecycle behavior changes. The repository gains a reproducible local/CI lint and formatting policy.

## AI usage

OpenAI Codex researched the current official tool releases, measured the repository lint baseline, implemented the pinned tool and CI entrypoints, applied the formatter migration, ran the validation commands, reviewed test-only changes for behavioral drift, and prepared this PR description.
## Self-review follow-up

A strict review found that a surviving version stamp could mask a deleted repository-local linter binary. The Make dependency graph now makes the stamp depend on the executable itself, so a missing binary is rebuilt automatically.

Regression proof:

1. install the pinned tool and retain its version stamp;
2. remove only `.tools/bin/golangci-lint`;
3. run `make lint-tools`;
4. verify that v2.13.1 is reinstalled and executable;
5. rerun the full Go suite, lint, repository checks, generated-contract checks, actionlint, and diff integrity.