### PR TITLE
fix(deps): override vulnerable ansi-regex

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,3 +130,8 @@ source / artifact / trigger / inference
   raw database bytes that contain the producing SQLite version and physical
   page-layout metadata. Keep committed fixture hashes pinned separately, and
   verify both semantic regeneration and cross-runtime read/write compatibility.
+- When remediating a transitive dependency vulnerability, declare the
+  resolution in the affected package manager's root manifest rather than
+  editing only the lockfile. Regenerate with the package-manager version pinned
+  in CI, preserve required license headers, and verify both a frozen install
+  and an authoritative audit eliminate every vulnerable dependency path.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,3 +165,7 @@ source / artifact / trigger / inference
   editing only the lockfile. Regenerate with the package-manager version pinned
   in CI, preserve required license headers, and verify both a frozen install
   and an authoritative audit eliminate every vulnerable dependency path.
+- When a test must cancel while a synchronous foreign-function call is in
+  flight, coordinate entry and release with explicit barriers instead of a
+  fixed sleep. Verify the public error and cleanup side effects under high
+  repetition on every supported architecture.

--- a/integrations/openclaw/plugins/memory-powercontext/package.json
+++ b/integrations/openclaw/plugins/memory-powercontext/package.json
@@ -38,6 +38,11 @@
     "typescript": "^5.9.2",
     "vitest": "^3.2.4"
   },
+  "pnpm": {
+    "overrides": {
+      "ansi-regex": "5.0.1"
+    }
+  },
   "peerDependencies": {
     "openclaw": ">=2026.8.1-beta.2"
   },

--- a/integrations/openclaw/plugins/memory-powercontext/pnpm-lock.yaml
+++ b/integrations/openclaw/plugins/memory-powercontext/pnpm-lock.yaml
@@ -12,12 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 lockfileVersion: '9.0'
 
 settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
+
+overrides:
+  ansi-regex: 5.0.1
 
 importers:
 
@@ -848,10 +850,6 @@ packages:
 
   ajv@8.20.0:
     resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
-
-  ansi-regex@5.0.0:
-    resolution: {integrity: sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==}
-    engines: {node: '>=8'}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -2941,8 +2939,6 @@ snapshots:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
-  ansi-regex@5.0.0: {}
-
   ansi-regex@5.0.1: {}
 
   ansi-styles@4.0.0:
@@ -4137,7 +4133,7 @@ snapshots:
 
   strip-ansi@6.0.0:
     dependencies:
-      ansi-regex: 5.0.0
+      ansi-regex: 5.0.1
 
   strip-ansi@6.0.1:
     dependencies:

