### PR TITLE
ci: require workflow timeouts and permissions

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -20,6 +20,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Check out
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7

--- a/.github/workflows/e2e-harness.yml
+++ b/.github/workflows/e2e-harness.yml
@@ -21,6 +21,7 @@ concurrency:
 jobs:
   validate:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Check out
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 concurrency:
   group: license-check-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -104,6 +104,7 @@ jobs:
 
   quality:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Check out
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -119,6 +120,7 @@ jobs:
 
   tests:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     defaults:
       run:
         shell: bash
@@ -137,6 +139,7 @@ jobs:
 
   pi-package:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Check out
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -149,6 +152,7 @@ jobs:
 
   check-docs:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Check out
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
   prepare:
     name: Freeze release identity
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     outputs:
       build_date: ${{ steps.release.outputs.build_date }}
       commit: ${{ steps.release.outputs.commit }}
@@ -265,6 +266,7 @@ jobs:
     name: Attach checksummed release assets
     needs: [prepare, binaries, images]
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
     permissions:
       contents: write
     steps:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,3 +130,8 @@ source / artifact / trigger / inference
   raw database bytes that contain the producing SQLite version and physical
   page-layout metadata. Keep committed fixture hashes pinned separately, and
   verify both semantic regeneration and cross-runtime read/write compatibility.
+- When a governance parser exempts a GitHub Actions reusable-workflow caller
+  from ordinary-job requirements, require a nonblank `uses` reference and
+  reject every keyword outside GitHub's supported caller-job set. Verify the
+  rule with fixtures for a valid caller, a blank reference, `timeout-minutes`,
+  and ordinary-only fields such as `runs-on` or `steps`.

--- a/tools/governance-check/main.go
+++ b/tools/governance-check/main.go
@@ -53,6 +53,17 @@ type issueConfig struct {
 	ContactLinks       []any `yaml:"contact_links"`
 }
 
+type workflowContract struct {
+	Permissions map[string]any         `yaml:"permissions"`
+	Jobs        map[string]workflowJob `yaml:"jobs"`
+}
+
+type workflowJob struct {
+	Uses           string         `yaml:"uses"`
+	TimeoutMinutes *int           `yaml:"timeout-minutes"`
+	Permissions    map[string]any `yaml:"permissions"`
+}
+
 func main() {
 	root := flag.String("root", ".", "repository root")
 	flag.Parse()
@@ -94,7 +105,10 @@ func checkRepository(root string) error {
 	}); err != nil {
 		return err
 	}
-	return checkIssueConfig(root)
+	if err := checkIssueConfig(root); err != nil {
+		return err
+	}
+	return checkWorkflowContracts(root)
 }
 
 func requirePhrases(root, name string, phrases []string) error {
@@ -177,6 +191,50 @@ func checkIssueConfig(root string) error {
 	}
 	if config.ContactLinks == nil {
 		return fmt.Errorf("%s must declare contact_links, even when empty", name)
+	}
+	return nil
+}
+
+func checkWorkflowContracts(root string) error {
+	patterns := []string{
+		filepath.Join(root, ".github", "workflows", "*.yml"),
+		filepath.Join(root, ".github", "workflows", "*.yaml"),
+	}
+	var paths []string
+	for _, pattern := range patterns {
+		matches, err := filepath.Glob(pattern)
+		if err != nil {
+			return fmt.Errorf("enumerate workflows: %w", err)
+		}
+		paths = append(paths, matches...)
+	}
+	if len(paths) == 0 {
+		return errors.New(".github/workflows must contain at least one workflow")
+	}
+	for _, path := range paths {
+		contents, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("read workflow %s: %w", filepath.Base(path), err)
+		}
+		var document any
+		if err := yaml.UnmarshalStrict(contents, &document); err != nil {
+			return fmt.Errorf("workflow %s is invalid YAML: %w", filepath.Base(path), err)
+		}
+		var workflow workflowContract
+		if err := yaml.Unmarshal(contents, &workflow); err != nil {
+			return fmt.Errorf("workflow %s cannot be inspected: %w", filepath.Base(path), err)
+		}
+		if len(workflow.Jobs) == 0 {
+			return fmt.Errorf("workflow %s must define jobs", filepath.Base(path))
+		}
+		for name, job := range workflow.Jobs {
+			if workflow.Permissions == nil && job.Permissions == nil {
+				return fmt.Errorf("workflow %s job %s must declare least-privilege permissions", filepath.Base(path), name)
+			}
+			if job.Uses == "" && (job.TimeoutMinutes == nil || *job.TimeoutMinutes <= 0) {
+				return fmt.Errorf("workflow %s job %s must declare a positive timeout-minutes", filepath.Base(path), name)
+			}
+		}
 	}
 	return nil
 }

