### PR TITLE
docs: add security reporting policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,8 +12,9 @@ development line.
 | Earlier commits, snapshots, and downstream forks | No |
 
 This policy will be updated when the project publishes its first supported
-release. Until then, users should reproduce a suspected vulnerability against
-the latest `main` commit before reporting it when that is safe and practical.
+release. Reports should identify the commit that was tested. When it is safe
+and practical, also state whether the issue reproduces on the latest `main`,
+but do not delay a report or perform unsafe verification solely to do so.
 
 ## Reporting a Vulnerability
 
@@ -36,10 +37,10 @@ Use synthetic or redacted examples. Never include real credentials, API
 tokens, private Source or Memory content, customer data, database contents, or
 unredacted sensitive local paths in a report or proof of concept.
 
-If the issue is in a third-party dependency, report it to that project's
-maintainers as well. Submit a private report here when the dependency issue is
-exploitable through PowerContext Go or requires a repository-specific
-mitigation.
+If the issue is in a third-party dependency, follow that project's security
+policy and use its confidential reporting channel as well. Submit a private
+report here when the dependency issue is exploitable through PowerContext Go
+or requires a repository-specific mitigation.
 
 ## What to Expect
 
@@ -60,8 +61,10 @@ not currently operate a vulnerability-reward or bug-bounty program.
 
 ## Coordinated Disclosure
 
-Keep the report and all related technical details confidential until
-maintainers confirm that affected users have a reasonable repair or mitigation
-path and agree on a disclosure date. Maintainers will use GitHub Security
+Keep the report and all related technical details confidential while
+maintainers validate the issue and prepare a reasonable repair or mitigation
+path. The reporter and maintainers should coordinate a disclosure date; if
+they cannot agree on timing, they should communicate before disclosure so
+affected users can be protected. Maintainers will use GitHub Security
 Advisories for private collaboration and publication when an advisory is
 appropriate.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,67 @@
+# Security Policy
+
+## Supported Versions
+
+PowerContext Go is currently a pre-release project and has not published any
+tagged releases. Security fixes are provided only for the current `main`
+development line.
+
+| Development line | Supported |
+| --- | --- |
+| Current `main` | Yes |
+| Earlier commits, snapshots, and downstream forks | No |
+
+This policy will be updated when the project publishes its first supported
+release. Until then, users should reproduce a suspected vulnerability against
+the latest `main` commit before reporting it when that is safe and practical.
+
+## Reporting a Vulnerability
+
+Report suspected vulnerabilities through the repository's
+[private vulnerability reporting form](https://github.com/ob-labs/powercontext-go/security/advisories/new).
+Do not disclose vulnerability details in a public issue, discussion, pull
+request, commit, or other public channel.
+
+Include enough information for maintainers to reproduce and assess the report:
+
+- the affected commit, build, component, and relevant configuration or build
+  tags;
+- the required access, trust boundary, and other attack prerequisites;
+- the security impact and the behavior an attacker can observe or control;
+- minimal reproduction steps or a sanitized proof of concept;
+- known mitigations or a suggested repair, when available; and
+- any requested disclosure constraints and how you would like to be credited.
+
+Use synthetic or redacted examples. Never include real credentials, API
+tokens, private Source or Memory content, customer data, database contents, or
+unredacted sensitive local paths in a report or proof of concept.
+
+If the issue is in a third-party dependency, report it to that project's
+maintainers as well. Submit a private report here when the dependency issue is
+exploitable through PowerContext Go or requires a repository-specific
+mitigation.
+
+## What to Expect
+
+- GitHub records the private report immediately. Maintainers aim to acknowledge
+  it within five business days.
+- Maintainers will validate the affected surface, attempt to reproduce the
+  issue, assess severity, and request missing information when necessary.
+- While an accepted report remains under active investigation, maintainers aim
+  to provide a status update at least every ten business days.
+- For an accepted vulnerability, maintainers will coordinate the repair,
+  advisory, release or mitigation guidance, and reporter credit before public
+  disclosure.
+- If a report is declined, maintainers will explain whether it is out of scope,
+  not reproducible, already known, or not considered a security boundary.
+
+Response targets are not a guaranteed resolution deadline. The project does
+not currently operate a vulnerability-reward or bug-bounty program.
+
+## Coordinated Disclosure
+
+Keep the report and all related technical details confidential until
+maintainers confirm that affected users have a reasonable repair or mitigation
+path and agree on a disclosure date. Maintainers will use GitHub Security
+Advisories for private collaboration and publication when an advisory is
+appropriate.


### PR DESCRIPTION
## Summary

- add a root-level `SECURITY.md` for the current pre-release development line
- direct vulnerability reports to GitHub's private security-advisory form
- document sanitized report contents, response targets, accepted/declined handling, and coordinated disclosure
- enable GitHub private vulnerability reporting for the repository

Closes #20.
Part of #3 (`WP0-B`).

## Scope

This is a standalone governance and documentation change. It does not modify runtime behavior, dependencies, generated files, transport security, CodeQL, or general CI configuration.

## Validation

- `git diff --check origin/main...HEAD`
- exact source diff contains only `SECURITY.md`
- `GET /repos/ob-labs/powercontext-go/private-vulnerability-reporting` returns `{"enabled":true}`
- repository tags and releases are empty, matching the documented pre-release support boundary
- GitHub's current security-policy, private-reporting, and coordinated-disclosure guidance was checked against the policy
- self-review on exact Head `ae7d59136ada58b95b58acc07b2434f05fafad8d` fixed three ambiguities: reports must not be delayed for unsafe verification, upstream dependency reports must use a confidential channel, and disclosure timing must be coordinated rather than controlled unilaterally
- GitHub Actions on the current Head are the authoritative executable verification; see the Checks tab for their conclusions

Go tests were not duplicated locally because this change affects only a human-facing Markdown policy and a GitHub repository setting. The repository license configuration explicitly excludes Markdown. The repository's normal CI still runs on the exact PR Head.

## AI usage

OpenAI Codex was used to inspect the repository state, draft and self-review the policy, execute the repository changes, and verify the final scope. The initial Head also received a separate read-only review before the follow-up safety clarifications.