### PR TITLE
docs: add contribution and review contracts

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,73 @@
+name: Bug report
+description: Report reproducible incorrect behavior or a regression
+title: "bug: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Provide observable evidence and remove credentials, private Source or Memory content, and unrelated logs.
+
+  - type: textarea
+    id: current_behavior
+    attributes:
+      label: Current behavior
+      description: What happened, including the public command, API, adapter, or workflow surface involved?
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected_behavior
+    attributes:
+      label: Expected behavior
+      description: What observable result should have occurred instead?
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Minimal reproduction
+      description: Provide the smallest deterministic sequence that reproduces the problem.
+      placeholder: |
+        1. Configure ...
+        2. Run ...
+        3. Observe ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Redacted evidence
+      description: Include bounded logs, errors, response status, or failing assertions. State when a path was skipped.
+      render: text
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Include PowerContext Go commit/version, Go version, OS/architecture, database, and relevant adapter.
+      placeholder: |
+        PowerContext Go: commit or version
+        Go: go version
+        OS/architecture:
+        Database/profile:
+        Adapter or client:
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: confirmations
+    attributes:
+      label: Confirmations
+      options:
+        - label: I searched existing issues and pull requests for the same problem.
+          required: true
+        - label: I removed credentials, private content, and unbounded logs from this report.
+          required: true
+        - label: I identified any skipped or unavailable verification instead of reporting it as passing.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+blank_issues_enabled: false
+contact_links: []

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,6 @@
-name: Feature or compatibility proposal
-description: Propose a bounded capability, compatibility change, or quality gate
-title: "proposal: "
+name: Feature request
+description: Request a bounded capability or quality improvement
+title: "feature: "
 labels:
   - enhancement
 body:
@@ -29,26 +29,10 @@ body:
       required: true
 
   - type: textarea
-    id: non_goals
-    attributes:
-      label: Non-goals
-      description: State adjacent behavior that must remain unchanged or be handled separately.
-    validations:
-      required: true
-
-  - type: textarea
     id: evidence
     attributes:
       label: Acceptance evidence
       description: Which tests, commands, generated checks, or runtime observations will prove completion?
-    validations:
-      required: true
-
-  - type: textarea
-    id: alternatives
-    attributes:
-      label: Alternatives considered
-      description: Describe simpler alternatives and why they do not meet the required outcome.
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,65 @@
+name: Feature or compatibility proposal
+description: Propose a bounded capability, compatibility change, or quality gate
+title: "proposal: "
+labels:
+  - enhancement
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What user, compatibility, maintenance, or assurance problem needs to be solved?
+    validations:
+      required: true
+
+  - type: textarea
+    id: outcome
+    attributes:
+      label: Observable outcome
+      description: Describe the externally verifiable final behavior or gate.
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Proposed scope
+      description: List the smallest files, surfaces, or jobs that need to change.
+    validations:
+      required: true
+
+  - type: textarea
+    id: non_goals
+    attributes:
+      label: Non-goals
+      description: State adjacent behavior that must remain unchanged or be handled separately.
+    validations:
+      required: true
+
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Acceptance evidence
+      description: Which tests, commands, generated checks, or runtime observations will prove completion?
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Describe simpler alternatives and why they do not meet the required outcome.
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: confirmations
+    attributes:
+      label: Confirmations
+      options:
+        - label: I checked that this work is not already assigned or implemented by an open pull request.
+          required: true
+        - label: I will keep repair, tooling, governance, generator, and feature behavior changes independently reviewable.
+          required: true
+        - label: I will not satisfy the proposal by weakening tests, broadening exclusions, or converting execution into skips.
+          required: true

