### PR TITLE
chore: enforce misspell gate

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,6 +26,7 @@ linters:
     - errcheck
     - govet
     - ineffassign
+    - misspell
     - staticcheck
     - unused
     - wastedassign


### PR DESCRIPTION
## Summary

- enable the pinned `misspell` linter as the final currently missing high-signal spelling gate
- keep the change configuration-only because the measured repository baseline is already clean

## Rationale

This is the next single-gate WP0-B slice from #3. The baseline produced zero findings, so no unrelated wording changes or exclusions are included.

This PR is stacked on #24 (`codex/wp0-unused`).

## Behavior, API, and compatibility

- no code, public API, protocol, dependency, or generated-contract changes
- future spelling regressions in linted source are now rejected by the common lint command

## Validation

Run on Linux with Go 1.27 and golangci-lint v2.13.1:

- `go test ./...`
- `make test-race`
- `make lint` (`0 issues`)
- `make check`
- `make check-generated`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12`
- `git diff --cached --check`

Exact head validated: `549f715c974d1f10f6b233f926205fd6fe33dcf5`.

## AI usage

Implemented with Codex assistance. The exact submitted diff was self-reviewed and the commands above were run against it.