### PR TITLE
chore: enforce unused code gate

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -27,6 +27,7 @@ linters:
     - govet
     - ineffassign
     - staticcheck
+    - unused
     - wastedassign
     - whitespace
   settings:

--- a/internal/cli/process.go
+++ b/internal/cli/process.go
@@ -82,10 +82,6 @@ func runJSONCommand(
 	return result, nil
 }
 
-func runProcessCommand(parent context.Context, executable string, arguments ...string) ([]byte, error) {
-	return runProcessCommandWithEnvironment(parent, nil, executable, arguments...)
-}
-
 func runProcessCommandWithEnvironment(
 	parent context.Context,
 	environment map[string]string,

--- a/internal/handoffreport/models.go
+++ b/internal/handoffreport/models.go
@@ -382,13 +382,6 @@ func optionalKey(value *string) string {
 	return *value
 }
 
-func timeTextPtr(value *time.Time) any {
-	if value == nil {
-		return nil
-	}
-	return TimestampText(*value)
-}
-
 func artifactRefMap(value *artifact.Ref) any {
 	if value == nil {
 		return nil

--- a/internal/runtime/scope_cache.go
+++ b/internal/runtime/scope_cache.go
@@ -87,22 +87,6 @@ func (c *scopeCache) lease(key string) (*scopeLease, func()) {
 	return lease, func() { once.Do(func() { c.release(entry) }) }
 }
 
-func (c *scopeCache) acquire(ctx context.Context, key string) (func(), error) {
-	lease, releaseLease := c.lease(key)
-	releaseToken, err := lease.acquire(ctx)
-	if err != nil {
-		releaseLease()
-		return nil, err
-	}
-	var once sync.Once
-	return func() {
-		once.Do(func() {
-			releaseToken()
-			releaseLease()
-		})
-	}, nil
-}
-
 func (l *scopeLease) contended() bool {
 	return l != nil && l.entry != nil && len(l.entry.semaphore.token) == 0
 }

--- a/internal/sqlstore/memory_entries.go
+++ b/internal/sqlstore/memory_entries.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"database/sql"
 	"errors"
-	"fmt"
 
 	"github.com/ob-labs/powercontext-go/artifact"
 	"github.com/ob-labs/powercontext-go/artifact/memory"
@@ -201,23 +200,4 @@ func nullableText(value *string) any {
 		return nil
 	}
 	return *value
-}
-
-func validateMemoryEntryAnchor(ref artifact.Ref, item memory.ManifestEntry, version memory.EntryVersion) error {
-	if version.MemoryArtifactID != ref.ID() || version.EntryID != item.EntryID() ||
-		version.EntryVersionID != item.EntryVersionID() || version.EntryContentHash != item.EntryContentHash() {
-		return &memory.InvalidCitationError{Code: "cross-identity"}
-	}
-	hash, err := memory.EntryContentHash(version.Kind, version.Text, version.Sources, version.Artifacts)
-	if err != nil {
-		return err
-	}
-	if hash != item.EntryContentHash() {
-		return &memory.InvalidCitationError{Code: "hash-mismatch"}
-	}
-	return nil
-}
-
-func memoryEntryIdentity(entry memory.EntryVersion) string {
-	return fmt.Sprintf("%s/%s@%s", entry.MemoryArtifactID, entry.EntryID, entry.EntryVersionID)
 }

--- a/source/catalog_test.go
+++ b/source/catalog_test.go
@@ -40,7 +40,7 @@ func (referencedSource) SourceMaterialization() source.Materialization {
 }
 func (referencedSource) SourceDescription() (string, bool) { return "", false }
 
-type adapter struct{ resolveReferenced bool }
+type adapter struct{}
 
 func (adapter) Name() string { return "capture" }
 func (a adapter) Resolve(_ context.Context, value input) (capturedSource, error) {


### PR DESCRIPTION
## Summary

- enable the pinned `unused` linter as a dedicated WP0-B gate
- remove five unreferenced private helpers after checking the complete repository for callers and build-tag variants
- remove one unused test-only field without changing test behavior

## Rationale

This is the next reviewable lint slice from #3. The measured baseline contained six findings, all private and unreachable; deleting them is smaller and safer than adding exclusions.

This PR is stacked on #23 (`codex/wp0-staticcheck`).

## Behavior, API, and compatibility

- no exported API or protocol changes
- no dependency or generated-contract changes
- no intended runtime behavior changes; only unreachable private code was removed

## Validation

Run on Linux with Go 1.27 and golangci-lint v2.13.1:

- `go test ./...`
- `make test-race`
- `make lint` (`0 issues`)
- `make check`
- `make check-generated`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12`
- `git diff --cached --check`

Exact head validated: `183b40f0bec12476036fdda62361ff5a596ceaa3`.

## AI usage

Implemented with Codex assistance. The exact submitted diff was self-reviewed and the commands above were run against it.