--- a/.github/ISSUE_TEMPLATE/proposal.yml
+++ b/.github/ISSUE_TEMPLATE/proposal.yml
@@ -1,0 +1,93 @@
+name: Contract or platform proposal
+description: Propose a change to a compatibility-sensitive contract or ownership boundary
+title: "proposal: "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form for public API, persistence, wire behavior, lifecycle or concurrency ownership, and supported platform changes. Use the feature request form for bounded capabilities that do not change those contracts.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What compatibility, ownership, or platform problem needs a design decision?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: contract_surface
+    attributes:
+      label: Contract surface
+      description: Which compatibility-sensitive boundary is affected most directly?
+      options:
+        - Public Go API
+        - HTTP, MCP, or other wire behavior
+        - Persistence or migration format
+        - Lifecycle or concurrency ownership
+        - Supported Go toolchain or platform
+        - Other compatibility-sensitive boundary
+    validations:
+      required: true
+
+  - type: textarea
+    id: outcome
+    attributes:
+      label: Observable outcome
+      description: Describe the externally verifiable result of the proposed change.
+    validations:
+      required: true
+
+  - type: textarea
+    id: compatibility
+    attributes:
+      label: Compatibility and migration impact
+      description: Identify preserved behavior, breaking changes, migration requirements, and affected consumers.
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Proposed scope
+      description: List the smallest packages, contracts, files, or jobs that need to change.
+    validations:
+      required: true
+
+  - type: textarea
+    id: non_goals
+    attributes:
+      label: Non-goals
+      description: State adjacent behavior that must remain unchanged or be handled separately.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Describe simpler alternatives and why they do not meet the required outcome.
+    validations:
+      required: true
+
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Acceptance evidence
+      description: Which public-entrypoint tests, compatibility checks, migrations, or runtime observations will prove completion?
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: confirmations
+    attributes:
+      label: Confirmations
+      options:
+        - label: I checked that this proposal is not already assigned or implemented by an open pull request.
+          required: true
+        - label: I will keep repair, tooling, governance, generator, and feature behavior changes independently reviewable.
+          required: true
+        - label: I will not satisfy the proposal by weakening tests, broadening exclusions, or converting execution into skips.
+          required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,44 @@
+## Tracking
+
+- Tracking issue:
+- Relationship: `Part of #...` or `Closes #...`
+
+## Problem and rationale
+
+Describe the verified problem and why this is the smallest safe solution.
+
+## Changes
+
+-
+
+## Behavior and compatibility
+
+- User-visible behavior:
+- Public API or protocol impact:
+- Breaking changes or migration requirements:
+- Explicit non-goals:
+
+## Generated, dependency, and workflow impact
+
+- [ ] No generated contract changed, or every required output was regenerated from its source.
+- [ ] No dependency changed, or `go.mod` and `go.sum` are complete and verified.
+- [ ] No CI or release contract changed, or stable job names, permissions, timeouts, and failure evidence were reviewed.
+- [ ] No credential, private Source/Memory content, or unredacted production log is included.
+
+## Validation
+
+List the exact commands run against the submitted Head and their results.
+
+```text
+
+```
+
+- [ ] `git diff --check`
+- [ ] `git status --short` was inspected after validation.
+- [ ] Relevant generated, race, compatibility, process, adapter, documentation, or release checks were run.
+- [ ] Any skipped or unavailable check is identified above and is not represented as passing.
+
+## AI usage
+
+State whether AI assistance was used, what it changed, and how the submitted result was independently reviewed and
+verified.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,3 +130,7 @@ source / artifact / trigger / inference
   raw database bytes that contain the producing SQLite version and physical
   page-layout metadata. Keep committed fixture hashes pinned separately, and
   verify both semantic regeneration and cross-runtime read/write compatibility.
+- When blank Issues are disabled, inventory every supported request class and
+  provide a distinct validated form or contact route for each. Verify that the
+  chooser routes bounded features separately from compatibility-sensitive
+  contract or platform proposals.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,8 +19,11 @@ reviewable concern.
 
 1. Search open issues and pull requests for the same scope.
 2. Check whether someone is already assigned or has publicly claimed the work.
