### PR TITLE
ci: add CGO-disabled portable SDK cross-build gate

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -19,7 +19,7 @@ Two Go-specific workflows extend, rather than replace, that Python topology:
 
 | Go workflow | Purpose |
 | --- | --- |
-| `migration-gates.yml` | Reusable PR assurance called by `master.yml`: frozen Python Oracle regeneration, Python↔Go interoperability, HTTP differential, race/fuzz, live OceanBase, host adapters, evaluation, and four-platform standard/Full builds. |
+| `migration-gates.yml` | Reusable PR assurance called by `master.yml`: frozen Python Oracle regeneration, Python↔Go interoperability, HTTP differential, race/fuzz, live OceanBase, host adapters, evaluation, four-platform standard/Full builds, and CGO-disabled portable SDK cross-builds. |
 | `provider-smoke.yml` | Explicitly dispatched, credentialed, bounded real-provider verification; never required on an ordinary pull request. |
 
 The committed `test/conformance/testdata/python-v0.0.2` baseline remains immutable. Pull requests execute the pinned

--- a/.github/workflows/migration-gates.yml
+++ b/.github/workflows/migration-gates.yml
@@ -52,6 +52,20 @@ jobs:
       - name: Build the standard Docker image
         run: docker build --pull --target powercontext -t powercontext:ci .
 
+  portable-sdk:
+    name: Portable SDK cross-builds
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - name: Check out
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Set up the Go environment
+        uses: ./.github/actions/setup-go-env
+
+      - name: Cross-build public packages with CGO disabled
+        run: make check-portable
+
   frozen-oracle:
     name: Frozen Python Oracle and differential fixtures
     runs-on: ubuntu-24.04

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,3 +156,7 @@ source / artifact / trigger / inference
   install with the project-selected `go env GOVERSION` as the minimum
   `GOTOOLCHAIN`. Verify from an older bootstrap Go release that the installed
   binary can process the module's declared Go version.
+- When a CI Makefile target iterates over a platform or package matrix, verify
+  a successful fake command observes every required entry and intended
+  environment. Make a non-final entry fail, then verify the target exits
+  nonzero without running later entries.

--- a/Makefile
+++ b/Makefile
@@ -13,11 +13,16 @@ COMMIT ?= $(shell git rev-parse HEAD 2>/dev/null || printf unknown)
 BUILD_DATE ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
 LDFLAGS := -s -w -X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.date=$(BUILD_DATE)
 
+# Deliberate public packages that downstream Go consumers must be able to
+# import without CGO, matching the platform matrix used by CI.
+PORTABLE_PACKAGES := ./api/... ./artifact/... ./client/... ./inference/... ./openapi/... ./source/... ./trigger/...
+PORTABLE_TARGETS := linux/amd64 linux/arm64 darwin/amd64 darwin/arm64
+
 .PHONY: generate check-generated module-check contract-test license-check license-fix fmt fmt-check vet \
 	test unit-test e2e-test test-sqlite test-race test-full test-oceanbase-live real-provider-test \
 	pi-test docs-sync docs-test docs-build harness-sync harness-check harness-compose-check \
 	harness-compose-acceptance harness-compose-down build build-full smoke smoke-full check \
-	package-standard package-full clean
+	check-portable package-standard package-full clean
 
 generate:
 	$(GO) generate ./openapi
@@ -149,6 +154,16 @@ package-full: build-full
 		-output dist -syft "$(SYFT)"
 
 check: module-check fmt-check vet
+
+# Prove the deliberate public SDK surface stays CGO-free and cross-compilable
+# for every supported platform. A failure here means a public package gained a
+# CGO dependency or platform-specific code that breaks pure-Go consumers.
+check-portable:
+	@for target in $(PORTABLE_TARGETS); do \
+		os=$${target%/*}; arch=$${target#*/}; \
+		printf 'building portable SDK for %s/%s: ' "$$os" "$$arch"; \
+		CGO_ENABLED=0 GOOS=$$os GOARCH=$$arch $(GO) build $(PORTABLE_PACKAGES) && echo OK || exit 1; \
+	done
 
 clean:
 	$(RM) -r bin dist coverage site

