### PR TITLE
ci: verify Windows contract checkout

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,30 @@
+# Every supported source and contract text format is checked out with LF so
+# frozen hashes and generated-contract diff checks are independent of a
+# contributor's core.autocrlf setting. Binary fixtures are never transformed.
+*.c text eol=lf
+*.css text eol=lf
+*.go text eol=lf
+*.h text eol=lf
+*.html text eol=lf
+*.js text eol=lf
+*.json text eol=lf
+*.md text eol=lf
+*.mjs text eol=lf
+*.py text eol=lf
+*.sh text eol=lf
+*.toml text eol=lf
+*.ts text eol=lf
+*.tsx text eol=lf
+*.yaml text eol=lf
+*.yml text eol=lf
+Dockerfile text eol=lf
+
+*.db binary
+*.db-shm binary
+*.db-wal binary
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.pdf binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,7 @@
 # Every supported source and contract text format is checked out with LF so
 # frozen hashes and generated-contract diff checks are independent of a
 # contributor's core.autocrlf setting. Binary fixtures are never transformed.
+.gitattributes text eol=lf
 *.c text eol=lf
 *.css text eol=lf
 *.go text eol=lf
@@ -8,6 +9,7 @@
 *.html text eol=lf
 *.js text eol=lf
 *.json text eol=lf
+*.jsonl text eol=lf
 *.md text eol=lf
 *.mjs text eol=lf
 *.py text eol=lf
@@ -15,6 +17,7 @@
 *.toml text eol=lf
 *.ts text eol=lf
 *.tsx text eol=lf
+*.txt text eol=lf
 *.yaml text eol=lf
 *.yml text eol=lf
 Dockerfile text eol=lf

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -21,6 +21,7 @@ Two Go-specific workflows extend, rather than replace, that Python topology:
 | --- | --- |
 | `migration-gates.yml` | Reusable PR assurance called by `master.yml`: frozen Python Oracle regeneration, Python↔Go interoperability, HTTP differential, race/fuzz, live OceanBase, host adapters, evaluation, and four-platform standard/Full builds. |
 | `provider-smoke.yml` | Explicitly dispatched, credentialed, bounded real-provider verification; never required on an ordinary pull request. |
+| `windows-contract.yml` | Windows checkout-only contract guard: verifies LF attributes, frozen fixture SHA-256 values, and generated-contract cleanliness without claiming Windows binary support. |
 
 The committed `test/conformance/testdata/python-v0.0.2` baseline remains immutable. Pull requests execute the pinned
 Python Oracle to prove that regenerated portable fixtures, database interoperability, and HTTP behavior still match;

--- a/.github/workflows/windows-contract.yml
+++ b/.github/workflows/windows-contract.yml
@@ -30,17 +30,24 @@ jobs:
         run: |
           $ErrorActionPreference = 'Stop'
           $textPaths = @(
+            '.gitattributes',
             'openapi/powercontext.yaml',
             'api/v1/oas_client_gen.go',
             'client/invoker_gen.go',
             'internal/mcpapi/schemas_gen.go',
             'integrations/dsh/plugins/powercontext/src/operations.generated.ts',
-            'test/conformance/testdata/python-v0.0.2/manifest.json'
+            'test/conformance/testdata/python-v0.0.2/manifest.json',
+            'artifact/memory/prompts/conversation.txt',
+            'evaluation/tests/contract/fixtures/swebench_pro_public_v2.jsonl'
           )
           foreach ($path in $textPaths) {
             $attribute = git check-attr eol -- $path
             if ($attribute -ne "${path}: eol: lf") {
               throw "expected LF checkout attribute for $path; got $attribute"
+            }
+            $bytes = [IO.File]::ReadAllBytes($path)
+            if ([Array]::IndexOf($bytes, [byte]13) -ge 0) {
+              throw "expected LF checkout bytes for $path"
             }
           }
 

--- a/.github/workflows/windows-contract.yml
+++ b/.github/workflows/windows-contract.yml
@@ -1,0 +1,69 @@
+name: Windows contract checkout
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: windows-contract-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  windows-contract:
+    name: windows-contract
+    runs-on: windows-2025
+    timeout-minutes: 10
+    steps:
+      - name: Check out with repository attributes
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+
+      - name: Verify LF attributes and frozen fixture hashes
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $textPaths = @(
+            'openapi/powercontext.yaml',
+            'api/v1/oas_client_gen.go',
+            'client/invoker_gen.go',
+            'internal/mcpapi/schemas_gen.go',
+            'integrations/dsh/plugins/powercontext/src/operations.generated.ts',
+            'test/conformance/testdata/python-v0.0.2/manifest.json'
+          )
+          foreach ($path in $textPaths) {
+            $attribute = git check-attr eol -- $path
+            if ($attribute -ne "${path}: eol: lf") {
+              throw "expected LF checkout attribute for $path; got $attribute"
+            }
+          }
+
+          $manifestPath = 'test/conformance/testdata/python-v0.0.2/manifest.json'
+          $manifest = Get-Content -Raw $manifestPath | ConvertFrom-Json
+          foreach ($property in $manifest.fixture_sha256.PSObject.Properties) {
+            $path = Join-Path (Split-Path $manifestPath) $property.Name
+            $actual = (Get-FileHash -Algorithm SHA256 $path).Hash.ToLowerInvariant()
+            if ($actual -ne $property.Value) {
+              throw "frozen fixture SHA-256 mismatch for $($property.Name): got $actual, want $($property.Value)"
+            }
+          }
+
+          $contractPaths = @(
+            '.gitattributes',
+            'openapi',
+            'api/v1',
+            'client/invoker_gen.go',
+            'internal/mcpapi/schemas_gen.go',
+            'integrations/dsh/plugins/powercontext/openapi/powercontext.yaml',
+            'integrations/dsh/plugins/powercontext/src/operations.generated.ts',
+            'integrations/opencode/plugins/powercontext/src/operations.generated.ts',
+            'integrations/pi/plugins/powercontext/src/operations.generated.ts',
+            'test/conformance/testdata/python-v0.0.2'
+          )
+          & git diff --exit-code -- @contractPaths

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,3 +130,8 @@ source / artifact / trigger / inference
   raw database bytes that contain the producing SQLite version and physical
   page-layout metadata. Keep committed fixture hashes pinned separately, and
   verify both semantic regeneration and cross-runtime read/write compatibility.