--- a/internal/sqlstore/seekdb/seekdb_test.go
+++ b/internal/sqlstore/seekdb/seekdb_test.go
@@ -179,7 +179,7 @@ int seekdb_connection_options(void *handle, SeekDBConnectionOptions *out) {
 		t.Cleanup(func() {
 			_ = os.WriteFile(released, []byte("released"), 0o600)
 		})
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(t.Context())
 		result := make(chan error, 1)
 		go func() {
 			instance, openErr := Open(ctx, Config{Path: filepath.Join(root, "data"), LibraryPath: library})

--- a/internal/sqlstore/seekdb/seekdb_test.go
+++ b/internal/sqlstore/seekdb/seekdb_test.go
@@ -120,12 +120,25 @@ static void mark(const char *name, const char *value) {
     fclose(file);
 }
 
+static void wait_for_release(const char *name) {
+    const char *path = getenv(name);
+    if (path == NULL) return;
+    for (;;) {
+        FILE *file = fopen(path, "r");
+        if (file != NULL) {
+            fclose(file);
+            return;
+        }
+        struct timespec delay = { .tv_sec = 0, .tv_nsec = 1000000 };
+        nanosleep(&delay, NULL);
+    }
+}
+
 int seekdb_open(const char *directory, const char **error, void **out) {
     (void)directory;
     (void)error;
     mark("POWERCONTEXT_SEEKDB_TEST_OPENED", "opened");
-    struct timespec delay = { .tv_sec = 0, .tv_nsec = 100000000 };
-    nanosleep(&delay, NULL);
+    wait_for_release("POWERCONTEXT_SEEKDB_TEST_RELEASED");
     *out = (void *)0x1;
     return 0;
 }
@@ -159,8 +172,13 @@ int seekdb_connection_options(void *handle, SeekDBConnectionOptions *out) {
 	for attempt := 0; attempt < 3; attempt++ {
 		opened := filepath.Join(root, "opened-"+strconv.Itoa(attempt))
 		closed := filepath.Join(root, "closed-"+strconv.Itoa(attempt))
+		released := filepath.Join(root, "released-"+strconv.Itoa(attempt))
 		t.Setenv("POWERCONTEXT_SEEKDB_TEST_OPENED", opened)
 		t.Setenv("POWERCONTEXT_SEEKDB_TEST_CLOSED", closed)
+		t.Setenv("POWERCONTEXT_SEEKDB_TEST_RELEASED", released)
+		t.Cleanup(func() {
+			_ = os.WriteFile(released, []byte("released"), 0o600)
+		})
 		ctx, cancel := context.WithCancel(context.Background())
 		result := make(chan error, 1)
 		go func() {
@@ -188,6 +206,9 @@ int seekdb_connection_options(void *handle, SeekDBConnectionOptions *out) {
 		cancel()
 		cancel()
 		cancel()
+		if err := os.WriteFile(released, []byte("released"), 0o600); err != nil {
+			t.Fatal(err)
+		}
 		if openErr := <-result; !errors.Is(openErr, context.Canceled) {
 			t.Fatalf("open error = %v, want context cancellation", openErr)
 		}


### PR DESCRIPTION
## Summary

- add a package-root pnpm override that resolves every current `ansi-regex`
  request in the OpenClaw memory plugin to the patched `5.0.1` release
- regenerate the lockfile with pnpm 10.34.5, remove `ansi-regex@5.0.0`, and
  preserve the Apache-2.0 header
- record reusable dependency-remediation and native-test synchronization rules
  in `AGENTS.md`
- replace the SeekDB cancellation fixture's timing-dependent native sleep with
  an explicit entry/release barrier after exact-head linux-arm64 CI exposed the
  sleep race; production SeekDB behavior is unchanged

Closes #11.

## Security rationale

The vulnerable runtime path was:

`openclaw -> qrcode -> yargs -> cliui@6.0.0 -> strip-ansi@6.0.0 -> ansi-regex@5.0.0`

GitHub Advisory `GHSA-93q8-gq69-wqmw` / `CVE-2021-3807` marks
`ansi-regex >=5.0.0,<5.0.1` as vulnerable and `5.0.1` as the first patched
5.x release. The root manifest override is compatible with the current graph
and avoids upgrading OpenClaw or unrelated transitive dependencies.

## CI follow-up

The first refreshed exact-head run failed only in
`Full build tags (linux-arm64)`. The failure came from
`TestOpenClosesNativeInstanceWhenCancellationRepeatsDuringHandshake`: its C
fixture wrote an entry marker and then called `nanosleep` once, assuming the
call would last 100 ms. POSIX permits `nanosleep` to return early when a signal
interrupts it, so the native call could finish before the Go test issued
cancellation.

The fixture now blocks on an explicit release marker. The Go side observes
entry, cancels the context, and then releases the native call. This preserves
the same public `Open` error and native-close assertions without relying on
scheduler timing or a longer timeout.

## Behavior and compatibility

- no application API, protocol, persistence, generated contract, or host
  version change
- no production SeekDB implementation change
- the OpenClaw plugin keeps its existing dependency ranges and resolves the
  vulnerable transitive edge to `ansi-regex@5.0.1`

## Validation

Security and package checks:

- current `main`: `pnpm audit --json` reports one HIGH advisory on
  `ansi-regex@5.0.0`
- final candidate: pnpm 10.34.5 frozen install succeeds, `pnpm why ansi-regex`
  reports only `5.0.1`, and `pnpm audit --json` reports zero vulnerabilities
- Node 24.15.0: typecheck, 16/16 Vitest tests, and build pass with no generated
  `dist` difference
- `license-eye`: 959 files checked, 0 invalid

SeekDB cancellation checks:

- WSL Go 1.27 targeted test: 200 repeated runs pass
- race-enabled targeted test: 50 repeated runs pass
- full `internal/sqlstore/seekdb` package passes
- a disposable mutant with both post-native cancellation checks removed fails
  with `open error = <nil>, want context cancellation`

GitHub exact-head evidence for `b34d189bb8de8fa9cd7465e3ed66c8c39403c0f9`:

- 4/4 workflow runs completed successfully: Main, E2E harness, CodeQL, and
  License Check
- 27/27 check runs completed successfully, including linux-arm64 Full build
  tags, race/fuzz/module integrity, both acceptance backends, coverage, and
  all Linux/macOS standard/full matrices
- PR merge state is `CLEAN` and `MERGEABLE`; the GitHub merge-ref tree matches
  the reviewed Head tree

## AI usage

Implemented and reviewed with Codex assistance. The advisory range, dependency
graph, Base/Head audit result, POSIX interruption behavior, deterministic test
mutation, final diff, comments, merge ref, and exact-head CI were verified
against current sources and reproducible commands.
