### PR TITLE
test: record upstream parity contract as separate concepts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,10 +167,12 @@ source / artifact / trigger / inference
   reject every keyword outside GitHub's supported caller-job set. Verify the
   rule with fixtures for a valid caller, a blank reference, `timeout-minutes`,
   and ordinary-only fields such as `runs-on` or `steps`.
-- When a repository gate mirrors an external structured schema, validate every
-  supported variant's required attributes and keep a valid fixture plus a
-  failing mutant for each variant boundary. Recheck the assumptions against
-  the current official schema before changing the validator.
+- When a repository gate reads a versioned structured contract or mirrors an
+  external schema, reject duplicate and unknown fields, validate compound
+  identifiers by their exact segment shape, and check executable workflow
+  steps by the complete required operation rather than substring presence.
+  Keep a valid fixture plus a failing mutant for each boundary, and recheck the
+  assumptions against the current official schema before changing the gate.
 - When blank Issues are disabled, inventory every supported request class and
   provide a distinct validated form or contact route for each. Verify that the
   chooser routes bounded features separately from compatibility-sensitive

--- a/test/conformance/README.md
+++ b/test/conformance/README.md
@@ -4,6 +4,16 @@ This directory makes the Python `v0.0.2` implementation at commit
 `3a6cb0151670eaff7dc0293466edd673124e80da` an executable Oracle rather than
 an informal reference.
 
+- `parity-contract.json` records the upstream parity identity as four
+  separate concepts: the upstream repository, the exact target SHA, the
+  frozen release Oracle, and the active parity target. `parity_contract_test.go`
+  proves the frozen Oracle commit is identical across the contract, the Go
+  test constant, `manifest.json`, and the `frozen-oracle` CI checkout, and
+  rejects any conflation between the frozen Oracle and the parity targets.
+  Update the active parity target only deliberately: confirm the upstream CI
+  run at the new commit is green, record the new exact target SHA and its
+  test inventory together in one reviewed change, and keep the frozen
+  Oracle untouched until a new versioned Oracle directory is accepted.
 - `testdata/python-v0.0.2/manifest.json` freezes OpenAPI, SQLite schema,
   Prompt, fixture, and Python-test inventories.
 - `traceability.json` inventories every one of the 622 frozen Python test

--- a/test/conformance/parity-contract.json
+++ b/test/conformance/parity-contract.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "upstream": {
+    "repository": "oceanbase/powercontext",
+    "url": "https://github.com/oceanbase/powercontext",
+    "default_branch": "master"
+  },
+  "frozen_release_oracle": {
+    "commit": "3a6cb0151670eaff7dc0293466edd673124e80da",
+    "baseline": "python-v0.0.2",
+    "evidence_directory": "test/conformance/testdata/python-v0.0.2"
+  },
+  "exact_target_sha": "f2ec1f75e5e1b46ad0626ab8390801b88966b6f5",
+  "target_test_case_count": 759,
+  "active_parity_target": "f2ec1f75e5e1b46ad0626ab8390801b88966b6f5"
+}