+- When defining or changing LF checkout rules, enumerate every tracked
+  byte-sensitive prompt, schema, dataset, fixture, and generated-contract
+  format. Verify representative paths with `git check-attr eol` and raw
+  working-tree bytes in a fresh `core.autocrlf=true` checkout so clean-filter
+  normalization cannot hide CRLF.

--- a/tools/release/workflow_test.go
+++ b/tools/release/workflow_test.go
@@ -37,8 +37,9 @@ func TestContinuousIntegrationPreservesPythonTopologyAndGoAssurance(t *testing.T
 		"release.yml":         true,
 	}
 	goAssurance := map[string]bool{
-		"migration-gates.yml": true,
-		"provider-smoke.yml":  true,
+		"migration-gates.yml":  true,
+		"provider-smoke.yml":   true,
+		"windows-contract.yml": true,
 	}
 	paths, err := filepath.Glob(filepath.Join(workflows, "*.yml"))
 	if err != nil {
@@ -75,6 +76,11 @@ func TestContinuousIntegrationPreservesPythonTopologyAndGoAssurance(t *testing.T
 		"provider-smoke.yml": {
 			"name: Provider smoke", "workflow_dispatch:", "environment: provider-smoke",
 			"TestRealProviderSmoke", "timeout-minutes: 10",
+		},
+		"windows-contract.yml": {
+			"name: Windows contract checkout", "runs-on: windows-2025", "timeout-minutes: 10",
+			"Verify LF attributes and frozen fixture hashes", "Get-FileHash -Algorithm SHA256",
+			"git check-attr eol", "git diff --exit-code",
 		},
 		"e2e-harness.yml": {
 			"name: E2E harness", "validate:", "acceptance:", "database: [sqlite, oceanbase]",

--- a/tools/release/workflow_test.go
+++ b/tools/release/workflow_test.go
@@ -17,6 +17,7 @@ package main
 import (
 	"io/fs"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -117,6 +118,33 @@ func TestContinuousIntegrationPreservesPythonTopologyAndGoAssurance(t *testing.T
 	}
 	if strings.Contains(string(e2eHarness), "continue-on-error:") {
 		t.Error("e2e-harness.yml must not suppress acceptance or evidence failures")
+	}
+}
+
+func TestFrozenTextAssetsDeclareLFCheckout(t *testing.T) {
+	repository := filepath.Clean(filepath.Join("..", ".."))
+	paths := []string{
+		".gitattributes",
+		"openapi/powercontext.yaml",
+		"artifact/memory/prompts/conversation.txt",
+		"artifact/memory/prompts/extraction.schema.json",
+		"evaluation/tests/contract/fixtures/swebench_pro_public_v2.jsonl",
+		"api/v1/oas_client_gen.go",
+	}
+	for _, path := range paths {
+		t.Run(path, func(t *testing.T) {
+			command := exec.CommandContext(t.Context(), "git", "check-attr", "eol", "--", path)
+			command.Dir = repository
+			output, err := command.Output()
+			if err != nil {
+				t.Fatal(err)
+			}
+			got := strings.TrimSpace(string(output))
+			want := path + ": eol: lf"
+			if got != want {
+				t.Fatalf("checkout attribute = %q, want %q", got, want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary  - add `.gitattributes` that enforces LF checkout for supported source, generated-contract, fixture, and documentation text formats while retaining database and media fixtures as binary - add a Windows 2025 checkout-only `windows-contract` job with no binary-support claim - verify LF attributes, all six frozen Python v0.0.2 fixture SHA-256 values, and generated-contract/worktree cleanliness on Windows - register the workflow in the release workflow topology contract and CI documentation  ## Rationale  WP0-B in #3 requires a lightweight Windows checkout boundary that catches CRLF drift without treating Windows as a supported binary-release target. Before this change the repository had no `.gitattributes`; a contributor's `core.autocrlf` could rewrite hashed JSON fixtures or generated contracts.  A native fresh Git clone with `core.autocrlf=true` was created from the exact submitted tree. The fixture hashes matched, `authority-rows.json` reported `eol: lf`, and the contract paths had no diff.  This PR is stacked on #30 (`codex/wp0-workflow-hardening`).  ## Behavior, API, and compatibility  - no application, public API, protocol, dependency, or generated-contract behavior change - database fixtures remain binary and never receive line-ending conversion - the Windows job checks checkout bytes and contract cleanliness only; it does not build or publish a Windows binary  ## Validation  - native fresh Windows-style clone with `core.autocrlf=true`: all frozen fixture SHA-256 values matched and contract diff was clean - `make governance-check` - `go test ./...` - `make lint` (`0 issues`) - `make check` - `make check-generated` - `make license-check` - `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12` - `git diff --cached --check`  Exact head validated: `c69c5f9176bae51bdd5041d380a073e5599a83de`.  ## AI usage  Implemented with Codex assistance. The workflow, Git attributes, and topology test were self-reviewed and verified with the commands above.