--- a/tools/release/makefile_test.go
+++ b/tools/release/makefile_test.go
@@ -19,6 +19,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -56,6 +57,113 @@ func TestBuildAllUsesReadonlyModuleResolution(t *testing.T) {
 	}
 	if !strings.Contains(string(output), "go build -mod=readonly ./...") {
 		t.Fatalf("make build-all does not use readonly module resolution:\n%s", output)
+	}
+}
+
+func TestCheckPortableBuildsEverySupportedTargetWithoutCGO(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the repository Makefile requires a POSIX shell")
+	}
+
+	repository := filepath.Clean(filepath.Join("..", ".."))
+	temporary := t.TempDir()
+	callLog := filepath.Join(temporary, "calls.txt")
+	fakeGo := filepath.Join(temporary, "go")
+	const fakeGoScript = `#!/bin/sh
+set -eu
+
+case "${1:-} ${2:-}" in
+  "env GOEXE")
+    exit 0
+    ;;
+  "env GOVERSION")
+    printf 'go1.27.0\n'
+    exit 0
+    ;;
+esac
+
+printf '%s|%s|%s|%s\n' "$GOOS" "$GOARCH" "$CGO_ENABLED" "$*" >> "$PORTABLE_CALL_LOG"
+`
+	if err := os.WriteFile(fakeGo, []byte(fakeGoScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	command := exec.CommandContext(t.Context(), "make", "check-portable", "GO="+fakeGo)
+	command.Dir = repository
+	command.Env = append(os.Environ(), "PORTABLE_CALL_LOG="+callLog)
+	if output, err := command.CombinedOutput(); err != nil {
+		t.Fatalf("make check-portable failed: %v\n%s", err, output)
+	}
+
+	payload, err := os.ReadFile(callLog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const arguments = "build ./api/... ./artifact/... ./client/... ./inference/... ./openapi/... ./source/... ./trigger/..."
+	want := []string{
+		"linux|amd64|0|" + arguments,
+		"linux|arm64|0|" + arguments,
+		"darwin|amd64|0|" + arguments,
+		"darwin|arm64|0|" + arguments,
+	}
+	got := strings.Split(strings.TrimSpace(string(payload)), "\n")
+	if !slices.Equal(got, want) {
+		t.Fatalf("portable build calls = %q, want %q", got, want)
+	}
+}
+
+func TestCheckPortableStopsAfterTheFirstFailedBuild(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the repository Makefile requires a POSIX shell")
+	}
+
+	repository := filepath.Clean(filepath.Join("..", ".."))
+	temporary := t.TempDir()
+	callLog := filepath.Join(temporary, "calls.txt")
+	fakeGo := filepath.Join(temporary, "go")
+	const fakeGoScript = `#!/bin/sh
+set -eu
+
+case "${1:-} ${2:-}" in
+  "env GOEXE")
+    exit 0
+    ;;
+  "env GOVERSION")
+    printf 'go1.27.0\n'
+    exit 0
+    ;;
+esac
+
+target="$GOOS/$GOARCH"
+printf '%s\n' "$target" >> "$PORTABLE_CALL_LOG"
+if [ "$target" = "$PORTABLE_FAIL_TARGET" ]; then
+	exit 23
+fi
+`
+	if err := os.WriteFile(fakeGo, []byte(fakeGoScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	command := exec.CommandContext(t.Context(), "make", "check-portable", "GO="+fakeGo)
+	command.Dir = repository
+	command.Env = append(
+		os.Environ(),
+		"PORTABLE_CALL_LOG="+callLog,
+		"PORTABLE_FAIL_TARGET=linux/arm64",
+	)
+	output, err := command.CombinedOutput()
+	if err == nil {
+		t.Fatalf("make check-portable succeeded after a failed cross-build:\n%s", output)
+	}
+
+	payload, readErr := os.ReadFile(callLog)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	want := []string{"linux/amd64", "linux/arm64"}
+	got := strings.Split(strings.TrimSpace(string(payload)), "\n")
+	if !slices.Equal(got, want) {
+		t.Fatalf("portable build calls after failure = %q, want %q", got, want)
 	}
 }
 

--- a/tools/release/makefile_test.go
+++ b/tools/release/makefile_test.go
@@ -99,16 +99,39 @@ printf '%s|%s|%s|%s\n' "$GOOS" "$GOARCH" "$CGO_ENABLED" "$*" >> "$PORTABLE_CALL_
 	if err != nil {
 		t.Fatal(err)
 	}
-	const arguments = "build ./api/... ./artifact/... ./client/... ./inference/... ./openapi/... ./source/... ./trigger/..."
-	want := []string{
-		"linux|amd64|0|" + arguments,
-		"linux|arm64|0|" + arguments,
-		"darwin|amd64|0|" + arguments,
-		"darwin|arm64|0|" + arguments,
+	wantTargets := []string{"darwin/amd64", "darwin/arm64", "linux/amd64", "linux/arm64"}
+	wantPackages := []string{
+		"./api/...",
+		"./artifact/...",
+		"./client/...",
+		"./inference/...",
+		"./openapi/...",
+		"./source/...",
+		"./trigger/...",
 	}
-	got := strings.Split(strings.TrimSpace(string(payload)), "\n")
-	if !slices.Equal(got, want) {
-		t.Fatalf("portable build calls = %q, want %q", got, want)
+	lines := strings.Split(strings.TrimSpace(string(payload)), "\n")
+	gotTargets := make([]string, 0, len(lines))
+	for _, line := range lines {
+		parts := strings.SplitN(line, "|", 4)
+		if len(parts) != 4 {
+			t.Fatalf("portable build call %q has %d fields, want 4", line, len(parts))
+		}
+		gotTargets = append(gotTargets, parts[0]+"/"+parts[1])
+		if parts[2] != "0" {
+			t.Errorf("portable build %s/%s CGO_ENABLED = %q, want 0", parts[0], parts[1], parts[2])
+		}
+		arguments := strings.Fields(parts[3])
+		if len(arguments) == 0 || arguments[0] != "build" {
+			t.Fatalf("portable build %s/%s arguments = %q, want build command", parts[0], parts[1], arguments)
+		}
+		gotPackages := slices.Sorted(slices.Values(arguments[1:]))
+		if !slices.Equal(gotPackages, wantPackages) {
+			t.Errorf("portable build %s/%s packages = %q, want %q", parts[0], parts[1], gotPackages, wantPackages)
+		}
+	}
+	gotTargets = slices.Sorted(slices.Values(gotTargets))
+	if !slices.Equal(gotTargets, wantTargets) {
+		t.Fatalf("portable build targets = %q, want %q", gotTargets, wantTargets)
 	}
 }
 
@@ -136,7 +159,7 @@ esac
 
 target="$GOOS/$GOARCH"
 printf '%s\n' "$target" >> "$PORTABLE_CALL_LOG"
-if [ "$target" = "$PORTABLE_FAIL_TARGET" ]; then
+if [ "$(grep -c '^' "$PORTABLE_CALL_LOG")" -eq 2 ]; then
 	exit 23
 fi
 `
@@ -149,7 +172,6 @@ fi
 	command.Env = append(
 		os.Environ(),
 		"PORTABLE_CALL_LOG="+callLog,
-		"PORTABLE_FAIL_TARGET=linux/arm64",
 	)
 	output, err := command.CombinedOutput()
 	if err == nil {
@@ -160,10 +182,9 @@ fi
 	if readErr != nil {
 		t.Fatal(readErr)
 	}
-	want := []string{"linux/amd64", "linux/arm64"}
 	got := strings.Split(strings.TrimSpace(string(payload)), "\n")
-	if !slices.Equal(got, want) {
-		t.Fatalf("portable build calls after failure = %q, want %q", got, want)
+	if len(got) != 2 {
+		t.Fatalf("portable build calls after second-call failure = %q, want exactly 2 calls", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

Add a CGO-disabled portable SDK cross-build gate for the deliberate public packages:

- `make check-portable` cross-builds `./api/... ./artifact/... ./client/... ./inference/... ./openapi/... ./source/... ./trigger/...` with `CGO_ENABLED=0` for the exact four-platform matrix CI already uses (linux/amd64, linux/arm64, darwin/amd64, darwin/arm64)
- a stable `portable-sdk` job in `migration-gates.yml` runs the target on every PR
- `.github/workflows/README.md` documents the new gate
- `tools/release/makefile_test.go` executes the real Make target through a controlled Go boundary, proving the complete matrix and that a non-final build failure stops the gate
- `AGENTS.md` records the reusable failure-path verification rule for CI matrix loops

Closes #33 (extracted from #3 WP0-C: "CGO-disabled cross-builds for portable public Client, domain, and generated API packages").

## Relationship to #34

#34 implements the same WP0-C item in parallel. Its current Head has evolved since this PR was opened and now also uses explicit per-iteration failure propagation, the same four-platform matrix, public-package wildcards, and `./openapi/...`; those are no longer differentiators.

The remaining structural differences are:

1. This PR is self-contained on current `main` and adds the job to the existing reusable `migration-gates.yml`; #34 is stacked on `codex/wp0-make-contract` and adds a separate job directly to `master.yml`.
2. This PR adds behavior-level regression tests that run the real Make target, compare the required target and package sets without order sensitivity, verify `CGO_ENABLED=0`, and inject a failure on the second iteration. #34's current test checks the Makefile contract text.

Only one implementation should be retained to avoid duplicate portable SDK gates.

## Behavior, API, and compatibility

- no public API, protocol, dependency, runtime, or generated-contract changes
- compile-only verification; does not claim Windows binary support and does not touch the CGO-required Server or persistence layer
- all existing gates from current `main` remain unchanged

## Validation

Current Head `2e47a463446cf044584059dad1c198c03e56d8d3`:

- `make check-portable` with Go 1.27 — linux/amd64, linux/arm64, darwin/amd64, and darwin/arm64 all report `OK`
- Linux-amd64 `tools/release` test binary under WSL — portable matrix, fail-fast, Go compatibility, coverage workflow, immutable-action, and shared-Go-setup contracts pass
- fail-fast mutation proof — removing `|| exit 1` makes `TestCheckPortableStopsAfterTheFirstFailedBuild` fail; restoring it makes the test pass
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12` — no findings
- `git diff --check` — clean
- exact-Head GitHub checks — 27/27 successful, including portable-sdk, tests, lint, coverage, CodeQL, race/fuzz/module integrity, SQLite/OceanBase acceptance, and four-platform Standard/Full jobs

Native Windows `go test ./tools/release` has three platform-specific failures that reproduce identically on `origin/main` (POSIX executable mode and LF-only workflow matching); they are not introduced by this PR. The exact-Head Linux/macOS CI matrix is green.