### PR TITLE
chore: enforce staticcheck gate

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -27,6 +27,7 @@ linters:
     - govet
     - ineffassign
     - staticcheck
+    - unused
     - wastedassign
     - whitespace
   settings:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,12 +26,21 @@ linters:
     - errcheck
     - govet
     - ineffassign
+    - staticcheck
     - wastedassign
     - whitespace
   settings:
     govet:
       enable:
         - shadow
+    staticcheck:
+      checks:
+        - all
+        # Domain and CLI errors deliberately preserve their user-facing names.
+        - -ST1005
+        # Type spelling and quick-fix suggestions are style-only churn.
+        - -ST1023
+        - -QF*
   exclusions:
     generated: strict
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,6 +121,9 @@ source / artifact / trigger / inference
 - Merge with an existing rule when the lesson is already covered. Keep the
   stronger wording and remove duplication so this file remains a practical
   engineering contract rather than an append-only incident log.
+- When a Go package has build-tagged implementation variants, keep its package
+  documentation in an untagged `doc.go`. Verify the package `Doc` field with
+  `go list -e` under every supported `GOOS` and CGO selection.
 - When a CI end-to-end test starts a compiled Go service under a readiness
   deadline, build the binary once before the deadline and pass its absolute
   path to every test worker. Verify the workflow with empty `GOMODCACHE` and

