### PR TITLE
ci: verify dependency license evidence

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -6,7 +6,7 @@ counterpart or enforces a Go release constraint that does not exist in Python.
 
 | Python workflow | Go workflow | Deliberate adaptation |
 | --- | --- | --- |
-| `master.yml` | `master.yml` | Go module, formatting, vet, generated transport contracts, Go tests, and the same Pi package replace Python lock, prek, and interpreter tests. |
+| `master.yml` | `master.yml` | Go module, formatting, vet, built-binary dependency-license evidence, generated transport contracts, Go tests, and the same Pi package replace Python lock, prek, and interpreter tests. |
 | `e2e-harness.yml` | `e2e-harness.yml` | The same validate/SQLite/OceanBase/evidence lifecycle drives the Go process and live OceanBase acceptance tests. |
 | `license-check.yml` | `license-check.yml` | Both call SkyWalking Eyes 0.8.0 directly. `make license-check` and `make license-fix` remain local entry points. |
 | `deploy-docs.yml` | `deploy-docs.yml` | Both build locked Zensical documentation and deploy GitHub Pages. |

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -11,6 +11,32 @@ permissions:
   contents: read
 
 jobs:
+  license-dependencies:
+    name: license-dependencies
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    env:
+      GOTOOLCHAIN: local
+      GOFLAGS: -mod=readonly
+    steps:
+      - name: Check out
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Set up the environment
+        uses: ./.github/actions/setup-go-env
+
+      - name: Verify dependency license evidence
+        run: make license-dependencies
+
+      - name: Upload dependency license evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: dependency-licenses-${{ github.sha }}
+          path: coverage/dependencies.json
+          if-no-files-found: warn
+          retention-days: 14
+
   quality:
     runs-on: ubuntu-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ GOMODCACHE ?=
 PNPM ?= pnpm
 UV ?= uv
 LICENSE_EYE ?= $(GO) run github.com/apache/skywalking-eyes/cmd/license-eye@v0.8.0
+LICENSE_DEPENDENCY_OUTPUT ?= coverage/dependencies.json
 
 STANDARD_TAGS := sqlite_fts5
 FULL_TAGS := sqlite_fts5,local_embeddings,ORT
@@ -18,7 +19,7 @@ LDFLAGS := -s -w -X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.dat
 PORTABLE_PACKAGES := ./api/... ./artifact/... ./client/... ./inference/... ./openapi/... ./source/... ./trigger/...
 PORTABLE_TARGETS := linux/amd64 linux/arm64 darwin/amd64 darwin/arm64
 
-.PHONY: generate check-generated module-check contract-test license-check license-fix fmt fmt-check vet \
+.PHONY: generate check-generated module-check contract-test license-check license-fix license-dependencies fmt fmt-check vet \
 	test unit-test e2e-test test-sqlite test-race test-full test-oceanbase-live real-provider-test \
 	pi-test docs-sync docs-test docs-build harness-sync harness-check harness-compose-check \
 	harness-compose-acceptance harness-compose-down build build-full smoke smoke-full check \
@@ -48,6 +49,10 @@ license-check:
 license-fix:
 	$(LICENSE_EYE) -c .licenserc.yaml header fix
 	$(LICENSE_EYE) -c .licenserc.yaml header check
+
+license-dependencies: build
+	@$(RM) "$(LICENSE_DEPENDENCY_OUTPUT)"
+	$(GO) run ./tools/release licenses -binary bin/powercontext -edition standard -output "$(LICENSE_DEPENDENCY_OUTPUT)"
 
 fmt:
 	$(GOFMT) -w $$(find . -name '*.go' -not -path './vendor/*')

--- a/tools/release/license_inventory.go
+++ b/tools/release/license_inventory.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+type licenseInventoryOptions struct {
+	Binary     string
+	Edition    string
+	Output     string
+	Repository string
+}
+
+type licenseInventoryResult struct {
+	GoModules          int    `json:"go_modules"`
+	NativeDependencies int    `json:"native_dependencies"`
+	Output             string `json:"output"`
+}
+
+func runLicenseInventory(arguments []string, output io.Writer) error {
+	flags := flag.NewFlagSet("licenses", flag.ContinueOnError)
+	flags.SetOutput(io.Discard)
+	options := new(licenseInventoryOptions)
+	flags.StringVar(&options.Binary, "binary", "", "built powercontext binary")
+	flags.StringVar(&options.Edition, "edition", "standard", "standard or full")
+	flags.StringVar(&options.Output, "output", "", "new dependency-license manifest path")
+	flags.StringVar(&options.Repository, "repository", ".", "repository root")
+	if err := flags.Parse(arguments); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 || options.Binary == "" || options.Output == "" ||
+		(options.Edition != "standard" && options.Edition != "full") {
+		return errors.New("licenses requires binary, output, and standard or full edition")
+	}
+	repository, err := filepath.Abs(options.Repository)
+	if err != nil {
+		return err
+	}
+	assets, err := readAssets(repository)
+	if err != nil {
+		return err
+	}
+	manifest, _, err := collectLicenses(options.Binary, repository, options.Edition, assets)
+	if err != nil {
+		return err
+	}
+	encoded, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return err
+	}
+	encoded = append(encoded, '\n')
+	if err := os.MkdirAll(filepath.Dir(options.Output), 0o755); err != nil {
+		return err
+	}
+	if err := writeNewFile(options.Output, encoded, 0o644); err != nil {
+		return err
+	}
+	return json.NewEncoder(output).Encode(licenseInventoryResult{
+		GoModules: len(manifest.Modules), NativeDependencies: len(manifest.Native), Output: filepath.Base(options.Output),
+	})
+}