--- a/tools/governance-check/main.go
+++ b/tools/governance-check/main.go
@@ -59,9 +59,10 @@ type workflowContract struct {
 }
 
 type workflowJob struct {
-	Uses           string         `yaml:"uses"`
-	TimeoutMinutes *int           `yaml:"timeout-minutes"`
-	Permissions    map[string]any `yaml:"permissions"`
+	Uses               *string        `yaml:"uses"`
+	TimeoutMinutes     *int           `yaml:"timeout-minutes"`
+	Permissions        map[string]any `yaml:"permissions"`
+	AdditionalKeywords map[string]any `yaml:",inline"`
 }
 
 func main() {
@@ -231,9 +232,32 @@ func checkWorkflowContracts(root string) error {
 			if workflow.Permissions == nil && job.Permissions == nil {
 				return fmt.Errorf("workflow %s job %s must declare least-privilege permissions", filepath.Base(path), name)
 			}
-			if job.Uses == "" && (job.TimeoutMinutes == nil || *job.TimeoutMinutes <= 0) {
+			if job.Uses != nil {
+				if err := job.checkReusableWorkflowCaller(); err != nil {
+					return fmt.Errorf("workflow %s job %s %w", filepath.Base(path), name, err)
+				}
+				continue
+			}
+			if job.TimeoutMinutes == nil || *job.TimeoutMinutes <= 0 {
 				return fmt.Errorf("workflow %s job %s must declare a positive timeout-minutes", filepath.Base(path), name)
 			}
+		}
+	}
+	return nil
+}
+
+func (job workflowJob) checkReusableWorkflowCaller() error {
+	if strings.TrimSpace(*job.Uses) == "" {
+		return errors.New("must name a reusable workflow")
+	}
+	if job.TimeoutMinutes != nil {
+		return errors.New("may only use reusable-workflow caller keywords; found \"timeout-minutes\"")
+	}
+	for keyword := range job.AdditionalKeywords {
+		switch keyword {
+		case "name", "with", "secrets", "strategy", "needs", "if", "concurrency":
+		default:
+			return fmt.Errorf("may only use reusable-workflow caller keywords; found %q", keyword)
 		}
 	}
 	return nil

--- a/tools/governance-check/main_test.go
+++ b/tools/governance-check/main_test.go
@@ -60,6 +60,36 @@ func TestCheckRepositoryEnforcesGovernanceContract(t *testing.T) {
 			},
 			wantError: "least-privilege permissions",
 		},
+		{
+			name: "valid reusable workflow caller",
+			mutate: func(t *testing.T, root string) {
+				writeFixtureFile(t, root, ".github/workflows/main.yml", reusableWorkflowCaller())
+			},
+		},
+		{
+			name: "reusable workflow caller with timeout",
+			mutate: func(t *testing.T, root string) {
+				writeFixtureFile(t, root, ".github/workflows/main.yml", reusableWorkflowCaller("    timeout-minutes: 10"))
+			},
+			wantError: "reusable-workflow caller keywords",
+		},
+		{
+			name: "reusable workflow caller with blank reference",
+			mutate: func(t *testing.T, root string) {
+				writeFixtureFile(t, root, ".github/workflows/main.yml", reusableWorkflowCallerWithReference(" "))
+			},
+			wantError: "must name a reusable workflow",
+		},
+		{
+			name: "reusable workflow caller with ordinary job fields",
+			mutate: func(t *testing.T, root string) {
+				writeFixtureFile(t, root, ".github/workflows/main.yml", reusableWorkflowCaller(
+					"    runs-on: ubuntu-24.04",
+					"    steps: []",
+				))
+			},
+			wantError: "reusable-workflow caller keywords",
+		},
 	}
 
 	for _, test := range tests {
@@ -144,6 +174,23 @@ func validWorkflowWithoutPermissions() string {
 		"    timeout-minutes: 10",
 		"    steps: []",
 	}, "\n") + "\n"
+}
+
+func reusableWorkflowCaller(extraLines ...string) string {
+	return reusableWorkflowCallerWithReference("./.github/workflows/reusable.yml", extraLines...)
+}
+
+func reusableWorkflowCallerWithReference(reference string, extraLines ...string) string {
+	lines := []string{
+		"name: CI",
+		"permissions:",
+		"  contents: read",
+		"jobs:",
+		"  delegated:",
+		"    uses: \"" + reference + "\"",
+	}
+	lines = append(lines, extraLines...)
+	return strings.Join(lines, "\n") + "\n"
 }
 
 func writeFixtureFile(t *testing.T, root, name, contents string) {

--- a/tools/governance-check/main_test.go
+++ b/tools/governance-check/main_test.go
@@ -46,6 +46,20 @@ func TestCheckRepositoryEnforcesGovernanceContract(t *testing.T) {
 			},
 			wantError: "duplicate field ID",
 		},