--- a/inference/tracing_test.go
+++ b/inference/tracing_test.go
@@ -45,7 +45,7 @@ func TestInferenceSpanRecordsNoModelContent(t *testing.T) {
 		t.Fatalf("spans = %#v", spans)
 	}
 	for _, value := range spans[0].Attributes() {
-		encoded := strings.ToLower(string(value.Key) + value.Value.Emit())
+		encoded := strings.ToLower(string(value.Key) + value.Value.String())
 		for _, forbidden := range []string{"secret", "prompt", "content", "vector", "credential"} {
 			if strings.Contains(encoded, forbidden) {
 				t.Fatalf("span attribute exposes %q: %s", forbidden, encoded)
@@ -112,7 +112,7 @@ func TestPromptedGeneratorRetrySpansExcludeInputOutputAndFeedback(t *testing.T) 
 			t.Fatalf("span name = %q", span.Name())
 		}
 		for _, value := range span.Attributes() {
-			encoded := strings.ToLower(string(value.Key) + value.Value.Emit())
+			encoded := strings.ToLower(string(value.Key) + value.Value.String())
 			for _, forbidden := range []string{
 				"secret", "traveler", "aisle", "redacted", "candidate", "feedback", "schema", "prompt", "content",
 			} {
@@ -173,7 +173,7 @@ func TestEmbeddingSpanNestsUnderActiveOperationWithoutRecordingTextOrVectors(t *
 		t.Fatalf("embedding parent = %s, want %s", embeddingSpan.Parent().SpanID(), operationSpan.SpanContext().SpanID())
 	}
 	for _, value := range embeddingSpan.Attributes() {
-		encoded := strings.ToLower(string(value.Key) + value.Value.Emit())
+		encoded := strings.ToLower(string(value.Key) + value.Value.String())
 		for _, forbidden := range []string{"secret", "bounded", "evidence", "vector", "embedding.value", "content"} {
 			if strings.Contains(encoded, forbidden) {
 				t.Fatalf("embedding span attribute exposes %q: %s", forbidden, encoded)

--- a/internal/cli/process.go
+++ b/internal/cli/process.go
@@ -82,10 +82,6 @@ func runJSONCommand(
 	return result, nil
 }
 
-func runProcessCommand(parent context.Context, executable string, arguments ...string) ([]byte, error) {
-	return runProcessCommandWithEnvironment(parent, nil, executable, arguments...)
-}
-
 func runProcessCommandWithEnvironment(
 	parent context.Context,
 	environment map[string]string,

--- a/internal/handoffreport/models.go
+++ b/internal/handoffreport/models.go
@@ -382,13 +382,6 @@ func optionalKey(value *string) string {
 	return *value
 }
 
-func timeTextPtr(value *time.Time) any {
-	if value == nil {
-		return nil
-	}
-	return TimestampText(*value)
-}
-
 func artifactRefMap(value *artifact.Ref) any {
 	if value == nil {
 		return nil

--- a/internal/runtime/scope_cache.go
+++ b/internal/runtime/scope_cache.go
@@ -87,22 +87,6 @@ func (c *scopeCache) lease(key string) (*scopeLease, func()) {
 	return lease, func() { once.Do(func() { c.release(entry) }) }
 }
 
-func (c *scopeCache) acquire(ctx context.Context, key string) (func(), error) {
-	lease, releaseLease := c.lease(key)
-	releaseToken, err := lease.acquire(ctx)
-	if err != nil {
-		releaseLease()
-		return nil, err
-	}
-	var once sync.Once
-	return func() {
-		once.Do(func() {
-			releaseToken()
-			releaseLease()
-		})
-	}, nil
-}
-
 func (l *scopeLease) contended() bool {
 	return l != nil && l.entry != nil && len(l.entry.semaphore.token) == 0
 }

--- a/internal/sqlstore/memory_entries.go
+++ b/internal/sqlstore/memory_entries.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"database/sql"
 	"errors"
-	"fmt"
 
 	"github.com/ob-labs/powercontext-go/artifact"
 	"github.com/ob-labs/powercontext-go/artifact/memory"
@@ -201,23 +200,4 @@ func nullableText(value *string) any {
 		return nil
 	}
 	return *value
-}
-
-func validateMemoryEntryAnchor(ref artifact.Ref, item memory.ManifestEntry, version memory.EntryVersion) error {
-	if version.MemoryArtifactID != ref.ID() || version.EntryID != item.EntryID() ||
-		version.EntryVersionID != item.EntryVersionID() || version.EntryContentHash != item.EntryContentHash() {
-		return &memory.InvalidCitationError{Code: "cross-identity"}
-	}
-	hash, err := memory.EntryContentHash(version.Kind, version.Text, version.Sources, version.Artifacts)
-	if err != nil {
-		return err
-	}
-	if hash != item.EntryContentHash() {
-		return &memory.InvalidCitationError{Code: "hash-mismatch"}
-	}
-	return nil
-}
-
-func memoryEntryIdentity(entry memory.EntryVersion) string {
-	return fmt.Sprintf("%s/%s@%s", entry.MemoryArtifactID, entry.EntryID, entry.EntryVersionID)
 }

--- a/internal/sqlstore/seekdb/doc.go
+++ b/internal/sqlstore/seekdb/doc.go
@@ -1,0 +1,16 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package seekdb loads and owns the embedded seekDB runtime used by the SQL store.
+package seekdb

--- a/internal/sqlstore/seekdb/seekdb.go
+++ b/internal/sqlstore/seekdb/seekdb.go
@@ -14,6 +14,7 @@
 
 //go:build cgo && (darwin || linux)
 
+// Package seekdb loads and owns the embedded seekDB runtime used by the SQL store.
 package seekdb
 
 /*

--- a/internal/sqlstore/seekdb/seekdb.go
+++ b/internal/sqlstore/seekdb/seekdb.go
@@ -14,7 +14,6 @@
 
 //go:build cgo && (darwin || linux)
 
-// Package seekdb loads and owns the embedded seekDB runtime used by the SQL store.
 package seekdb
 
 /*

--- a/server/runtime_tracing_test.go
+++ b/server/runtime_tracing_test.go
@@ -53,7 +53,7 @@ func TestRuntimeStageSpansInheritApplicationContextWithoutRawScope(t *testing.T)
 		}
 		serialized := strings.Builder{}
 		for _, attribute := range stage.Attributes() {
-			serialized.WriteString(attribute.Value.Emit())
+			serialized.WriteString(attribute.Value.String())
 		}
 		if strings.Contains(serialized.String(), "private-scope") {
 			t.Fatalf("%s leaked raw Scope: %s", name, serialized.String())

--- a/source/catalog_test.go
+++ b/source/catalog_test.go
@@ -44,7 +44,7 @@ type adapter struct{ resolveReferenced bool }
 
 func (adapter) Name() string { return "capture" }
 func (a adapter) Resolve(_ context.Context, value input) (capturedSource, error) {
-	return capturedSource{name: value.name}, nil
+	return capturedSource(value), nil
 }
 
 func (adapter) Read(_ context.Context, value capturedSource) (string, error) {

--- a/source/catalog_test.go
+++ b/source/catalog_test.go
@@ -40,7 +40,7 @@ func (referencedSource) SourceMaterialization() source.Materialization {
 }
 func (referencedSource) SourceDescription() (string, bool) { return "", false }
 
-type adapter struct{ resolveReferenced bool }
+type adapter struct{}
 
 func (adapter) Name() string { return "capture" }
 func (a adapter) Resolve(_ context.Context, value input) (capturedSource, error) {

--- a/tools/release/workflow_test.go
+++ b/tools/release/workflow_test.go
@@ -117,16 +117,16 @@ func TestContinuousIntegrationPreservesPythonTopologyAndGoAssurance(t *testing.T
 func TestCIThirdPartyExecutablesUseImmutableReferences(t *testing.T) {
 	repository := filepath.Clean(filepath.Join("..", ".."))
 	actionUse := regexp.MustCompile(
-		"(?m)^[\\t ]*(?:-[\\t ]*)?uses:[\\t ]+([^@\\s]+)@([^\\s#]+)([^\\r\\n]*)$",
+		`(?m)^[\t ]*(?:-[\t ]*)?uses:[\t ]+([^@\s]+)@([^\s#]+)([^\r\n]*)$`,
 	)
 	containerUse := regexp.MustCompile(
-		"(?m)^[\\t ]*(?:container|image|[A-Z][A-Z0-9_]*_IMAGE):[\\t ]+([^\\s#]+)",
+		`(?m)^[\t ]*(?:container|image|[A-Z][A-Z0-9_]*_IMAGE):[\t ]+([^\s#]+)`,
 	)
 	dockerActionUse := regexp.MustCompile(
-		"(?m)^[\\t ]*(?:-[\\t ]*)?uses:[\\t ]+docker://([^\\s#]+)",
+		`(?m)^[\t ]*(?:-[\t ]*)?uses:[\t ]+docker://([^\s#]+)`,
 	)
 	commit := regexp.MustCompile("^[0-9a-f]{40}$")
-	containerDigest := regexp.MustCompile("^[^@\\s]+@sha256:[0-9a-f]{64}$")
+	containerDigest := regexp.MustCompile(`^[^@\s]+@sha256:[0-9a-f]{64}$`)
 	staticContainerReferences := 0
 
 	err := filepath.WalkDir(filepath.Join(repository, ".github"), func(path string, entry fs.DirEntry, walkErr error) error {


### PR DESCRIPTION
## Summary

- enable the pinned `staticcheck` linter as the next WP0-B quality gate
- replace deprecated OpenTelemetry attribute rendering in tracing tests
- keep seekDB package documentation available across every build-tag variant and codify the cross-platform verification rule
- apply behavior-preserving simplifications reported by the enabled checks
- keep user-visible/domain error strings stable by explicitly disabling ST1005, plus the style-only ST1023 and QF quick-fix families

## Rationale

This is the next low-noise static-analysis slice from #3. The initial measured baseline was 85 findings: 66 would have changed user-facing error text or were style-only suggestions. The submitted policy keeps the high-signal checks active without creating compatibility churn.

The package documentation now lives in an untagged `doc.go`, so it remains visible when build tags select either the embedded seekDB implementation or its stub.

This PR is stacked on #22 (`codex/wp0-govet-shadow`).

## Behavior, API, and compatibility

- no public API or protocol changes
- no production error-string changes
- no dependency or generated-contract changes
- tracing test serialization now uses the supported OpenTelemetry `Value.String` API
- seekDB package documentation is identical across Windows, Linux, and macOS build selections with CGO enabled or disabled

## Validation

Local evidence on Go 1.27:

- targeted Head Staticcheck policy: `0 issues`
- the same policy against exact Base reports the 7 findings repaired by this PR
- `go test -count=1 ./inference ./source`
- `go test -count=1 ./tools/release -run '^TestCIThirdPartyExecutablesUseImmutableReferences$'`
- `make license-check` (`955` files checked, `0` invalid)
- `go list -e` package-document matrix for Windows, Linux, and macOS with CGO enabled and disabled
- `git diff --check`

Exact-Head GitHub Actions completed with 22/22 successful check runs, including lint, quality, tests, license, E2E acceptance, standard/full Linux and macOS builds, host adapters, OceanBase live compatibility, and contract/race/fuzz/module-integrity assurance.

Exact head validated: `faf006cf54b435aa14e4ce4e7ff8f4b85385a3c2`.

## AI usage

Implemented with Codex assistance. The exact submitted diff was self-reviewed and the commands above were run against it.