-3. Link substantial changes to a tracking issue before implementation.
-4. Keep repairs, tooling, generators, governance, and feature behavior in separate pull requests.
+3. Open a contract or platform proposal before implementing changes to public APIs, persistence formats, wire behavior,
+   lifecycle or concurrency ownership, or supported Go toolchains and platforms.
+4. Link substantial changes to a tracking issue before implementation. Narrow bug fixes and maintenance work do not
+   need a separate proposal when an existing issue already captures the scope.
+5. Keep repairs, tooling, generators, governance, and feature behavior in separate pull requests.
 
 Do not include credentials, access tokens, private source content, or unredacted production logs in an issue, commit,
 test fixture, or pull request. Report security vulnerabilities through the repository security policy rather than a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,95 @@
+# Contributing to PowerContext Go
+
+PowerContext Go accepts focused fixes, compatibility work, documentation, and quality improvements that preserve the
+repository's observable contracts. Start from the current repository state and keep each pull request limited to one
+reviewable concern.
+
+## Support and compatibility policy
+
+- Go 1.27.0 is the minimum supported toolchain. The `go` directive in `go.mod` is authoritative.
+- Compatibility jobs use `GOTOOLCHAIN=local`; an automatic toolchain download must not hide a minimum-version failure.
+- Raising the Go version requires a tracking issue and coordinated updates to `go.mod`, CI, Docker and release builders,
+  the README, and this document.
+- `main` is the current default integration branch. Derive a pull request's base from the live repository policy instead
+  of assuming a historical development branch.
+- The frozen Python v0.0.2 Oracle under `test/conformance/testdata/python-v0.0.2` is immutable. A newer compatibility
+  target must use a separate versioned baseline.
+
+## Before starting work
+
+1. Search open issues and pull requests for the same scope.
+2. Check whether someone is already assigned or has publicly claimed the work.
+3. Link substantial changes to a tracking issue before implementation.
+4. Keep repairs, tooling, generators, governance, and feature behavior in separate pull requests.
+
+Do not include credentials, access tokens, private source content, or unredacted production logs in an issue, commit,
+test fixture, or pull request. Report security vulnerabilities through the repository security policy rather than a
+public issue.
+
+## Development environment
+
+Use the repository Make targets so local and CI execution share the same pinned tools and commands:
+
+```sh
+make build-all
+make lint
+make check
+make contract-test
+make unit-test
+make e2e-test
+```
+
+`make lint` installs the pinned golangci-lint release under `.tools/bin`. Its embedded gofmt, gofumpt, and goimports
+versions are the formatting authority; no mutable global linter installation is required.
+
+Run `make coverage` when a change affects executable Go behavior. It uses race-enabled atomic coverage and rejects a
+material regression from the recorded baseline.
+
+## Code and generated contracts
+
+- Match the existing package boundaries, names, and error model. Avoid unrelated refactors or speculative extension
+  points.
+- Keep public packages deliberate. New public APIs require an observable consumer need and compatibility tests.
+- `openapi/powercontext.yaml` is the HTTP source of truth. Do not hand-edit generated files under `api/v1`, the generated
+  Client invoker, MCP schemas, or retained adapter operation tables.
+- After changing a generator input, run `make check-generated` and commit every required generated output.
+- Preserve repository-local tool pinning and do not replace exact versions or Action SHAs with `latest`, a branch, or a
+  mutable tag.
+
+## Tests and validation
+
+Choose checks that prove the changed contract, then run the repository gates that cover the affected surface:
+
+- Go implementation or test changes: `go test ./...`, `make test-race`, `make lint`, and `make check`.
+- OpenAPI or generator changes: `make contract-test` and `make check-generated`.
+- Host adapter changes: the adapter's install, build, generated-diff, unit, surface, and real call-through tests.
+- Documentation changes: `make docs-test`.
+- License-header changes: `make license-check`.
+- Release or native-asset changes: the relevant standard and Full build, package, and smoke targets.
+
+Before committing, inspect the actual output of:
+
+```sh
+git diff --check
+git status --short
+```
+
+If a required check cannot run because of credentials, native assets, or an external service, state exactly what was
+not executed and why. A skipped suite or an all-skipped compatibility path is not a passing result.
+
+## Commits and pull requests
+
+Use a concise Conventional Commit-style subject such as `fix: handle cleanup errors` or
+`ci: add readonly build gate`.
+
+Every implementation pull request must:
+
+- link its tracking issue and say whether it closes the issue or is only part of it;
+- explain the problem, rationale, observable behavior, API or compatibility impact, and explicit non-goals;
+- list the exact validation commands that were run against the submitted Head;
+- identify generated, dependency, workflow, security, or user-facing changes;
+- disclose material AI assistance and describe the human verification performed;
+- avoid weakening assertions, broad exclusions, hidden skips, or unrelated cleanup to make a gate pass.
+
+After every pushed change, recheck the exact pull request Head, current comments, and current CI conclusions before
+claiming the work is ready.

