### PR TITLE
build: enforce strict Makefile execution

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,7 @@
 # Every supported source and contract text format is checked out with LF so
 # frozen hashes and generated-contract diff checks are independent of a
 # contributor's core.autocrlf setting. Binary fixtures are never transformed.
+.gitattributes text eol=lf
 *.c text eol=lf
 *.css text eol=lf
 *.go text eol=lf
@@ -18,6 +19,7 @@
 *.yaml text eol=lf
 *.yml text eol=lf
 Dockerfile text eol=lf
+Makefile text eol=lf
 
 *.db binary
 *.db-shm binary

--- a/.github/workflows/windows-contract.yml
+++ b/.github/workflows/windows-contract.yml
@@ -30,6 +30,8 @@ jobs:
         run: |
           $ErrorActionPreference = 'Stop'
           $textPaths = @(
+            '.gitattributes',
+            'Makefile',
             'openapi/powercontext.yaml',
             'api/v1/oas_client_gen.go',
             'client/invoker_gen.go',
@@ -56,6 +58,7 @@ jobs:
 
           $contractPaths = @(
             '.gitattributes',
+            'Makefile',
             'openapi',
             'api/v1',
             'client/invoker_gen.go',

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,3 +130,10 @@ source / artifact / trigger / inference
   raw database bytes that contain the producing SQLite version and physical
   page-layout metadata. Keep committed fixture hashes pinned separately, and
   verify both semantic regeneration and cross-runtime read/write compatibility.
+- When Make recipes enable Bash nounset or pipefail globally, expand optional
+  environment variables in preflight guards with explicit defaults and run
+  real failed-pipeline and missing-variable probes on every supported Make
+  runtime; source-text checks alone do not prove the execution contract.
+- When adding a repository-owned extensionless text file, give it an
+  explicit `text eol=lf` attribute and include it in the Windows checkout
+  attribute and clean-diff probes so `core.autocrlf` cannot silently change it.

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,10 @@
+SHELL := bash
+.SHELLFLAGS := -euo pipefail -c
+.DEFAULT_GOAL := help
+.DELETE_ON_ERROR:
+.SUFFIXES:
+MAKEFLAGS += --no-builtin-rules
+
 GO ?= go
 GOCACHE ?=
 GOMODCACHE ?=
@@ -22,11 +29,14 @@ COMMIT ?= $(shell git rev-parse HEAD 2>/dev/null || printf unknown)
 BUILD_DATE ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
 LDFLAGS := -s -w -X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.date=$(BUILD_DATE)
 
-.PHONY: lint-tools lint lint-fix generate check-generated module-check contract-test license-check license-fix fmt fmt-check vet build-all coverage coverage-check governance-check \
+.PHONY: help lint-tools lint lint-fix generate check-generated module-check contract-test license-check license-fix fmt fmt-check vet build-all coverage coverage-check governance-check \
 	test unit-test e2e-test test-sqlite test-race test-full test-oceanbase-live real-provider-test \
 	pi-test docs-sync docs-test docs-build harness-sync harness-check harness-compose-check \
 	harness-compose-acceptance harness-compose-down build build-full smoke smoke-full check \
 	package-standard package-full clean
+
+help: ## Show supported development, verification, and release commands.
+	@awk 'BEGIN { FS = ":.*##"; print "Supported targets:" } /^[[:alnum:]_-]+:.*##/ { printf "  %-28s %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
 
 $(GOLANGCI_LINT): Makefile
 	@mkdir -p "$(TOOLS_BIN)"
@@ -36,76 +46,76 @@ $(GOLANGCI_LINT_STAMP): $(GOLANGCI_LINT)
 	@$(RM) $(TOOLS_BIN)/.golangci-lint-*
 	@touch "$@"
 
-lint-tools: $(GOLANGCI_LINT_STAMP)
+lint-tools: $(GOLANGCI_LINT_STAMP) ## Install the pinned lint tool under .tools/bin.
 
-lint: lint-tools
+lint: lint-tools ## Run the pinned lint policy.
 	"$(GOLANGCI_LINT)" run
 
-lint-fix: lint-tools
+lint-fix: lint-tools ## Format and apply supported automatic lint fixes.
 	"$(GOLANGCI_LINT)" fmt
 	"$(GOLANGCI_LINT)" run --fix
 
-generate:
+generate: ## Regenerate checked-in OpenAPI and MCP outputs.
 	$(GO) generate ./openapi
 	$(GO) run ./tools/mcp-schema-generate
 
-check-generated:
+check-generated: ## Verify generated contracts and traceability outputs are clean.
 	$(GO) generate ./openapi
 	$(GO) run ./tools/mcp-schema-generate
 	$(GO) run ./tools/traceability-generate -check
 	git diff --exit-code -- openapi api/v1 client/invoker_gen.go internal/mcpapi/schemas_gen.go integrations/dsh/plugins/powercontext/src/operations.generated.ts
 
-module-check:
+module-check: ## Verify tidy readonly module metadata and checksums.
 	$(GO) mod tidy -diff
 	$(GO) mod verify
 
-contract-test: check-generated
+contract-test: check-generated ## Test the generated OpenAPI transport contract.
 	CGO_ENABLED=1 $(GO) test -tags '$(STANDARD_TAGS)' \
 		./openapi ./api/v1 ./client ./internal/httpapi ./internal/mcpapi ./server
 
-license-check:
+license-check: ## Verify required Apache-2.0 source headers.
 	$(LICENSE_EYE) -c .licenserc.yaml header check
 
-license-fix:
+license-fix: ## Repair eligible source headers and recheck them.
 	$(LICENSE_EYE) -c .licenserc.yaml header fix
 	$(LICENSE_EYE) -c .licenserc.yaml header check
 
-fmt: lint-tools
+fmt: lint-tools ## Format supported source with the pinned formatter set.
 	"$(GOLANGCI_LINT)" fmt
 
-fmt-check: lint-tools
+fmt-check: lint-tools ## Verify supported source formatting without edits.
 	"$(GOLANGCI_LINT)" fmt --diff
 
-vet:
+vet: ## Run Go vet across all packages.
 	$(GO) vet ./...
 
-build-all:
+build-all: ## Build all Go packages with readonly module resolution.
 	$(GO) build -mod=readonly ./...
 
-test: unit-test e2e-test
+test: unit-test e2e-test ## Run the standard unit and end-to-end suites.
 
-unit-test:
+unit-test: ## Run standard-tag unit tests.
 	CGO_ENABLED=1 $(GO) test -tags '$(STANDARD_TAGS)' \
 		$$(go list ./... | grep -v '/test/e2e$$')
 
-e2e-test:
+e2e-test: ## Run standard-tag process-level end-to-end tests.
 	CGO_ENABLED=1 $(GO) test -count=1 -tags '$(STANDARD_TAGS)' ./test/e2e
 	$(MAKE) smoke VERSION=ci COMMIT=$$(git rev-parse HEAD) BUILD_DATE=1970-01-01T00:00:00Z
 
-test-sqlite:
+test-sqlite: ## Run all standard-tag tests against SQLite.
 	CGO_ENABLED=1 $(GO) test -tags '$(STANDARD_TAGS)' ./...
 
-test-race:
+test-race: ## Run all Go tests with the race detector.
 	CGO_ENABLED=1 $(GO) test -race ./...
 
-coverage:
+coverage: ## Generate race-enabled atomic coverage and enforce its baseline.
 	@mkdir -p "$(COVERAGE_DIR)"
 	CGO_ENABLED=1 $(GO) test -race -covermode=atomic -coverprofile="$(COVERAGE_PROFILE)" ./...
 	$(GO) tool cover -func="$(COVERAGE_PROFILE)" > "$(COVERAGE_SUMMARY)"
 	@tail -n 1 "$(COVERAGE_SUMMARY)"
 	@$(MAKE) coverage-check
 
-coverage-check:
+coverage-check: ## Check an existing coverage summary against the minimum.
 	@test -s "$(COVERAGE_SUMMARY)" || { echo 'coverage summary is missing or empty' >&2; exit 2; }
 	@actual=$$(awk 'END { value = $$3; sub(/%$$/, "", value); print value }' "$(COVERAGE_SUMMARY)"); \
 		test -n "$$actual" || { echo 'coverage total could not be parsed' >&2; exit 2; }; \
@@ -116,80 +126,80 @@ coverage-check:
 			exit 1; \
 		fi
 
-governance-check:
+governance-check: ## Verify contribution, review, and workflow contracts.
 	$(GO) run ./tools/governance-check
 
-test-full:
+test-full: ## Run Full native-asset tests.
 	@test -d "$(TOKENIZERS_LIB_DIR)" || { echo 'TOKENIZERS_LIB_DIR must contain libtokenizers.a' >&2; exit 2; }
 	CGO_ENABLED=1 CGO_LDFLAGS="$(CGO_LDFLAGS) -L$(TOKENIZERS_LIB_DIR)" \
 		$(GO) test -tags '$(FULL_TAGS)' ./...
 
-test-oceanbase-live:
+test-oceanbase-live: ## Run the disposable live OceanBase compatibility smoke test.
 	@test -n "$$POWERCONTEXT_TEST_OCEANBASE_URL" || { echo 'POWERCONTEXT_TEST_OCEANBASE_URL must name a dedicated OceanBase MySQL-mode database' >&2; exit 2; }
 	$(GO) test -count=1 -run TestLiveOceanBaseProfileSmoke -v ./test/e2e
 
-real-provider-test:
+real-provider-test: ## Run explicit credentialed real-provider smoke tests.
 	@test -n "$$POWERCONTEXT_REAL_SMOKE_GENERATION_MODEL$$POWERCONTEXT_REAL_SMOKE_EMBEDDING_MODEL" || \
 		{ echo 'set at least one POWERCONTEXT_REAL_SMOKE_*_MODEL variable' >&2; exit 2; }
 	$(GO) test -count=1 -run '^TestRealProviderSmoke$$' ./internal/modelprovider
 
-pi-test:
+pi-test: ## Install, test, and type-check the Pi adapter package.
 	$(PNPM) --dir integrations/pi/plugins/powercontext install --frozen-lockfile
 	$(PNPM) --dir integrations/pi/plugins/powercontext test
 	$(PNPM) --dir integrations/pi/plugins/powercontext run typecheck
 
-docs-sync:
+docs-sync: ## Synchronize the locked documentation environment.
 	$(UV) sync --project tools/docs --frozen
 
-docs-test:
+docs-test: ## Strictly build documentation without publishing it.
 	$(UV) run --project tools/docs --frozen zensical build -s
 
-docs-build:
+docs-build: ## Clean and build the documentation site.
 	$(UV) run --project tools/docs --frozen zensical build --clean
 
-harness-sync:
+harness-sync: ## Download and verify the E2E harness module graph.
 	$(GO) mod download
 	$(GO) mod verify
 
-harness-check:
+harness-check: ## Validate E2E harness scripts and compile the test package.
 	sh -n test/e2e/run.sh
 	CGO_ENABLED=1 $(GO) test -run '^$$' -tags '$(STANDARD_TAGS)' ./test/e2e
 
-harness-compose-check:
+harness-compose-check: ## Validate SQLite and OceanBase harness definitions.
 	POWERCONTEXT_E2E_DATABASE=sqlite test/e2e/run.sh check
 	POWERCONTEXT_E2E_DATABASE=oceanbase test/e2e/run.sh check
 
-harness-compose-acceptance:
+harness-compose-acceptance: ## Run the containerized E2E acceptance harness.
 	test/e2e/run.sh acceptance
 
-harness-compose-down:
+harness-compose-down: ## Stop the E2E harness containers.
 	test/e2e/run.sh down
 
-build:
+build: ## Build the standard PowerContext server binary.
 	mkdir -p bin
 	CGO_ENABLED=1 $(GO) build -tags '$(STANDARD_TAGS)' -trimpath \
 		-ldflags '$(LDFLAGS)' -o bin/powercontext ./cmd/powercontext
 
-build-full:
+build-full: ## Build the Full native-asset server binary.
 	@test -d "$(TOKENIZERS_LIB_DIR)" || { echo 'TOKENIZERS_LIB_DIR must contain libtokenizers.a' >&2; exit 2; }
 	mkdir -p bin
 	CGO_ENABLED=1 CGO_LDFLAGS="$(CGO_LDFLAGS) -L$(TOKENIZERS_LIB_DIR)" \
 		$(GO) build -tags '$(FULL_TAGS)' -trimpath -ldflags '$(LDFLAGS)' \
 		-o bin/powercontext-full ./cmd/powercontext
 
-smoke: build
+smoke: build ## Build and smoke-test the standard server binary.
 	$(GO) run ./tools/process-smoke -binary bin/powercontext -version "$(VERSION)"
 
-smoke-full: build-full
+smoke-full: build-full ## Build and smoke-test the Full server binary.
 	$(GO) run ./tools/process-smoke -binary bin/powercontext-full -version "$(VERSION)"
 
-package-standard: build
+package-standard: build ## Build a standard release archive and SBOM.
 	$(GO) run ./tools/release package \
 		-binary bin/powercontext -edition standard \
 		-version "$(VERSION)" -commit "$(COMMIT)" -build-date "$(BUILD_DATE)" \
 		-output dist -syft "$(SYFT)"
 
-package-full: build-full
+package-full: build-full ## Build a Full release archive and SBOM.
 	@test -d "$(ONNXRUNTIME_LIB_DIR)" || { echo 'ONNXRUNTIME_LIB_DIR must contain ONNX Runtime libraries' >&2; exit 2; }
 	$(GO) run ./tools/release package \
 		-binary bin/powercontext-full \
@@ -197,7 +207,7 @@ package-full: build-full
 		-version "$(VERSION)" -commit "$(COMMIT)" -build-date "$(BUILD_DATE)" \
 		-output dist -syft "$(SYFT)"
 
-check: module-check fmt-check vet
+check: module-check fmt-check vet ## Run the core module, formatting, and vet checks.
 
-clean:
+clean: ## Remove known local build, distribution, coverage, and site outputs.
 	$(RM) -r bin dist coverage site

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SHELL := bash
-.SHELLFLAGS := -euo pipefail -c
+export SHELLOPTS := errexit:nounset:pipefail
 .DEFAULT_GOAL := help
 .DELETE_ON_ERROR:
 .SUFFIXES:
@@ -135,11 +135,11 @@ test-full: ## Run Full native-asset tests.
 		$(GO) test -tags '$(FULL_TAGS)' ./...
 
 test-oceanbase-live: ## Run the disposable live OceanBase compatibility smoke test.
-	@test -n "$$POWERCONTEXT_TEST_OCEANBASE_URL" || { echo 'POWERCONTEXT_TEST_OCEANBASE_URL must name a dedicated OceanBase MySQL-mode database' >&2; exit 2; }
+	@test -n "$${POWERCONTEXT_TEST_OCEANBASE_URL:-}" || { echo 'POWERCONTEXT_TEST_OCEANBASE_URL must name a dedicated OceanBase MySQL-mode database' >&2; exit 2; }
 	$(GO) test -count=1 -run TestLiveOceanBaseProfileSmoke -v ./test/e2e
 
 real-provider-test: ## Run explicit credentialed real-provider smoke tests.
-	@test -n "$$POWERCONTEXT_REAL_SMOKE_GENERATION_MODEL$$POWERCONTEXT_REAL_SMOKE_EMBEDDING_MODEL" || \
+	@test -n "$${POWERCONTEXT_REAL_SMOKE_GENERATION_MODEL:-}$${POWERCONTEXT_REAL_SMOKE_EMBEDDING_MODEL:-}" || \
 		{ echo 'set at least one POWERCONTEXT_REAL_SMOKE_*_MODEL variable' >&2; exit 2; }
 	$(GO) test -count=1 -run '^TestRealProviderSmoke$$' ./internal/modelprovider
 

--- a/tools/release/workflow_test.go
+++ b/tools/release/workflow_test.go
@@ -15,8 +15,10 @@
 package main
 
 import (
+	"errors"
 	"io/fs"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -296,28 +298,130 @@ func TestLicenseHeadersHaveOneLocalRepairAndCIContract(t *testing.T) {
 	}
 }
 
-func TestMakefileDeclaresStrictDiscoverableExecution(t *testing.T) {
-	repository := filepath.Clean(filepath.Join("..", ".."))
-	payload, err := os.ReadFile(filepath.Join(repository, "Makefile"))
+func TestMakefileDefaultGoalListsSupportedTargets(t *testing.T) {
+	defaultOutput, err := runMake(t, nil, "", "--no-print-directory")
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("run default Make goal: %v\n%s", err, defaultOutput)
 	}
-	contents := string(payload)
-	for _, required := range []string{
-		"SHELL := bash",
-		".SHELLFLAGS := -euo pipefail -c",
-		".DEFAULT_GOAL := help",
-		".DELETE_ON_ERROR:",
-		".SUFFIXES:",
-		"MAKEFLAGS += --no-builtin-rules",
-		"help: ## Show supported development, verification, and release commands.",
-		"lint: lint-tools ##",
-		"check: module-check fmt-check vet ##",
-		"build-all: ##",
-		"governance-check: ##",
-	} {
-		if !strings.Contains(contents, required) {
-			t.Errorf("Makefile is missing %q", required)
+	helpOutput, err := runMake(t, nil, "", "--no-print-directory", "help")
+	if err != nil {
+		t.Fatalf("run Make help goal: %v\n%s", err, helpOutput)
+	}
+	if defaultOutput != helpOutput {
+		t.Errorf("default Make output differs from help output\ndefault:\n%s\nhelp:\n%s", defaultOutput, helpOutput)
+	}
+	for _, target := range []string{"lint", "check", "test", "build", "package-full", "governance-check"} {
+		if !strings.Contains(helpOutput, "  "+target+" ") {
+			t.Errorf("Make help output is missing %q\n%s", target, helpOutput)
 		}
 	}
+}
+
+func TestMakefileRejectsFailedPipelines(t *testing.T) {
+	const probe = `.PHONY: strict-shell-probe
+strict-shell-probe:
+	@false | true
+	@printf 'strict shell did not stop\n'
+`
+	output, err := runMake(
+		t,
+		nil,
+		probe,
+		"--no-print-directory",
+		"-f", "Makefile",
+		"-f", "-",
+		"strict-shell-probe",
+	)
+	if err == nil {
+		t.Fatalf("failed pipeline did not stop Make\n%s", output)
+	}
+	if _, ok := errors.AsType[*exec.ExitError](err); !ok {
+		t.Fatalf("run strict Make probe: %v\n%s", err, output)
+	}
+	if strings.Contains(output, "strict shell did not stop") {
+		t.Fatalf("Make continued after a failed pipeline\n%s", output)
+	}
+}
+
+func TestMakefileMissingCredentialTargetsKeepActionableErrors(t *testing.T) {
+	tests := []struct {
+		name      string
+		target    string
+		variables []string
+		want      string
+	}{
+		{
+			name:      "OceanBase URL",
+			target:    "test-oceanbase-live",
+			variables: []string{"POWERCONTEXT_TEST_OCEANBASE_URL"},
+			want:      "POWERCONTEXT_TEST_OCEANBASE_URL must name a dedicated OceanBase MySQL-mode database",
+		},
+		{
+			name:   "real provider model",
+			target: "real-provider-test",
+			variables: []string{
+				"POWERCONTEXT_REAL_SMOKE_GENERATION_MODEL",
+				"POWERCONTEXT_REAL_SMOKE_EMBEDDING_MODEL",
+			},
+			want: "set at least one POWERCONTEXT_REAL_SMOKE_*_MODEL variable",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			output, err := runMake(
+				t,
+				environmentWithout(test.variables...),
+				"",
+				"--no-print-directory",
+				test.target,
+			)
+			if err == nil {
+				t.Fatalf("make %s succeeded without required configuration\n%s", test.target, output)
+			}
+			if _, ok := errors.AsType[*exec.ExitError](err); !ok {
+				t.Fatalf("run make %s: %v\n%s", test.target, err, output)
+			}
+			if !strings.Contains(output, test.want) {
+				t.Errorf("make %s output is missing %q\n%s", test.target, test.want, output)
+			}
+			if strings.Contains(output, "unbound variable") {
+				t.Errorf("make %s exposed a shell nounset error instead of the target guidance\n%s", test.target, output)
+			}
+		})
+	}
+}
+
+func runMake(t *testing.T, environment []string, stdin string, arguments ...string) (string, error) {
+	t.Helper()
+	repository := filepath.Clean(filepath.Join("..", ".."))
+	command := exec.CommandContext(t.Context(), "make", arguments...)
+	command.Dir = repository
+	command.Env = environment
+	if stdin != "" {
+		command.Stdin = strings.NewReader(stdin)
+	}
+	output, err := command.CombinedOutput()
+	return string(output), err
+}
+
+func environmentWithout(names ...string) []string {
+	environment := os.Environ()
+	filtered := make([]string, 0, len(environment))
+	for _, entry := range environment {
+		name, _, ok := strings.Cut(entry, "=")
+		if !ok {
+			continue
+		}
+		excluded := false
+		for _, candidate := range names {
+			if strings.EqualFold(name, candidate) {
+				excluded = true
+				break
+			}
+		}
+		if !excluded {
+			filtered = append(filtered, entry)
+		}
+	}
+	return filtered
 }

--- a/tools/release/workflow_test.go
+++ b/tools/release/workflow_test.go
@@ -295,3 +295,29 @@ func TestLicenseHeadersHaveOneLocalRepairAndCIContract(t *testing.T) {
 		}
 	}
 }
+
+func TestMakefileDeclaresStrictDiscoverableExecution(t *testing.T) {
+	repository := filepath.Clean(filepath.Join("..", ".."))
+	payload, err := os.ReadFile(filepath.Join(repository, "Makefile"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	contents := string(payload)
+	for _, required := range []string{
+		"SHELL := bash",
+		".SHELLFLAGS := -euo pipefail -c",
+		".DEFAULT_GOAL := help",
+		".DELETE_ON_ERROR:",
+		".SUFFIXES:",
+		"MAKEFLAGS += --no-builtin-rules",
+		"help: ## Show supported development, verification, and release commands.",
+		"lint: lint-tools ##",
+		"check: module-check fmt-check vet ##",
+		"build-all: ##",
+		"governance-check: ##",
+	} {
+		if !strings.Contains(contents, required) {
+			t.Errorf("Makefile is missing %q", required)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- make `help` the default, documented Make entry point and add a short description for every supported public target
- run Make recipes through Bash with deterministic `errexit`, `nounset`, and `pipefail` semantics on both GNU Make 3.81 and 4.3
- disable implicit built-in rules and suffix rules, and delete failed file targets
- preserve actionable preflight errors when optional OceanBase or real-provider variables are unset
- pin the extensionless `Makefile` to LF and cover it in the Windows checkout contract
- replace source-text assertions with real Make execution tests for the default goal, failed pipelines, and missing credentials

## Rationale

WP0-C in #3 requires strict, discoverable, repository-owned developer commands. The original implementation used `.SHELLFLAGS`, which GNU Make 3.81 silently ignored, and Bash nounset masked two existing configuration errors on newer Make versions. This revision keeps the strict contract portable across the supported developer environments while preserving the target-specific guidance.

This PR is stacked on #31 (`codex/wp0-windows-contract`) and now includes the current base at `22485138835f805f507c05fe62ab0c4af31c9a3b`.

## Behavior, API, and compatibility

- no public API, protocol, dependency, generated-contract, persistence, or runtime behavior changes
- invoking `make` prints the same supported-command list as `make help`
- recipes stop on unset variables, failed commands, and failed pipeline members
- missing optional credential variables still return the repository's actionable error messages
- a failed file target is removed by Make rather than left as a reusable partial artifact
- `Makefile` is checked out with LF even when `core.autocrlf=true`

## Validation

- Windows GNU Make 3.81: default/help, failed-pipeline, and missing-credential behavior tests
- WSL GNU Make 4.3: the same behavior tests and direct Base-versus-Head regression probes
- `go test ./tools/release -run '^Test(BareMakeListsSupportedTargets|MakefileRejectsFailedPipelines|MakefileMissingCredentialTargetsKeepActionableErrors|FrozenTextAssetsDeclareLFCheckout|BuildAllUsesReadonlyModuleResolution|CoverageTargetUsesRaceAtomicProfileAndThreshold)$' -count=1`
- cross-compiled Linux `tools/release` test binary: `PASS` for the complete package suite
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/windows-contract.yml .github/workflows/master.yml .github/workflows/codeql.yml`
- `git diff --check`
- exact-Head GitHub Actions: all visible checks passed, including Windows contract, go-compat, lint, quality, tests, coverage, CodeQL, race/fuzz/module integrity, Standard/Full platform matrices, OceanBase, and both acceptance profiles

Exact head validated: `81fda8cfc21c9aa207e2dcff052961e97b4b27f0`.

## AI usage

Implemented and reviewed with Codex assistance. The final five-file Diff, red/green regression behavior, base synchronization, Linux package tests, Windows/WSL Make behavior, and exact-Head CI results were verified directly.