### PR TITLE
ci: verify portable public SDK builds

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -6,7 +6,7 @@ counterpart or enforces a Go release constraint that does not exist in Python.
 
 | Python workflow | Go workflow | Deliberate adaptation |
 | --- | --- | --- |
-| `master.yml` | `master.yml` | Pinned lint and formatting, an independent Go 1.27 readonly package build, race-enabled atomic coverage, machine-checked contribution contracts, Go module verification, vet, generated transport contracts, Go tests, and the same Pi package replace Python lock, prek, and interpreter tests. |
+| `master.yml` | `master.yml` | Pinned lint and formatting, independent Go 1.27 readonly full-module and CGO-disabled public SDK builds, race-enabled atomic coverage, machine-checked contribution contracts, Go module verification, vet, generated transport contracts, Go tests, and the same Pi package replace Python lock, prek, and interpreter tests. |
 | `e2e-harness.yml` | `e2e-harness.yml` | The same validate/SQLite/OceanBase/evidence lifecycle drives the Go process and live OceanBase acceptance tests. |
 | `license-check.yml` | `license-check.yml` | Both call SkyWalking Eyes 0.8.0 directly. `make license-check` and `make license-fix` remain local entry points. |
 | `deploy-docs.yml` | `deploy-docs.yml` | Both build locked Zensical documentation and deploy GitHub Pages. |

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -44,6 +44,23 @@ jobs:
       - name: Build every package with readonly modules
         run: make build-all
 
+  portable-sdk:
+    name: portable-sdk
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    env:
+      GOTOOLCHAIN: local
+      GOFLAGS: -mod=readonly
+    steps:
+      - name: Check out
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Set up the environment
+        uses: ./.github/actions/setup-go-env
+
+      - name: Cross-build the portable public SDK
+        run: make portable-sdk
+
   coverage:
     name: coverage
     runs-on: ubuntu-24.04

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,3 +130,8 @@ source / artifact / trigger / inference
   raw database bytes that contain the producing SQLite version and physical
   page-layout metadata. Keep committed fixture hashes pinned separately, and
   verify both semantic regeneration and cross-runtime read/write compatibility.
+- When a CI gate derives package or platform coverage from Make variables,
+  execute the target with a recording command and assert the complete
+  invocation matrix, critical environment assignments, and fail-fast behavior.
+  Verify mutants that remove an entry, unset the constraint, and fail the first
+  iteration are rejected.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,7 +166,9 @@ source / artifact / trigger / inference
   execute the target with a recording command and assert the complete
   invocation matrix, critical environment assignments, and fail-fast behavior.
   Verify mutants that remove an entry, unset the constraint, and fail the first
-  iteration are rejected.
+  iteration are rejected. If the recorder reuses a Go test binary, terminate
+  helper invocations explicitly and run the probe under race-enabled coverage
+  so test-harness output cannot corrupt command substitution.
 - When a governance parser exempts a GitHub Actions reusable-workflow caller
   from ordinary-job requirements, require a nonblank `uses` reference and
   reject every keyword outside GitHub's supported caller-job set. Verify the

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,9 @@ COVERAGE_PROFILE ?= $(COVERAGE_DIR)/coverage.out
 COVERAGE_SUMMARY ?= $(COVERAGE_DIR)/summary.txt
 COVERAGE_MINIMUM ?= 16.0
 
+PORTABLE_SDK_PACKAGES := ./api/... ./artifact/... ./client/... ./inference/... ./openapi/... ./source/... ./trigger/...
+PORTABLE_SDK_TARGETS := linux/amd64 linux/arm64 darwin/amd64 darwin/arm64
+
 STANDARD_TAGS := sqlite_fts5
 FULL_TAGS := sqlite_fts5,local_embeddings,ORT
 VERSION ?= devel
@@ -29,7 +32,7 @@ COMMIT ?= $(shell git rev-parse HEAD 2>/dev/null || printf unknown)
 BUILD_DATE ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
 LDFLAGS := -s -w -X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.date=$(BUILD_DATE)
 
-.PHONY: help lint-tools lint lint-fix generate check-generated module-check contract-test license-check license-fix fmt fmt-check vet build-all coverage coverage-check governance-check \
+.PHONY: help lint-tools lint lint-fix generate check-generated module-check contract-test license-check license-fix fmt fmt-check vet build-all portable-sdk coverage coverage-check governance-check \
 	test unit-test e2e-test test-sqlite test-race test-full test-oceanbase-live real-provider-test \
 	pi-test docs-sync docs-test docs-build harness-sync harness-check harness-compose-check \
 	harness-compose-acceptance harness-compose-down build build-full smoke smoke-full check \
@@ -91,6 +94,11 @@ vet: ## Run Go vet across all packages.
 
 build-all: ## Build all Go packages with readonly module resolution.
 	$(GO) build -mod=readonly ./...