--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ example, privacy-safe `log/slog` setup under `internal/observability/logging`.
 See [`docs/architecture/README.md`](docs/architecture/README.md) for the full
 directory map and dependency rules.
 
+See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the supported Go policy, change boundaries, validation requirements, and
+pull request contract.
+
 ## Build and verify
 
 The standard build uses CGO and statically embeds the same sqlite-vec 0.1.9


### PR DESCRIPTION
## Summary

- add a project-specific CONTRIBUTING guide with the Go 1.27 support policy, frozen-Oracle boundary, validation matrix, and pull request requirements
- add distinct structured Bug, Feature, and Contract/Platform Proposal Issue forms, then disable blank contributor Issues
- add a pull request template that requires issue relationship, behavior and compatibility impact, exact validation, generated/dependency/workflow review, and AI disclosure
- link the contribution contract from the README
- record the learned invariant that every supported request class needs a validated route before blank Issues are disabled

## Rationale

WP0-B in #3 requires contribution and structured Issue/PR contracts so the new quality gates remain usable. The original Head combined ordinary feature requests with compatibility-sensitive proposals even though #3 requires separate bug, feature, and proposal routes. The final forms keep bounded features lightweight while routing public API, persistence, wire behavior, lifecycle/concurrency ownership, and supported toolchain/platform changes through a focused proposal stage.

The project-specific security reporting policy remains in #21 and is intentionally not duplicated here.

This PR is stacked on #27 (`codex/wp0-coverage`) and has been synchronized with its current Head.

## Behavior, API, and compatibility

- documentation and GitHub contribution UX only
- no public API, runtime, dependency, generated-contract, workflow, or repository-setting changes in the net PR diff
- blank contributor Issues are disabled only after Bug, Feature, and Contract/Platform Proposal routes are present
- narrow bug fixes and maintenance work do not require a separate proposal when an existing issue already captures the scope

## Validation

Local validation against exact Head `987e2a8ee3874b8e07ea8e411d9a7c463b43a8de`:

- the pre-fix Issue-route inventory probe failed with missing `proposal.yml`; the same probe passes on the final Head with exactly three supported routes
- parsed every Issue form as YAML and checked route identity, unique IDs, supported control types, required top-level structure, chooser configuration, and the proposal compatibility-boundary dropdown
- checked the added dropdown and validation shape against GitHub's current official Issue Form schema
- `make docs-test` (`No issues found`)
- `make license-check` (`965` checked, `0` invalid)
- `git diff --check origin/codex/wp0-coverage...HEAD`
- confirmed the latest-Base net diff contains exactly 8 files and no runtime, dependency, generated-contract, workflow, or repository-setting changes

Remote validation on the same exact Head:

- 26/26 checks succeeded, 0 failed, 0 pending, and 0 skipped
- includes CodeQL, lint, quality, tests, race/fuzz/module integrity with a real Docker build, coverage, Go compatibility, docs/license, SQLite/OceanBase Acceptance, Frozen Oracle/differential, host adapters, evaluation, live OceanBase, and all standard/full platform builds

## AI usage

Implemented with Codex assistance. The submitted text and templates were reviewed against Issue #3, the current repository contracts, GitHub's official Issue Form and pull request template documentation, and Go's official 1.27/toolchain documentation. The final exact Head was locally validated and then confirmed by the complete remote matrix above.