+		{
+			name: "workflow job without timeout",
+			mutate: func(t *testing.T, root string) {
+				writeFixtureFile(t, root, ".github/workflows/main.yml", validWorkflow(false))
+			},
+			wantError: "timeout-minutes",
+		},
+		{
+			name: "workflow job without permissions",
+			mutate: func(t *testing.T, root string) {
+				writeFixtureFile(t, root, ".github/workflows/main.yml", validWorkflowWithoutPermissions())
+			},
+			wantError: "least-privilege permissions",
+		},
 	}
 
 	for _, test := range tests {
@@ -84,6 +98,7 @@ func writeGovernanceFixture(t *testing.T) string {
 		"problem", "outcome", "scope", "non_goals", "evidence", "alternatives", "confirmations",
 	}))
 	writeFixtureFile(t, root, ".github/ISSUE_TEMPLATE/config.yml", "blank_issues_enabled: false\ncontact_links: []\n")
+	writeFixtureFile(t, root, ".github/workflows/main.yml", validWorkflow(true))
 	return root
 }
 
@@ -102,6 +117,33 @@ func validIssueForm(name string, ids []string) string {
 		builder.WriteString("  - type: textarea\n    id: " + id + "\n    validations:\n      required: true\n")
 	}
 	return builder.String()
+}
+
+func validWorkflow(includeTimeout bool) string {
+	lines := []string{
+		"name: CI",
+		"permissions:",
+		"  contents: read",
+		"jobs:",
+		"  test:",
+		"    runs-on: ubuntu-24.04",
+	}
+	if includeTimeout {
+		lines = append(lines, "    timeout-minutes: 10")
+	}
+	lines = append(lines, "    steps: []")
+	return strings.Join(lines, "\n") + "\n"
+}
+
+func validWorkflowWithoutPermissions() string {
+	return strings.Join([]string{
+		"name: CI",
+		"jobs:",
+		"  test:",
+		"    runs-on: ubuntu-24.04",
+		"    timeout-minutes: 10",
+		"    steps: []",
+	}, "\n") + "\n"
 }
 
 func writeFixtureFile(t *testing.T, root, name, contents string) {


### PR DESCRIPTION
## Summary

- add explicit timeouts to every ordinary job that lacked one in the main, E2E harness, documentation deploy, and release workflows
- add the missing workflow-level least-privilege `contents: read` permission to the license check
- extend the governance checker to reject ordinary workflow jobs with no positive timeout or no workflow/job-level permissions
- validate that the reusable-workflow exception has a nonblank `uses` reference and only GitHub-supported caller-job keywords
- add focused regression cases for missing timeout, missing permissions, and malformed reusable-workflow callers

## Rationale

WP0-B in #3 requires explicit job bounds and least-privilege permissions. Reusable-workflow caller jobs are intentionally excluded from the timeout rule because GitHub Actions does not allow `timeout-minutes` on jobs that use a reusable workflow; their called workflows define the executable job bounds.

The caller exception now rejects blank references, `timeout-minutes`, and ordinary-only fields such as `runs-on` or `steps`, so adding a `uses` key cannot bypass the ordinary-job timeout contract.

This PR is stacked on #29 (`codex/wp0-governance-contract`).

## Behavior, API, and compatibility

- no application, public API, dependency, or generated-contract changes
- preserves all job names and commands
- only bounds existing CI execution and makes existing permission and caller-job policy machine checked

## Validation

- regression proof: the malformed-caller cases failed against `1acb4a38248ae74c9dad6bf3625d4618bd27e844` and pass after the fix
- `go test ./tools/governance-check -count=1`
- `go test -race ./tools/governance-check -count=1`
- `go vet ./tools/governance-check`
- `make governance-check`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12`
- LF checkout: `go mod tidy -diff`, `go mod verify`, and golangci format verification passed
- merged current Base `764ac0426cd568c789f8d7bd7cf669c2efe4b371`; the combined Issue Form and workflow governance tests pass
- `git diff --check`
- exact-Head GitHub Actions: 27/27 checks succeeded, including Analyze Go and CodeQL
- Main run 33230722738: the failed-only rerun passed after a transient Tsinghua PyPI mirror 403; the exact Head did not change

Exact head validated: `a6dfab415b236e2b2fb6c1a2615837a338dca493`.

## AI usage

Implemented with Codex assistance. The exact submitted workflow and validator changes were self-reviewed and checked with the commands above.