+
+portable-sdk: ## Cross-build the deliberate public SDK packages without CGO.
+	@for target in $(PORTABLE_SDK_TARGETS); do \
+		GOOS=$${target%/*} GOARCH=$${target#*/} CGO_ENABLED=0 $(GO) build -mod=readonly $(PORTABLE_SDK_PACKAGES) || exit 1; \
+	done
 
 test: unit-test e2e-test ## Run the standard unit and end-to-end suites.
 

--- a/tools/release/makefile_test.go
+++ b/tools/release/makefile_test.go
@@ -114,7 +114,7 @@ func runPortableSDKGoHelper(t *testing.T) {
 	}
 	arguments := os.Args[separator+1:]
 	if len(arguments) == 0 || arguments[0] != "build" {
-		return
+		os.Exit(0)
 	}
 	target := os.Getenv("GOOS") + "/" + os.Getenv("GOARCH")
 	line := target + " CGO_ENABLED=" + os.Getenv("CGO_ENABLED") + " " + strings.Join(arguments, " ") + "\n"
@@ -132,6 +132,7 @@ func runPortableSDKGoHelper(t *testing.T) {
 	if target == os.Getenv("POWERCONTEXT_PORTABLE_GO_FAIL_TARGET") {
 		os.Exit(23)
 	}
+	os.Exit(0)
 }
 
 func TestMakefileRejectsFailedPipelines(t *testing.T) {

--- a/tools/release/workflow_test.go
+++ b/tools/release/workflow_test.go
@@ -62,7 +62,7 @@ func TestContinuousIntegrationPreservesPythonTopologyAndGoAssurance(t *testing.T
 	required := map[string][]string{
 		"master.yml": {
 			"name: Main", "quality:", "run: make check", "run: make contract-test",
-			"tests:", "run: make unit-test", "run: make e2e-test", "pi-package:", "check-docs:",
+			"portable-sdk:", "run: make portable-sdk", "tests:", "run: make unit-test", "run: make e2e-test", "pi-package:", "check-docs:",
 			"migration-assurance:", "uses: ./.github/workflows/migration-gates.yml",
 		},
 		"migration-gates.yml": {
@@ -314,6 +314,10 @@ func TestMakefileDeclaresStrictDiscoverableExecution(t *testing.T) {
 		"lint: lint-tools ##",
 		"check: module-check fmt-check vet ##",
 		"build-all: ##",
+		"portable-sdk: ##",
+		"./openapi/...",
+		"linux/arm64 darwin/amd64 darwin/arm64",
+		"$(GO) build -mod=readonly $(PORTABLE_SDK_PACKAGES) || exit 1",
 		"governance-check: ##",
 	} {
 		if !strings.Contains(contents, required) {

--- a/tools/release/workflow_test.go
+++ b/tools/release/workflow_test.go
@@ -17,8 +17,10 @@ package main
 import (
 	"io/fs"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -296,6 +298,101 @@ func TestLicenseHeadersHaveOneLocalRepairAndCIContract(t *testing.T) {
 	}
 }
 
+func TestPortableSDKMakeTargetBuildsExactMatrix(t *testing.T) {
+	if os.Getenv("POWERCONTEXT_PORTABLE_GO_HELPER") == "1" {
+		runPortableSDKGoHelper(t)
+		return
+	}
+
+	calls, output, err := runPortableSDKMake(t, "")
+	if err != nil {
+		t.Fatalf("make portable-sdk failed: %v\n%s", err, output)
+	}
+	want := []string{
+		"linux/amd64 CGO_ENABLED=0 build -mod=readonly ./api/... ./artifact/... ./client/... ./inference/... ./openapi/... ./source/... ./trigger/...",
+		"linux/arm64 CGO_ENABLED=0 build -mod=readonly ./api/... ./artifact/... ./client/... ./inference/... ./openapi/... ./source/... ./trigger/...",
+		"darwin/amd64 CGO_ENABLED=0 build -mod=readonly ./api/... ./artifact/... ./client/... ./inference/... ./openapi/... ./source/... ./trigger/...",
+		"darwin/arm64 CGO_ENABLED=0 build -mod=readonly ./api/... ./artifact/... ./client/... ./inference/... ./openapi/... ./source/... ./trigger/...",
+	}
+	if !slices.Equal(calls, want) {
+		t.Errorf("portable-sdk calls = %q, want %q", calls, want)
+	}
+}
+
+func TestPortableSDKMakeTargetStopsOnFirstFailure(t *testing.T) {
+	calls, output, err := runPortableSDKMake(t, "linux/amd64")
+	if err == nil {
+		t.Fatalf("make portable-sdk succeeded after the first target failed\n%s", output)
+	}
+	want := []string{
+		"linux/amd64 CGO_ENABLED=0 build -mod=readonly ./api/... ./artifact/... ./client/... ./inference/... ./openapi/... ./source/... ./trigger/...",
+	}
+	if !slices.Equal(calls, want) {
+		t.Errorf("portable-sdk calls after failure = %q, want %q", calls, want)
+	}
+}
+
+func runPortableSDKMake(t *testing.T, failTarget string) ([]string, string, error) {
+	t.Helper()
+	makePath, err := exec.LookPath("make")
+	if err != nil {
+		t.Skip("make is required to verify the portable SDK target")
+	}
+	logPath := filepath.Join(t.TempDir(), "portable-sdk-go.log")
+	args := []string{
+		"--no-print-directory",
+		"portable-sdk",
+		`GO="$${POWERCONTEXT_PORTABLE_GO_HELPER_BINARY}" -test.run=TestPortableSDKMakeTargetBuildsExactMatrix --`,
+		"GOLANGCI_LINT=unused",
+	}
+	if failTarget != "" {
+		args = append(args, ".SHELLFLAGS=-u -o pipefail -c")
+	}
+	command := exec.CommandContext(t.Context(), makePath, args...)
+	command.Dir = filepath.Clean(filepath.Join("..", ".."))
+	command.Env = append(os.Environ(),
+		"POWERCONTEXT_PORTABLE_GO_HELPER=1",
+		"POWERCONTEXT_PORTABLE_GO_HELPER_BINARY="+filepath.ToSlash(os.Args[0]),
+		"POWERCONTEXT_PORTABLE_GO_LOG="+logPath,
+		"POWERCONTEXT_PORTABLE_GO_FAIL_TARGET="+failTarget,
+	)
+	output, runErr := command.CombinedOutput()
+	payload, readErr := os.ReadFile(logPath)
+	if readErr != nil {
+		t.Fatalf("read portable SDK helper log: %v\n%s", readErr, output)
+	}
+	lines := strings.Split(strings.TrimSpace(strings.ReplaceAll(string(payload), "\r\n", "\n")), "\n")
+	return lines, string(output), runErr
+}
+
+func runPortableSDKGoHelper(t *testing.T) {
+	t.Helper()
+	separator := slices.Index(os.Args, "--")
+	if separator == -1 {
+		t.Fatal("portable SDK helper arguments are missing the separator")
+	}
+	arguments := os.Args[separator+1:]
+	if len(arguments) == 0 || arguments[0] != "build" {
+		return
+	}
+	target := os.Getenv("GOOS") + "/" + os.Getenv("GOARCH")
+	line := target + " CGO_ENABLED=" + os.Getenv("CGO_ENABLED") + " " + strings.Join(arguments, " ") + "\n"
+	logFile, err := os.OpenFile(os.Getenv("POWERCONTEXT_PORTABLE_GO_LOG"), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := logFile.WriteString(line); err != nil {
+		_ = logFile.Close()
+		t.Fatal(err)
+	}
+	if err := logFile.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if target == os.Getenv("POWERCONTEXT_PORTABLE_GO_FAIL_TARGET") {
+		os.Exit(23)
+	}
+}
+
 func TestMakefileDeclaresStrictDiscoverableExecution(t *testing.T) {
 	repository := filepath.Clean(filepath.Join("..", ".."))
 	payload, err := os.ReadFile(filepath.Join(repository, "Makefile"))
@@ -315,9 +412,6 @@ func TestMakefileDeclaresStrictDiscoverableExecution(t *testing.T) {
 		"check: module-check fmt-check vet ##",
 		"build-all: ##",
 		"portable-sdk: ##",
-		"./openapi/...",
-		"linux/arm64 darwin/amd64 darwin/arm64",
-		"$(GO) build -mod=readonly $(PORTABLE_SDK_PACKAGES) || exit 1",
 		"governance-check: ##",
 	} {
 		if !strings.Contains(contents, required) {


### PR DESCRIPTION
## Summary

- define the deliberate public SDK package set with `./api/...`, `./artifact/...`, `./client/...`, `./inference/...`, `./openapi/...`, `./source/...`, and `./trigger/...`
- cross-build it with `CGO_ENABLED=0` for the existing supported Linux and macOS amd64/arm64 matrix
- make every target iteration explicitly fail the Make recipe when its build fails
- retain the stable `portable-sdk` CI job and workflow topology contract

## Rationale

This is part of WP0-C in #3. A self-review found that the initial target list was incomplete and that the loop depended on shell fail-fast behavior. The exact submitted version now uses the same four-platform matrix as the repository's existing platform jobs, includes `openapi` and all Artifact subpackages, and exits explicitly on each failed compilation.

PR #35 provides a parallel `main`-based implementation for the same work item. This PR remains a corrected stacked implementation.

## Behavior and compatibility

- no public API, protocol, dependency, runtime, or generated-contract changes
- does not claim Windows server/release support
- rejects any CGO dependency or cross-platform build break introduced into the deliberate public package set

## Validation

- `GOTOOLCHAIN=local GOFLAGS=-mod=readonly make portable-sdk`
- mutation: `make portable-sdk PORTABLE_SDK_PACKAGES=./internal/sqlstore/sqlitevec` fails as expected with `CGO_ENABLED=0`
- `go test ./...`
- `make lint` (`0 issues`)
- `make check`
- `make check-generated`
- `make license-check`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12`
- `git diff --check`

Exact head validated: `eac7fbdc9dcf0c62e57a3f25d49d34cf9c195005`.

## AI usage

Implemented with Codex assistance. The public package set and fail-fast behavior were self-reviewed and verified with the commands above.