### PR TITLE
docs: require use-modern-go for every session

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,21 @@ source / artifact / trigger / inference
 - Do not introduce `pkg`, `src`, `common`, `utils`, `helpers`, or global
   `models`, `services`, and `repositories` packages.
 
+## Mandatory Modern Go skill
+
+- At the start of every agent session in this repository, load and follow the
+  installed `use-modern-go` skill from
+  `https://github.com/JetBrains/go-modern-guidelines` before performing
+  repository work.
+- Before analyzing, reviewing, writing, modifying, fixing, or refactoring Go
+  code, run the skill's `list` command for each relevant Go file or the
+  repository's resolved Go version, and read the complete unfiltered output.
+  Follow every applicable returned guideline.
+- Use the skill's `explain` command only for specific guideline IDs that need
+  further evaluation. If the skill is unavailable, cannot be loaded, or its
+  wrapper fails, stop before changing Go code and report the blocker instead
+  of relying on remembered guidance.
+
 ## Go conventions
 
 - Put `context.Context` first on every operation that can block or perform I/O.


### PR DESCRIPTION
## Summary

- require every agent session in this repository to load and follow the `use-modern-go` skill
- require the skill's complete `list` output before Go analysis, review, or code changes
- stop Go modifications when the skill or its wrapper is unavailable instead of relying on remembered guidance

## Verification

- `use-modern-go list --file-path D:\test\github\powercontext-go\trigger\trigger.go`
- `git diff --check origin/main...HEAD`
- confirmed the PR changes only `AGENTS.md`

Go tests were not run because this is an `AGENTS.md`-only instruction change with no Go source or build configuration changes.