--- a/tools/release/main.go
+++ b/tools/release/main.go
@@ -23,7 +23,7 @@ import (
 
 func main() {
 	if len(os.Args) < 2 {
-		fatal(errors.New("usage: release <asset|package|metadata|checksum|verify> [flags]"))
+		fatal(errors.New("usage: release <asset|package|metadata|checksum|licenses|verify> [flags]"))
 	}
 	var err error
 	switch os.Args[1] {
@@ -35,6 +35,8 @@ func main() {
 		err = runMetadata(os.Args[2:])
 	case "checksum":
 		err = runChecksum(os.Args[2:])
+	case "licenses":
+		err = runLicenseInventory(os.Args[2:], os.Stdout)
 	case "verify":
 		err = runVerify(os.Args[2:])
 	default:

--- a/tools/release/main_test.go
+++ b/tools/release/main_test.go
@@ -16,7 +16,9 @@ package main
 
 import (
 	"archive/tar"
+	"bytes"
 	"compress/gzip"
+	"encoding/json"
 	"errors"
 	"io"
 	"os"
@@ -27,6 +29,43 @@ import (
 	"testing"
 	"time"
 )
+
+func TestLicenseInventoryWritesBoundedDependencyEvidence(t *testing.T) {
+	t.Parallel()
+	binary, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	repository := filepath.Clean(filepath.Join("..", ".."))
+	output := filepath.Join(t.TempDir(), "dependencies.json")
+	var stdout bytes.Buffer
+	if inventoryErr := runLicenseInventory([]string{
+		"-binary", binary, "-edition", "standard", "-output", output, "-repository", repository,
+	}, &stdout); inventoryErr != nil {
+		t.Fatal(inventoryErr)
+	}
+	var result licenseInventoryResult
+	if decodeErr := json.Unmarshal(stdout.Bytes(), &result); decodeErr != nil {
+		t.Fatal(decodeErr)
+	}
+	if result.GoModules == 0 || result.NativeDependencies != 1 || result.Output != "dependencies.json" {
+		t.Fatalf("license inventory result = %#v", result)
+	}
+	contents, err := os.ReadFile(output)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var manifest dependencyManifest
+	if err := json.Unmarshal(contents, &manifest); err != nil {
+		t.Fatal(err)
+	}
+	if manifest.SchemaVersion != 1 || len(manifest.Modules) != result.GoModules || len(manifest.Native) != result.NativeDependencies {
+		t.Fatalf("license manifest = %#v", manifest)
+	}
+	if len(manifest.Native[0].Licenses) != 1 || manifest.Native[0].Path != "github.com/asg017/sqlite-vec" {
+		t.Fatalf("native license evidence = %#v", manifest.Native)
+	}
+}
 
 func TestGenerateSBOMUsesStablePublicIdentity(t *testing.T) {
 	if runtime.GOOS == "windows" {

--- a/tools/release/workflow_test.go
+++ b/tools/release/workflow_test.go
@@ -61,7 +61,7 @@ func TestContinuousIntegrationPreservesPythonTopologyAndGoAssurance(t *testing.T
 	required := map[string][]string{
 		"master.yml": {
 			"name: Main", "quality:", "run: make check", "run: make contract-test",
-			"tests:", "run: make unit-test", "run: make e2e-test", "pi-package:", "check-docs:",
+			"license-dependencies:", "run: make license-dependencies", "tests:", "run: make unit-test", "run: make e2e-test", "pi-package:", "check-docs:",
 			"migration-assurance:", "uses: ./.github/workflows/migration-gates.yml",
 		},
 		"migration-gates.yml": {


### PR DESCRIPTION
## Summary

- add `release licenses`, which reads a built binary's actual Go build info and verifies top-level license/notice evidence for every linked module
- write a bounded JSON dependency-license manifest and report module/native dependency counts
- add an idempotent `make license-dependencies` target for the standard binary
- add a stable `license-dependencies` CI job that uploads the JSON evidence for 14 days
- add a real-binary regression test and extend the workflow topology contract

## Rationale

WP0-C in #3 requires dependency license evidence before release packaging. The repository already uses `collectLicenses` during release archive creation; this change exposes that same implementation for ordinary pull requests rather than creating a second license scanner.

This PR is stacked on #35 (`codex/issue-33-portable-sdk`), which owns the portable SDK gate. It intentionally does not depend on the duplicate #34 chain.

## Behavior, API, and compatibility

- no public API, protocol, generated-contract, or runtime behavior changes
- fails when a module referenced by the built standard binary is unavailable in the Go module cache or lacks a top-level license/notice file
- standard evidence includes the embedded sqlite-vec license; Full native assets remain validated through the release packaging path

## Validation

- `make license-dependencies` run twice, both times producing a manifest with 95 Go modules and 1 native dependency
- JSON manifest structural check via `jq`
- `go test ./...`
- `make check` with the required SQLite include path
- `make check-generated`
- `make license-check`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12`
- `git diff --cached --check`

Exact head validated: `d6eed940a60eed44a2e98fbecdb3a91c5ec08133`.

## AI usage

Implemented with Codex assistance. The real-binary test and generated evidence path were self-reviewed with test-guard and verified by the commands above.