### PR TITLE
ci: enforce governance contract

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -6,7 +6,7 @@ counterpart or enforces a Go release constraint that does not exist in Python.
 
 | Python workflow | Go workflow | Deliberate adaptation |
 | --- | --- | --- |
-| `master.yml` | `master.yml` | Pinned lint and formatting, an independent Go 1.27 readonly package build, race-enabled atomic coverage, Go module verification, vet, generated transport contracts, Go tests, and the same Pi package replace Python lock, prek, and interpreter tests. |
+| `master.yml` | `master.yml` | Pinned lint and formatting, an independent Go 1.27 readonly package build, race-enabled atomic coverage, machine-checked contribution contracts, Go module verification, vet, generated transport contracts, Go tests, and the same Pi package replace Python lock, prek, and interpreter tests. |
 | `e2e-harness.yml` | `e2e-harness.yml` | The same validate/SQLite/OceanBase/evidence lifecycle drives the Go process and live OceanBase acceptance tests. |
 | `license-check.yml` | `license-check.yml` | Both call SkyWalking Eyes 0.8.0 directly. `make license-check` and `make license-fix` remain local entry points. |
 | `deploy-docs.yml` | `deploy-docs.yml` | Both build locked Zensical documentation and deploy GitHub Pages. |

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -85,6 +85,23 @@ jobs:
           if-no-files-found: warn
           retention-days: 14
 
+  governance-contract:
+    name: governance-contract
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    env:
+      GOTOOLCHAIN: local
+      GOFLAGS: -mod=readonly
+    steps:
+      - name: Check out
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Set up the environment
+        uses: ./.github/actions/setup-go-env
+
+      - name: Check contribution and review contracts
+        run: make governance-check
+
   quality:
     runs-on: ubuntu-latest
     steps:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,3 +130,7 @@ source / artifact / trigger / inference
   raw database bytes that contain the producing SQLite version and physical
   page-layout metadata. Keep committed fixture hashes pinned separately, and
   verify both semantic regeneration and cross-runtime read/write compatibility.
+- When a repository gate mirrors an external structured schema, validate every
+  supported variant's required attributes and keep a valid fixture plus a
+  failing mutant for each variant boundary. Recheck the assumptions against
+  the current official schema before changing the validator.

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ COMMIT ?= $(shell git rev-parse HEAD 2>/dev/null || printf unknown)
 BUILD_DATE ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
 LDFLAGS := -s -w -X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.date=$(BUILD_DATE)
 
-.PHONY: lint-tools lint lint-fix generate check-generated module-check contract-test license-check license-fix fmt fmt-check vet build-all coverage coverage-check \
+.PHONY: lint-tools lint lint-fix generate check-generated module-check contract-test license-check license-fix fmt fmt-check vet build-all coverage coverage-check governance-check \
 	test unit-test e2e-test test-sqlite test-race test-full test-oceanbase-live real-provider-test \
 	pi-test docs-sync docs-test docs-build harness-sync harness-check harness-compose-check \
 	harness-compose-acceptance harness-compose-down build build-full smoke smoke-full check \
@@ -115,6 +115,9 @@ coverage-check:
 			printf 'coverage %s%% is below minimum %s%%\n' "$$actual" "$(COVERAGE_MINIMUM)" >&2; \
 			exit 1; \
 		fi
+
+governance-check:
+	$(GO) run ./tools/governance-check
 
 test-full:
 	@test -d "$(TOKENIZERS_LIB_DIR)" || { echo 'TOKENIZERS_LIB_DIR must contain libtokenizers.a' >&2; exit 2; }

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	golang.org/x/mod v0.40.0
 	golang.org/x/text v0.41.0
 	google.golang.org/genai v1.65.0
+	gopkg.in/yaml.v2 v2.4.0
 )
 
 require (
@@ -121,7 +122,6 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	google.golang.org/grpc v1.82.1 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect
 )
 