--- a/test/conformance/parity_contract_test.go
+++ b/test/conformance/parity_contract_test.go
@@ -1,0 +1,183 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conformance_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v2"
+)
+
+// The parity contract records four separate concepts from the WP1 epic (#3):
+// the upstream repository, the exact target SHA, the frozen release Oracle,
+// and the active parity target. They must stay distinct, well-formed facts.
+type parityContract struct {
+	SchemaVersion int `json:"schema_version"`
+	Upstream      struct {
+		Repository    string `json:"repository"`
+		URL           string `json:"url"`
+		DefaultBranch string `json:"default_branch"`
+	} `json:"upstream"`
+	FrozenReleaseOracle struct {
+		Commit            string `json:"commit"`
+		Baseline          string `json:"baseline"`
+		EvidenceDirectory string `json:"evidence_directory"`
+	} `json:"frozen_release_oracle"`
+	ExactTargetSHA      string `json:"exact_target_sha"`
+	TargetTestCaseCount int    `json:"target_test_case_count"`
+	ActiveParityTarget  string `json:"active_parity_target"`
+}
+
+var commitSHA256Pattern = regexp.MustCompile(`^[0-9a-f]{40}$`)
+
+func TestParityContractRecordsSeparateConcepts(t *testing.T) {
+	contract := readParityContract(t)
+	root := repositoryRoot(t)
+
+	if contract.SchemaVersion != 1 {
+		t.Fatalf("parity contract schema version = %d, want 1", contract.SchemaVersion)
+	}
+
+	// Concept 1: the upstream repository identity.
+	slug := contract.Upstream.Repository
+	owner, name, split := strings.Cut(slug, "/")
+	if !split || owner == "" || name == "" || strings.ContainsRune(slug, ' ') {
+		t.Fatalf("upstream repository %q is not a GitHub owner/name slug", slug)
+	}
+	if want := "https://github.com/" + slug; contract.Upstream.URL != want {
+		t.Errorf("upstream URL = %q, want %q", contract.Upstream.URL, want)
+	}
+	if contract.Upstream.DefaultBranch == "" {
+		t.Error("upstream default branch is empty")
+	}
+
+	// Concept 2: the frozen release Oracle.
+	oracle := contract.FrozenReleaseOracle.Commit
+	if !commitSHA256Pattern.MatchString(oracle) {
+		t.Fatalf("frozen release Oracle commit %q is not a 40-hex SHA-1", oracle)
+	}
+	if oracle != oracleCommit {
+		t.Errorf("frozen release Oracle commit = %s, want the oracleCommit constant %s", oracle, oracleCommit)
+	}
+	if contract.FrozenReleaseOracle.Baseline != "python-v0.0.2" {
+		t.Errorf("frozen release Oracle baseline = %q, want %q", contract.FrozenReleaseOracle.Baseline, "python-v0.0.2")
+	}
+	evidence := filepath.Clean(filepath.FromSlash(contract.FrozenReleaseOracle.EvidenceDirectory))
+	if filepath.IsAbs(evidence) || evidence == ".." || strings.HasPrefix(evidence, ".."+string(filepath.Separator)) {
+		t.Fatalf("Oracle evidence directory escapes the repository: %q", evidence)
+	}
+	if info, err := os.Stat(filepath.Join(root, evidence)); err != nil || !info.IsDir() {
+		t.Errorf("Oracle evidence directory %s is missing: %v", evidence, err)
+	}
+	var manifest struct {
+		OracleCommit string `json:"oracle_commit"`
+	}
+	decodeJSONFile(t, filepath.Join(root, evidence, "manifest.json"), &manifest)
+	if manifest.OracleCommit != oracle {
+		t.Errorf("manifest.json oracle_commit = %s, want the contract frozen Oracle %s", manifest.OracleCommit, oracle)
+	}
+
+	// Concept 3: the exact target SHA and its recorded test inventory.
+	target := contract.ExactTargetSHA
+	if !commitSHA256Pattern.MatchString(target) {
+		t.Fatalf("exact target SHA %q is not a 40-hex SHA-1", target)
+	}
+	if target == oracle {
+		t.Errorf("exact target SHA collapses into the frozen release Oracle %s; they must stay separate concepts", oracle)
+	}
+	if contract.TargetTestCaseCount <= 0 {
+		t.Errorf("target test case count = %d, want a positive recorded inventory", contract.TargetTestCaseCount)
+	}
+
+	// Concept 4: the active parity target.
+	active := contract.ActiveParityTarget
+	if !commitSHA256Pattern.MatchString(active) {
+		t.Fatalf("active parity target %q is not a 40-hex SHA-1", active)
+	}
+	if active == oracle {
+		t.Errorf("active parity target collapses into the frozen release Oracle %s; parity work must measure a newer upstream state", oracle)
+	}
+}
+
+func TestParityContractMatchesFrozenOracleWorkflow(t *testing.T) {
+	contract := readParityContract(t)
+	root := repositoryRoot(t)
+
+	contents, err := os.ReadFile(filepath.Join(root, ".github", "workflows", "migration-gates.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var workflow struct {
+		Jobs map[string]struct {
+			Steps []struct {
+				Name string `yaml:"name"`
+				With struct {
+					Repository string `yaml:"repository"`
+					Ref        string `yaml:"ref"`
+				} `yaml:"with"`
+				Run string `yaml:"run"`
+			} `yaml:"steps"`
+		} `yaml:"jobs"`
+	}
+	if err := yaml.Unmarshal(contents, &workflow); err != nil {
+		t.Fatal(err)
+	}
+	job, ok := workflow.Jobs["frozen-oracle"]
+	if !ok {
+		t.Fatal("migration-gates.yml has no frozen-oracle job")
+	}
+	checkout, verify := "", ""
+	for _, step := range job.Steps {
+		switch step.Name {
+		case "Check out frozen Python Oracle":
+			checkout = step.Name
+			if step.With.Repository != contract.Upstream.Repository {
+				t.Errorf("frozen-oracle checkout repository = %q, want the contract upstream %q", step.With.Repository, contract.Upstream.Repository)
+			}
+			if step.With.Ref != contract.FrozenReleaseOracle.Commit {
+				t.Errorf("frozen-oracle checkout ref = %q, want the contract frozen Oracle %q", step.With.Ref, contract.FrozenReleaseOracle.Commit)
+			}
+		case "Verify Oracle identity":
+			verify = step.Name
+			if !strings.Contains(step.Run, contract.FrozenReleaseOracle.Commit) {
+				t.Errorf("Verify Oracle identity step does not pin the contract frozen Oracle %q", contract.FrozenReleaseOracle.Commit)
+			}
+		}
+	}
+	if checkout == "" {
+		t.Error("frozen-oracle job has no 'Check out frozen Python Oracle' step")
+	}
+	if verify == "" {
+		t.Error("frozen-oracle job has no 'Verify Oracle identity' step")
+	}
+}
+
+func readParityContract(t *testing.T) parityContract {
+	t.Helper()
+	contents, err := os.ReadFile(filepath.Join("parity-contract.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var contract parityContract
+	if err := json.Unmarshal(contents, &contract); err != nil {
+		t.Fatal(err)
+	}
+	return contract
+}

--- a/test/conformance/parity_contract_test.go
+++ b/test/conformance/parity_contract_test.go
@@ -15,12 +15,13 @@
 package conformance_test
 
 import (
-	"encoding/json"
+	"encoding/json/v2"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
+	"unicode"
 
 	"gopkg.in/yaml.v2"
 )
@@ -45,7 +46,51 @@ type parityContract struct {
 	ActiveParityTarget  string `json:"active_parity_target"`
 }
 
-var commitSHA256Pattern = regexp.MustCompile(`^[0-9a-f]{40}$`)
+var commitSHA1Pattern = regexp.MustCompile(`^[0-9a-f]{40}$`)
+
+func TestParityContractRejectsMalformedRepositorySlug(t *testing.T) {
+	for _, slug := range []string{"oceanbase/powercontext/extra", "oceanbase/\tpowercontext"} {
+		if validGitHubRepositorySlug(slug) {
+			t.Errorf("accepted malformed GitHub repository slug %q", slug)
+		}
+	}
+}
+
+func TestParityContractRejectsAmbiguousJSON(t *testing.T) {
+	contents, err := os.ReadFile("parity-contract.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tests := []struct {
+		name   string
+		mutant string
+	}{
+		{
+			name:   "duplicate member",
+			mutant: strings.Replace(string(contents), `"schema_version": 1,`, `"schema_version": 999, "schema_version": 1,`, 1),
+		},
+		{
+			name:   "unknown member",
+			mutant: strings.Replace(string(contents), `"schema_version": 1,`, `"schema_version": 1, "future_semantics": true,`, 1),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if test.mutant == string(contents) {
+				t.Fatal("mutant construction did not change the parity contract")
+			}
+			if _, err := decodeParityContract([]byte(test.mutant)); err == nil {
+				t.Error("accepted ambiguous parity contract JSON")
+			}
+		})
+	}
+}
+
+func TestFrozenOracleWorkflowRejectsNonVerifyingIdentityStep(t *testing.T) {
+	if validOracleIdentityCommand("echo "+oracleCommit, oracleCommit) {
+		t.Error("accepted an Oracle identity step that only prints the expected commit")
+	}
+}
 
 func TestParityContractRecordsSeparateConcepts(t *testing.T) {
 	contract := readParityContract(t)
@@ -57,8 +102,7 @@ func TestParityContractRecordsSeparateConcepts(t *testing.T) {
 
 	// Concept 1: the upstream repository identity.
 	slug := contract.Upstream.Repository
-	owner, name, split := strings.Cut(slug, "/")
-	if !split || owner == "" || name == "" || strings.ContainsRune(slug, ' ') {
+	if !validGitHubRepositorySlug(slug) {
 		t.Fatalf("upstream repository %q is not a GitHub owner/name slug", slug)
 	}
 	if want := "https://github.com/" + slug; contract.Upstream.URL != want {
@@ -70,7 +114,7 @@ func TestParityContractRecordsSeparateConcepts(t *testing.T) {
 
 	// Concept 2: the frozen release Oracle.
 	oracle := contract.FrozenReleaseOracle.Commit
-	if !commitSHA256Pattern.MatchString(oracle) {
+	if !commitSHA1Pattern.MatchString(oracle) {
 		t.Fatalf("frozen release Oracle commit %q is not a 40-hex SHA-1", oracle)
 	}
 	if oracle != oracleCommit {
@@ -96,7 +140,7 @@ func TestParityContractRecordsSeparateConcepts(t *testing.T) {
 
 	// Concept 3: the exact target SHA and its recorded test inventory.
 	target := contract.ExactTargetSHA
-	if !commitSHA256Pattern.MatchString(target) {
+	if !commitSHA1Pattern.MatchString(target) {
 		t.Fatalf("exact target SHA %q is not a 40-hex SHA-1", target)
 	}
 	if target == oracle {
@@ -108,7 +152,7 @@ func TestParityContractRecordsSeparateConcepts(t *testing.T) {
 
 	// Concept 4: the active parity target.
 	active := contract.ActiveParityTarget
-	if !commitSHA256Pattern.MatchString(active) {
+	if !commitSHA1Pattern.MatchString(active) {
 		t.Fatalf("active parity target %q is not a 40-hex SHA-1", active)
 	}
 	if active == oracle {
@@ -156,7 +200,7 @@ func TestParityContractMatchesFrozenOracleWorkflow(t *testing.T) {
 			}
 		case "Verify Oracle identity":
 			verify = step.Name
-			if !strings.Contains(step.Run, contract.FrozenReleaseOracle.Commit) {
+			if !validOracleIdentityCommand(step.Run, contract.FrozenReleaseOracle.Commit) {
 				t.Errorf("Verify Oracle identity step does not pin the contract frozen Oracle %q", contract.FrozenReleaseOracle.Commit)
 			}
 		}
@@ -175,9 +219,28 @@ func readParityContract(t *testing.T) parityContract {
 	if err != nil {
 		t.Fatal(err)
 	}
-	var contract parityContract
-	if err := json.Unmarshal(contents, &contract); err != nil {
+	contract, err := decodeParityContract(contents)
+	if err != nil {
 		t.Fatal(err)
 	}
 	return contract
+}
+
+func decodeParityContract(contents []byte) (parityContract, error) {
+	var contract parityContract
+	if err := json.Unmarshal(contents, &contract, json.RejectUnknownMembers(true)); err != nil {
+		return parityContract{}, err
+	}
+	return contract, nil
+}
+
+func validGitHubRepositorySlug(slug string) bool {
+	owner, name, split := strings.Cut(slug, "/")
+	return split && owner != "" && name != "" && !strings.ContainsRune(name, '/') &&
+		strings.IndexFunc(slug, unicode.IsSpace) < 0
+}
+
+func validOracleIdentityCommand(command, commit string) bool {
+	want := `test "$(git -C _oracle rev-parse HEAD)" = ` + commit
+	return strings.TrimSpace(command) == want
 }


### PR DESCRIPTION
## Summary

Record the four upstream parity concepts from WP1 (#3) as separate machine-checked facts, closing #41:

- `test/conformance/parity-contract.json` records:
  - **upstream repository**: `oceanbase/powercontext` (slug + canonical URL + default branch);
  - **frozen release Oracle**: `3a6cb0151670eaff7dc0293466edd673124e80da` (`python-v0.0.2`, evidence directory);
  - **exact target SHA**: `f2ec1f75e5e1b46ad0626ab8390801b88966b6f5` with its recorded inventory of 759 Python test cases;
  - **active parity target**: `f2ec1f75e5e1b46ad0626ab8390801b88966b6f5` (separate field; currently equals the target SHA, per the epic's referenced green upstream CI run 33041759193).
- `test/conformance/parity_contract_test.go` fails when any field is missing or malformed, when the frozen Oracle commit disagrees with the `oracleCommit` Go test constant, `manifest.json`, or the `frozen-oracle` CI job checkout ref, or when the target SHA or active parity target collapses into the frozen Oracle.
- `test/conformance/README.md` documents the deliberate procedure for advancing the active parity target.

Today these four concepts live only as prose in the epic plus scattered constants; nothing prevented a future change from conflating the v0.0.2 Oracle with the newer parity target.

## Evidence

- The 759-test inventory at the target SHA was verified against a local upstream checkout using the repository's own counting convention (`tests` + `integrations` + `e2e`, `(async )?def test_`): oracle `3a6cb01` = 622 cases (matches the frozen manifest exactly), target `f2ec1f7` = 759 cases (matches the epic exactly). Current upstream master (`04d2585`) is already at 798, which is why an explicit contract matters now.

## Negative proof

The gate was demonstrated to catch both drift classes:

- collapsing `active_parity_target` into the frozen Oracle → `TestParityContractRecordsSeparateConcepts` fails with "active parity target collapses into the frozen release Oracle";
- changing the `frozen-oracle` workflow checkout `ref` → `TestParityContractMatchesFrozenOracleWorkflow` fails with a ref mismatch.

## Behavior, API, and compatibility

- no public API, protocol, persistence, or generated-contract changes; `go.mod`/`go.sum` untouched (`gopkg.in/yaml.v2` is already a direct dependency used by `tools/governance-check`);
- runs inside the existing conformance suite in the `frozen-oracle` CI job (`go test ./test/conformance`); no new CI job.

## Validation

Run with the local Go 1.27 toolchain on the exact PR head:

- `go test -count=1 ./test/conformance/` — ok (full suite, including both new tests)
- `go vet ./test/conformance/` — clean
- `make license-check` — 782 valid, 0 invalid
- `make fmt-check` — clean
- `git diff --check` — clean