--- a/tools/governance-check/main.go
+++ b/tools/governance-check/main.go
@@ -26,7 +26,10 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-var goDirective = regexp.MustCompile(`(?m)^go[ \t]+1\.27\.0\r?$`)
+var (
+	goDirective  = regexp.MustCompile(`(?m)^go[ \t]+1\.27\.0\r?$`)
+	issueFieldID = regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
+)
 
 type issueForm struct {
 	Name        string         `yaml:"name"`
@@ -38,14 +41,39 @@ type issueControl struct {
 	Type       string `yaml:"type"`
 	ID         string `yaml:"id"`
 	Attributes struct {
-		Options []struct {
-			Label    string `yaml:"label"`
-			Required bool   `yaml:"required"`
-		} `yaml:"options"`
+		Label   string        `yaml:"label"`
+		Value   string        `yaml:"value"`
+		Options []issueOption `yaml:"options"`
 	} `yaml:"attributes"`
 	Validations struct {
 		Required bool `yaml:"required"`
 	} `yaml:"validations"`
+}
+
+type issueOption struct {
+	Value      string
+	Label      string
+	Required   bool
+	isCheckbox bool
+}
+
+func (option *issueOption) UnmarshalYAML(unmarshal func(any) error) error {
+	var value string
+	if err := unmarshal(&value); err == nil {
+		option.Value = value
+		return nil
+	}
+	var checkbox struct {
+		Label    string `yaml:"label"`
+		Required bool   `yaml:"required"`
+	}
+	if err := unmarshal(&checkbox); err != nil {
+		return err
+	}
+	option.Label = checkbox.Label
+	option.Required = checkbox.Required
+	option.isCheckbox = true
+	return nil
 }
 
 type issueConfig struct {
@@ -129,6 +157,9 @@ func checkIssueForm(root, name string, requiredIDs []string) error {
 	seen := make(map[string]struct{})
 	for _, control := range form.Body {
 		if control.Type == "markdown" {
+			if strings.TrimSpace(control.Attributes.Value) == "" {
+				return fmt.Errorf("%s markdown element must define a value", name)
+			}
 			continue
 		}
 		if control.Type != "textarea" && control.Type != "input" && control.Type != "dropdown" && control.Type != "checkboxes" {
@@ -136,6 +167,12 @@ func checkIssueForm(root, name string, requiredIDs []string) error {
 		}
 		if control.ID == "" {
 			return fmt.Errorf("%s contains a field without an ID", name)
+		}
+		if !issueFieldID.MatchString(control.ID) {
+			return fmt.Errorf("%s contains invalid field ID %q", name, control.ID)
+		}
+		if strings.TrimSpace(control.Attributes.Label) == "" {
+			return fmt.Errorf("%s field %q must define a label", name, control.ID)
 		}
 		if _, exists := seen[control.ID]; exists {
 			return fmt.Errorf("%s contains duplicate field ID %q", name, control.ID)
@@ -146,9 +183,24 @@ func checkIssueForm(root, name string, requiredIDs []string) error {
 				return fmt.Errorf("%s checkboxes field %q must define options", name, control.ID)
 			}
 			for _, option := range control.Attributes.Options {
-				if strings.TrimSpace(option.Label) == "" || !option.Required {
+				if !option.isCheckbox || strings.TrimSpace(option.Label) == "" || !option.Required {
 					return fmt.Errorf("%s checkboxes field %q must require every labeled option", name, control.ID)
 				}
+			}
+		} else if control.Type == "dropdown" {
+			if len(control.Attributes.Options) == 0 {
+				return fmt.Errorf("%s dropdown field %q must define options", name, control.ID)
+			}
+			seenOptions := make(map[string]struct{}, len(control.Attributes.Options))
+			for _, option := range control.Attributes.Options {
+				value := strings.TrimSpace(option.Value)
+				if option.isCheckbox || value == "" {
+					return fmt.Errorf("%s dropdown field %q must define non-empty text options", name, control.ID)
+				}
+				if _, exists := seenOptions[value]; exists {
+					return fmt.Errorf("%s dropdown field %q contains duplicate option %q", name, control.ID, value)
+				}
+				seenOptions[value] = struct{}{}
 			}
 		} else if !control.Validations.Required {
 			return fmt.Errorf("%s field %q must be required", name, control.ID)

--- a/tools/governance-check/main.go
+++ b/tools/governance-check/main.go
@@ -1,0 +1,191 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"gopkg.in/yaml.v2"
+)
+
+var goDirective = regexp.MustCompile(`(?m)^go[ \t]+1\.27\.0\r?$`)
+
+type issueForm struct {
+	Name        string         `yaml:"name"`
+	Description string         `yaml:"description"`
+	Body        []issueControl `yaml:"body"`
+}
+
+type issueControl struct {
+	Type       string `yaml:"type"`
+	ID         string `yaml:"id"`
+	Attributes struct {
+		Options []struct {
+			Label    string `yaml:"label"`
+			Required bool   `yaml:"required"`
+		} `yaml:"options"`
+	} `yaml:"attributes"`
+	Validations struct {
+		Required bool `yaml:"required"`
+	} `yaml:"validations"`
+}
+
+type issueConfig struct {
+	BlankIssuesEnabled *bool `yaml:"blank_issues_enabled"`
+	ContactLinks       []any `yaml:"contact_links"`
+}
+
+func main() {
+	root := flag.String("root", ".", "repository root")
+	flag.Parse()
+	if flag.NArg() != 0 {
+		fmt.Fprintln(os.Stderr, "governance-check: positional arguments are not supported")
+		os.Exit(2)
+	}
+	if err := checkRepository(*root); err != nil {
+		fmt.Fprintln(os.Stderr, "governance-check:", err)
+		os.Exit(1)
+	}
+}
+
+func checkRepository(root string) error {
+	module, err := readRepositoryFile(root, "go.mod")
+	if err != nil {
+		return err
+	}
+	if !goDirective.Match(module) {
+		return errors.New("go.mod must declare the supported Go 1.27.0 toolchain")
+	}
+	if err := requirePhrases(root, "CONTRIBUTING.md", []string{
+		"GOTOOLCHAIN=local", "make lint", "make check-generated", "tracking issue", "AI assistance",
+	}); err != nil {
+		return err
+	}
+	if err := requirePhrases(root, ".github/pull_request_template.md", []string{
+		"## Tracking", "Part of #", "Closes #", "## Behavior and compatibility", "## Validation", "git diff --check", "## AI usage",
+	}); err != nil {
+		return err
+	}
+	if err := checkIssueForm(root, ".github/ISSUE_TEMPLATE/bug_report.yml", []string{
+		"current_behavior", "expected_behavior", "reproduction", "evidence", "environment", "confirmations",
+	}); err != nil {
+		return err
+	}
+	if err := checkIssueForm(root, ".github/ISSUE_TEMPLATE/feature_request.yml", []string{
+		"problem", "outcome", "scope", "non_goals", "evidence", "alternatives", "confirmations",
+	}); err != nil {
+		return err
+	}
+	return checkIssueConfig(root)
+}
+
+func requirePhrases(root, name string, phrases []string) error {
+	contents, err := readRepositoryFile(root, name)
+	if err != nil {
+		return err
+	}
+	for _, phrase := range phrases {
+		if !strings.Contains(string(contents), phrase) {
+			return fmt.Errorf("%s must contain %q", name, phrase)
+		}
+	}
+	return nil
+}
+
+func checkIssueForm(root, name string, requiredIDs []string) error {
+	contents, err := readRepositoryFile(root, name)
+	if err != nil {
+		return err
+	}
+	var document any
+	if err := yaml.UnmarshalStrict(contents, &document); err != nil {
+		return fmt.Errorf("%s is not valid Issue form YAML: %w", name, err)
+	}
+	var form issueForm
+	if err := yaml.Unmarshal(contents, &form); err != nil {
+		return fmt.Errorf("%s is not valid Issue form YAML: %w", name, err)
+	}
+	if strings.TrimSpace(form.Name) == "" || strings.TrimSpace(form.Description) == "" || len(form.Body) == 0 {
+		return fmt.Errorf("%s must define a name, description, and body", name)
+	}
+	seen := make(map[string]struct{})
+	for _, control := range form.Body {
+		if control.Type == "markdown" {
+			continue
+		}
+		if control.Type != "textarea" && control.Type != "input" && control.Type != "dropdown" && control.Type != "checkboxes" {
+			return fmt.Errorf("%s contains unsupported field type %q", name, control.Type)
+		}
+		if control.ID == "" {
+			return fmt.Errorf("%s contains a field without an ID", name)
+		}
+		if _, exists := seen[control.ID]; exists {
+			return fmt.Errorf("%s contains duplicate field ID %q", name, control.ID)
+		}
+		seen[control.ID] = struct{}{}
+		if control.Type == "checkboxes" {
+			if len(control.Attributes.Options) == 0 {
+				return fmt.Errorf("%s checkboxes field %q must define options", name, control.ID)
+			}
+			for _, option := range control.Attributes.Options {
+				if strings.TrimSpace(option.Label) == "" || !option.Required {
+					return fmt.Errorf("%s checkboxes field %q must require every labeled option", name, control.ID)
+				}
+			}
+		} else if !control.Validations.Required {
+			return fmt.Errorf("%s field %q must be required", name, control.ID)
+		}
+	}
+	for _, id := range requiredIDs {
+		if _, exists := seen[id]; !exists {
+			return fmt.Errorf("%s is missing required field ID %q", name, id)
+		}
+	}
+	return nil
+}
+
+func checkIssueConfig(root string) error {
+	const name = ".github/ISSUE_TEMPLATE/config.yml"
+	contents, err := readRepositoryFile(root, name)
+	if err != nil {
+		return err
+	}
+	var config issueConfig
+	if err := yaml.UnmarshalStrict(contents, &config); err != nil {
+		return fmt.Errorf("%s is invalid: %w", name, err)
+	}
+	if config.BlankIssuesEnabled == nil || *config.BlankIssuesEnabled {
+		return fmt.Errorf("%s must disable blank issues", name)
+	}
+	if config.ContactLinks == nil {
+		return fmt.Errorf("%s must declare contact_links, even when empty", name)
+	}
+	return nil
+}
+
+func readRepositoryFile(root, name string) ([]byte, error) {
+	path := filepath.Join(root, filepath.FromSlash(name))
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", name, err)
+	}
+	return contents, nil
+}

--- a/tools/governance-check/main_test.go
+++ b/tools/governance-check/main_test.go
@@ -1,0 +1,116 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCheckRepositoryEnforcesGovernanceContract(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		mutate    func(t *testing.T, root string)
+		wantError string
+	}{
+		{name: "valid contract"},
+		{
+			name: "missing pull request tracking relationship",
+			mutate: func(t *testing.T, root string) {
+				writeFixtureFile(t, root, ".github/pull_request_template.md", validPullRequestTemplate(false))
+			},
+			wantError: "Part of #",
+		},
+		{
+			name: "duplicate issue form field",
+			mutate: func(t *testing.T, root string) {
+				contents := validIssueForm("Bug report", []string{
+					"current_behavior", "current_behavior", "expected_behavior", "reproduction", "evidence", "environment", "confirmations",
+				})
+				writeFixtureFile(t, root, ".github/ISSUE_TEMPLATE/bug_report.yml", contents)
+			},
+			wantError: "duplicate field ID",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			root := writeGovernanceFixture(t)
+			if test.mutate != nil {
+				test.mutate(t, root)
+			}
+			err := checkRepository(root)
+			if test.wantError == "" {
+				if err != nil {
+					t.Fatalf("checkRepository() error = %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), test.wantError) {
+				t.Fatalf("checkRepository() error = %v, want substring %q", err, test.wantError)
+			}
+		})
+	}
+}
+
+func writeGovernanceFixture(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	writeFixtureFile(t, root, "go.mod", "module example.invalid/project\r\n\r\ngo 1.27.0\r\n")
+	writeFixtureFile(t, root, "CONTRIBUTING.md", strings.Join([]string{
+		"GOTOOLCHAIN=local", "make lint", "make check-generated", "tracking issue", "AI assistance",
+	}, "\n"))
+	writeFixtureFile(t, root, ".github/pull_request_template.md", validPullRequestTemplate(true))
+	writeFixtureFile(t, root, ".github/ISSUE_TEMPLATE/bug_report.yml", validIssueForm("Bug report", []string{
+		"current_behavior", "expected_behavior", "reproduction", "evidence", "environment", "confirmations",
+	}))
+	writeFixtureFile(t, root, ".github/ISSUE_TEMPLATE/feature_request.yml", validIssueForm("Feature proposal", []string{
+		"problem", "outcome", "scope", "non_goals", "evidence", "alternatives", "confirmations",
+	}))
+	writeFixtureFile(t, root, ".github/ISSUE_TEMPLATE/config.yml", "blank_issues_enabled: false\ncontact_links: []\n")
+	return root
+}
+
+func validPullRequestTemplate(includeRelationship bool) string {
+	parts := []string{"## Tracking", "Closes #", "## Behavior and compatibility", "## Validation", "git diff --check", "## AI usage"}
+	if includeRelationship {
+		parts = append(parts, "Part of #")
+	}
+	return strings.Join(parts, "\n")
+}
+
+func validIssueForm(name string, ids []string) string {
+	var builder strings.Builder
+	builder.WriteString("name: " + name + "\ndescription: Evidence-bearing form\nbody:\n")
+	for _, id := range ids {
+		builder.WriteString("  - type: textarea\n    id: " + id + "\n    validations:\n      required: true\n")
+	}
+	return builder.String()
+}
+
+func writeFixtureFile(t *testing.T, root, name, contents string) {
+	t.Helper()
+	path := filepath.Join(root, filepath.FromSlash(name))
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/tools/governance-check/main_test.go
+++ b/tools/governance-check/main_test.go
@@ -46,6 +46,67 @@ func TestCheckRepositoryEnforcesGovernanceContract(t *testing.T) {
 			},
 			wantError: "duplicate field ID",
 		},
+		{
+			name: "valid dropdown",
+			mutate: func(t *testing.T, root string) {
+				appendFixtureFile(t, root, ".github/ISSUE_TEMPLATE/feature_request.yml", `
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      options:
+        - Low
+        - High
+    validations:
+      required: true
+`)
+			},
+		},
+		{
+			name: "missing field label",
+			mutate: func(t *testing.T, root string) {
+				replaceFixtureText(t, root, ".github/ISSUE_TEMPLATE/bug_report.yml", "      label: current_behavior\n", "")
+			},
+			wantError: "must define a label",
+		},
+		{
+			name: "missing markdown value",
+			mutate: func(t *testing.T, root string) {
+				replaceFixtureText(t, root, ".github/ISSUE_TEMPLATE/bug_report.yml", "      value: Provide bounded evidence.\n", "")
+			},
+			wantError: "markdown element must define a value",
+		},
+		{
+			name: "invalid field ID",
+			mutate: func(t *testing.T, root string) {
+				appendFixtureFile(t, root, ".github/ISSUE_TEMPLATE/feature_request.yml", `
+  - type: textarea
+    id: invalid id
+    attributes:
+      label: Invalid ID
+    validations:
+      required: true
+`)
+			},
+			wantError: "contains invalid field ID",
+		},
+		{
+			name: "duplicate dropdown option",
+			mutate: func(t *testing.T, root string) {
+				appendFixtureFile(t, root, ".github/ISSUE_TEMPLATE/feature_request.yml", `
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      options:
+        - Low
+        - Low
+    validations:
+      required: true
+`)
+			},
+			wantError: "contains duplicate option",
+		},
 	}
 
 	for _, test := range tests {
@@ -97,11 +158,43 @@ func validPullRequestTemplate(includeRelationship bool) string {
 
 func validIssueForm(name string, ids []string) string {
 	var builder strings.Builder
-	builder.WriteString("name: " + name + "\ndescription: Evidence-bearing form\nbody:\n")
+	builder.WriteString("name: " + name + "\ndescription: Evidence-bearing form\nbody:\n  - type: markdown\n    attributes:\n      value: Provide bounded evidence.\n")
 	for _, id := range ids {
-		builder.WriteString("  - type: textarea\n    id: " + id + "\n    validations:\n      required: true\n")
+		if id == "confirmations" {
+			builder.WriteString("  - type: checkboxes\n    id: confirmations\n    attributes:\n      label: Confirmations\n      options:\n        - label: I verified the report.\n          required: true\n")
+			continue
+		}
+		builder.WriteString("  - type: textarea\n    id: " + id + "\n    attributes:\n      label: " + id + "\n    validations:\n      required: true\n")
 	}
 	return builder.String()
+}
+
+func appendFixtureFile(t *testing.T, root, name, contents string) {
+	t.Helper()
+	path := filepath.Join(root, filepath.FromSlash(name))
+	existing, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, append(existing, contents...), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func replaceFixtureText(t *testing.T, root, name, old, replacement string) {
+	t.Helper()
+	path := filepath.Join(root, filepath.FromSlash(name))
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	updated := strings.Replace(string(contents), old, replacement, 1)
+	if updated == string(contents) {
+		t.Fatalf("%s does not contain %q", name, old)
+	}
+	if err := os.WriteFile(path, []byte(updated), 0o600); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func writeFixtureFile(t *testing.T, root, name, contents string) {


### PR DESCRIPTION
## Tracking

- Tracking issue: #3
- Relationship: `Part of #3` (WP0-B)

## Summary

- add a repository governance checker for the Go 1.27 support declaration, CONTRIBUTING requirements, pull request contract, Issue form structure, required fields, and blank-issue policy
- validate the current `bug_report.yml`, bounded `feature_request.yml`, and compatibility-sensitive `proposal.yml` routes against the current GitHub Issue Form schema
- accept valid dropdown syntax and reject missing labels, missing markdown values, invalid IDs, duplicate dropdown options, optional required fields, and required fields using the wrong control type
- add a stable `governance-contract` CI job using the local Go toolchain and readonly module resolution
- promote the already-pinned YAML parser from an indirect to a direct tool dependency
- sync the latest `codex/wp0-contributing` base while preserving its Issue routes, CodeQL workflow, native build dependencies, and learned engineering rules

## Problem and rationale

WP0-B in #3 requires contribution contracts to be machine checked rather than trusted as static text. The original checker shared an incomplete Issue Form model with its tests: it accepted forms GitHub could not render and rejected valid dropdown options. The stacked base later split bounded features from contract/platform proposals, so the checker now validates both routes and their required control types.

## Behavior, API, and compatibility

- no runtime, public API, protocol, persistence, or generated-contract changes
- the new job fails on unsupported Go policy drift, missing contribution/PR requirements, malformed or duplicate Issue form fields, weakened required controls, optional evidence fields, or re-enabled blank issues
- explicit non-goal: repository settings and branch protection remain unchanged

## Generated, dependency, and workflow impact

- no generated contract changed
- `gopkg.in/yaml.v2` remains at the existing pinned version and is promoted from indirect to direct because the new tool imports it
- `master.yml` gains the stable `governance-contract` job; the latest base's CodeQL and native SQLite dependency behavior is preserved
- no credential, private Source/Memory content, or unredacted production log is included

## Validation

Local Windows checks on exact Head `764ac0426cd568c789f8d7bd7cf669c2efe4b371`:

- `go test ./tools/governance-check -count=1 -v` — 12 governance scenarios passed
- `go test -race ./tools/governance-check -count=1` — passed
- `go run ./tools/governance-check` — passed against the real repository
- `go mod verify` — all modules verified
- pinned golangci-lint on `./tools/governance-check` — `0 issues`
- pinned formatter diff for both governance-check Go files — clean
- focused workflow contract tests unaffected by line endings — passed
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12` — passed
- `git diff --check` and unmerged-index check — clean

The full Windows `go test ./...`, `make lint`, and `make check` remain unavailable as passing claims because the unchanged Base reproduces CGO/sqlite-header, symlink privilege, Unix mode, Windows URI, frozen LF hash, and CRLF `go.sum` comparison failures. Those failures were reproduced on unmodified Heads and were not changed in this PR.

Remote exact-Head evidence:

- all 27 GitHub checks succeeded, including CodeQL, governance-contract, lint, quality, coverage, unit/E2E acceptance, race/fuzz/module integrity, Frozen Python Oracle, OceanBase live compatibility, host adapters, real Docker build, and all Standard/Full linux/darwin architecture jobs

## AI usage

Implemented with Codex assistance. The Issue Form assumptions were checked against the current official GitHub Docs source. Regression tests were run red/green against the real checker, the dropdown duplicate test received an additional discriminative mutant check, the latest stacked base was merged with semantic conflict inspection, and the final exact Head was verified locally and by the complete remote matrix.
