### PR TITLE
test: inventory all 759 tests at the active parity target

### DIFF
--- a/.github/workflows/migration-gates.yml
+++ b/.github/workflows/migration-gates.yml
@@ -98,6 +98,16 @@ jobs:
       - name: Verify Oracle identity
         run: test "$(git -C _oracle rev-parse HEAD)" = 3a6cb0151670eaff7dc0293466edd673124e80da
 
+      - name: Check out the active parity target
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          repository: oceanbase/powercontext
+          ref: f2ec1f75e5e1b46ad0626ab8390801b88966b6f5
+          path: _target
+
+      - name: Verify parity target identity
+        run: test "$(git -C _target rev-parse HEAD)" = f2ec1f75e5e1b46ad0626ab8390801b88966b6f5
+
       - name: Set up the Go environment
         uses: ./.github/actions/setup-go-env
 
@@ -140,6 +150,7 @@ jobs:
             --expected test/conformance/testdata/python-v0.0.2/scheduler.db
           go run ./tools/fixture-generate -python _oracle -check
           go run ./tools/traceability-generate -check
+          go run ./tools/parity-inventory-generate -upstream _target -check
 
       - name: Run Python to Go to Python compatibility tests
         env:

--- a/test/conformance/README.md
+++ b/test/conformance/README.md
@@ -20,6 +20,17 @@ an informal reference.
   functions and records whether its evidence is case-specific or supporting.
   It is generated from `traceability-rules.json`; do not edit the generated
   table by hand.
+- `parity-inventory.json` inventories all 759 Python test cases at the
+  active parity target recorded in `parity-contract.json`. Every case
+  carries a mode (`go-port`, `cross-layer`, or `retained-host`) and a
+  status: `mapped` cases have case-specific evidence that resolves against
+  real test declarations, `pending` cases await the port that owns their
+  mode (for example WP2 for the transport surface). The 622 frozen Oracle
+  cases inherit their `traceability.json` mappings verbatim. It is
+  generated from `parity-inventory-rules.json` plus an upstream checkout
+  pinned at the contract target SHA; do not edit the generated inventory
+  by hand, and update the pinned mapped/pending counts only together with
+  the rule changes that move cases between the two states.
 - `authority_test.go` proves Python SQLite → Go read/write → Python back-read.
 - `review_database_test.go` proves Python Candidate → Go revise/approve →
   Python Artifact back-read and continued Candidate writes against the same
@@ -38,10 +49,22 @@ go run ./tools/traceability-generate
 go run ./tools/traceability-generate -check
 ```
 
-The frozen-Oracle CI job independently checks out the exact Python commit,
-runs its suite, regenerates the deterministic fixtures, and enables both
-Python back-read tests. A changed Oracle commit requires deliberate fixture
-regeneration and review; changing only a hash to silence drift is not valid.
+Regenerate or check the active parity target inventory against an upstream
+checkout pinned at the contract target SHA (the generator verifies
+`git rev-parse HEAD` before extracting):
+
+```sh
+git -C ../powercontext checkout f2ec1f75e5e1b46ad0626ab8390801b88966b6f5
+go run ./tools/parity-inventory-generate -upstream ../powercontext
+go run ./tools/parity-inventory-generate -upstream ../powercontext -check
+```
+
+The frozen-Oracle CI job checks out both the exact Oracle commit and the
+active parity target, runs the Oracle suite, regenerates the deterministic
+fixtures, verifies both generated inventories byte-for-byte, and enables
+both Python back-read tests. A changed Oracle commit requires deliberate
+fixture regeneration and review; changing only a hash to silence drift is
+not valid.
 
 The rules carry a monotonically increasing checkpoint for case-specific
 evidence. A changed Oracle case must add or update its exact `cases` mapping;

--- a/test/conformance/parity-inventory-rules.json
+++ b/test/conformance/parity-inventory-rules.json
@@ -1,0 +1,108 @@
+{
+  "schema_version": 1,
+  "comment": "Mode assignments for the delta between the frozen v0.0.2 Oracle (622 cases) and the active parity target (759 cases). Cases listed under \"cases\" carry resolvable evidence and become status=mapped; every other delta case becomes status=pending with the file mode and is expected to gain evidence as the relevant port lands (for example WP2 for the transport surface). Frozen Oracle cases inherit their mappings from traceability.json and never appear here.",
+  "files": {
+    "e2e/bub/tests/test_bub_transport_trust.py": {
+      "mode": "retained-host",
+      "reason": "Bub plugin transport trust behavior; evidence will live in the retained Bub adapter tests once WP2 aligns the shared loopback vectors."
+    },
+    "e2e/bub/tests/test_harbor_agent.py": {
+      "mode": "retained-host",
+      "reason": "Bub harbor agent installation behavior owned by the retained Bub adapter."
+    },
+    "tests/e2e/test_pydantic_ai_chain.py": {
+      "mode": "cross-layer",
+      "reason": "End-to-end capture/checkpoint/recall/search chain crossing the Pydantic AI adapter and the Server."
+    },
+    "tests/e2e/test_workbuddy_service_chain.py": {
+      "mode": "cross-layer",
+      "reason": "End-to-end chain crossing the WorkBuddy hook and the shared MCP service configuration."
+    },
+    "tests/integrations/test_hermes_provider.py": {
+      "mode": "retained-host",
+      "reason": "Hermes provider plugin behavior; evidence will live in the retained Hermes adapter tests."
+    },
+    "tests/langchain_middleware/test_middleware.py": {
+      "mode": "retained-host",
+      "reason": "LangChain middleware observable behavior owned by the LangChain adapter named in the WP2 retained-adapter alignment list."
+    },
+    "tests/langchain_middleware/test_packaging.py": {
+      "mode": "retained-host",
+      "reason": "LangChain middleware packaging owned by the LangChain adapter."
+    },
+    "tests/langchain_middleware/test_scope.py": {
+      "mode": "retained-host",
+      "reason": "LangChain scope handling owned by the LangChain adapter."
+    },
+    "tests/langchain_middleware/test_settings.py": {
+      "mode": "retained-host",
+      "reason": "LangChain settings handling owned by the LangChain adapter."
+    },
+    "tests/pydantic_ai_adapter/test_capability.py": {
+      "mode": "retained-host",
+      "reason": "Pydantic AI adapter capability behavior owned by the Pydantic AI adapter."
+    },
+    "tests/pydantic_ai_adapter/test_capture.py": {
+      "mode": "retained-host",
+      "reason": "Pydantic AI shared capture behavior owned by the Pydantic AI adapter."
+    },
+    "tests/pydantic_ai_adapter/test_packaging.py": {
+      "mode": "retained-host",
+      "reason": "Pydantic AI adapter packaging owned by the Pydantic AI adapter."
+    },
+    "tests/pydantic_ai_adapter/test_settings_scope.py": {
+      "mode": "retained-host",
+      "reason": "Pydantic AI settings and scope behavior owned by the Pydantic AI adapter."
+    },
+    "tests/pydantic_ai_adapter/test_toolset.py": {
+      "mode": "retained-host",
+      "reason": "Pydantic AI toolset behavior owned by the Pydantic AI adapter."
+    },
+    "tests/test_cli.py": {
+      "mode": "go-port",
+      "reason": "CLI server command transport overrides; the CLI is Go (internal/cli) and the behavior is part of the WP2 transport surface."
+    },
+    "tests/test_cli_workbuddy.py": {
+      "mode": "go-port",
+      "reason": "WorkBuddy setup/doctor CLI commands; the CLI is Go (internal/cli)."
+    },
+    "tests/test_docker_contract.py": {
+      "mode": "go-port",
+      "reason": "Dockerfile and container invocation contract owned by this repository."
+    },
+    "tests/test_docs_remote_access_contract.py": {
+      "mode": "go-port",
+      "reason": "Documentation contract for non-loopback binds owned by this repository."
+    },
+    "tests/test_doctor_integrations.py": {
+      "mode": "go-port",
+      "reason": "CLI doctor integrations matrix; the CLI is Go (internal/cli)."
+    },
+    "tests/test_hermes_cli.py": {
+      "mode": "go-port",
+      "reason": "Hermes setup CLI commands; the CLI is Go (internal/cli)."
+    },
+    "tests/test_opencode_cli.py": {
+      "mode": "go-port",
+      "reason": "OpenCode activation probe CLI commands; the CLI is Go (internal/cli)."
+    },
+    "tests/test_setup_select.py": {
+      "mode": "go-port",
+      "reason": "Interactive/non-interactive host selection CLI; the CLI is Go (internal/cli)."
+    },
+    "tests/test_transport.py": {
+      "mode": "go-port",
+      "reason": "Shared loopback/plaintext transport policy across Client, CLI, and Server; the Go port of this policy is WP2.",
+      "cases": {
+        "test_vendored_plugin_shares_the_loopback_host_set": {
+          "mode": "cross-layer",
+          "reason": "Asserts retained plugins share the core loopback host set; crosses the Go core and retained adapters."
+        },
+        "test_vendored_plugin_matches_the_shared_plaintext_policy": {
+          "mode": "cross-layer",
+          "reason": "Asserts retained plugins match the core plaintext policy; crosses the Go core and retained adapters."
+        }
+      }
+    }
+  }
+}

--- a/test/conformance/parity-inventory.json
+++ b/test/conformance/parity-inventory.json
@@ -1,0 +1,12430 @@
+{
+  "schema_version": 1,
+  "target_commit": "f2ec1f75e5e1b46ad0626ab8390801b88966b6f5",
+  "oracle_commit": "3a6cb0151670eaff7dc0293466edd673124e80da",
+  "python_test_file_count": 127,
+  "python_test_case_count": 759,
+  "mapped_case_count": 622,
+  "pending_case_count": 137,
+  "entries": [
+    {
+      "python": {
+        "file": "e2e/bub/tests/test_bub_capture.py",
+        "name": "test_tool_capture_redacts_credentials_before_crossing_the_client_boundary",
+        "line": 27
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/bub/tests/test_plugin.py",
+          "test": "test_capture_content_redacts_sensitive_fields_before_transport"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "e2e/bub/tests/test_bub_transport_trust.py",
+        "name": "test_plugin_refuses_a_plaintext_non_loopback_server_by_default",
+        "line": 38
+      },
+      "mode": "retained-host",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "e2e/bub/tests/test_bub_transport_trust.py",
+        "name": "test_trusting_the_transport_supplies_the_client_an_explicit_vouched_transport",
+        "line": 81
+      },
+      "mode": "retained-host",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "e2e/bub/tests/test_bub_transport_trust.py",
+        "name": "test_load_state_carries_the_transport_vouch_to_tool_settings",
+        "line": 107
+      },
+      "mode": "retained-host",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "e2e/bub/tests/test_bub_transport_trust.py",
+        "name": "test_tools_refuse_a_plaintext_non_loopback_server_by_default",
+        "line": 127
+      },
+      "mode": "retained-host",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "e2e/bub/tests/test_bub_transport_trust.py",
+        "name": "test_tools_honour_the_operator_transport_vouch",
+        "line": 139
+      },
+      "mode": "retained-host",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "e2e/bub/tests/test_evidence_redaction.py",
+        "name": "test_resolved_instruction_evidence_matches_harbor_acp_summaries",
+        "line": 37
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/bub/tests/test_plugin.py",
+          "test": "test_capture_content_redacts_sensitive_fields_before_transport"
+        },
+        {
+          "kind": "go",
+          "file": "internal/observability/logging/logger_test.go",
+          "test": "TestJSONLoggerEmitsOnlyOperationalFields"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "e2e/bub/tests/test_evidence_redaction.py",
+        "name": "test_final_evidence_redacts_configured_secrets_and_preserves_the_public_schema",
+        "line": 57
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/bub/tests/test_plugin.py",
+          "test": "test_capture_content_redacts_sensitive_fields_before_transport"
+        },
+        {
+          "kind": "go",
+          "file": "internal/observability/logging/logger_test.go",
+          "test": "TestJSONLoggerEmitsOnlyOperationalFields"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "e2e/bub/tests/test_harbor_agent.py",
+        "name": "test_install_bub_command_provides_powercontext_version",
+        "line": 24
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/python_contract_test.go",
+          "test": "TestCLIVersionReportsBuildVersion"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "e2e/bub/tests/test_harbor_agent.py",
+        "name": "test_install_bub_command_overrides_release_floor_for_mounted_source",
+        "line": 30
+      },
+      "mode": "retained-host",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "e2e/bub/tests/test_long_horizon_acceptance.py",
+        "name": "test_memory_acceptance_does_not_require_the_harbor_task_to_pass",
+        "line": 37
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "test/e2e/http_memory_test.go",
+          "test": "TestHTTPSourceAndMemorySQLiteVerticalSlice"
+        },
+        {
+          "kind": "go",
+          "file": "internal/contextpack/builder_test.go",
+          "test": "TestBuilderPreservesOrderAndFiltersDuplicateOrInvalidHits"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "e2e/bub/tests/test_workload_catalog.py",
+        "name": "test_workloads_can_be_selected_by_multiple_ids_or_category",
+        "line": 25
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/bub/tests/test_client.py",
+          "test": "test_prepared_context_accepts_exact_ready_and_empty_contracts"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "e2e/bub/tests/test_workload_catalog.py",
+        "name": "test_batch_category_cannot_escape_the_runtime_dataset",
+        "line": 67
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "evaluation/tests/unit/test_artifacts.py",
+          "test": "test_unsafe_relative_paths_are_rejected"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/artifacts/experience/test_incubation.py",
+        "name": "test_pipeline_maps_only_bounded_task_outcomes_to_exact_source_refs",
+        "line": 67
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "artifact/experience/incubation_test.go",
+          "test": "TestLLMCandidatePipelineMapsBoundedTaskOutcomes"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/artifacts/experience/test_incubation.py",
+        "name": "test_pipeline_skips_generation_when_the_window_has_no_task_outcomes",
+        "line": 98
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "artifact/experience/incubation_test.go",
+          "test": "TestLLMCandidatePipelineSkipsIneligibleWindow"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/artifacts/experience/test_incubation.py",
+        "name": "test_pipeline_rejects_evidence_outside_the_current_window",
+        "line": 111
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "artifact/experience/incubation_test.go",
+          "test": "TestLLMCandidatePipelineRejectsEvidenceOutsideWindow"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/artifacts/experience/test_models.py",
+        "name": "test_experience_content_preserves_a_complete_reusable_judgment",
+        "line": 32
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "artifact/experience/model_test.go",
+          "test": "TestExperienceContentPreservesCompleteReusableJudgment"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/artifacts/experience/test_models.py",
+        "name": "test_experience_content_requires_every_judgment_part",
+        "line": 41
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "artifact/experience/model_test.go",
+          "test": "TestExperienceContentRequiresEveryJudgmentPart"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/artifacts/experience/test_models.py",
+        "name": "test_experience_content_rejects_blank_judgment_parts",
+        "line": 50
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "artifact/experience/model_test.go",
+          "test": "TestExperienceContentRejectsBlankJudgmentParts"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/artifacts/experience/test_models.py",
+        "name": "test_experience_content_bounds_each_judgment_part",
+        "line": 59
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "artifact/experience/model_test.go",
+          "test": "TestExperienceContentBoundsEveryJudgmentPart"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/artifacts/handoff/test_generation.py",
+        "name": "test_llm_pipeline_maps_only_bounded_evidence_and_preserves_objective",
+        "line": 59
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "artifact/handoff/generation_test.go",
+          "test": "TestLLMGenerationPipelineMapsBoundedEvidence"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/artifacts/handoff/test_generation.py",
+        "name": "test_llm_pipeline_rejects_evidence_outside_the_bounded_request",
+        "line": 99
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "artifact/handoff/generation_test.go",
+          "test": "TestLLMGenerationPipelineRejectsOutsideEvidence"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/artifacts/handoff/test_generation.py",
+        "name": "test_llm_pipeline_rejects_uncited_statements",
+        "line": 127
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "artifact/handoff/generation_test.go",
+          "test": "TestLLMGenerationPipelineRejectsUncitedStatement"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/artifacts/handoff/test_models.py",
+        "name": "test_draft_preserves_inspected_content_during_finalization",
+        "line": 45
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "artifact/handoff/model_test.go",
+          "test": "TestHandoffDraftPreservesInspectedContentDuringFinalization"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/artifacts/handoff/test_models.py",
+        "name": "test_content_contract_rejects_incomplete_handoffs",
+        "line": 79
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "artifact/handoff/model_test.go",
+          "test": "TestHandoffContentContractRejectsIncompleteHandoffs"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/artifacts/handoff/test_models.py",
+        "name": "test_handoff_values_are_frozen_after_validation",
+        "line": 84
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "artifact/handoff/model_test.go",
+          "test": "TestHandoffValuesAreImmutableAfterValidation"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/artifacts/handoff/test_models.py",
+        "name": "test_unknown_content_and_envelope_versions_are_rejected",
+        "line": 95
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "artifact/handoff/model_test.go",
+          "test": "TestHandoffUnknownContentAndEnvelopeVersionsAreRejected"
+        },
+        {
+          "kind": "go",
+          "file": "internal/endpoint/handoff_model_test.go",
+          "test": "TestHandoffWireRejectsUnknownSchemaVersions"
+        },
+        {
+          "kind": "go",
+          "file": "internal/sqlstore/handoff_codec_test.go",
+          "test": "TestHandoffCodecRejectsUnknownContentSchema"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/artifacts/handoff/test_models.py",
+        "name": "test_handoff_content_is_bounded",
+        "line": 113
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "artifact/handoff/model_test.go",
+          "test": "TestHandoffContentIsBounded"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/artifacts/handoff/test_models.py",
+        "name": "test_prepare_action_requires_unique_bounded_evidence",
+        "line": 128
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "artifact/handoff/model_test.go",
+          "test": "TestHandoffPrepareRequiresUniqueBoundedEvidence"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/artifacts/handoff/test_models.py",
+        "name": "test_activation_adds_the_boundary_source_once_and_rejects_duplicate_evidence",
+        "line": 144
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "artifact/handoff/model_test.go",
+          "test": "TestHandoffActivateAddsBoundaryOnceAndRejectsInvalidEvidence"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/artifacts/handoff/test_models.py",
+        "name": "test_resolution_requires_one_evidence_check_per_statement",
+        "line": 163
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "artifact/handoff/model_test.go",
+          "test": "TestHandoffResolutionRequiresOneEvidenceCheckPerStatement"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/artifacts/handoff/test_service.py",
+        "name": "test_prepare_generates_a_draft_from_exact_bounded_evidence",
+        "line": 153
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "artifact/handoff/service_test.go",
+          "test": "TestHandoffServicePrepareGeneratesDraftFromExactBoundedEvidence"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/artifacts/handoff/test_service.py",
+        "name": "test_prepare_requires_a_configured_generation_pipeline",
+        "line": 172
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "artifact/handoff/service_test.go",
+          "test": "TestHandoffServicePrepareRequiresConfiguredGenerationPipeline"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/artifacts/handoff/test_service.py",
+        "name": "test_prepare_rejects_pipeline_contract_violations",
+        "line": 211
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "artifact/handoff/service_test.go",
+          "test": "TestHandoffServicePrepareRejectsPipelineContractViolations"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/artifacts/handoff/test_service.py",
+        "name": "test_draft_can_be_corrected_before_temporary_handoff_is_finalized",
+        "line": 233
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "artifact/handoff/service_test.go",
+          "test": "TestHandoffServiceDraftCanBeCorrectedBeforeTemporaryHandoffFinalized"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/artifacts/handoff/test_service.py",
+        "name": "test_commit_is_idempotent_and_omission_references_are_not_lineage",
+        "line": 266
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "artifact/handoff/service_test.go",
+          "test": "TestHandoffServiceCommitIsIdempotentAndOmissionsAreNotLineage"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/artifacts/handoff/test_service.py",
+        "name": "test_stale_prepared_handoff_cannot_replace_a_newer_milestone",
+        "line": 285
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "artifact/handoff/service_test.go",
+          "test": "TestHandoffServiceStalePreparedCannotReplaceNewerMilestone"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/artifacts/handoff/test_service.py",
+        "name": "test_continue_reports_evidence_availability_per_statement",
+        "line": 303
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "artifact/handoff/service_test.go",
+          "test": "TestHandoffServiceContinueReportsEvidenceAvailabilityPerStatement"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/artifacts/handoff/test_service.py",
+        "name": "test_commit_revalidates_evidence_after_preparation",
+        "line": 332
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "artifact/handoff/service_test.go",
+          "test": "TestHandoffServiceCommitRevalidatesEvidenceAfterPreparation"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/artifacts/handoff/test_service.py",
+        "name": "test_exact_old_revision_remains_historical_input",
+        "line": 346
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "artifact/handoff/service_test.go",
+          "test": "TestHandoffServiceExactOldRevisionRemainsHistoricalInput"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/artifacts/handoff/test_service.py",
+        "name": "test_cross_scope_prepared_handoff_is_rejected",
+        "line": 376
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "artifact/handoff/service_test.go",
+          "test": "TestHandoffServiceRejectsCrossScopePreparedHandoff"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/artifacts/handoff/test_service.py",
+        "name": "test_continue_latest_reports_empty_without_a_committed_milestone",
+        "line": 392
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "artifact/handoff/service_test.go",
+          "test": "TestHandoffServiceContinueLatestReportsEmptyWithoutMilestone"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/artifacts/memory/test_canonical.py",
+        "name": "test_entry_hash_uses_normalized_content_and_sorted_refs",
+        "line": 37
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "artifact/memory/canonical_test.go",
+          "test": "TestEntryHashNormalizesContentAndSortsDeduplicatesRefs"
+        },
+        {
+          "kind": "go",
+          "file": "test/conformance/domain_contract_test.go",
+          "test": "TestGoMemoryCanonicalBytesMatchFrozenPythonOracle"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/artifacts/memory/test_canonical.py",
+        "name": "test_entry_hash_covers_kind_text_and_both_evidence_sets",
+        "line": 56
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "artifact/memory/canonical_test.go",
+          "test": "TestEntryHashCoversKindTextAndBothEvidenceSets"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/artifacts/memory/test_canonical.py",
+        "name": "test_memory_hash_covers_complete_manifest_and_change_summary",
+        "line": 83
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "artifact/memory/canonical_test.go",
+          "test": "TestContentHashCoversChangeOperation"
+        },
+        {
+          "kind": "go",
+          "file": "test/conformance/domain_contract_test.go",
+          "test": "TestGoMemoryCanonicalBytesMatchFrozenPythonOracle"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/artifacts/memory/test_canonical.py",
+        "name": "test_limits_are_measured_after_normalization",
+        "line": 117
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "artifact/memory/canonical_test.go",
+          "test": "TestNormalizationLimitsMatchPythonSemantics"
+        },
+        {
+          "kind": "go",
+          "file": "artifact/memory/canonical_test.go",
+          "test": "TestNormalizationUsesFrozenPythonWhitespaceSemantics"
+        },
+        {
+          "kind": "go",
+          "file": "test/conformance/domain_contract_test.go",
+          "test": "TestGoMemoryCanonicalBytesMatchFrozenPythonOracle"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/artifacts/memory/test_canonical.py",
+        "name": "test_embedding_validation_rejects_wrong_or_non_finite_vectors",
+        "line": 134
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "artifact/memory/canonical_test.go",
+          "test": "TestEmbeddingValidationRejectsWrongOrNonFiniteVectors"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/artifacts/memory/test_canonical.py",
+        "name": "test_embedding_normalization_produces_a_unit_vector",
+        "line": 145
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "artifact/memory/canonical_test.go",
+          "test": "TestEmbeddingNormalizationIsOverflowStable"
+        },
+        {
+          "kind": "go",
+          "file": "test/conformance/domain_contract_test.go",
+          "test": "TestGoMemoryCanonicalBytesMatchFrozenPythonOracle"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/artifacts/memory/test_canonical.py",
+        "name": "test_embedding_normalization_rejects_zero_vectors",
+        "line": 150
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "artifact/memory/canonical_test.go",
+          "test": "TestEmbeddingNormalizationIsOverflowStable"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/artifacts/memory/test_canonical.py",
+        "name": "test_embedding_hash_binds_profile_and_entry_content",
+        "line": 155
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "artifact/memory/canonical_test.go",
+          "test": "TestEmbeddingHashBindsProfileAndEntryContent"
+        },
+        {
+          "kind": "go",
+          "file": "test/conformance/domain_contract_test.go",
+          "test": "TestGoMemoryCanonicalBytesMatchFrozenPythonOracle"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/artifacts/memory/test_extraction.py",
+        "name": "test_llm_pipeline_maps_only_bounded_evidence_to_untrusted_candidates",
+        "line": 49
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "artifact/memory/extraction_test.go",
+          "test": "TestLLMCandidatePipelineMapsOnlyBoundedEvidence"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/artifacts/memory/test_extraction.py",
+        "name": "test_llm_pipeline_rejects_evidence_outside_the_bounded_request",
+        "line": 80
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "artifact/memory/extraction_test.go",
+          "test": "TestLLMCandidatePipelineRejectsOutsideEvidence"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/artifacts/memory/test_fusion.py",
+        "name": "test_rrf_merges_channels_and_uses_stable_identity_ties",
+        "line": 44
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "artifact/memory/search_test.go",
+          "test": "TestRRFUsesStableIdentityTieBreak"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/artifacts/memory/test_fusion.py",
+        "name": "test_single_channel_uses_public_rrf_score_and_identity_order",
+        "line": 55
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "artifact/memory/search_test.go",
+          "test": "TestSingleChannelUsesPublicRRFScoreAndInputRankOrder"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/artifacts/memory/test_fusion.py",
+        "name": "test_duplicate_channel_rows_contribute_only_the_first_rank",
+        "line": 66
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "artifact/memory/search_test.go",
+          "test": "TestDuplicateChannelRowsContributeOnlyFirstRank"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/artifacts/memory/test_fusion.py",
+        "name": "test_limit_must_be_positive",
+        "line": 75
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "artifact/memory/search_test.go",
+          "test": "TestFuseRankingsRequiresPositiveLimit"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/artifacts/memory/test_fusion.py",
+        "name": "test_fts_admission_rejects_single_common_term_but_keeps_specific_overlap",
+        "line": 80
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "artifact/memory/search_test.go",
+          "test": "TestFTSAdmissionRejectsSingleCommonTermButKeepsSpecificOverlap"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/artifacts/memory/test_fusion.py",
+        "name": "test_fts_admission_keeps_one_term_queries_usable",
+        "line": 98
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "artifact/memory/search_test.go",
+          "test": "TestFTSAdmissionKeepsOneTermQueriesUsable"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/artifacts/memory/test_fusion.py",
+        "name": "test_vector_admission_converts_unit_l2_distance_to_cosine_threshold",
+        "line": 104
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "artifact/memory/search_test.go",
+          "test": "TestVectorAdmissionUsesUnitL2CosineThreshold"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/artifacts/memory/test_models.py",
+        "name": "test_memory_models_express_exact_revision_and_entry_identity",
+        "line": 29
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "artifact/memory/model_test.go",
+          "test": "TestMemoryModelsExpressExactRevisionAndEntryIdentity"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/artifacts/memory/test_models.py",
+        "name": "test_memory_entry_kind_is_an_open_non_empty_string",
+        "line": 56
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "artifact/memory/model_test.go",
+          "test": "TestMemoryEntryKindRemainsOpenAndNonEmptyAfterCanonicalization"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/artifacts/memory/test_prompts.py",
+        "name": "test_runtime_defaults_to_the_existing_coding_profile",
+        "line": 27
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "artifact/memory/extraction_test.go",
+          "test": "TestRuntimeDefaultsToCodingExtractionProfile"
+        },
+        {
+          "kind": "go",
+          "file": "server/config_test.go",
+          "test": "TestDefaultConfigUsesPersistentUserStorage"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/artifacts/memory/test_prompts.py",
+        "name": "test_conversation_profile_selects_its_versioned_policy",
+        "line": 35
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "artifact/memory/extraction_test.go",
+          "test": "TestConversationProfileSelectsVersionedPolicy"
+        },
+        {
+          "kind": "go",
+          "file": "server/config_test.go",
+          "test": "TestLoadConfigMatchesFrozenServerEnvironment"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/artifacts/memory/test_reranking.py",
+        "name": "test_llm_reranker_preserves_identity_and_normalizes_selected_ranks",
+        "line": 56
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "artifact/memory/reranking_test.go",
+          "test": "TestLLMRerankerNormalizesSparseRanks"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/artifacts/memory/test_reranking.py",
+        "name": "test_llm_reranker_falls_back_to_coarse_order_when_no_rank_is_valid",
+        "line": 79
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "artifact/memory/reranking_test.go",
+          "test": "TestLLMRerankerFallsBackToCoarseOrder"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/artifacts/memory/test_service.py",
+        "name": "test_memory_search_applies_injected_reranker_after_coarse_fusion",
+        "line": 55
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "artifact/memory/service_contract_test.go",
+          "test": "TestMemorySearchAppliesInjectedRerankerAfterCoarseFusion"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/artifacts/memory/test_service.py",
+        "name": "test_memory_entry_can_be_deactivated_and_reactivated_without_rewriting_content",
+        "line": 81
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/sqlstore/memory_service_test.go",
+          "test": "TestMemoryServiceAppendReviseAndStateTransitionsUseAtomicRepository"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/artifacts/memory/test_service.py",
+        "name": "test_memory_organize_deduplicates_and_normalizes_existing_entries",
+        "line": 112
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/sqlstore/memory_service_test.go",
+          "test": "TestMemoryOrganizeDeduplicatesAndNormalizesExistingEntries"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/artifacts/skill/test_external.py",
+        "name": "test_codex_provider_discovers_and_exactly_resolves_a_local_package",
+        "line": 57
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "artifact/skill/external_test.go",
+          "test": "TestCodexProviderDiscoversAndExactlyResolvesLocalPackage"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/artifacts/skill/test_external.py",
+        "name": "test_exact_resolution_rejects_content_drift_until_rescan",
+        "line": 75
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "artifact/skill/external_test.go",
+          "test": "TestExactResolutionRejectsContentDriftUntilRescan"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/artifacts/skill/test_external.py",
+        "name": "test_resolution_is_bound_to_the_configured_host_and_root",
+        "line": 92
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "artifact/skill/external_test.go",
+          "test": "TestResolutionIsBoundToConfiguredHostAndRoot"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/artifacts/skill/test_external.py",
+        "name": "test_scan_skips_invalid_or_symlinked_packages",
+        "line": 107
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "artifact/skill/external_test.go",
+          "test": "TestScanSkipsInvalidOrSymlinkedPackages"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/artifacts/skill/test_external.py",
+        "name": "test_codex_provider_requires_unique_stable_root_ids",
+        "line": 135
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "artifact/skill/external_test.go",
+          "test": "TestCodexProviderRequiresUniqueStableRootIDs"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/artifacts/skill/test_external.py",
+        "name": "test_agent_provider_discovers_codex_and_claude_code_targets",
+        "line": 146
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "artifact/skill/external_test.go",
+          "test": "TestAgentProviderDiscoversCodexAndClaudeCodeTargets"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/artifacts/skill/test_models.py",
+        "name": "test_skill_content_requires_complete_portable_instructions",
+        "line": 21
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "artifact/skill/external_test.go",
+          "test": "TestSkillContentRequiresCompletePortableInstructions"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/artifacts/skill/test_models.py",
+        "name": "test_skill_content_rejects_incomplete_or_ambiguous_text",
+        "line": 41
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "artifact/skill/external_test.go",
+          "test": "TestSkillContentRequiresCompletePortableInstructions"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/artifacts/skill/test_registry.py",
+        "name": "test_registry_refreshes_projection_and_checks_live_availability",
+        "line": 44
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "artifact/skill/external_test.go",
+          "test": "TestRegistryRefreshesProjectionAndChecksLiveAvailability"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/artifacts/skill/test_registry.py",
+        "name": "test_registry_is_scope_isolated",
+        "line": 88
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/sqlstore/product_surfaces_test.go",
+          "test": "TestExternalSkillReplacementIsScopedAtomicAndDeterministic"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/artifacts/skill/test_registry.py",
+        "name": "test_agent_registry_removes_a_provider_when_its_targets_are_unconfigured",
+        "line": 117
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/sqlstore/product_surfaces_test.go",
+          "test": "TestExternalSkillReplacementAtomicallyCoversAllAgentProviders"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/inference/test_pydantic_ai.py",
+        "name": "test_structured_generator_binds_schema_and_usage",
+        "line": 163
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "inference/prompted_test.go",
+          "test": "TestPromptedGeneratorMatchesFrozenConversationAndUsage"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/inference/test_pydantic_ai.py",
+        "name": "test_structured_generator_passes_explicit_model_settings",
+        "line": 182
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "inference/prompted_test.go",
+          "test": "TestPromptedGeneratorMatchesFrozenConversationAndUsage"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/inference/test_pydantic_ai.py",
+        "name": "test_structured_generator_maps_rate_limit_without_exposing_provider_body",
+        "line": 207
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "inference/prompted_test.go",
+          "test": "TestPromptedGeneratorPreservesStableProviderFailureAndCause"
+        },
+        {
+          "kind": "go",
+          "file": "internal/modelprovider/openai_test.go",
+          "test": "TestOpenAISDKRetriesAreDisabledAndErrorsAreSanitized"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/inference/test_pydantic_ai.py",
+        "name": "test_structured_generator_times_out_and_cancels_underlying_call",
+        "line": 228
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "inference/prompted_test.go",
+          "test": "TestPromptedGeneratorTotalWallClockTimeoutAndCallerCancellation"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/inference/test_pydantic_ai.py",
+        "name": "test_generation_readiness_probe_uses_one_bounded_text_request",
+        "line": 259
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "inference/probe_test.go",
+          "test": "TestProbeTextModelUsesMinimalUnstructuredRequest"
+        },
+        {
+          "kind": "go",
+          "file": "server/application_readiness_test.go",
+          "test": "TestGenerationReadinessUsesRawMinimalProviderRequest"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/inference/test_pydantic_ai.py",
+        "name": "test_generation_readiness_probe_maps_bad_provider_endpoint_without_leaking_body",
+        "line": 272
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "server/application_readiness_test.go",
+          "test": "TestApplicationReadinessClassifiesConfiguredInferenceWithoutLeakingFailures"
+        },
+        {
+          "kind": "go",
+          "file": "internal/modelprovider/openai_test.go",
+          "test": "TestOpenAISDKRetriesAreDisabledAndErrorsAreSanitized"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/inference/test_pydantic_ai.py",
+        "name": "test_invalid_structured_output_maps_to_stable_error",
+        "line": 285
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "inference/prompted_test.go",
+          "test": "TestPromptedGeneratorExhaustsRequestBudgetWithoutReturningUsage"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/inference/test_pydantic_ai.py",
+        "name": "test_instrumented_generation_spans_exclude_schema_retry_content",
+        "line": 301
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "inference/tracing_test.go",
+          "test": "TestPromptedGeneratorRetrySpansExcludeInputOutputAndFeedback"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/inference/test_pydantic_ai.py",
+        "name": "test_embedding_adapter_returns_validated_vectors_and_usage",
+        "line": 343
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "inference/embedding_test.go",
+          "test": "TestBatchedEmbeddingModelPreservesOrderAndUsage"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/inference/test_pydantic_ai.py",
+        "name": "test_embedding_adapter_preserves_order_across_bounded_provider_batches",
+        "line": 358
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "inference/embedding_test.go",
+          "test": "TestBatchedEmbeddingModelPreservesOrderAndUsage"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/inference/test_pydantic_ai.py",
+        "name": "test_embedding_adapter_enforces_unit_normalization_profile",
+        "line": 377
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "inference/embedding_test.go",
+          "test": "TestBatchedEmbeddingModelUsesOverflowStableUnitNormalization"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/inference/test_pydantic_ai.py",
+        "name": "test_embedding_adapter_maps_provider_errors_and_preserves_cause",
+        "line": 396
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "inference/embedding_test.go",
+          "test": "TestBatchedEmbeddingModelMapsTransportFailureToUnavailableWithCause"
+        },
+        {
+          "kind": "go",
+          "file": "inference/errors_test.go",
+          "test": "TestWrappedInferenceErrorsPreserveCauseWithoutLeakingItsText"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/inference/test_pydantic_ai.py",
+        "name": "test_instrumented_embedding_spans_nest_under_the_active_span_without_recording_text",
+        "line": 412
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "inference/tracing_test.go",
+          "test": "TestEmbeddingSpanNestsUnderActiveOperationWithoutRecordingTextOrVectors"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/inference/test_pydantic_ai.py",
+        "name": "test_embedding_adapter_maps_empty_provider_data_to_unavailable",
+        "line": 441
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "inference/embedding_test.go",
+          "test": "TestBatchedEmbeddingModelMapsTransportFailureToUnavailableWithCause"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/inference/test_tokens.py",
+        "name": "test_character_estimator_is_deterministic_for_ascii_and_non_ascii_text",
+        "line": 20
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "inference/tokens_test.go",
+          "test": "TestCharacterEstimatorIsDeterministicForASCIIAndNonASCIIText"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/persistence/test_artifacts.py",
+        "name": "test_two_artifact_families_share_revisions_and_ordered_direct_lineage",
+        "line": 43
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/sqlstore/artifacts_test.go",
+          "test": "TestArtifactRepositoryPreservesPayloadRevisionAndOrderedLineage"
+        },
+        {
+          "kind": "go",
+          "file": "internal/sqlstore/artifacts_test.go",
+          "test": "TestMemoryAndHandoffPayloadsMatchPythonFieldOrder"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/persistence/test_artifacts.py",
+        "name": "test_stale_artifact_revision_fails_optimistic_head_cas",
+        "line": 101
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/sqlstore/artifacts_test.go",
+          "test": "TestArtifactRepositoryPreservesPayloadRevisionAndOrderedLineage"
+        },
+        {
+          "kind": "go",
+          "file": "internal/sqlstore/artifacts_test.go",
+          "test": "TestArtifactRepositoryConcurrentCASHasOneWinner"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/persistence/test_artifacts.py",
+        "name": "test_lifecycle_committed_after_the_head_read_conflicts",
+        "line": 133
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/sqlstore/artifact_create_conflict_test.go",
+          "test": "TestArtifactInitialCreateIsAtomicAcrossConnections"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/persistence/test_artifacts.py",
+        "name": "test_artifact_lineage_and_head_foreign_keys_are_enforced",
+        "line": 173
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/sqlstore/artifacts_test.go",
+          "test": "TestArtifactLineageAndHeadForeignKeysAreEnforced"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/persistence/test_cursors.py",
+        "name": "test_source_cursor_uses_generation_compare_and_swap",
+        "line": 31
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/sqlstore/review_test.go",
+          "test": "TestSourceCursorRepositoryCASAndPythonPayload"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/persistence/test_cursors.py",
+        "name": "test_source_cursor_initial_creation_is_safe_across_connections",
+        "line": 66
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/sqlstore/review_test.go",
+          "test": "TestSourceCursorInitialCreateIsAtomicAcrossConnections"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/persistence/test_experience_index.py",
+        "name": "test_artifact_head_search_projection_schema_is_mysql_compilable",
+        "line": 55
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/sqlstore/database_oceanbase_test.go",
+          "test": "TestMySQLSchemaUsesPythonPayloadVariants"
+        },
+        {
+          "kind": "go",
+          "file": "internal/sqlstore/database_oceanbase_test.go",
+          "test": "TestEveryMySQLUTF8MB4KeyStaysBelowInnoDBLimit"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/persistence/test_experience_index.py",
+        "name": "test_sqlite_startup_upgrades_legacy_artifact_heads_without_searchable_text",
+        "line": 63
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/sqlstore/experience_index_migration_test.go",
+          "test": "TestSQLiteExperienceIndexUpgradesLegacyArtifactHeadsIdempotently"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/persistence/test_experience_index.py",
+        "name": "test_oceanbase_startup_upgrades_legacy_artifact_heads_with_mediumtext",
+        "line": 91
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/sqlstore/experience_index_migration_test.go",
+          "test": "TestOceanBaseExperienceIndexUsesMediumTextMigration"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/persistence/test_experience_index.py",
+        "name": "test_sqlite_experience_fts_tracks_only_approved_current_heads_and_rebuilds",
+        "line": 105
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/sqlstore/experience_index_test.go",
+          "test": "TestSQLiteExperienceFTSTracksCurrentHeadsAndRebuilds"
+        },
+        {
+          "kind": "go",
+          "file": "internal/sqlstore/review_test.go",
+          "test": "TestReviewApproveCommitsCandidateArtifactAndLineage"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/persistence/test_external_skills.py",
+        "name": "test_external_skill_projection_is_replaced_per_provider_host",
+        "line": 39
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/sqlstore/product_surfaces_test.go",
+          "test": "TestExternalSkillReplacementIsScopedAtomicAndDeterministic"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/persistence/test_external_skills.py",
+        "name": "test_external_skill_projection_is_scope_isolated",
+        "line": 76
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/sqlstore/product_surfaces_test.go",
+          "test": "TestExternalSkillReplacementIsScopedAtomicAndDeterministic"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/persistence/test_memory.py",
+        "name": "test_memory_schema_is_mysql_compilable_and_respects_key_and_payload_limits",
+        "line": 53
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/sqlstore/database_oceanbase_test.go",
+          "test": "TestMySQLSchemaUsesPythonPayloadVariants"
+        },
+        {
+          "kind": "go",
+          "file": "internal/sqlstore/database_oceanbase_test.go",
+          "test": "TestEveryMySQLUTF8MB4KeyStaysBelowInnoDBLimit"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/persistence/test_memory.py",
+        "name": "test_sqlite_memory_backend_commits_authoritative_history_and_fts",
+        "line": 75
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/sqlstore/memory_test.go",
+          "test": "TestMemoryRepositoryCommitsAuthorityAndProjectionAtomically"
+        },
+        {
+          "kind": "go",
+          "file": "internal/sqlstore/sqlite_memory_fts_test.go",
+          "test": "TestSQLiteMemoryFTSIndexRebuildAndSearch"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/persistence/test_memory.py",
+        "name": "test_sqlite_memory_backend_rebuilds_head_and_fts_projections",
+        "line": 136
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/sqlstore/sqlite_memory_fts_test.go",
+          "test": "TestSQLiteMemoryFTSIndexRebuildAndSearch"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/persistence/test_memory.py",
+        "name": "test_scope_bound_contexts_do_not_share_rows",
+        "line": 177
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/sqlstore/memory_test.go",
+          "test": "TestMemoryRepositoriesAreScopeIsolated"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/persistence/test_mysql_schema.py",
+        "name": "test_mysql_ddl_uses_utf8mb4_bin_for_identity_keys",
+        "line": 48
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/sqlstore/database_oceanbase_test.go",
+          "test": "TestEveryCoreMySQLVarcharUsesBinaryIdentityCollation"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/persistence/test_mysql_schema.py",
+        "name": "test_mysql_ddl_uses_mediumblob_for_every_canonical_payload",
+        "line": 56
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/sqlstore/database_oceanbase_test.go",
+          "test": "TestMySQLSchemaUsesPythonPayloadVariants"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/persistence/test_mysql_schema.py",
+        "name": "test_every_mysql_utf8mb4_key_stays_below_the_innodb_limit",
+        "line": 69
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/sqlstore/database_oceanbase_test.go",
+          "test": "TestEveryMySQLUTF8MB4KeyStaysBelowInnoDBLimit"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/persistence/test_oceanbase_profile.py",
+        "name": "test_config_rejects_non_official_or_incomplete_urls",
+        "line": 96
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/sqlstore/database_oceanbase_test.go",
+          "test": "TestOceanBaseDriverConfigRejectsIncompleteOrWrongURLsWithoutLeakingSecrets"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/persistence/test_oceanbase_profile.py",
+        "name": "test_config_and_validation_errors_never_render_the_password",
+        "line": 101
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/sqlstore/database_oceanbase_test.go",
+          "test": "TestOceanBaseDriverConfigRejectsIncompleteOrWrongURLsWithoutLeakingSecrets"
+        },
+        {
+          "kind": "go",
+          "file": "server/config_test.go",
+          "test": "TestProcessConfigValidatesOceanBaseURLWithoutLeakingPassword"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/persistence/test_oceanbase_profile.py",
+        "name": "test_official_dialect_builds_an_async_engine_without_opening_a_connection",
+        "line": 117
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/sqlstore/database_oceanbase_test.go",
+          "test": "TestOceanBaseDriverConfigPreservesFrozenURLContract"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/persistence/test_oceanbase_profile.py",
+        "name": "test_oceanbase_profile_hides_sql_parameters",
+        "line": 130
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/observability/logging/logger_test.go",
+          "test": "TestJSONLoggerEmitsOnlyOperationalFields"
+        },
+        {
+          "kind": "go",
+          "file": "server/config_test.go",
+          "test": "TestProcessConfigValidatesOceanBaseURLWithoutLeakingPassword"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/persistence/test_oceanbase_profile.py",
+        "name": "test_profile_requires_an_oceanbase_mysql_tenant",
+        "line": 154
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/sqlstore/database_oceanbase_test.go",
+          "test": "TestOceanBaseProfileRequiresMySQLTenant"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/persistence/test_oceanbase_profile.py",
+        "name": "test_live_oceanbase_profile_smoke",
+        "line": 179
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "test/e2e/oceanbase_live_test.go",
+          "test": "TestLiveOceanBaseProfileSmoke"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/persistence/test_provider.py",
+        "name": "test_provider_translates_repository_source_identity_conflicts",
+        "line": 57
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/sqlstore/sources_test.go",
+          "test": "TestSourceRepositoryPythonPayloadAndIdempotence"
+        },
+        {
+          "kind": "go",
+          "file": "test/e2e/http_memory_test.go",
+          "test": "TestHTTPSourceAndMemorySQLiteVerticalSlice"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/persistence/test_provider.py",
+        "name": "test_source_window_artifact_and_cursor_are_one_transaction",
+        "line": 71
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/sqlstore/memory_flush_test.go",
+          "test": "TestMemoryFlushArtifactAndCursorCASAreOneTransaction"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/persistence/test_provider.py",
+        "name": "test_concurrent_capture_and_flush_preserve_monotonic_idempotent_behavior",
+        "line": 110
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/sqlstore/sources_test.go",
+          "test": "TestSourceRepositorySerializesConcurrentJournalPositions"
+        },
+        {
+          "kind": "go",
+          "file": "internal/sqlstore/memory_flush_test.go",
+          "test": "TestMemoryFlushArtifactAndCursorCASAreOneTransaction"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/persistence/test_provider.py",
+        "name": "test_candidate_inference_does_not_hold_the_database_transaction",
+        "line": 140
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/sqlstore/memory_flush_test.go",
+          "test": "TestMemoryFlushPlanningDoesNotHoldDatabaseTransaction"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/persistence/test_seekdb_profile.py",
+        "name": "test_config_requires_an_explicit_non_empty_path",
+        "line": 87
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/sqlstore/seekdb/seekdb_test.go",
+          "test": "TestCanonicalPathRequiresNonEmptyTrimmedValue"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/persistence/test_seekdb_profile.py",
+        "name": "test_dialect_terminates_connections_on_close",
+        "line": 94
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "server/seekdb_test.go",
+          "test": "TestSeekDBInstanceClosesPoolBeforeNativeRuntime"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/persistence/test_seekdb_profile.py",
+        "name": "test_engine_uses_the_local_socket",
+        "line": 102
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/sqlstore/database_seekdb_test.go",
+          "test": "TestSeekDBDriverConfigUsesLocalUnixSocket"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/persistence/test_seekdb_profile.py",
+        "name": "test_profile_closes_engine_before_instance",
+        "line": 135
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "server/seekdb_test.go",
+          "test": "TestSeekDBInstanceClosesPoolBeforeNativeRuntime"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/persistence/test_seekdb_profile.py",
+        "name": "test_profile_finishes_shutdown_before_propagating_repeated_cancellation",
+        "line": 157
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "server/seekdb_test.go",
+          "test": "TestSeekDBInstanceFinishesCleanupBeforePropagatingCancellation"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/persistence/test_seekdb_profile.py",
+        "name": "test_profile_closes_instance_if_open_is_cancelled_repeatedly",
+        "line": 225
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/sqlstore/seekdb/seekdb_test.go",
+          "test": "TestOpenClosesNativeInstanceWhenCancellationRepeatsDuringHandshake"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/persistence/test_sources.py",
+        "name": "test_two_source_adapters_share_one_repository_and_journal",
+        "line": 37
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/sqlstore/sources_test.go",
+          "test": "TestTwoSourceAdaptersShareRepositoryAndJournal"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/persistence/test_sources.py",
+        "name": "test_reusing_a_stable_source_identity_with_different_payload_is_a_conflict",
+        "line": 69
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/sqlstore/sources_test.go",
+          "test": "TestSourceRepositoryPythonPayloadAndIdempotence"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/persistence/test_sources.py",
+        "name": "test_repository_rejects_a_scope_outside_the_relational_identity_baseline",
+        "line": 90
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/sqlstore/sources_test.go",
+          "test": "TestSourceRepositoryRejectsScopeOutsideRelationalIdentityBaseline"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/persistence/test_sources.py",
+        "name": "test_source_journal_allocator_serializes_concurrent_scope_writes_without_idempotency_gaps",
+        "line": 106
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/sqlstore/sources_test.go",
+          "test": "TestSourceRepositorySerializesConcurrentJournalPositions"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/persistence/test_sqlite_profile.py",
+        "name": "test_sqlite_config_requires_the_async_dialect",
+        "line": 32
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "server/config_test.go",
+          "test": "TestSQLiteDSNPreservesFrozenAbsoluteAndRelativePaths"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/persistence/test_sqlite_profile.py",
+        "name": "test_sqlite_profile_creates_a_missing_database_directory",
+        "line": 37
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/sqlstore/database_test.go",
+          "test": "TestSQLiteProfileCreatesMissingDatabaseDirectory"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/persistence/test_sqlite_profile.py",
+        "name": "test_sqlite_pragmas_enforce_lineage_source_foreign_keys",
+        "line": 49
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/sqlstore/database_test.go",
+          "test": "TestOpenSQLiteInitializesSchemaAndEveryConnection"
+        },
+        {
+          "kind": "go",
+          "file": "internal/sqlstore/artifacts_test.go",
+          "test": "TestArtifactLineageAndHeadForeignKeysAreEnforced"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/review/test_generation.py",
+        "name": "test_generation_without_model_fails_before_candidate_persistence",
+        "line": 77
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/review/generation_test.go",
+          "test": "TestGenerationWithoutModelFailsBeforeEvidenceOrCandidatePersistence"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/review/test_generation.py",
+        "name": "test_experience_generation_uses_exact_source_and_supports_no_op",
+        "line": 98
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/review/generation_test.go",
+          "test": "TestExperienceGenerationUsesExactEvidenceTargetAndSupportsNoOp"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/review/test_generation.py",
+        "name": "test_experience_generation_targets_an_exact_approved_revision",
+        "line": 140
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/review/generation_test.go",
+          "test": "TestExperienceGenerationUsesExactEvidenceTargetAndSupportsNoOp"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/review/test_generation.py",
+        "name": "test_managed_skill_generation_enforces_origin_specific_lineage",
+        "line": 188
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/review/generation_test.go",
+          "test": "TestManagedSkillGenerationEnforcesOriginSpecificLineage"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/review/test_models.py",
+        "name": "test_candidate_requires_bounded_exact_evidence",
+        "line": 27
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/review/model_test.go",
+          "test": "TestCandidateRequiresBoundedExactEvidence"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/review/test_models.py",
+        "name": "test_candidate_terminal_fields_match_status",
+        "line": 48
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/review/model_test.go",
+          "test": "TestCandidateTerminalFieldsMatchStatus"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/review/test_persistence.py",
+        "name": "test_revise_appends_an_immutable_candidate_version",
+        "line": 37
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/sqlstore/review_contract_test.go",
+          "test": "TestReviewRevisionAppendsImmutableFamilyTypedCandidateVersion"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/review/test_service.py",
+        "name": "test_memory_write_remains_direct_and_does_not_create_a_candidate",
+        "line": 109
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/sqlstore/memory_service_test.go",
+          "test": "TestMemoryWriteRemainsDirectAndDoesNotCreateReviewCandidate"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/review/test_service.py",
+        "name": "test_experience_projection_failure_rolls_back_approval_artifact_and_status",
+        "line": 123
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/sqlstore/review_test.go",
+          "test": "TestReviewApprovalRollsBackWhenProjectionFails"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/review/test_service.py",
+        "name": "test_experience_candidate_revise_approve_and_retrieval_gate",
+        "line": 163
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/sqlstore/review_contract_test.go",
+          "test": "TestReviewRevisionAppendsImmutableFamilyTypedCandidateVersion"
+        },
+        {
+          "kind": "go",
+          "file": "server/application_test.go",
+          "test": "TestGoClientExercisesReviewHTTPRuntimeSQLiteVerticalSlice"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/review/test_service.py",
+        "name": "test_rejected_candidate_is_terminal_and_scope_evidence_isolated",
+        "line": 239
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/sqlstore/review_contract_test.go",
+          "test": "TestReviewRejectIsTerminalAndEvidenceIsScopeIsolated"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/review/test_service.py",
+        "name": "test_managed_skill_uses_review_gate_and_exact_replacement_lineage",
+        "line": 280
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/sqlstore/review_contract_test.go",
+          "test": "TestManagedSkillApprovalValidatesLineageBeforeArtifactWrite"
+        },
+        {
+          "kind": "go",
+          "file": "server/application_test.go",
+          "test": "TestGoClientExercisesReviewHTTPRuntimeSQLiteVerticalSlice"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/review/test_service.py",
+        "name": "test_managed_skill_approval_validates_family_lineage",
+        "line": 364
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/sqlstore/review_contract_test.go",
+          "test": "TestManagedSkillApprovalValidatesLineageBeforeArtifactWrite"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/review/test_service.py",
+        "name": "test_stale_experience_target_keeps_candidate_pending",
+        "line": 409
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/sqlstore/review_contract_test.go",
+          "test": "TestReviewStaleExperienceTargetKeepsCandidatePending"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/review/test_service.py",
+        "name": "test_failed_candidate_status_update_rolls_back_artifact_commit",
+        "line": 457
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/sqlstore/review_contract_test.go",
+          "test": "TestReviewApprovalRollsBackWhenCandidateStatusUpdateFails"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/runtime/test_experience_incubation.py",
+        "name": "test_incubation_uses_an_independent_cursor_and_keeps_candidates_gated",
+        "line": 67
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/runtime/experience_incubation_test.go",
+          "test": "TestExperienceIncubationUsesTwoStagesAndExactWindowEvidence"
+        },
+        {
+          "kind": "go",
+          "file": "internal/sqlstore/experience_incubation_test.go",
+          "test": "TestExperienceCandidatesAndCursorCASAreOneTransaction"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/runtime/test_experience_incubation.py",
+        "name": "test_incubation_retries_the_same_window_after_generation_failure",
+        "line": 123
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/runtime/experience_incubation_test.go",
+          "test": "TestExperienceIncubationRetriesSameWindowAfterGenerationFailure"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/runtime/test_experience_incubation.py",
+        "name": "test_incubation_uses_the_fixed_source_window_budget",
+        "line": 153
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/runtime/experience_incubation_test.go",
+          "test": "TestScheduledExperienceIncubationUsesFixedSourceWindowBudget"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/runtime/test_experience_incubation.py",
+        "name": "test_scheduled_incubation_requires_a_configured_pipeline",
+        "line": 181
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "server/config_test.go",
+          "test": "TestScheduledExperienceIncubationRequiresGenerationModel"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/runtime/test_external_skills.py",
+        "name": "test_runtime_exposes_configured_external_skill_registry_without_a_model",
+        "line": 51
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/runtime/external_skill_application_test.go",
+          "test": "TestRuntimeExposesConfiguredExternalSkillRegistryWithoutModel"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/runtime/test_external_skills.py",
+        "name": "test_runtime_reports_unconfigured_external_skill_registry",
+        "line": 91
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/runtime/external_skill_application_test.go",
+          "test": "TestRuntimeReportsUnconfiguredExternalSkillRegistry"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/runtime/test_external_skills.py",
+        "name": "test_explicit_external_skill_import_captures_exact_snapshot_and_enters_review",
+        "line": 117
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "test/e2e/http_memory_test.go",
+          "test": "TestHTTPSourceAndMemorySQLiteVerticalSlice"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/runtime/test_external_skills.py",
+        "name": "test_external_skill_import_requires_generation_model_before_snapshot",
+        "line": 153
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/runtime/external_skill_application_test.go",
+          "test": "TestExternalSkillImportRequiresGenerationBeforeSnapshot"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/runtime/test_external_skills.py",
+        "name": "test_external_skill_import_rejects_package_drift_before_generation",
+        "line": 180
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "artifact/skill/external_test.go",
+          "test": "TestExactResolutionRejectsContentDriftUntilRescan"
+        },
+        {
+          "kind": "go",
+          "file": "test/e2e/http_memory_test.go",
+          "test": "TestHTTPSourceAndMemorySQLiteVerticalSlice"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/runtime/test_prepared_context.py",
+        "name": "test_builder_preserves_order_and_filters_duplicate_or_invalid_hits",
+        "line": 72
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/contextpack/builder_test.go",
+          "test": "TestBuilderPreservesOrderAndFiltersDuplicateOrInvalidHits"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/runtime/test_prepared_context.py",
+        "name": "test_builder_truncates_unicode_and_owns_the_final_output_budget",
+        "line": 93
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/contextpack/builder_test.go",
+          "test": "TestBuilderTruncatesUnicodeDeterministicallyWithinFinalBudget"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/runtime/test_prepared_context.py",
+        "name": "test_builder_does_not_accept_truncated_unicode_below_the_minimum_byte_size",
+        "line": 108
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/contextpack/builder_test.go",
+          "test": "TestBuilderRejectsTruncatedUnicodeBelowMinimumByteSize"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/runtime/test_prepared_context.py",
+        "name": "test_builder_skips_an_entry_that_cannot_fit_but_keeps_a_later_shorter_one",
+        "line": 127
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/contextpack/builder_test.go",
+          "test": "TestBuilderSkipsUnfittableEntryAndKeepsLaterShortEntry"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/runtime/test_prepared_context.py",
+        "name": "test_builder_rejects_a_hit_from_a_different_memory_head",
+        "line": 143
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/contextpack/builder_test.go",
+          "test": "TestBuilderRejectsHitFromDifferentMemoryHead"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/runtime/test_prepared_context.py",
+        "name": "test_builder_prepares_experience_without_a_memory_head_and_keeps_v1_envelope",
+        "line": 154
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/contextpack/builder_test.go",
+          "test": "TestBuilderPreparesExperienceWithoutMemoryHead"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/runtime/test_prepared_context.py",
+        "name": "test_builder_keeps_memory_primary_and_bounds_experience_share",
+        "line": 176
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/contextpack/builder_test.go",
+          "test": "TestBuilderKeepsMemoryPrimaryAndBoundsExperienceShare"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/runtime/test_prepared_context.py",
+        "name": "test_builder_rejects_non_experience_recall_hits",
+        "line": 194
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/contextpack/builder_test.go",
+          "test": "TestBuilderRejectsNonExperienceRecallHit"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/runtime/test_prepared_context.py",
+        "name": "test_prepare_request_rejects_values_outside_the_runtime_contract",
+        "line": 215
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/contextpack/builder_test.go",
+          "test": "TestRequestValidationAndEmptyContext"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/runtime/test_prepared_context.py",
+        "name": "test_empty_context_has_no_source_specific_status_or_content",
+        "line": 220
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/contextpack/builder_test.go",
+          "test": "TestRequestValidationAndEmptyContext"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/runtime/test_readiness.py",
+        "name": "test_builtin_runtime_reports_runtime_and_database_readiness",
+        "line": 29
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "server/application_test.go",
+          "test": "TestOpenApplicationReportsRuntimeAndDatabaseReadiness"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/runtime/test_scheduler.py",
+        "name": "test_scheduler_persists_one_stable_source_window_job",
+        "line": 108
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/scheduler/scheduler_test.go",
+          "test": "TestSchedulerPersistsOneStableSourceWindowJob"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/runtime/test_scheduler.py",
+        "name": "test_scheduler_creates_missing_database_parent_directory",
+        "line": 127
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/scheduler/scheduler_test.go",
+          "test": "TestSchedulerCreatesMissingDatabaseParentDirectory"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/runtime/test_scheduler.py",
+        "name": "test_scheduler_interval_activates_the_source_window_policy",
+        "line": 142
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/scheduler/scheduler_test.go",
+          "test": "TestSchedulerTimingAndHandlerFailureIsolation"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/runtime/test_scheduler.py",
+        "name": "test_scheduler_interval_activates_experience_incubation",
+        "line": 155
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/scheduler/scheduler_test.go",
+          "test": "TestSchedulerActivatesExperienceIncubationInterval"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/runtime/test_scheduler.py",
+        "name": "test_scheduler_persists_and_reconciles_independent_jobs",
+        "line": 172
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/scheduler/scheduler_test.go",
+          "test": "TestSchedulerPersistsStableJobAndReconcilesDisabledJob"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/runtime/test_scheduler.py",
+        "name": "test_scheduled_noop_logs_a_bounded_outcome",
+        "line": 193
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "server/logging_test.go",
+          "test": "TestScheduledNoopLogsBoundedOutcome"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/runtime/test_scheduler.py",
+        "name": "test_scheduled_experience_logs_candidate_count_without_scope",
+        "line": 209
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "server/logging_test.go",
+          "test": "TestScheduledExperienceLogsCandidateCountWithoutScope"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/runtime/test_scheduler.py",
+        "name": "test_scheduler_requires_file_storage_and_one_live_owner",
+        "line": 225
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/scheduler/scheduler_test.go",
+          "test": "TestSchedulerEnforcesOneLiveOwner"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/runtime/test_scope_cache.py",
+        "name": "test_scope_cache_does_not_evict_a_lock_with_holders_or_waiters",
+        "line": 67
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/runtime/lifecycle_test.go",
+          "test": "TestScopeCacheNeverEvictsLockWithHolderOrWaiter"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/runtime/test_statistics.py",
+        "name": "test_scoped_statistics_reports_current_inventory_and_recall_reduction",
+        "line": 45
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "test/e2e/http_memory_test.go",
+          "test": "TestHTTPSourceAndMemorySQLiteVerticalSlice"
+        },
+        {
+          "kind": "go",
+          "file": "server/application_test.go",
+          "test": "TestOpenApplicationPersistsBusinessInferenceAndRecallAcrossRestartWithoutMeteringReadiness"
+        },
+        {
+          "kind": "go",
+          "file": "internal/sqlstore/product_surfaces_test.go",
+          "test": "TestScopedStatisticsPreservesIncompleteUsageAndRecallProfile"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/runtime/test_statistics.py",
+        "name": "test_recall_estimates_each_source_as_complete_text",
+        "line": 118
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/sqlstore/recall_tokens_test.go",
+          "test": "TestRelationalRecallTokenEstimatorResolvesMemoryAndRecursiveArtifactLineage"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/runtime/test_work_continuity.py",
+        "name": "test_verified_work_claims_require_exact_evidence",
+        "line": 59
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/work/model_test.go",
+          "test": "TestVerifiedWorkClaimsRequireExactEvidence"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/runtime/test_work_continuity.py",
+        "name": "test_acknowledgement_cannot_accept_unavailable_handoff_evidence",
+        "line": 87
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/runtime/work_application_test.go",
+          "test": "TestAcknowledgementCannotAcceptUnavailableHandoffEvidence"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/runtime/test_work_continuity.py",
+        "name": "test_acknowledgement_requires_an_inspected_target_and_receiver_checks",
+        "line": 134
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/work/model_test.go",
+          "test": "TestAcknowledgementRequiresInspectedTargetAndReceiverChecks"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/runtime/test_work_continuity.py",
+        "name": "test_work_contract_rejects_a_verified_cross_record_claim_when_evidence_is_missing",
+        "line": 166
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/runtime/work_application_test.go",
+          "test": "TestWorkContractRejectsVerifiedClaimWithMissingEvidence"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/runtime/test_work_continuity.py",
+        "name": "test_continuity_projects_the_result_loop_in_stable_journal_order",
+        "line": 193
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "test/e2e/http_memory_test.go",
+          "test": "TestHTTPSourceAndMemorySQLiteVerticalSlice"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/runtime/test_work_continuity.py",
+        "name": "test_continuity_does_not_cover_an_acceptance_with_an_unlinked_outcome",
+        "line": 269
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/work/continuity_test.go",
+          "test": "TestContinuityDoesNotCoverAcceptanceWithUnlinkedOutcome"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/runtime/test_work_continuity.py",
+        "name": "test_task_outcome_rejects_a_non_receipt_result_link",
+        "line": 315
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/runtime/work_application_test.go",
+          "test": "TestTaskOutcomeRejectsNonReceiptResultLink"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/runtime/test_work_continuity.py",
+        "name": "test_continuity_excludes_malformed_work_records_without_failing_the_report",
+        "line": 338
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/work/continuity_test.go",
+          "test": "TestContinuityExcludesMalformedWorkRecords"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/claude_code_plugin/test_contract.py",
+        "name": "test_repository_exposes_a_claude_marketplace",
+        "line": 35
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/claude-code/tests/test_contract.py",
+          "test": "test_repository_exposes_a_claude_marketplace"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/claude_code_plugin/test_contract.py",
+        "name": "test_plugin_uses_standard_component_discovery",
+        "line": 50
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/claude-code/tests/test_contract.py",
+          "test": "test_plugin_uses_standard_component_discovery"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/claude_code_plugin/test_contract.py",
+        "name": "test_hook_uses_exec_form_and_does_not_capture_stop",
+        "line": 60
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/claude-code/tests/test_contract.py",
+          "test": "test_hook_uses_exec_form_and_does_not_capture_stop"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/claude_code_plugin/test_contract.py",
+        "name": "test_mcp_uses_claude_top_level_server_map_and_optional_header_helper",
+        "line": 69
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/claude-code/tests/test_contract.py",
+          "test": "test_mcp_uses_claude_top_level_server_map_and_optional_header_helper"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/claude_code_plugin/test_contract.py",
+        "name": "test_mcp_header_helper_command_does_not_depend_on_plugin_root",
+        "line": 84
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/claude-code/tests/test_contract.py",
+          "test": "test_mcp_header_helper_command_does_not_depend_on_plugin_root"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/claude_code_plugin/test_contract.py",
+        "name": "test_header_helper_omits_authorization_when_unset",
+        "line": 105
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/claude-code/tests/test_contract.py",
+          "test": "test_header_helper_omits_authorization_when_unset"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/claude_code_plugin/test_contract.py",
+        "name": "test_header_helper_emits_configured_authorization_without_logging_it",
+        "line": 120
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/claude-code/tests/test_contract.py",
+          "test": "test_header_helper_emits_configured_authorization_without_logging_it"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/claude_code_plugin/test_contract.py",
+        "name": "test_scope_matches_codex_remote_normalization",
+        "line": 146
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/claude-code/tests/test_contract.py",
+          "test": "test_scope_matches_codex_remote_normalization"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/claude_code_plugin/test_contract.py",
+        "name": "test_scope_override_wins",
+        "line": 154
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/claude-code/tests/test_contract.py",
+          "test": "test_scope_override_wins"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/claude_code_plugin/test_contract.py",
+        "name": "test_scope_reads_the_shared_git_private_workstream_binding",
+        "line": 158
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/claude-code/tests/test_contract.py",
+          "test": "test_scope_reads_the_shared_git_private_workstream_binding"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/claude_code_plugin/test_contract.py",
+        "name": "test_settings_reject_unsafe_server_urls",
+        "line": 177
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/claude-code/tests/test_contract.py",
+          "test": "test_settings_reject_unsafe_server_urls"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/claude_code_plugin/test_contract.py",
+        "name": "test_environment_override_controls_prompt_capture",
+        "line": 182
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/claude-code/tests/test_contract.py",
+          "test": "test_environment_override_controls_prompt_capture"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/claude_code_plugin/test_contract.py",
+        "name": "test_project_context_skill_preserves_explicit_memory_and_handoff_boundaries",
+        "line": 192
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/claude-code/tests/test_contract.py",
+          "test": "test_project_context_skill_preserves_explicit_memory_and_handoff_boundaries"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/claude_code_plugin/test_contract.py",
+        "name": "test_claude_integration_does_not_embed_machine_specific_windows_paths",
+        "line": 206
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/claude-code/tests/test_contract.py",
+          "test": "test_claude_integration_does_not_embed_machine_specific_windows_paths"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/claude_code_plugin/test_hook.py",
+        "name": "test_user_prompt_submit_injects_prepared_context_and_captures_prompt",
+        "line": 67
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/claude-code/tests/test_hook.py",
+          "test": "test_user_prompt_submit_injects_prepared_context_and_captures_prompt"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/claude_code_plugin/test_hook.py",
+        "name": "test_user_prompt_submit_reads_utf8_stdin_on_windows_encodings",
+        "line": 112
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/claude-code/tests/test_hook.py",
+          "test": "test_user_prompt_submit_reads_utf8_stdin_on_windows_encodings"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/claude_code_plugin/test_hook.py",
+        "name": "test_user_prompt_compatibility_fallback_is_supported",
+        "line": 152
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/claude-code/tests/test_hook.py",
+          "test": "test_user_prompt_compatibility_fallback_is_supported"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/claude_code_plugin/test_hook.py",
+        "name": "test_unexpected_recall_failure_does_not_prevent_prompt_capture",
+        "line": 186
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/claude-code/tests/test_hook.py",
+          "test": "test_unexpected_recall_failure_does_not_prevent_prompt_capture"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/claude_code_plugin/test_hook.py",
+        "name": "test_capture_failure_does_not_prevent_context_injection",
+        "line": 221
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/claude-code/tests/test_hook.py",
+          "test": "test_capture_failure_does_not_prevent_context_injection"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/claude_code_plugin/test_hook.py",
+        "name": "test_recall_and_capture_share_one_http_deadline",
+        "line": 254
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/claude-code/tests/test_hook.py",
+          "test": "test_recall_and_capture_share_one_http_deadline"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/claude_code_plugin/test_hook.py",
+        "name": "test_prompt_capture_can_be_disabled",
+        "line": 289
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/claude-code/tests/test_hook.py",
+          "test": "test_prompt_capture_can_be_disabled"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/claude_code_plugin/test_hook.py",
+        "name": "test_context_request_uses_prepare_once",
+        "line": 329
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/claude-code/tests/test_hook.py",
+          "test": "test_context_request_uses_prepare_once"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/claude_code_plugin/test_hook.py",
+        "name": "test_capture_prompt_is_idempotent_and_is_not_a_task_outcome",
+        "line": 361
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/claude-code/tests/test_hook.py",
+          "test": "test_capture_prompt_is_idempotent_and_is_not_a_task_outcome"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/claude_code_plugin/test_hook.py",
+        "name": "test_http_failures_are_non_blocking_and_content_free",
+        "line": 412
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/claude-code/tests/test_hook.py",
+          "test": "test_http_failures_are_non_blocking_and_content_free"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/claude_code_plugin/test_hook.py",
+        "name": "test_unknown_schema_and_oversized_content_are_not_injected",
+        "line": 440
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/claude-code/tests/test_hook.py",
+          "test": "test_unknown_schema_and_oversized_content_are_not_injected"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/claude_code_plugin/test_hook.py",
+        "name": "test_malformed_prepared_context_is_not_injected",
+        "line": 473
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/claude-code/tests/test_hook.py",
+          "test": "test_malformed_prepared_context_is_not_injected"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/claude_code_plugin/test_hook.py",
+        "name": "test_hook_refuses_redirects",
+        "line": 494
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/claude-code/tests/test_hook.py",
+          "test": "test_hook_refuses_redirects"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/claude_code_plugin/test_hook.py",
+        "name": "test_hook_rejects_an_oversized_response_body",
+        "line": 536
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/claude-code/tests/test_hook.py",
+          "test": "test_hook_rejects_an_oversized_response_body"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/codex_plugin/test_contract.py",
+        "name": "test_scope_normalizes_network_git_remotes",
+        "line": 36
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/codex/tests/test_contract.py",
+          "test": "test_scope_normalizes_network_git_remotes"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/codex_plugin/test_contract.py",
+        "name": "test_scope_override_wins",
+        "line": 44
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/codex/tests/test_contract.py",
+          "test": "test_scope_override_wins"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/codex_plugin/test_contract.py",
+        "name": "test_scope_binding_is_persisted_in_git_private_state",
+        "line": 54
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/codex/tests/test_contract.py",
+          "test": "test_scope_binding_is_persisted_in_git_private_state"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/codex_plugin/test_contract.py",
+        "name": "test_scope_binding_requires_a_git_workspace",
+        "line": 80
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/codex/tests/test_contract.py",
+          "test": "test_scope_binding_requires_a_git_workspace"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/codex_plugin/test_contract.py",
+        "name": "test_codex_settings_precedence_and_validation",
+        "line": 91
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/codex/tests/test_contract.py",
+          "test": "test_codex_settings_precedence_and_validation"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/codex_plugin/test_contract.py",
+        "name": "test_codex_settings_load_the_optional_mcp_authorization_environment",
+        "line": 108
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/codex/tests/test_contract.py",
+          "test": "test_codex_settings_load_the_optional_mcp_authorization_environment"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/codex_plugin/test_contract.py",
+        "name": "test_codex_mcp_uses_an_optional_authorization_environment",
+        "line": 121
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/codex/tests/test_contract.py",
+          "test": "test_codex_mcp_uses_an_optional_authorization_environment"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/codex_plugin/test_contract.py",
+        "name": "test_codex_settings_reject_invalid_authorization_headers",
+        "line": 135
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/codex/tests/test_contract.py",
+          "test": "test_codex_settings_reject_invalid_authorization_headers"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/codex_plugin/test_contract.py",
+        "name": "test_codex_settings_ignore_unscoped_legacy_names",
+        "line": 146
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/codex/tests/test_contract.py",
+          "test": "test_codex_settings_ignore_unscoped_legacy_names"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/codex_plugin/test_contract.py",
+        "name": "test_codex_settings_reject_unsafe_or_ambiguous_mcp_urls",
+        "line": 166
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/codex/tests/test_contract.py",
+          "test": "test_codex_settings_reject_unsafe_or_ambiguous_mcp_urls"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/codex_plugin/test_contract.py",
+        "name": "test_codex_settings_normalize_the_mcp_path_to_http_base",
+        "line": 174
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/codex/tests/test_contract.py",
+          "test": "test_codex_settings_normalize_the_mcp_path_to_http_base"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/codex_plugin/test_contract.py",
+        "name": "test_project_context_skill_uses_the_high_level_work_continuity_loop",
+        "line": 180
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/codex/tests/test_contract.py",
+          "test": "test_project_context_skill_uses_the_high_level_work_continuity_loop"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/codex_plugin/test_contract.py",
+        "name": "test_powercontext_plugin_advertises_the_one_turn_handoff",
+        "line": 202
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/codex/tests/test_contract.py",
+          "test": "test_powercontext_plugin_advertises_the_one_turn_handoff"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/codex_plugin/test_recall.py",
+        "name": "test_recall_emits_bounded_untrusted_context",
+        "line": 56
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/codex/tests/test_recall.py",
+          "test": "test_recall_emits_bounded_untrusted_context"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/codex_plugin/test_recall.py",
+        "name": "test_recall_reads_utf8_stdin_on_windows_encodings",
+        "line": 105
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/codex/tests/test_recall.py",
+          "test": "test_recall_reads_utf8_stdin_on_windows_encodings"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/codex_plugin/test_recall.py",
+        "name": "test_recall_failure_is_non_blocking",
+        "line": 145
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/codex/tests/test_recall.py",
+          "test": "test_recall_failure_is_non_blocking"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/codex_plugin/test_recall.py",
+        "name": "test_recall_authentication_failure_is_non_blocking_and_content_free",
+        "line": 185
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/codex/tests/test_recall.py",
+          "test": "test_recall_authentication_failure_is_non_blocking_and_content_free"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/codex_plugin/test_recall.py",
+        "name": "test_recall_records_exact_injected_context_only_when_eval_trace_is_enabled",
+        "line": 215
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/codex/tests/test_recall.py",
+          "test": "test_recall_records_exact_injected_context_only_when_eval_trace_is_enabled"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/codex_plugin/test_recall.py",
+        "name": "test_recall_does_not_write_an_evaluation_trace_by_default",
+        "line": 270
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/codex/tests/test_recall.py",
+          "test": "test_recall_does_not_write_an_evaluation_trace_by_default"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/codex_plugin/test_recall.py",
+        "name": "test_recall_uses_the_eval_home_when_codex_filters_the_trace_path",
+        "line": 304
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/codex/tests/test_recall.py",
+          "test": "test_recall_uses_the_eval_home_when_codex_filters_the_trace_path"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/codex_plugin/test_recall.py",
+        "name": "test_hook_accepts_codex_event_name_variants",
+        "line": 337
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/codex/tests/test_recall.py",
+          "test": "test_hook_accepts_codex_event_name_variants"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/codex_plugin/test_recall.py",
+        "name": "test_normal_empty_context_emits_a_generic_diagnostic",
+        "line": 376
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/codex/tests/test_recall.py",
+          "test": "test_normal_empty_context_emits_a_generic_diagnostic"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/codex_plugin/test_recall.py",
+        "name": "test_unknown_prepared_context_schema_fails_open_without_exposing_response",
+        "line": 407
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/codex/tests/test_recall.py",
+          "test": "test_unknown_prepared_context_schema_fails_open_without_exposing_response"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/codex_plugin/test_recall.py",
+        "name": "test_hook_injects_runtime_content_without_a_second_selection",
+        "line": 429
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/codex/tests/test_recall.py",
+          "test": "test_hook_injects_runtime_content_without_a_second_selection"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/codex_plugin/test_recall.py",
+        "name": "test_hook_rejects_runtime_content_over_the_requested_budget",
+        "line": 439
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/codex/tests/test_recall.py",
+          "test": "test_hook_rejects_runtime_content_over_the_requested_budget"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/codex_plugin/test_recall.py",
+        "name": "test_context_request_uses_the_prepare_endpoint_once",
+        "line": 444
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/codex/tests/test_recall.py",
+          "test": "test_context_request_uses_the_prepare_endpoint_once"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/codex_plugin/test_recall.py",
+        "name": "test_context_prepare_404_is_reported_as_a_version_mismatch",
+        "line": 483
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/codex/tests/test_recall.py",
+          "test": "test_context_prepare_404_is_reported_as_a_version_mismatch"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/codex_plugin/test_recall.py",
+        "name": "test_capture_prompt_is_idempotent_and_preserves_provenance",
+        "line": 507
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/codex/tests/test_recall.py",
+          "test": "test_capture_prompt_is_idempotent_and_preserves_provenance"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/codex_plugin/test_recall.py",
+        "name": "test_flush_reaches_the_captured_source_position",
+        "line": 563
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/codex/tests/test_recall.py",
+          "test": "test_flush_reaches_the_captured_source_position"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/codex_plugin/test_recall.py",
+        "name": "test_flush_is_bounded_by_settings",
+        "line": 595
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/codex/tests/test_recall.py",
+          "test": "test_flush_is_bounded_by_settings"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/codex_plugin/test_recall.py",
+        "name": "test_hook_refuses_redirects",
+        "line": 619
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/codex/tests/test_recall.py",
+          "test": "test_hook_refuses_redirects"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/codex_plugin/test_recall.py",
+        "name": "test_hook_aborts_a_slow_response_at_the_request_deadline",
+        "line": 660
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/codex/tests/test_recall.py",
+          "test": "test_hook_aborts_a_slow_response_at_the_request_deadline"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/codex_plugin/test_recall.py",
+        "name": "test_prompt_capture_can_be_disabled",
+        "line": 695
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/codex/tests/test_recall.py",
+          "test": "test_prompt_capture_can_be_disabled"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/codex_plugin/test_skill_projection.py",
+        "name": "test_exact_managed_skill_projects_to_a_new_codex_skill_directory",
+        "line": 31
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/artifact_commands_test.go",
+          "test": "TestExactManagedSkillProjectsToNewCodexSkillDirectory"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/codex_plugin/test_skill_projection.py",
+        "name": "test_projection_never_overwrites_an_existing_directory",
+        "line": 59
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/artifact_commands_test.go",
+          "test": "TestCodexProjectionNeverOverwritesExistingDirectory"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/codex_plugin/test_skill_projection.py",
+        "name": "test_managed_projection_can_be_inspected_and_safely_updated",
+        "line": 76
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/webui/skill_projection_test.go",
+          "test": "TestDashboardSkillProjectionStatusAndPublish"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/codex_plugin/test_skill_projection.py",
+        "name": "test_managed_projection_refuses_to_replace_modified_or_foreign_content",
+        "line": 105
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/webui/skill_projection_test.go",
+          "test": "TestDashboardSkillProjectionRoutesValidateAuthorityAndScope"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/codex_plugin/test_skill_projection.py",
+        "name": "test_projection_rejects_managed_content_that_is_not_a_valid_codex_skill",
+        "line": 143
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/artifact_commands_test.go",
+          "test": "TestCodexProjectionRejectsInvalidManagedContent"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/codex_plugin/test_skill_projection.py",
+        "name": "test_exact_managed_skill_projects_to_claude_code",
+        "line": 161
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/artifact_commands_test.go",
+          "test": "TestClaudeCodeProjectionUsesSharedAgentProjection"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/e2e/real_experience_skill/test_journey.py",
+        "name": "test_real_codex_experience_skill_journey",
+        "line": 27
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/runtime/experience_incubation_test.go",
+          "test": "TestExperienceIncubationUsesTwoStagesAndExactWindowEvidence"
+        },
+        {
+          "kind": "go",
+          "file": "server/application_test.go",
+          "test": "TestGoClientGeneratesReviewedExperienceAndSkillCandidates"
+        },
+        {
+          "kind": "go",
+          "file": "internal/sqlstore/review_test.go",
+          "test": "TestReviewApproveCommitsCandidateArtifactAndLineage"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/e2e/real_experience_skill/test_recall_evaluation.py",
+        "name": "test_approved_experience_improves_next_coding_task_success",
+        "line": 24
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/runtime/context_application_test.go",
+          "test": "TestContextApplicationRecallsExperienceWithinOneScopedOperation"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/e2e/test_builtin_runtime.py",
+        "name": "test_builtin_runtime_uses_sqlite_fts_without_vector_extension",
+        "line": 47
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "server/application_test.go",
+          "test": "TestOpenApplicationProvidesRunnableSQLiteVerticalSlice"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/e2e/test_builtin_runtime.py",
+        "name": "test_same_scope_read_only_searches_do_not_serialize_reranking",
+        "line": 113
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/runtime/lifecycle_test.go",
+          "test": "TestScopedReadsForSameScopeCanOverlap"
+        },
+        {
+          "kind": "go",
+          "file": "artifact/memory/service_contract_test.go",
+          "test": "TestMemorySearchAppliesInjectedRerankerAfterCoarseFusion"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/e2e/test_candidate_review.py",
+        "name": "test_http_sdk_experience_review_vertical_slice",
+        "line": 86
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "server/application_test.go",
+          "test": "TestGoClientExercisesReviewHTTPRuntimeSQLiteVerticalSlice"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/e2e/test_candidate_review.py",
+        "name": "test_candidate_cli_lists_shows_revises_approves_and_rejects",
+        "line": 248
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/python_contract_test.go",
+          "test": "TestCLICandidateLifecycleCommandsBuildTypedRequests"
+        },
+        {
+          "kind": "go",
+          "file": "internal/cli/python_contract_test.go",
+          "test": "TestCLICandidateRevisionCommandsBuildTypedProposals"
+        },
+        {
+          "kind": "go",
+          "file": "server/application_test.go",
+          "test": "TestGoClientExercisesReviewHTTPRuntimeSQLiteVerticalSlice"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/e2e/test_claude_code_service_chain.py",
+        "name": "test_claude_sessions_and_codex_share_one_project_memory",
+        "line": 64
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/claude-code/tests/test_hook.py",
+          "test": "test_user_prompt_submit_injects_prepared_context_and_captures_prompt"
+        },
+        {
+          "kind": "go",
+          "file": "test/e2e/http_memory_test.go",
+          "test": "TestHTTPSourceAndMemorySQLiteVerticalSlice"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/e2e/test_claude_code_service_chain.py",
+        "name": "test_claude_plugin_mcp_supports_explicit_memory_and_handoff_workflows",
+        "line": 150
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/claude-code/tests/test_contract.py",
+          "test": "test_project_context_skill_preserves_explicit_memory_and_handoff_boundaries"
+        },
+        {
+          "kind": "go",
+          "file": "internal/mcpapi/server_test.go",
+          "test": "TestServerExposesFrozenToolSet"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/e2e/test_codex_service_chain.py",
+        "name": "test_codex_hook_http_sdk_and_mcp_share_one_composed_context",
+        "line": 55
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/codex/tests/test_recall.py",
+          "test": "test_context_request_uses_the_prepare_endpoint_once"
+        },
+        {
+          "kind": "go",
+          "file": "test/e2e/http_memory_test.go",
+          "test": "TestHTTPSourceAndMemorySQLiteVerticalSlice"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/e2e/test_dsh_http_chain.py",
+        "name": "test_dsh_http_paths_work_without_a_model",
+        "line": 38
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "ts",
+          "file": "integrations/dsh/plugins/powercontext/tests/e2e/call-through.spec.ts",
+          "test": "remembers, searches, prepares, and captures over HTTP"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/e2e/test_external_skill_registry.py",
+        "name": "test_http_sdk_external_skill_registry_preserves_host_local_authority",
+        "line": 39
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/runtime/external_skill_application_test.go",
+          "test": "TestRuntimeExposesConfiguredExternalSkillRegistryWithoutModel"
+        },
+        {
+          "kind": "go",
+          "file": "artifact/skill/external_test.go",
+          "test": "TestRegistryRefreshesProjectionAndChecksLiveAvailability"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/e2e/test_external_skill_registry.py",
+        "name": "test_http_sdk_explicitly_imports_exact_external_snapshot_into_review",
+        "line": 111
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/runtime/external_skill_application_test.go",
+          "test": "TestExternalSkillImportRequiresGenerationBeforeSnapshot"
+        },
+        {
+          "kind": "go",
+          "file": "test/e2e/http_memory_test.go",
+          "test": "TestHTTPSourceAndMemorySQLiteVerticalSlice"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/e2e/test_handoff_runtime.py",
+        "name": "test_runtime_owns_handoff_trigger_activation_and_deduplication",
+        "line": 62
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "test/e2e/http_memory_test.go",
+          "test": "TestHTTPSourceAndMemorySQLiteVerticalSlice"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/e2e/test_handoff_runtime.py",
+        "name": "test_handoff_trigger_state_survives_runtime_restart",
+        "line": 103
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "server/application_test.go",
+          "test": "TestOpenApplicationPersistsBusinessInferenceAndRecallAcrossRestartWithoutMeteringReadiness"
+        },
+        {
+          "kind": "go",
+          "file": "internal/scheduler/scheduler_test.go",
+          "test": "TestSchedulerPersistsStableJobAndReconcilesDisabledJob"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/e2e/test_handoff_runtime.py",
+        "name": "test_handoff_runtime_supports_temporary_transfer_and_durable_milestones",
+        "line": 140
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "artifact/handoff/service_test.go",
+          "test": "TestHandoffServiceDraftCanBeCorrectedBeforeTemporaryHandoffFinalized"
+        },
+        {
+          "kind": "go",
+          "file": "test/e2e/http_memory_test.go",
+          "test": "TestHTTPSourceAndMemorySQLiteVerticalSlice"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/e2e/test_handoff_runtime.py",
+        "name": "test_handoff_runtime_rejects_stale_and_cross_scope_use",
+        "line": 246
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "artifact/handoff/service_test.go",
+          "test": "TestHandoffServiceStalePreparedCannotReplaceNewerMilestone"
+        },
+        {
+          "kind": "go",
+          "file": "artifact/handoff/service_test.go",
+          "test": "TestHandoffServiceRejectsCrossScopePreparedHandoff"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/e2e/test_handoff_runtime.py",
+        "name": "test_handoff_runtime_recovers_only_explicitly_committed_milestones",
+        "line": 294
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "artifact/handoff/service_test.go",
+          "test": "TestHandoffServiceContinueLatestReportsEmptyWithoutMilestone"
+        },
+        {
+          "kind": "go",
+          "file": "test/e2e/http_memory_test.go",
+          "test": "TestHTTPSourceAndMemorySQLiteVerticalSlice"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/e2e/test_langgraph_chain.py",
+        "name": "test_langgraph_write_then_recall_over_real_http",
+        "line": 98
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/langgraph/tests/test_tools.py",
+          "test": "test_remember_then_search_roundtrips_through_the_server"
+        },
+        {
+          "kind": "go",
+          "file": "test/e2e/http_memory_test.go",
+          "test": "TestHTTPSourceAndMemorySQLiteVerticalSlice"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/e2e/test_langgraph_chain.py",
+        "name": "test_inspect_recall_example_runs",
+        "line": 165
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/langgraph/tests/test_recall.py",
+          "test": "test_recall_injects_context_labelled_untrusted"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/e2e/test_mcp_transport.py",
+        "name": "test_mcp_projects_curated_tools_at_the_configured_server_path",
+        "line": 43
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/mcpapi/server_test.go",
+          "test": "TestServerExposesFrozenToolSet"
+        },
+        {
+          "kind": "go",
+          "file": "server/http_test.go",
+          "test": "TestOptionalMCPRouteUsesConfiguredPath"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/e2e/test_mcp_transport.py",
+        "name": "test_mcp_handoff_tools_share_one_source_to_artifact_lifecycle",
+        "line": 157
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/mcpapi/server_test.go",
+          "test": "TestToolCallUsesEndpointDefaultsAndStructuredContent"
+        },
+        {
+          "kind": "go",
+          "file": "test/e2e/http_memory_test.go",
+          "test": "TestHTTPSourceAndMemorySQLiteVerticalSlice"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/e2e/test_mcp_transport.py",
+        "name": "test_mcp_endpoint_is_absent_when_disabled_by_server_settings",
+        "line": 251
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "server/http_test.go",
+          "test": "TestOptionalMCPRouteUsesConfiguredPath"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/e2e/test_memory_search_concurrency.py",
+        "name": "test_memory_search_stays_consistent_when_append_advances_head_before_index_query",
+        "line": 94
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/runtime/memory_search_concurrency_test.go",
+          "test": "TestMemorySearchRetriesOneAdvancedHead"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/e2e/test_memory_search_concurrency.py",
+        "name": "test_memory_search_keeps_the_completed_revision_snapshot_when_head_advances_during_reranking",
+        "line": 155
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/runtime/memory_search_concurrency_test.go",
+          "test": "TestMemorySearchKeepsCompletedRevisionWhenHeadAdvancesDuringReranking"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/e2e/test_memory_search_concurrency.py",
+        "name": "test_memory_search_reports_revision_conflict_when_every_attempt_starts_from_a_stale_head",
+        "line": 192
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/runtime/memory_search_concurrency_test.go",
+          "test": "TestMemorySearchReturnsConflictAfterThreeAdvancedHeads"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/e2e/test_observability.py",
+        "name": "test_observability_signals_correlate_without_counting_the_mcp_bridge",
+        "line": 200
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "server/logging_test.go",
+          "test": "TestMCPLogsLogicalCallWithoutStreamableHTTPDuplicate"
+        },
+        {
+          "kind": "go",
+          "file": "server/http_test.go",
+          "test": "TestHTTPAndMCPMetricsUseBoundedOperationLabels"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/e2e/test_observability.py",
+        "name": "test_database_failure_log_does_not_include_memory_content",
+        "line": 290
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "server/logging_test.go",
+          "test": "TestHTTPFailureLogsApplicationAndTransportWithoutErrorContent"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/e2e/test_observability.py",
+        "name": "test_inference_spans_join_the_operation_trace_only_when_instrumented",
+        "line": 333
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "inference/tracing_test.go",
+          "test": "TestEmbeddingSpanNestsUnderActiveOperationWithoutRecordingTextOrVectors"
+        },
+        {
+          "kind": "go",
+          "file": "inference/tracing_test.go",
+          "test": "TestInferenceTracingFollowsProviderSamplingSetting"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/e2e/test_observability.py",
+        "name": "test_memory_read_stage_spans_are_bounded_and_nested",
+        "line": 360
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/runtime/tracing_test.go",
+          "test": "TestMemoryReadStagesAreBoundedAndNestedWithinOneScopedOperation"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/e2e/test_observability.py",
+        "name": "test_scope_lock_stage_span_reports_contention_and_closes_at_acquisition",
+        "line": 562
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/runtime/tracing_test.go",
+          "test": "TestScopeLockStageReportsContentionAndEndsAtAcquisition"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/e2e/test_observability.py",
+        "name": "test_scope_lock_is_released_when_stage_teardown_fails",
+        "line": 620
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/runtime/tracing_test.go",
+          "test": "TestScopeLockIsReleasedWhenTraceTeardownPanics"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/e2e/test_observability.py",
+        "name": "test_vector_search_exports_embedding_under_memory_search_without_recording_text",
+        "line": 641
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "inference/tracing_test.go",
+          "test": "TestEmbeddingSpanNestsUnderActiveOperationWithoutRecordingTextOrVectors"
+        },
+        {
+          "kind": "go",
+          "file": "internal/runtime/tracing_test.go",
+          "test": "TestMemoryReadStagesAreBoundedAndNestedWithinOneScopedOperation"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/e2e/test_observability.py",
+        "name": "test_injected_always_on_embedding_skips_readiness_but_traces_vector_search",
+        "line": 710
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "server/application_readiness_test.go",
+          "test": "TestConfiguredEmbeddingReadinessIsUntracedButRuntimeEmbeddingIsTraced"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/e2e/test_opencode_plugin_host.py",
+        "name": "test_opencode_run_normalizes_prompt_before_recall_and_capture",
+        "line": 65
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "ts",
+          "file": "integrations/opencode/plugins/powercontext/tests/plugin.spec.ts",
+          "test": "normalizes the JSON string representation emitted by opencode run"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/e2e/test_pydantic_ai_chain.py",
+        "name": "test_pydantic_ai_capture_checkpoint_recall_and_search_chain",
+        "line": 56
+      },
+      "mode": "cross-layer",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/e2e/test_pydantic_ai_chain.py",
+        "name": "test_pydantic_ai_final_flush_catches_up_across_more_than_ten_source_windows",
+        "line": 148
+      },
+      "mode": "cross-layer",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/e2e/test_reviewed_generation.py",
+        "name": "test_http_sdk_generates_reviewed_experience_and_managed_skill_candidates",
+        "line": 60
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "server/application_test.go",
+          "test": "TestGoClientGeneratesReviewedExperienceAndSkillCandidates"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/e2e/test_reviewed_generation.py",
+        "name": "test_http_generation_reports_missing_model_without_creating_a_candidate",
+        "line": 115
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/review/generation_test.go",
+          "test": "TestGenerationWithoutModelFailsBeforeEvidenceOrCandidatePersistence"
+        },
+        {
+          "kind": "go",
+          "file": "server/http_test.go",
+          "test": "TestHTTPGenerationUnavailableUsesStable503Envelope"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/e2e/test_runtime_server.py",
+        "name": "test_server_databases_share_source_to_memory_search_behavior",
+        "line": 161
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "test/e2e/http_memory_test.go",
+          "test": "TestHTTPSourceAndMemorySQLiteVerticalSlice"
+        },
+        {
+          "kind": "go",
+          "file": "test/e2e/oceanbase_live_test.go",
+          "test": "TestLiveOceanBaseProfileSmoke"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/e2e/test_runtime_server.py",
+        "name": "test_server_databases_keep_case_and_accent_variant_identities_distinct",
+        "line": 233
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/sqlstore/sources_test.go",
+          "test": "TestSourceRepositoryKeepsCaseAndAccentVariantIdentitiesDistinct"
+        },
+        {
+          "kind": "go",
+          "file": "test/e2e/oceanbase_live_test.go",
+          "test": "TestLiveOceanBaseProfileSmoke"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/e2e/test_runtime_server.py",
+        "name": "test_inference_failure_degrades_readiness_without_blocking_database_operations",
+        "line": 284
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "server/application_readiness_test.go",
+          "test": "TestApplicationReadinessClassifiesConfiguredInferenceWithoutLeakingFailures"
+        },
+        {
+          "kind": "go",
+          "file": "server/http_test.go",
+          "test": "TestHTTPReadinessMapsNotReadyAndDegradedStatuses"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/e2e/test_runtime_server.py",
+        "name": "test_sdk_handoff_lifecycle_reaches_generation_and_persistence",
+        "line": 319
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "test/e2e/http_memory_test.go",
+          "test": "TestHTTPSourceAndMemorySQLiteVerticalSlice"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/e2e/test_runtime_server.py",
+        "name": "test_sdk_closes_the_delegation_handoff_and_outcome_loop",
+        "line": 412
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "test/e2e/http_memory_test.go",
+          "test": "TestHTTPSourceAndMemorySQLiteVerticalSlice"
+        },
+        {
+          "kind": "go",
+          "file": "internal/runtime/work_application_test.go",
+          "test": "TestAcknowledgementCannotAcceptUnavailableHandoffEvidence"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/e2e/test_runtime_server.py",
+        "name": "test_server_databases_share_vector_and_hybrid_search_behavior",
+        "line": 577
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/sqlstore/sqlite_memory_vector_test.go",
+          "test": "TestSQLiteVec0ReplaceHydrateAndSearch"
+        },
+        {
+          "kind": "go",
+          "file": "test/e2e/oceanbase_live_test.go",
+          "test": "TestLiveOceanBaseProfileSmoke"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/e2e/test_runtime_server.py",
+        "name": "test_sdk_memory_lifecycle_reaches_one_composed_runtime",
+        "line": 647
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "server/application_test.go",
+          "test": "TestOpenApplicationProvidesRunnableSQLiteVerticalSlice"
+        },
+        {
+          "kind": "go",
+          "file": "test/e2e/http_memory_test.go",
+          "test": "TestHTTPSourceAndMemorySQLiteVerticalSlice"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/e2e/test_runtime_server.py",
+        "name": "test_runtime_conflicts_keep_http_and_sdk_error_context",
+        "line": 751
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "client/client_test.go",
+          "test": "TestClientPreservesDeclaredServerErrorContext"
+        },
+        {
+          "kind": "go",
+          "file": "client/client_test.go",
+          "test": "TestAsServerErrorPreservesStableContext"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/e2e/test_runtime_server.py",
+        "name": "test_memory_search_returns_revision_conflict_as_http_409",
+        "line": 798
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/runtime/memory_search_concurrency_test.go",
+          "test": "TestMemorySearchReturnsConflictAfterThreeAdvancedHeads"
+        },
+        {
+          "kind": "go",
+          "file": "client/client_test.go",
+          "test": "TestClientPreservesDeclaredServerErrorContext"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/e2e/test_runtime_server.py",
+        "name": "test_runtime_server_rejects_non_strict_transport_values",
+        "line": 828
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "client/client_test.go",
+          "test": "TestClientValidatesRequestsBeforeTransport"
+        },
+        {
+          "kind": "go",
+          "file": "openapi/python_contract_test.go",
+          "test": "TestGeneratedTransportRejectsValuesOutsideOpenAPI"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/e2e/test_scheduled_experience_incubation.py",
+        "name": "test_scheduler_incubates_task_outcome_once_and_preserves_review_gating",
+        "line": 83
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/runtime/experience_incubation_test.go",
+          "test": "TestScheduledExperienceIncubationUsesFixedSourceWindowBudget"
+        },
+        {
+          "kind": "go",
+          "file": "server/application_test.go",
+          "test": "TestOpenApplicationOwnsBothPersistentSchedulerJobs"
+        },
+        {
+          "kind": "go",
+          "file": "internal/sqlstore/review_test.go",
+          "test": "TestReviewApproveCommitsCandidateArtifactAndLineage"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/e2e/test_server_cli.py",
+        "name": "test_capabilities_flow_through_server_sdk_and_cli",
+        "line": 30
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/root_test.go",
+          "test": "TestCapabilitiesUsesEnvironmentAndWritesHumanOutput"
+        },
+        {
+          "kind": "go",
+          "file": "server/http_test.go",
+          "test": "TestSystemHTTPVerticalSlice"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/e2e/test_sqlite_vec.py",
+        "name": "test_sqlite_vec_supports_vector_and_hybrid_search",
+        "line": 52
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/sqlstore/sqlite_memory_vector_test.go",
+          "test": "TestSQLiteVec0ReplaceHydrateAndSearch"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/e2e/test_statistics_flow.py",
+        "name": "test_statistics_survive_the_authenticated_http_business_flow_and_restart",
+        "line": 102
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "server/application_test.go",
+          "test": "TestOpenApplicationPersistsBusinessInferenceAndRecallAcrossRestartWithoutMeteringReadiness"
+        },
+        {
+          "kind": "go",
+          "file": "test/e2e/http_memory_test.go",
+          "test": "TestHTTPSourceAndMemorySQLiteVerticalSlice"
+        },
+        {
+          "kind": "go",
+          "file": "internal/httpapi/middleware_test.go",
+          "test": "TestWrapBearerPolicy"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/e2e/test_workbuddy_service_chain.py",
+        "name": "test_workbuddy_hook_and_mcp_share_one_service_configuration",
+        "line": 51
+      },
+      "mode": "cross-layer",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/evaluation/test_locomo_benchmark.py",
+        "name": "test_canonical_locomo_dataset_has_expected_shape_and_scored_selection",
+        "line": 45
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/benchmark/locomo/locomo_test.go",
+          "test": "TestCanonicalLoCoMoDatasetHasExpectedShapeAndScoredSelection"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/evaluation/test_locomo_benchmark.py",
+        "name": "test_session_source_contains_dialogue_and_date_without_qa_annotations",
+        "line": 61
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/benchmark/locomo/locomo_test.go",
+          "test": "TestSessionSourceContainsDialogueAndDateWithoutQAAnnotations"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/evaluation/test_locomo_benchmark.py",
+        "name": "test_answer_metrics_and_session_provenance_are_deterministic",
+        "line": 74
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/benchmark/locomo/locomo_test.go",
+          "test": "TestAnswerMetricsAndSessionProvenanceAreDeterministic"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/evaluation/test_locomo_benchmark.py",
+        "name": "test_summary_keeps_errors_in_accuracy_denominator",
+        "line": 85
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/benchmark/locomo/locomo_test.go",
+          "test": "TestSummaryKeepsErrorsInAccuracyDenominator"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/evaluation/test_locomo_benchmark.py",
+        "name": "test_diagnostics_report_unknown_fallback_quality_and_cost",
+        "line": 119
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/benchmark/locomo/locomo_test.go",
+          "test": "TestDiagnosticsReportUnknownFallbackQualityAndCost"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/evaluation/test_locomo_benchmark.py",
+        "name": "test_run_manifest_is_stable_and_excludes_database_credentials",
+        "line": 155
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/benchmark/locomo/locomo_test.go",
+          "test": "TestRunManifestIsStableAndExcludesDatabaseCredentials"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/evaluation/test_locomo_benchmark.py",
+        "name": "test_run_manifest_records_inference_aware_answer_policy",
+        "line": 209
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/benchmark/locomo/locomo_test.go",
+          "test": "TestRunManifestRecordsInferenceAwareAnswerPolicy"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/evaluation/test_locomo_benchmark.py",
+        "name": "test_run_manifest_records_unknown_fallback_inference_policy",
+        "line": 255
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/benchmark/locomo/locomo_test.go",
+          "test": "TestRunManifestRecordsUnknownFallbackInferencePolicy"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/evaluation/test_locomo_benchmark.py",
+        "name": "test_rejudge_manifest_freezes_answers_and_records_independent_judge",
+        "line": 304
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/benchmark/locomo/locomo_test.go",
+          "test": "TestRejudgeManifestFreezesAnswersAndRecordsIndependentJudge"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/evaluation/test_locomo_prompts.py",
+        "name": "test_inference_aware_answer_policy_is_explicit_and_requires_source_content",
+        "line": 31
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/benchmark/locomo/locomo_test.go",
+          "test": "TestInferenceAwareAnswerPolicyIsExplicitAndRequiresSourceContent"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/evaluation/test_locomo_prompts.py",
+        "name": "test_unknown_fallback_answer_policy_is_explicit_and_mutually_exclusive",
+        "line": 42
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/benchmark/locomo/locomo_test.go",
+          "test": "TestUnknownFallbackAnswerPolicyIsExplicitAndMutuallyExclusive"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/evaluation/test_locomo_prompts.py",
+        "name": "test_judge_profiles_keep_strict_and_topical_contracts_distinct",
+        "line": 52
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/benchmark/locomo/locomo_test.go",
+          "test": "TestJudgeProfilesKeepStrictAndTopicalContractsDistinct"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/integrations/test_hermes_provider.py",
+        "name": "test_prefetch_uses_profile_and_user_scoped_context",
+        "line": 156
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/hermes/tests/test_provider.py",
+          "test": "test_prefetch_uses_profile_and_user_scoped_context"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/integrations/test_hermes_provider.py",
+        "name": "test_evaluation_trace_is_partitioned_by_session_and_records_parent",
+        "line": 169
+      },
+      "mode": "retained-host",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/integrations/test_hermes_provider.py",
+        "name": "test_evaluation_trace_slash_command_reads_named_session",
+        "line": 207
+      },
+      "mode": "retained-host",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/integrations/test_hermes_provider.py",
+        "name": "test_register_does_not_install_session_bound_slash_handlers",
+        "line": 231
+      },
+      "mode": "retained-host",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/integrations/test_hermes_provider.py",
+        "name": "test_powercontext_subcommands_are_available_to_hermes_completer",
+        "line": 257
+      },
+      "mode": "retained-host",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/integrations/test_hermes_provider.py",
+        "name": "test_standalone_command_companion_registers_before_agent_and_forwards",
+        "line": 273
+      },
+      "mode": "retained-host",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/integrations/test_hermes_provider.py",
+        "name": "test_standalone_command_companion_keeps_interleaved_sessions_isolated",
+        "line": 321
+      },
+      "mode": "retained-host",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/integrations/test_hermes_provider.py",
+        "name": "test_queue_prefetch_honors_max_bytes_environment_override",
+        "line": 386
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/hermes/tests/test_provider.py",
+          "test": "test_queue_prefetch_honors_max_bytes_environment_override"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/integrations/test_hermes_provider.py",
+        "name": "test_queue_prefetch_does_not_wait_for_http",
+        "line": 400
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/hermes/tests/test_provider.py",
+          "test": "test_queue_prefetch_does_not_wait_for_http"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/integrations/test_hermes_provider.py",
+        "name": "test_json_config_is_loaded_from_hermes_home",
+        "line": 425
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/hermes/tests/test_provider.py",
+          "test": "test_json_config_is_loaded_from_hermes_home"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/integrations/test_hermes_provider.py",
+        "name": "test_cli_reads_the_same_json_config_path",
+        "line": 451
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/hermes/tests/test_provider.py",
+          "test": "test_cli_reads_the_same_json_config_path"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/integrations/test_hermes_provider.py",
+        "name": "test_memory_setup_schema_exposes_powercontext_configuration",
+        "line": 460
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/hermes/tests/test_provider.py",
+          "test": "test_memory_setup_schema_exposes_powercontext_configuration"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/integrations/test_hermes_provider.py",
+        "name": "test_memory_setup_saves_powercontext_json_and_preserves_existing_values",
+        "line": 476
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/hermes/tests/test_provider.py",
+          "test": "test_memory_setup_saves_powercontext_json_and_preserves_existing_values"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/integrations/test_hermes_provider.py",
+        "name": "test_sync_turn_is_flushed_before_session_end",
+        "line": 499
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/hermes/tests/test_provider.py",
+          "test": "test_sync_turn_is_flushed_before_session_end"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/integrations/test_hermes_provider.py",
+        "name": "test_sync_turn_does_not_wait_for_http",
+        "line": 511
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/hermes/tests/test_provider.py",
+          "test": "test_sync_turn_does_not_wait_for_http"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/integrations/test_hermes_provider.py",
+        "name": "test_session_end_skips_flush_when_memory_extraction_is_disabled",
+        "line": 536
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/hermes/tests/test_provider.py",
+          "test": "test_session_end_skips_flush_when_memory_extraction_is_disabled"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/integrations/test_hermes_provider.py",
+        "name": "test_pre_compress_persists_context_before_compression",
+        "line": 546
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/hermes/tests/test_provider.py",
+          "test": "test_pre_compress_persists_context_before_compression"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/integrations/test_hermes_provider.py",
+        "name": "test_pre_compress_is_disabled_by_default",
+        "line": 565
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/hermes/tests/test_provider.py",
+          "test": "test_pre_compress_is_disabled_by_default"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/integrations/test_hermes_provider.py",
+        "name": "test_pre_compress_filters_roles_and_redacts_secrets",
+        "line": 573
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/hermes/tests/test_provider.py",
+          "test": "test_pre_compress_filters_roles_and_redacts_secrets"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/integrations/test_hermes_provider.py",
+        "name": "test_pre_compress_captures_only_new_overlapping_windows",
+        "line": 593
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/hermes/tests/test_provider.py",
+          "test": "test_pre_compress_captures_only_new_overlapping_windows"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/integrations/test_hermes_provider.py",
+        "name": "test_memory_write_retires_mapped_entries_for_replace_and_remove",
+        "line": 628
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/hermes/tests/test_provider.py",
+          "test": "test_memory_write_retires_mapped_entries_for_replace_and_remove"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/integrations/test_hermes_provider.py",
+        "name": "test_memory_write_matches_partial_old_text_for_replace_and_remove",
+        "line": 661
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/hermes/tests/test_provider.py",
+          "test": "test_memory_write_matches_partial_old_text_for_replace_and_remove"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/integrations/test_hermes_provider.py",
+        "name": "test_memory_write_does_not_retire_unmapped_same_text",
+        "line": 687
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/hermes/tests/test_provider.py",
+          "test": "test_memory_write_does_not_retire_unmapped_same_text"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/integrations/test_hermes_provider.py",
+        "name": "test_memory_map_refreshes_revision_after_multiple_writes",
+        "line": 706
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/hermes/tests/test_provider.py",
+          "test": "test_memory_map_refreshes_revision_after_multiple_writes"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/integrations/test_hermes_provider.py",
+        "name": "test_memory_write_skips_replace_and_remove_without_old_text",
+        "line": 745
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/hermes/tests/test_provider.py",
+          "test": "test_memory_write_skips_replace_and_remove_without_old_text"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/integrations/test_hermes_provider.py",
+        "name": "test_memory_write_worker_is_daemon_bounded_and_reports_overflow",
+        "line": 755
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/hermes/tests/test_provider.py",
+          "test": "test_memory_write_worker_is_daemon_bounded_and_reports_overflow"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/integrations/test_hermes_provider.py",
+        "name": "test_memory_tools_map_to_powercontext_operations",
+        "line": 776
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/hermes/tests/test_provider.py",
+          "test": "test_memory_tools_map_to_powercontext_operations"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/integrations/test_hermes_provider.py",
+        "name": "test_extended_tools_are_registered_and_scope_bound",
+        "line": 808
+      },
+      "mode": "retained-host",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/integrations/test_hermes_provider.py",
+        "name": "test_extended_slash_commands_dispatch_json_operations",
+        "line": 837
+      },
+      "mode": "retained-host",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/integrations/test_hermes_provider.py",
+        "name": "test_slash_commands_parse_unwrapped_citation_json_from_readme",
+        "line": 857
+      },
+      "mode": "retained-host",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/integrations/test_hermes_provider.py",
+        "name": "test_workstream_binding_is_shared_with_hermes_scope",
+        "line": 895
+      },
+      "mode": "retained-host",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/integrations/test_hermes_provider.py",
+        "name": "test_workstream_clear_restores_default_scope",
+        "line": 927
+      },
+      "mode": "retained-host",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/integrations/test_hermes_provider.py",
+        "name": "test_workstream_bind_isolates_queued_background_work",
+        "line": 968
+      },
+      "mode": "retained-host",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/integrations/test_hermes_provider.py",
+        "name": "test_backend_failure_fails_open",
+        "line": 1026
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/hermes/tests/test_provider.py",
+          "test": "test_backend_failure_fails_open"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/integrations/test_hermes_provider.py",
+        "name": "test_cli_registers_provider_commands",
+        "line": 1039
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/hermes/tests/test_provider.py",
+          "test": "test_cli_registers_provider_commands"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/integrations/test_hermes_provider.py",
+        "name": "test_http_client_dispatches_operation_paths_and_get_query",
+        "line": 1054
+      },
+      "mode": "retained-host",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/langchain_middleware/test_middleware.py",
+        "name": "test_middleware_injects_recall_without_persisting_it",
+        "line": 142
+      },
+      "mode": "retained-host",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/langchain_middleware/test_middleware.py",
+        "name": "test_middleware_injects_only_approved_experience",
+        "line": 169
+      },
+      "mode": "retained-host",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/langchain_middleware/test_middleware.py",
+        "name": "test_middleware_does_not_capture_completed_turn_by_default",
+        "line": 229
+      },
+      "mode": "retained-host",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/langchain_middleware/test_middleware.py",
+        "name": "test_middleware_captures_completed_turn_when_enabled",
+        "line": 254
+      },
+      "mode": "retained-host",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/langchain_middleware/test_middleware.py",
+        "name": "test_middleware_captures_tool_strategy_structured_response",
+        "line": 285
+      },
+      "mode": "retained-host",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/langchain_middleware/test_middleware.py",
+        "name": "test_async_agent_reaches_end_when_server_unreachable",
+        "line": 314
+      },
+      "mode": "retained-host",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/langchain_middleware/test_middleware.py",
+        "name": "test_sync_agent_reaches_end_when_server_unreachable",
+        "line": 334
+      },
+      "mode": "retained-host",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/langchain_middleware/test_packaging.py",
+        "name": "test_license_file_is_present_in_project",
+        "line": 52
+      },
+      "mode": "retained-host",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/langchain_middleware/test_packaging.py",
+        "name": "test_wheel_bundles_middleware_license_and_dependencies",
+        "line": 57
+      },
+      "mode": "retained-host",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/langchain_middleware/test_scope.py",
+        "name": "test_scope_type_is_owned_by_langchain_package",
+        "line": 22
+      },
+      "mode": "retained-host",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/langchain_middleware/test_scope.py",
+        "name": "test_missing_scope_names_langchain_configuration",
+        "line": 26
+      },
+      "mode": "retained-host",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/langchain_middleware/test_scope.py",
+        "name": "test_normalize_git_remote_removes_credentials",
+        "line": 41
+      },
+      "mode": "retained-host",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/langchain_middleware/test_scope.py",
+        "name": "test_resolve_scope_id_rejects_windows_local_remote",
+        "line": 46
+      },
+      "mode": "retained-host",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/langchain_middleware/test_settings.py",
+        "name": "test_langchain_settings_use_their_own_environment_prefix",
+        "line": 22
+      },
+      "mode": "retained-host",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/langchain_middleware/test_settings.py",
+        "name": "test_explicit_scope_overrides_langchain_settings",
+        "line": 36
+      },
+      "mode": "retained-host",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/langgraph_adapter/test_packaging.py",
+        "name": "test_license_file_is_present_in_project",
+        "line": 57
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/langgraph/tests/test_packaging.py",
+          "test": "test_license_file_is_present_in_project"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/langgraph_adapter/test_packaging.py",
+        "name": "test_wheel_bundles_license_and_metadata",
+        "line": 62
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/langgraph/tests/test_packaging.py",
+          "test": "test_wheel_bundles_license_and_metadata"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/langgraph_adapter/test_recall.py",
+        "name": "test_recall_supplies_no_prefix_when_context_is_empty",
+        "line": 121
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/langgraph/tests/test_recall.py",
+          "test": "test_recall_supplies_no_prefix_when_context_is_empty"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/langgraph_adapter/test_recall.py",
+        "name": "test_recall_injects_context_labelled_untrusted",
+        "line": 137
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/langgraph/tests/test_recall.py",
+          "test": "test_recall_injects_context_labelled_untrusted"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/langgraph_adapter/test_recall.py",
+        "name": "test_recall_does_not_accumulate_across_turns",
+        "line": 160
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/langgraph/tests/test_recall.py",
+          "test": "test_recall_does_not_accumulate_across_turns"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/langgraph_adapter/test_recall.py",
+        "name": "test_recall_completes_graph_for_over_limit_prompt",
+        "line": 198
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/langgraph/tests/test_recall.py",
+          "test": "test_recall_completes_graph_for_over_limit_prompt"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/langgraph_adapter/test_recall.py",
+        "name": "test_recall_isolates_cached_context_across_scopes",
+        "line": 225
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/langgraph/tests/test_recall.py",
+          "test": "test_recall_isolates_cached_context_across_scopes"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/langgraph_adapter/test_recall.py",
+        "name": "test_agent_reaches_end_when_server_unreachable",
+        "line": 278
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/langgraph/tests/test_recall.py",
+          "test": "test_agent_reaches_end_when_server_unreachable"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/langgraph_adapter/test_recall.py",
+        "name": "test_missing_scope_outside_repository_raises",
+        "line": 294
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/langgraph/tests/test_recall.py",
+          "test": "test_missing_scope_outside_repository_raises"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/langgraph_adapter/test_scope.py",
+        "name": "test_explicit_scope_takes_priority",
+        "line": 37
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/langgraph/tests/test_scope.py",
+          "test": "test_explicit_scope_takes_priority"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/langgraph_adapter/test_scope.py",
+        "name": "test_explicit_scope_over_length_is_hashed",
+        "line": 41
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/langgraph/tests/test_scope.py",
+          "test": "test_explicit_scope_over_length_is_hashed"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/langgraph_adapter/test_scope.py",
+        "name": "test_missing_scope_outside_repository_raises",
+        "line": 47
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/langgraph/tests/test_scope.py",
+          "test": "test_missing_scope_outside_repository_raises"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/langgraph_adapter/test_scope.py",
+        "name": "test_git_remote_is_derived_and_credentials_dropped",
+        "line": 53
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/langgraph/tests/test_scope.py",
+          "test": "test_git_remote_is_derived_and_credentials_dropped"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/langgraph_adapter/test_scope.py",
+        "name": "test_normalize_git_remote_forms",
+        "line": 76
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/langgraph/tests/test_scope.py",
+          "test": "test_normalize_git_remote_forms"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/langgraph_adapter/test_scope.py",
+        "name": "test_normalize_git_remote_rejects_non_network_remotes",
+        "line": 93
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/langgraph/tests/test_scope.py",
+          "test": "test_normalize_git_remote_rejects_non_network_remotes"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/langgraph_adapter/test_scope.py",
+        "name": "test_resolve_scope_id_rejects_windows_local_remote",
+        "line": 98
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/langgraph/tests/test_scope.py",
+          "test": "test_resolve_scope_id_rejects_windows_local_remote"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/langgraph_adapter/test_tools.py",
+        "name": "test_powercontext_tools_returns_three_base_tools",
+        "line": 80
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/langgraph/tests/test_tools.py",
+          "test": "test_powercontext_tools_returns_three_base_tools"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/langgraph_adapter/test_tools.py",
+        "name": "test_remember_then_search_roundtrips_through_the_server",
+        "line": 91
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/langgraph/tests/test_tools.py",
+          "test": "test_remember_then_search_roundtrips_through_the_server"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/langgraph_adapter/test_tools.py",
+        "name": "test_search_reports_no_matches_without_raising",
+        "line": 109
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/langgraph/tests/test_tools.py",
+          "test": "test_search_reports_no_matches_without_raising"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/langgraph_adapter/test_tools.py",
+        "name": "test_tools_return_error_string_when_server_unreachable",
+        "line": 119
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/langgraph/tests/test_tools.py",
+          "test": "test_tools_return_error_string_when_server_unreachable"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/langgraph_adapter/test_tools.py",
+        "name": "test_context_tool_completes_for_over_limit_query",
+        "line": 130
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/langgraph/tests/test_tools.py",
+          "test": "test_context_tool_completes_for_over_limit_query"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/langgraph_adapter/test_tools.py",
+        "name": "test_tools_reject_out_of_range_arguments_without_raising",
+        "line": 150
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/langgraph/tests/test_tools.py",
+          "test": "test_tools_reject_out_of_range_arguments_without_raising"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/pydantic_ai_adapter/test_capability.py",
+        "name": "test_context_is_replaced_once_per_run_when_reusing_old_history",
+        "line": 34
+      },
+      "mode": "retained-host",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/pydantic_ai_adapter/test_capability.py",
+        "name": "test_empty_context_is_not_injected",
+        "line": 72
+      },
+      "mode": "retained-host",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/pydantic_ai_adapter/test_capability.py",
+        "name": "test_unreachable_server_fails_open_for_recall",
+        "line": 96
+      },
+      "mode": "retained-host",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/pydantic_ai_adapter/test_capability.py",
+        "name": "test_authentication_failure_logs_one_credential_free_configuration_warning",
+        "line": 123
+      },
+      "mode": "retained-host",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/pydantic_ai_adapter/test_capture.py",
+        "name": "test_capture_disabled_makes_no_source_or_flush_requests",
+        "line": 56
+      },
+      "mode": "retained-host",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/pydantic_ai_adapter/test_capture.py",
+        "name": "test_capture_is_bounded_redacted_checkpointed_and_serialized_under_parallel_tools",
+        "line": 75
+      },
+      "mode": "retained-host",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/pydantic_ai_adapter/test_capture.py",
+        "name": "test_checkpoint_flush_catches_up_across_more_than_ten_source_windows",
+        "line": 149
+      },
+      "mode": "retained-host",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/pydantic_ai_adapter/test_capture.py",
+        "name": "test_shared_capture_redacts_compact_keys_and_structured_json_strings",
+        "line": 176
+      },
+      "mode": "retained-host",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/pydantic_ai_adapter/test_capture.py",
+        "name": "test_shared_capture_structures_supported_objects_without_stringifying_unknown_objects",
+        "line": 198
+      },
+      "mode": "retained-host",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/pydantic_ai_adapter/test_capture.py",
+        "name": "test_capture_redacts_pydantic_model_tool_results",
+        "line": 226
+      },
+      "mode": "retained-host",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/pydantic_ai_adapter/test_capture.py",
+        "name": "test_shared_capture_redacts_codex_auth_values_outside_sensitive_keys",
+        "line": 270
+      },
+      "mode": "retained-host",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/pydantic_ai_adapter/test_capture.py",
+        "name": "test_shared_capture_caches_codex_auth_until_the_file_changes",
+        "line": 292
+      },
+      "mode": "retained-host",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/pydantic_ai_adapter/test_capture.py",
+        "name": "test_capture_failure_does_not_change_tool_or_model_results_or_log_arbitrary_exception_messages",
+        "line": 329
+      },
+      "mode": "retained-host",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/pydantic_ai_adapter/test_capture.py",
+        "name": "test_flush_failure_does_not_change_model_result",
+        "line": 376
+      },
+      "mode": "retained-host",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/pydantic_ai_adapter/test_packaging.py",
+        "name": "test_integration_wheels_require_the_first_core_release_with_shared_capture",
+        "line": 78
+      },
+      "mode": "retained-host",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/pydantic_ai_adapter/test_packaging.py",
+        "name": "test_openai_install_command_is_consistent_across_public_guides",
+        "line": 85
+      },
+      "mode": "retained-host",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/pydantic_ai_adapter/test_packaging.py",
+        "name": "test_documented_openai_agent_constructs_from_installed_wheels",
+        "line": 96
+      },
+      "mode": "retained-host",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/pydantic_ai_adapter/test_settings_scope.py",
+        "name": "test_settings_load_all_environment_values_and_keep_token_secret",
+        "line": 35
+      },
+      "mode": "retained-host",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/pydantic_ai_adapter/test_settings_scope.py",
+        "name": "test_settings_reject_unsafe_server_urls",
+        "line": 69
+      },
+      "mode": "retained-host",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/pydantic_ai_adapter/test_settings_scope.py",
+        "name": "test_settings_require_a_bare_token_without_leaking_invalid_input",
+        "line": 74
+      },
+      "mode": "retained-host",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/pydantic_ai_adapter/test_settings_scope.py",
+        "name": "test_scope_reuses_codex_remote_normalization",
+        "line": 91
+      },
+      "mode": "retained-host",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/pydantic_ai_adapter/test_settings_scope.py",
+        "name": "test_scope_uses_normalized_git_origin_then_local_path",
+        "line": 95
+      },
+      "mode": "retained-host",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/pydantic_ai_adapter/test_settings_scope.py",
+        "name": "test_explicit_scope_skips_git_and_is_deterministically_bounded",
+        "line": 114
+      },
+      "mode": "retained-host",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/pydantic_ai_adapter/test_settings_scope.py",
+        "name": "test_constructor_scope_callback_wins_and_runs_once_per_agent_run",
+        "line": 130
+      },
+      "mode": "retained-host",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/pydantic_ai_adapter/test_toolset.py",
+        "name": "test_toolset_exposes_exact_schemas_instructions_request_mapping_and_full_responses",
+        "line": 32
+      },
+      "mode": "retained-host",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/pydantic_ai_adapter/test_toolset.py",
+        "name": "test_toolset_converts_client_failure_to_model_retry",
+        "line": 117
+      },
+      "mode": "retained-host",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/pydantic_ai_adapter/test_toolset.py",
+        "name": "test_toolset_uses_one_raw_token_client_per_run_and_closes_it",
+        "line": 139
+      },
+      "mode": "retained-host",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_api_contract.py",
+        "name": "test_contract_uses_the_namespaced_request_id_header",
+        "line": 113
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "openapi/python_contract_test.go",
+          "test": "TestContractUsesNamespacedRequestIDHeader"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_api_contract.py",
+        "name": "test_contract_declares_optional_bearer_authentication",
+        "line": 120
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "openapi/python_contract_test.go",
+          "test": "TestContractDeclaresOptionalBearerAuthentication"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_api_contract.py",
+        "name": "test_capabilities_report_semantics_without_runtime_tuning_values",
+        "line": 137
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "openapi/python_contract_test.go",
+          "test": "TestCapabilitiesReportSemanticsWithoutRuntimeTuningValues"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_api_contract.py",
+        "name": "test_readiness_operation_declares_the_unavailable_response",
+        "line": 156
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "openapi/python_contract_test.go",
+          "test": "TestReadinessOperationDeclaresUnavailableResponse"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_api_contract.py",
+        "name": "test_capture_operation_declares_its_typed_accepted_exchange",
+        "line": 160
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "openapi/python_contract_test.go",
+          "test": "TestCaptureOperationDeclaresTypedAcceptedExchange"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_api_contract.py",
+        "name": "test_stats_operation_exposes_dashboard_ready_scoped_values",
+        "line": 166
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "openapi/python_contract_test.go",
+          "test": "TestStatsOperationExposesDashboardReadyScopedValues"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_api_contract.py",
+        "name": "test_memory_operations_use_family_prefixed_paths_and_typed_requests",
+        "line": 194
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "openapi/python_contract_test.go",
+          "test": "TestMemoryOperationsUseFamilyPrefixedPathsAndTypedRequests"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_api_contract.py",
+        "name": "test_memory_search_declares_the_revision_conflict_response",
+        "line": 211
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "openapi/python_contract_test.go",
+          "test": "TestMemorySearchDeclaresRevisionConflictResponse"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_api_contract.py",
+        "name": "test_prepared_context_is_a_generic_typed_operation_outside_the_mcp_memory_tools",
+        "line": 215
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "openapi/python_contract_test.go",
+          "test": "TestPreparedContextIsGenericTypedOperationOutsideMemoryTools"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_api_contract.py",
+        "name": "test_experience_skill_and_review_operations_are_typed_and_family_routed",
+        "line": 228
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "openapi/python_contract_test.go",
+          "test": "TestExperienceSkillAndReviewOperationsAreTypedAndFamilyRouted"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_api_contract.py",
+        "name": "test_managed_skill_transport_rejects_untrimmed_projection_metadata",
+        "line": 288
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "openapi/python_contract_test.go",
+          "test": "TestManagedSkillTransportRejectsUntrimmedProjectionMetadata"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_api_contract.py",
+        "name": "test_external_skill_operations_preserve_local_authority_and_exact_resolution",
+        "line": 298
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "openapi/python_contract_test.go",
+          "test": "TestExternalSkillOperationsPreserveLocalAuthorityAndExactResolution"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_api_contract.py",
+        "name": "test_memory_search_mode_remains_on_the_search_request",
+        "line": 341
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "openapi/python_contract_test.go",
+          "test": "TestMemorySearchModeRemainsOnSearchRequest"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_api_contract.py",
+        "name": "test_candidate_transport_rejects_combined_evidence_over_limit",
+        "line": 351
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "openapi/python_contract_test.go",
+          "test": "TestCandidateTransportRejectsCombinedEvidenceOverLimit"
+        },
+        {
+          "kind": "go",
+          "file": "client/client_test.go",
+          "test": "TestClientRejectsCombinedCandidateEvidenceBeforeTransport"
+        },
+        {
+          "kind": "go",
+          "file": "internal/mcpapi/server_test.go",
+          "test": "TestMCPDecodeRejectsCombinedCandidateEvidence"
+        },
+        {
+          "kind": "go",
+          "file": "server/http_test.go",
+          "test": "TestHTTPCombinedCandidateEvidenceFailureMatchesFrozenPythonEnvelope"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_api_contract.py",
+        "name": "test_handoff_operations_expose_the_complete_explicit_lifecycle",
+        "line": 377
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "openapi/python_contract_test.go",
+          "test": "TestHandoffOperationsExposeCompleteExplicitLifecycle"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_api_contract.py",
+        "name": "test_work_operations_expose_the_high_level_continuity_loop",
+        "line": 400
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "openapi/python_contract_test.go",
+          "test": "TestWorkOperationsExposeHighLevelContinuityLoop"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_api_contract.py",
+        "name": "test_source_reference_keeps_name_as_the_source_type",
+        "line": 423
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "openapi/python_contract_test.go",
+          "test": "TestSourceReferenceKeepsNameAsSourceType"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_api_contract.py",
+        "name": "test_memory_transport_has_one_reference_shape_and_nested_citations",
+        "line": 430
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "openapi/python_contract_test.go",
+          "test": "TestMemoryTransportHasOneReferenceShapeAndNestedCitations"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_api_contract.py",
+        "name": "test_entry_list_hides_inactive_entries_unless_explicitly_requested",
+        "line": 443
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "openapi/python_contract_test.go",
+          "test": "TestEntryListHidesInactiveEntriesUnlessExplicitlyRequested"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_api_contract.py",
+        "name": "test_generated_transport_rejects_values_outside_openapi",
+        "line": 476
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "openapi/python_contract_test.go",
+          "test": "TestGeneratedTransportRejectsValuesOutsideOpenAPI"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_api_contract.py",
+        "name": "test_server_publishes_the_canonical_openapi_schema",
+        "line": 484
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "openapi/python_contract_test.go",
+          "test": "TestGeneratedServerRoutesMatchCanonicalOpenAPI"
+        },
+        {
+          "kind": "go",
+          "file": "openapi/contract_test.go",
+          "test": "TestFrozenOpenAPIAndGeneratedHandlerStayInSync"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_artifacts.py",
+        "name": "test_artifact_is_a_fixed_family_snapshot_with_direct_lineage",
+        "line": 52
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "artifact/model_test.go",
+          "test": "TestArtifactCopiesLineageAndRetainsOrder"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_artifacts.py",
+        "name": "test_artifact_reference_rejects_invalid_identity",
+        "line": 81
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "artifact/model_test.go",
+          "test": "TestArtifactReferenceRejectsInvalidIdentity"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_artifacts.py",
+        "name": "test_artifact_domain_values_reject_invalid_identity_and_lineage",
+        "line": 130
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "artifact/model_test.go",
+          "test": "TestArtifactDomainValuesRejectInvalidIdentityAndLineage"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_artifacts.py",
+        "name": "test_artifacts_reject_cross_family_revisions_before_storage",
+        "line": 136
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "artifact/model_test.go",
+          "test": "TestServiceRejectsCrossFamilyRevision"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_capabilities.py",
+        "name": "test_capabilities_require_the_complete_transport_shape",
+        "line": 21
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "openapi/python_contract_test.go",
+          "test": "TestCapabilitiesReportSemanticsWithoutRuntimeTuningValues"
+        },
+        {
+          "kind": "go",
+          "file": "openapi/python_contract_test.go",
+          "test": "TestGeneratedTransportRejectsValuesOutsideOpenAPI"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_capabilities.py",
+        "name": "test_capabilities_reject_unknown_transport_fields",
+        "line": 32
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "openapi/python_contract_test.go",
+          "test": "TestGeneratedTransportRejectsValuesOutsideOpenAPI"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_ci_release_verification.py",
+        "name": "test_release_smoke_resolves_console_script_from_verification_python",
+        "line": 39
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "tools/release/main_test.go",
+          "test": "TestReleaseArchiveKeepsStableExecutablePathAndMode"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_ci_release_verification.py",
+        "name": "test_pypi_release_requires_wheel_and_sdist",
+        "line": 52
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "tools/release/main_test.go",
+          "test": "TestReleaseWorkflowPublishesCompleteAssetsAndAllowsPrereleases"
+        },
+        {
+          "kind": "go",
+          "file": "tools/release/main_test.go",
+          "test": "TestNativeAssetManifestSupportsReleaseMatrix"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_ci_release_verification.py",
+        "name": "test_pypi_verification_retries_until_release_is_complete",
+        "line": 71
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "tools/release/main_test.go",
+          "test": "TestReleaseWorkflowPublishesCompleteAssetsAndAllowsPrereleases"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_ci_release_verification.py",
+        "name": "test_github_release_requires_published_state_and_expected_assets",
+        "line": 95
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "tools/release/main_test.go",
+          "test": "TestReleaseWorkflowPublishesCompleteAssetsAndAllowsPrereleases"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_ci_release_verification.py",
+        "name": "test_github_release_allows_prereleases",
+        "line": 114
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "tools/release/main_test.go",
+          "test": "TestReleaseWorkflowPublishesCompleteAssetsAndAllowsPrereleases"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_cli.py",
+        "name": "test_cli_help_exits_successfully",
+        "line": 128
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/python_contract_test.go",
+          "test": "TestCLIHelpAndInstalledRoleCommands"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_cli.py",
+        "name": "test_skill_cli_exposes_the_target_based_export_command",
+        "line": 136
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/python_contract_test.go",
+          "test": "TestSkillCLIExposesTargetBasedCodexExport"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_cli.py",
+        "name": "test_cli_version_reports_the_installed_distribution",
+        "line": 151
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/python_contract_test.go",
+          "test": "TestCLIVersionReportsBuildVersion"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_cli.py",
+        "name": "test_cli_exposes_installed_role_commands",
+        "line": 158
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/python_contract_test.go",
+          "test": "TestCLIHelpAndInstalledRoleCommands"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_cli.py",
+        "name": "test_client_settings_load_environment",
+        "line": 167
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/python_contract_test.go",
+          "test": "TestCLIClientSettingsLoadEnvironmentAndExplicitURLOverride"
+        },
+        {
+          "kind": "go",
+          "file": "internal/cli/python_contract_test.go",
+          "test": "TestCLITimeoutFlagAcceptsSecondsAndGoDuration"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_cli.py",
+        "name": "test_client_settings_reject_invalid_values",
+        "line": 178
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/python_contract_test.go",
+          "test": "TestCLIClientSettingsRejectInvalidEnvironment"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_cli.py",
+        "name": "test_server_command_layers_partial_cli_overrides_over_environment_settings",
+        "line": 203
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/python_contract_test.go",
+          "test": "TestServerCommandLayersPartialCLIOverridesOverEnvironment"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_cli.py",
+        "name": "test_server_command_rejects_an_unauthenticated_non_loopback_host_override",
+        "line": 246
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_cli.py",
+        "name": "test_server_command_reports_a_friendly_error_when_auth_lacks_a_token",
+        "line": 269
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_cli.py",
+        "name": "test_server_command_lets_a_loopback_override_repair_an_unsafe_environment_host",
+        "line": 291
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_cli.py",
+        "name": "test_server_command_does_not_load_client_settings",
+        "line": 313
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/python_contract_test.go",
+          "test": "TestServerCommandDoesNotLoadClientSettings"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_cli.py",
+        "name": "test_cli_reports_server_errors_with_request_context_without_a_traceback",
+        "line": 329
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/python_contract_test.go",
+          "test": "TestCLIReportsServerErrorWithRequestContext"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_cli.py",
+        "name": "test_client_command_prints_human_readable_output_by_default",
+        "line": 355
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/python_contract_test.go",
+          "test": "TestCLIPrintsHumanLivenessByDefault"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_cli.py",
+        "name": "test_stats_command_builds_request_and_prints_summary",
+        "line": 379
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/python_contract_test.go",
+          "test": "TestStatsCommandBuildsRequestAndPrintsSummary"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_cli.py",
+        "name": "test_client_generation_commands_build_requests_from_explicit_options",
+        "line": 413
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/python_contract_test.go",
+          "test": "TestCLIGenerationCommandsBuildTypedRequests"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_cli.py",
+        "name": "test_client_candidate_revision_commands_build_typed_proposals",
+        "line": 491
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/python_contract_test.go",
+          "test": "TestCLICandidateRevisionCommandsBuildTypedProposals"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_cli.py",
+        "name": "test_client_generation_commands_reject_invalid_reference_options",
+        "line": 599
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/python_contract_test.go",
+          "test": "TestCLIGenerationCommandsRejectInvalidReferencesAsUsage"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_cli.py",
+        "name": "test_client_external_skill_import_preserves_exact_identity_and_intent",
+        "line": 609
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/python_contract_test.go",
+          "test": "TestCLIExternalSkillImportPreservesIdentityAndIntent"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_cli.py",
+        "name": "test_client_skill_export_uses_configured_authentication",
+        "line": 648
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/python_contract_test.go",
+          "test": "TestCLISkillExportUsesConfiguredAuthentication"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_cli_workbuddy.py",
+        "name": "test_setup_workbuddy_installs_from_a_local_checkout",
+        "line": 88
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_cli_workbuddy.py",
+        "name": "test_setup_workbuddy_preserves_existing_settings_and_mcp",
+        "line": 158
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_cli_workbuddy.py",
+        "name": "test_setup_workbuddy_preserves_remote_authenticated_mcp_configuration",
+        "line": 200
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_cli_workbuddy.py",
+        "name": "test_setup_workbuddy_migrates_the_legacy_generated_mcp_entry",
+        "line": 234
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_cli_workbuddy.py",
+        "name": "test_setup_workbuddy_preserves_other_hooks_shared_scripts",
+        "line": 272
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_cli_workbuddy.py",
+        "name": "test_setup_workbuddy_refuses_an_unowned_skill",
+        "line": 291
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_cli_workbuddy.py",
+        "name": "test_setup_workbuddy_refreshes_an_owned_skill",
+        "line": 314
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_cli_workbuddy.py",
+        "name": "test_setup_workbuddy_stops_before_writes_when_settings_snapshot_is_unreadable",
+        "line": 334
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_cli_workbuddy.py",
+        "name": "test_setup_workbuddy_updates_an_existing_powercontext_hook",
+        "line": 353
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_cli_workbuddy.py",
+        "name": "test_setup_workbuddy_rolls_back_json_changes_on_failure",
+        "line": 397
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_cli_workbuddy.py",
+        "name": "test_doctor_workbuddy_reports_failures_before_install",
+        "line": 422
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_cli_workbuddy.py",
+        "name": "test_doctor_workbuddy_reports_ok_after_install",
+        "line": 439
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_cli_workbuddy.py",
+        "name": "test_setup_workbuddy_rejects_a_missing_plugin",
+        "line": 466
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_cli_workbuddy.py",
+        "name": "test_setup_workbuddy_remote_checkout_refreshes_the_requested_ref",
+        "line": 479
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_cli_workbuddy.py",
+        "name": "test_workbuddy_home_honors_the_environment_override",
+        "line": 501
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_client.py",
+        "name": "test_client_rejects_an_undeclared_success_status",
+        "line": 30
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "client/client_test.go",
+          "test": "TestClientRejectsUndeclaredSuccessStatus"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_client.py",
+        "name": "test_client_preserves_server_error_context",
+        "line": 53
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "client/client_test.go",
+          "test": "TestClientPreservesDeclaredServerErrorContext"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_client.py",
+        "name": "test_client_sends_an_explicit_bearer_token",
+        "line": 81
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "client/client_test.go",
+          "test": "TestClientSendsBearerAndPreservesCallerHTTPClient"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_client.py",
+        "name": "test_client_keeps_a_generic_server_error_when_the_error_body_is_invalid",
+        "line": 103
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "client/client_test.go",
+          "test": "TestClientKeepsGenericServerErrorForInvalidErrorBody"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_client.py",
+        "name": "test_client_rejects_an_invalid_success_response",
+        "line": 118
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "client/client_test.go",
+          "test": "TestClientRejectsInvalidSuccessResponse"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_client.py",
+        "name": "test_client_wraps_http_transport_failures",
+        "line": 136
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "client/client_test.go",
+          "test": "TestClientWrapsHTTPTransportFailure"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_client.py",
+        "name": "test_client_downloads_handoff_report_bytes_and_sets_download_flag",
+        "line": 154
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "client/client_test.go",
+          "test": "TestClientRendersAndDownloadsHandoffReportWithoutMutatingRequest"
+        },
+        {
+          "kind": "go",
+          "file": "client/client_test.go",
+          "test": "TestClientDownloadPreservesCanonicalJSONBytes"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_client.py",
+        "name": "test_client_settings_reject_ambiguous_or_sensitive_server_urls",
+        "line": 186
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "client/client_test.go",
+          "test": "TestClientURLValidationDoesNotExposeRejectedValue"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_client.py",
+        "name": "test_client_settings_error_repr_does_not_leak_url_credentials",
+        "line": 191
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "client/client_test.go",
+          "test": "TestClientConfigurationErrorRepresentationDoesNotExposeURLCredentials"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_client.py",
+        "name": "test_client_settings_hide_the_api_token",
+        "line": 198
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "client/client_test.go",
+          "test": "TestClientOptionsRepresentationsHideBearerToken"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_dashboard.py",
+        "name": "test_dashboard_is_enabled_by_default_without_authentication_or_scopes",
+        "line": 38
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/webui/handler_test.go",
+          "test": "TestMountAcceptsEnabledDashboardWithoutScopes"
+        },
+        {
+          "kind": "go",
+          "file": "server/config_test.go",
+          "test": "TestDefaultConfigUsesPersistentUserStorage"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_dashboard.py",
+        "name": "test_dashboard_can_be_disabled_explicitly",
+        "line": 71
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/webui/handler_test.go",
+          "test": "TestDisabledDashboardLeavesProductPagesAbsentAndHealthAvailable"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_dashboard.py",
+        "name": "test_dashboard_mount_failure_does_not_prevent_server_startup",
+        "line": 92
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "server/http_test.go",
+          "test": "TestDashboardPageIsPublicButScopeInventoryIsAuthenticated"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_dashboard.py",
+        "name": "test_dashboard_is_the_authenticated_server_ui_entry",
+        "line": 114
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/webui/handler_test.go",
+          "test": "TestDashboardRoutesAndHeaders"
+        },
+        {
+          "kind": "go",
+          "file": "server/http_test.go",
+          "test": "TestDashboardPageIsPublicButScopeInventoryIsAuthenticated"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_dashboard.py",
+        "name": "test_review_publishes_an_approved_managed_skill_into_configured_agent_targets",
+        "line": 197
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/webui/skill_projection_test.go",
+          "test": "TestDashboardSkillProjectionStatusAndPublish"
+        },
+        {
+          "kind": "go",
+          "file": "internal/webui/skill_projection_test.go",
+          "test": "TestDashboardSkillProjectionRoutesValidateAuthorityAndScope"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_dashboard.py",
+        "name": "test_handoff_report_page_is_available_without_the_statistics_dashboard",
+        "line": 391
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/webui/handler_test.go",
+          "test": "TestHandoffReportPageFeatureGate"
+        },
+        {
+          "kind": "go",
+          "file": "internal/webui/handler_test.go",
+          "test": "TestMountSupportsReportOnlyWebUI"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_dashboard.py",
+        "name": "test_handoff_report_page_contains_a_data_free_preview_template",
+        "line": 488
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/webui/handler_test.go",
+          "test": "TestHandoffReportPageContainsDataFreePreviewTemplate"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_dashboard_locale.py",
+        "name": "test_static_locale_catalogs_are_complete_and_not_mixed",
+        "line": 78
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/webui/handler_test.go",
+          "test": "TestDashboardRoutesAndHeaders"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_docker_contract.py",
+        "name": "test_dockerfile_pins_the_bind_environment_under_test",
+        "line": 47
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_docker_contract.py",
+        "name": "test_documented_container_invocation_starts_out_of_the_box",
+        "line": 53
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_docs_remote_access_contract.py",
+        "name": "test_docs_expose_a_non_loopback_bind_command",
+        "line": 103
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_docs_remote_access_contract.py",
+        "name": "test_documented_server_run_command_starts",
+        "line": 110
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_doctor_integrations.py",
+        "name": "test_doctor_integrations_json_includes_every_first_class_host",
+        "line": 125
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_doctor_integrations.py",
+        "name": "test_doctor_integrations_treats_missing_clis_as_success",
+        "line": 140
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_doctor_integrations.py",
+        "name": "test_doctor_integrations_prints_a_human_matrix",
+        "line": 155
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_doctor_integrations.py",
+        "name": "test_doctor_integrations_fails_when_a_present_plugin_is_broken",
+        "line": 167
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_doctor_integrations.py",
+        "name": "test_doctor_integrations_fails_when_a_present_cli_cannot_list_plugins",
+        "line": 181
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_doctor_integrations.py",
+        "name": "test_doctor_integrations_fails_when_a_present_opencode_skill_is_broken",
+        "line": 194
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_doctor_integrations.py",
+        "name": "test_doctor_integrations_succeeds_when_every_host_is_missing",
+        "line": 206
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_doctor_integrations.py",
+        "name": "test_default_doctor_does_not_scan_first_class_hosts",
+        "line": 216
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_doctor_integrations.py",
+        "name": "test_doctor_codex_still_fails_when_the_cli_is_missing",
+        "line": 243
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_dsh_cli.py",
+        "name": "test_dsh_executable_prefers_the_windows_cmd_shim",
+        "line": 39
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/system_contract_test.go",
+          "test": "TestDSHExecutablePrefersWindowsCommandShim"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_dsh_cli.py",
+        "name": "test_setup_dsh_rejects_plugin_without_bundle",
+        "line": 50
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/system_contract_test.go",
+          "test": "TestSetupDSHRejectsMissingBundleBeforeCommand"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_dsh_cli.py",
+        "name": "test_setup_dsh_rejects_a_ref_that_escapes_the_checkout_root",
+        "line": 67
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/system_contract_test.go",
+          "test": "TestResolveDSHPluginRejectsEscapingRef"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_dsh_cli.py",
+        "name": "test_setup_dsh_does_not_echo_source_credentials",
+        "line": 76
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/integration_hosts_test.go",
+          "test": "TestIntegrationGitSourcesAreCredentialFreeAndCanonical"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_dsh_cli.py",
+        "name": "test_setup_dsh_clones_a_github_url_and_replaces_a_broken_checkout",
+        "line": 89
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/system_contract_test.go",
+          "test": "TestResolveDSHPluginReplacesBrokenCheckout"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_dsh_cli.py",
+        "name": "test_doctor_dsh_requires_the_plugin_id_field",
+        "line": 119
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/system_contract_test.go",
+          "test": "TestDoctorDSHRequiresPluginID"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_dsh_cli.py",
+        "name": "test_doctor_dsh_reports_an_installed_plugin",
+        "line": 131
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/system_contract_test.go",
+          "test": "TestDoctorDSHReportsInstalledPlugin"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_git_source.py",
+        "name": "test_github_clone_url_rejects_unencrypted_http_source",
+        "line": 22
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/integration_hosts_test.go",
+          "test": "TestSetupClaudeCodeRejectsUnsafeURLBeforeHostInspection"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_handoff_report_canonical.py",
+        "name": "test_canonical_json_normalizes_nfc_and_rejects_floats",
+        "line": 63
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/handoffreport/service_test.go",
+          "test": "TestSelectionDigestIsLocaleIndependentAndCanonicalRejectsFloats"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_handoff_report_canonical.py",
+        "name": "test_selection_digest_is_locale_independent_but_report_digest_is_not",
+        "line": 70
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/handoffreport/service_test.go",
+          "test": "TestSelectionDigestIsLocaleIndependentAndCanonicalRejectsFloats"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_handoff_report_canonical.py",
+        "name": "test_digest_fields_are_stable_when_a_report_is_revalidated",
+        "line": 81
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/handoffreport/service_test.go",
+          "test": "TestDigestFieldsStayStableWhenReportIsRevalidated"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_handoff_report_catalog.py",
+        "name": "test_catalog_creates_projects_workstreams_and_resolves_scope_membership",
+        "line": 45
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/sqlstore/handoff_report_test.go",
+          "test": "TestHandoffReportCatalogCreatesProjectsAndResolvesScopeMembership"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_handoff_report_catalog.py",
+        "name": "test_project_and_workstream_updates_use_cas_and_preserve_revision_history",
+        "line": 77
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/sqlstore/handoff_report_test.go",
+          "test": "TestHandoffReportSchemaIsOptInAndCatalogRevisionsAreAtomic"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_handoff_report_catalog.py",
+        "name": "test_catalog_enforces_project_key_workstream_key_and_scope_identity_uniqueness",
+        "line": 154
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/sqlstore/handoff_report_test.go",
+          "test": "TestHandoffReportCatalogEnforcesProjectWorkstreamAndScopeUniqueness"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_handoff_report_catalog.py",
+        "name": "test_catalog_lists_with_cursor_and_excludes_archived_by_default",
+        "line": 217
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/sqlstore/handoff_report_test.go",
+          "test": "TestHandoffReportCatalogPaginatesAndExcludesArchivedProjectsByDefault"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_handoff_report_http.py",
+        "name": "test_handoff_report_catalog_and_json_projection_are_available_over_http",
+        "line": 26
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "test/e2e/http_memory_test.go",
+          "test": "TestHTTPSourceAndMemorySQLiteVerticalSlice"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_handoff_report_http.py",
+        "name": "test_handoff_report_routes_are_not_registered_when_feature_is_disabled",
+        "line": 262
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/httpapi/middleware_test.go",
+          "test": "TestWrapRejectsDisabledHandoffReportRoutesBeforeApplication"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_handoff_report_http.py",
+        "name": "test_disabled_handoff_report_does_not_create_report_tables",
+        "line": 272
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "server/application_test.go",
+          "test": "TestDisabledHandoffReportDoesNotCreateOptionalTables"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_handoff_report_models.py",
+        "name": "test_project_descriptor_is_versioned_frozen_and_serializes_schema_alias",
+        "line": 76
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/handoffreport/models_test.go",
+          "test": "TestProjectDescriptorIsVersionedImmutableAndSerializesSchemaAlias"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_handoff_report_models.py",
+        "name": "test_project_descriptor_rejects_invalid_timezone",
+        "line": 86
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/handoffreport/models_test.go",
+          "test": "TestProjectDescriptorRejectsInvalidTimezone"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_handoff_report_models.py",
+        "name": "test_workstream_descriptor_reuses_scope_identity_and_bounds_metadata",
+        "line": 91
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/handoffreport/models_test.go",
+          "test": "TestWorkstreamDescriptorReusesScopeIdentityAndBoundsMetadata"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_handoff_report_models.py",
+        "name": "test_activity_event_keeps_observation_untrusted_and_explicitly_timed",
+        "line": 104
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/handoffreport/models_test.go",
+          "test": "TestActivityEventKeepsObservationUntrustedAndExplicitlyTimed"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_handoff_report_models.py",
+        "name": "test_activity_event_does_not_invent_period_time",
+        "line": 117
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/handoffreport/models_test.go",
+          "test": "TestActivityEventDoesNotInventPeriodTime"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_handoff_report_models.py",
+        "name": "test_activity_event_validates_timestamp_basis_and_utc_observation",
+        "line": 135
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/handoffreport/models_test.go",
+          "test": "TestActivityEventValidatesTimestampBasisAndUTCObservation"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_handoff_report_models.py",
+        "name": "test_report_selection_entry_requires_exact_handoff_or_explicit_absence",
+        "line": 146
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/handoffreport/models_test.go",
+          "test": "TestReportSelectionEntryRequiresExactHandoffOrExplicitAbsence"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_handoff_report_models.py",
+        "name": "test_stable_sort_helpers_use_normalized_title_scope_and_effective_time",
+        "line": 176
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/handoffreport/models_test.go",
+          "test": "TestStableSortHelpersUseNormalizedTitleScopeAndEffectiveTime"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_handoff_report_repository.py",
+        "name": "test_activity_store_is_idempotent_and_rejects_payload_conflicts",
+        "line": 56
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/sqlstore/handoff_report_activity_repository_test.go",
+          "test": "TestActivityRepositoryIsIdempotentAndRejectsPayloadConflicts"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_handoff_report_repository.py",
+        "name": "test_idempotent_retry_ignores_only_server_owned_identity_and_observation_time",
+        "line": 77
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/sqlstore/handoff_report_activity_repository_test.go",
+          "test": "TestActivityRepositoryIdempotentRetryIgnoresOnlyServerOwnedIdentityAndObservationTime"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_handoff_report_repository.py",
+        "name": "test_record_revalidates_constructed_payload_before_indexing",
+        "line": 118
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/sqlstore/handoff_report_activity_repository_test.go",
+          "test": "TestActivityRepositoryRevalidatesConstructedPayloadBeforeIndexing"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_handoff_report_repository.py",
+        "name": "test_single_repository_serializes_concurrent_sqlite_records",
+        "line": 142
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/sqlstore/handoff_report_activity_repository_test.go",
+          "test": "TestActivityRepositorySerializesConcurrentSQLiteRecords"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_handoff_report_repository.py",
+        "name": "test_activity_store_lists_by_project_period_source_and_frozen_cursor",
+        "line": 175
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/sqlstore/handoff_report_activity_repository_test.go",
+          "test": "TestActivityRepositoryListsByProjectPeriodSourceAndFrozenCursor"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_handoff_report_repository.py",
+        "name": "test_list_requires_strict_integer_cursor_and_limit_values",
+        "line": 229
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/sqlstore/handoff_report_activity_repository_test.go",
+          "test": "TestActivityRepositoryRequiresStrictCursorAndLimitValues"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_handoff_report_repository.py",
+        "name": "test_retention_purge_is_project_scoped_and_does_not_regress_cursor",
+        "line": 248
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/sqlstore/handoff_report_activity_repository_test.go",
+          "test": "TestActivityRepositoryRetentionPurgeIsProjectScopedAndCursorMonotonic"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_handoff_report_repository.py",
+        "name": "test_all_report_table_names_use_the_isolated_prefix",
+        "line": 278
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/sqlstore/handoff_report_activity_repository_test.go",
+          "test": "TestHandoffReportTableNamesUseIsolatedPrefix"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_handoff_report_selection.py",
+        "name": "test_optimistic_selection_freezes_stable_heads_in_scope_order",
+        "line": 98
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/handoffreport/selection_test.go",
+          "test": "TestOptimisticSelectionFreezesStableHeadsInScopeOrder"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_handoff_report_selection.py",
+        "name": "test_optimistic_selection_preserves_explicit_no_handoff",
+        "line": 115
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/handoffreport/selection_test.go",
+          "test": "TestOptimisticSelectionPreservesExplicitNoHandoff"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_handoff_report_selection.py",
+        "name": "test_optimistic_selection_retries_a_change_then_freezes_stable_heads",
+        "line": 128
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/handoffreport/selection_test.go",
+          "test": "TestOptimisticSelectionRetriesChangeThenFreezesStableHeads"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_handoff_report_selection.py",
+        "name": "test_optimistic_selection_reports_busy_after_bounded_instability",
+        "line": 140
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/handoffreport/service_test.go",
+          "test": "TestOptimisticSelectionFailsAfterBoundedInstability"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_handoff_report_selection.py",
+        "name": "test_optimistic_selection_requires_a_strict_bounded_attempt_count",
+        "line": 154
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/handoffreport/selection_test.go",
+          "test": "TestOptimisticSelectionRequiresStrictBoundedAttemptCount"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_handoff_report_selection.py",
+        "name": "test_runtime_adapter_maps_only_existing_read_behaviors",
+        "line": 192
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/handoffreport/selection_test.go",
+          "test": "TestRuntimeHandoffReportReaderMapsOnlyExistingReadBehaviors"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_handoff_report_service.py",
+        "name": "test_service_assembles_exact_read_only_report_and_bilingual_markdown",
+        "line": 182
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/handoffreport/service_contract_test.go",
+          "test": "TestReportServiceAssemblesExactReadOnlyReportAndBilingualMarkdown"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_handoff_report_service.py",
+        "name": "test_service_projects_revision_history_only_through_the_frozen_selection",
+        "line": 213
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/handoffreport/service_test.go",
+          "test": "TestServiceProjectsRevisionHistoryOnlyThroughFrozenSelection"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_handoff_report_service.py",
+        "name": "test_service_bounds_revision_history_and_preserves_total_count",
+        "line": 238
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/handoffreport/service_test.go",
+          "test": "TestServiceBoundsRevisionHistoryAndPreservesTotalCount"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_handoff_report_service.py",
+        "name": "test_service_can_skip_evidence_checks_without_claiming_availability",
+        "line": 253
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/handoffreport/service_contract_test.go",
+          "test": "TestReportServiceCanSkipEvidenceChecksWithoutClaimingAvailability"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_handoff_report_service.py",
+        "name": "test_service_degrades_unavailable_evidence_checks_per_workstream",
+        "line": 266
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/handoffreport/service_contract_test.go",
+          "test": "TestReportServiceDegradesUnavailableEvidenceChecksPerWorkstream"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_handoff_report_service.py",
+        "name": "test_service_fails_closed_when_exact_read_does_not_match_frozen_selection",
+        "line": 283
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/handoffreport/service_contract_test.go",
+          "test": "TestReportServiceFailsClosedWhenExactReadDoesNotMatchFrozenSelection"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_handoff_report_service.py",
+        "name": "test_service_enforces_report_selection_limits_before_reading_handoffs",
+        "line": 296
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/handoffreport/service_contract_test.go",
+          "test": "TestReportServiceEnforcesSelectionLimitsBeforeReadingHandoffs"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_handoff_report_service.py",
+        "name": "test_markdown_carries_exact_selection_cursor_and_all_activity",
+        "line": 313
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/handoffreport/service_contract_test.go",
+          "test": "TestReportMarkdownCarriesExactSelectionCursorAndAllActivity"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_handoff_report_service.py",
+        "name": "test_markdown_escapes_user_text_and_uses_safe_backtick_delimiters",
+        "line": 354
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/handoffreport/service_contract_test.go",
+          "test": "TestReportMarkdownEscapesUserTextAndUsesSafeBacktickDelimiters"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_handoff_report_service.py",
+        "name": "test_canonical_report_rejects_wrong_project_revision_and_handoff_projection",
+        "line": 407
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/handoffreport/report_validation_test.go",
+          "test": "TestCanonicalReportRejectsWrongProjectRevisionAndHandoffProjection"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_handoff_report_service.py",
+        "name": "test_canonical_report_rejects_duplicate_scopes_and_activity_ids",
+        "line": 429
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/handoffreport/report_validation_test.go",
+          "test": "TestCanonicalReportRejectsDuplicateScopesAndActivityIDs"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_handoff_report_service.py",
+        "name": "test_canonical_report_rejects_invalid_assigned_activity_ownership",
+        "line": 461
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/handoffreport/report_validation_test.go",
+          "test": "TestCanonicalReportRejectsInvalidAssignedActivityOwnership"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_handoff_report_service.py",
+        "name": "test_canonical_report_rejects_invalid_unassigned_activity_and_selection",
+        "line": 471
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/handoffreport/report_validation_test.go",
+          "test": "TestCanonicalReportRejectsInvalidUnassignedActivityAndSelection"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_handoff_report_workspace.py",
+        "name": "test_repository_ref_normalizes_safe_remote_and_relative_subpath",
+        "line": 36
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/handoffreport/models_test.go",
+          "test": "TestRepositoryRefNormalizesSafeRemoteAndRelativeSubpath"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_handoff_report_workspace.py",
+        "name": "test_workspace_binding_requires_explicit_project_and_uses_cas_for_rebind",
+        "line": 58
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/sqlstore/handoff_report_test.go",
+          "test": "TestHandoffReportWorkspaceRequiresDetachBeforeProjectMove"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_handoff_report_workspace.py",
+        "name": "test_workspace_attach_rejects_unknown_project_and_missing_exact_version",
+        "line": 150
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/sqlstore/handoff_report_test.go",
+          "test": "TestHandoffReportWorkspaceRejectsUnknownProjectAndMissingExactVersion"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_hermes_cli.py",
+        "name": "test_setup_hermes_copies_provider_from_a_local_checkout",
+        "line": 71
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/integration_hosts_test.go",
+          "test": "TestSetupHermesStagesDoctorAndAtomicallyReplacesPlugin"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_hermes_cli.py",
+        "name": "test_setup_hermes_restores_both_plugins_when_second_replace_fails",
+        "line": 105
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_hermes_cli.py",
+        "name": "test_setup_hermes_restores_both_plugins_when_enable_fails",
+        "line": 146
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_hermes_cli.py",
+        "name": "test_setup_hermes_reports_missing_cli",
+        "line": 184
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/integration_hosts_test.go",
+          "test": "TestSetupHermesReportsMissingCLIWithoutMutation"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_hermes_cli.py",
+        "name": "test_doctor_hermes_reports_an_installed_provider",
+        "line": 196
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/integration_hosts_test.go",
+          "test": "TestHermesDiagnosticsCoverInstalledMissingBrokenAndUnsupportedProviders"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_hermes_cli.py",
+        "name": "test_doctor_hermes_reports_missing_provider",
+        "line": 225
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/integration_hosts_test.go",
+          "test": "TestHermesDiagnosticsCoverInstalledMissingBrokenAndUnsupportedProviders"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_hermes_cli.py",
+        "name": "test_doctor_hermes_rejects_a_broken_provider",
+        "line": 237
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/integration_hosts_test.go",
+          "test": "TestHermesDiagnosticsCoverInstalledMissingBrokenAndUnsupportedProviders"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_hermes_cli.py",
+        "name": "test_doctor_hermes_rejects_an_unsupported_version",
+        "line": 259
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/integration_hosts_test.go",
+          "test": "TestHermesDiagnosticsCoverInstalledMissingBrokenAndUnsupportedProviders"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_hermes_cli.py",
+        "name": "test_setup_hermes_remote_checkout_uses_the_requested_ref",
+        "line": 279
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/integration_hosts_test.go",
+          "test": "TestHermesRemoteCheckoutUsesRequestedRefAndSourceScopedCurrent"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_hermes_cli.py",
+        "name": "test_remote_checkout_is_source_scoped_and_refreshes_mutable_refs",
+        "line": 299
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/integration_hosts_test.go",
+          "test": "TestHermesRemoteCheckoutUsesRequestedRefAndSourceScopedCurrent"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_js_operations.py",
+        "name": "test_js_operations_cover_every_openapi_operation",
+        "line": 36
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "ts",
+          "file": "integrations/dsh/plugins/powercontext/tests/operations-coverage.spec.ts",
+          "test": "matches every OpenAPI operationId exactly"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_js_operations.py",
+        "name": "test_js_operations_record_method_path_location_and_scope",
+        "line": 50
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "ts",
+          "file": "integrations/dsh/plugins/powercontext/tests/operations-coverage.spec.ts",
+          "test": "records method, path, and location for each operation"
+        },
+        {
+          "kind": "ts",
+          "file": "integrations/dsh/plugins/powercontext/tests/operations-coverage.spec.ts",
+          "test": "matches generated method, path, location, and scope for every operation"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_js_operations.py",
+        "name": "test_committed_js_operations_match_openapi",
+        "line": 66
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "ts",
+          "file": "integrations/dsh/plugins/powercontext/tests/gen-check.spec.ts",
+          "test": "passes when the committed table matches OpenAPI"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_mcp.py",
+        "name": "test_mcp_exposes_only_the_agent_facing_server_operations",
+        "line": 112
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/mcpapi/server_test.go",
+          "test": "TestServerExposesFrozenToolSet"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_mcp.py",
+        "name": "test_mcp_exposes_read_only_handoff_report_tools_only_when_feature_routes_are_enabled",
+        "line": 148
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/mcpapi/server_test.go",
+          "test": "TestServerExposesFrozenToolSet"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_mcp.py",
+        "name": "test_mcp_handoff_picker_returns_structured_choices_without_elicitation",
+        "line": 168
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/mcpapi/handoff_picker_test.go",
+          "test": "TestHandoffPickerReturnsStructuredFallbackAndExactSelection"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_mcp.py",
+        "name": "test_mcp_handoff_picker_does_not_silently_resolve_an_ambiguous_work_id",
+        "line": 202
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/mcpapi/handoff_picker_test.go",
+          "test": "TestHandoffPickerPreservesAmbiguity"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_mcp.py",
+        "name": "test_mcp_handoff_picker_uses_native_form_elicitation",
+        "line": 225
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/mcpapi/handoff_picker_test.go",
+          "test": "TestHandoffPickerUsesNativeFormAndPreservesCancellation"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_mcp.py",
+        "name": "test_mcp_handoff_picker_preserves_cancelled_selection",
+        "line": 257
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/mcpapi/handoff_picker_test.go",
+          "test": "TestHandoffPickerUsesNativeFormAndPreservesCancellation"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_mcp.py",
+        "name": "test_mcp_handoff_picker_selects_project_then_workstream",
+        "line": 280
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/mcpapi/handoff_picker_test.go",
+          "test": "TestHandoffPickerSelectsProjectThenWorkstream"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_mcp.py",
+        "name": "test_mcp_describes_handoff_tool_side_effects_for_host_approval",
+        "line": 316
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/mcpapi/server_test.go",
+          "test": "TestHandoffToolAnnotationsMatchFrozenHostApprovalSemantics"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_mcp.py",
+        "name": "test_mcp_exact_entry_tools_use_nested_citations",
+        "line": 348
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/mcpapi/server_test.go",
+          "test": "TestToolSchemasPreserveDefaultsAndNestedCitations"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_mcp.py",
+        "name": "test_mcp_bridge_reuses_logical_request_id_and_is_marked_internal",
+        "line": 367
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/mcpapi/server_test.go",
+          "test": "TestToolCallUsesEndpointDefaultsAndStructuredContent"
+        },
+        {
+          "kind": "go",
+          "file": "server/logging_test.go",
+          "test": "TestMCPLogsLogicalCallWithoutStreamableHTTPDuplicate"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_mcp.py",
+        "name": "test_mcp_access_log_counts_the_logical_tool_call_without_the_bridge",
+        "line": 424
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "server/logging_test.go",
+          "test": "TestMCPLogsLogicalCallWithoutStreamableHTTPDuplicate"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_openclaw_cli.py",
+        "name": "test_resolve_openclaw_plugin_dir_accepts_checkout_root",
+        "line": 41
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/integration_hosts_test.go",
+          "test": "TestSetupOpenClawBuildsAndPreservesToolAllowlist"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_openclaw_cli.py",
+        "name": "test_checkout_target_rejects_path_traversal",
+        "line": 48
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/integration_hosts_test.go",
+          "test": "TestOpenClawServerURLNormalizationAndRemoteRefValidationMatchPython"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_openclaw_cli.py",
+        "name": "test_configure_openclaw_preserves_existing_tools_and_adds_missing_tools",
+        "line": 55
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/integration_hosts_test.go",
+          "test": "TestSetupOpenClawBuildsAndPreservesToolAllowlist"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_openclaw_cli.py",
+        "name": "test_configure_openclaw_initializes_local_gateway_when_mode_is_missing",
+        "line": 87
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/integration_hosts_test.go",
+          "test": "TestSetupOpenClawBuildsAndPreservesToolAllowlist"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_openclaw_cli.py",
+        "name": "test_install_openclaw_plugin_builds_installs_and_configures",
+        "line": 112
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/integration_hosts_test.go",
+          "test": "TestSetupOpenClawBuildsAndPreservesToolAllowlist"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_openclaw_cli.py",
+        "name": "test_setup_openclaw_exposes_source_ref_and_runtime_options",
+        "line": 151
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/integration_hosts_test.go",
+          "test": "TestOpenClawSetupFlagsPreservePythonDefaults"
+        },
+        {
+          "kind": "go",
+          "file": "internal/cli/integration_hosts_test.go",
+          "test": "TestSetupOpenClawBuildsAndPreservesToolAllowlist"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_openclaw_cli.py",
+        "name": "test_setup_openclaw_defaults_to_the_server_default_endpoint",
+        "line": 192
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/integration_hosts_test.go",
+          "test": "TestOpenClawSetupFlagsPreservePythonDefaults"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_openclaw_cli.py",
+        "name": "test_run_openclaw_diagnostics_reports_installed_plugin",
+        "line": 237
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/integration_hosts_test.go",
+          "test": "TestOpenClawDiagnosticsCoverInstalledMissingInactiveAndUnavailablePlugin"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_openclaw_cli.py",
+        "name": "test_run_openclaw_diagnostics_reports_missing_plugin",
+        "line": 251
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/integration_hosts_test.go",
+          "test": "TestOpenClawDiagnosticsCoverInstalledMissingInactiveAndUnavailablePlugin"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_openclaw_cli.py",
+        "name": "test_run_openclaw_diagnostics_rejects_inactive_plugin",
+        "line": 279
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/integration_hosts_test.go",
+          "test": "TestOpenClawDiagnosticsCoverInstalledMissingInactiveAndUnavailablePlugin"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_openclaw_cli.py",
+        "name": "test_run_openclaw_diagnostics_reports_missing_cli",
+        "line": 300
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/integration_hosts_test.go",
+          "test": "TestOpenClawDiagnosticsCoverInstalledMissingInactiveAndUnavailablePlugin"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_openclaw_cli.py",
+        "name": "test_doctor_openclaw_reports_an_installed_plugin_as_json",
+        "line": 312
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/integration_hosts_test.go",
+          "test": "TestOpenClawDiagnosticsCoverInstalledMissingInactiveAndUnavailablePlugin"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_openclaw_cli.py",
+        "name": "test_doctor_openclaw_exits_nonzero_when_plugin_is_missing",
+        "line": 330
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/integration_hosts_test.go",
+          "test": "TestDoctorOpenClawRequiresActiveSelectedMemoryPlugin"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_openclaw_configure_script.py",
+        "name": "test_allowlist_update_is_idempotent_and_preserves_unrelated_tools",
+        "line": 39
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/integration_hosts_test.go",
+          "test": "TestSetupOpenClawBuildsAndPreservesToolAllowlist"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_openclaw_configure_script.py",
+        "name": "test_enable_initializes_local_gateway_when_mode_is_missing",
+        "line": 64
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/integration_hosts_test.go",
+          "test": "TestSetupOpenClawBuildsAndPreservesToolAllowlist"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_openclaw_configure_script.py",
+        "name": "test_normalize_endpoint_rejects_unsafe_values",
+        "line": 100
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/integration_hosts_test.go",
+          "test": "TestOpenClawServerURLNormalizationAndRemoteRefValidationMatchPython"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_openclaw_configure_script.py",
+        "name": "test_normalize_endpoint_strips_trailing_slashes",
+        "line": 105
+      },
+      "mode": "retained-host",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/integration_hosts_test.go",
+          "test": "TestOpenClawServerURLNormalizationAndRemoteRefValidationMatchPython"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_opencode_cli.py",
+        "name": "test_setup_opencode_installs_plugin_and_owned_skill",
+        "line": 129
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/integration_hosts_test.go",
+          "test": "TestSetupOpenCodeProtectsAndPublishesOwnedSkill"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_opencode_cli.py",
+        "name": "test_remote_checkout_cache_is_scoped_by_source_and_resolved_commit",
+        "line": 156
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/integration_hosts_test.go",
+          "test": "TestOpenCodeRemoteCheckoutCacheIsSourceAndResolvedCommitScoped"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_opencode_cli.py",
+        "name": "test_remote_checkout_refresh_failure_keeps_previous_commit",
+        "line": 182
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/integration_hosts_test.go",
+          "test": "TestOpenCodeRemoteCheckoutFailureLeavesPreviousCommit"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_opencode_cli.py",
+        "name": "test_opencode_skill_refresh_replaces_only_an_owned_installation",
+        "line": 206
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/integration_hosts_test.go",
+          "test": "TestOpenCodeSkillRefreshIsAtomicAndOwned"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_opencode_cli.py",
+        "name": "test_setup_opencode_refuses_unowned_skill",
+        "line": 224
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/integration_hosts_test.go",
+          "test": "TestSetupOpenCodeRefusesUnownedSkillBeforePluginMutation"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_opencode_cli.py",
+        "name": "test_activation_probe_uses_headless_server_without_model",
+        "line": 246
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_opencode_cli.py",
+        "name": "test_run_opencode_probe_executes_request_waits_for_nonce_and_stops_process",
+        "line": 274
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_opencode_cli.py",
+        "name": "test_run_opencode_probe_handles_process_exit_and_stops_process",
+        "line": 285
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_opencode_cli.py",
+        "name": "test_run_opencode_probe_times_out_and_stops_process",
+        "line": 296
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_opencode_cli.py",
+        "name": "test_setup_opencode_requires_built_bundle",
+        "line": 308
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/integration_hosts_test.go",
+          "test": "TestSetupOpenCodeRejectsUnsupportedVersionAndUnbuiltBundle"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_opencode_cli.py",
+        "name": "test_setup_opencode_rejects_unsupported_version",
+        "line": 323
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/integration_hosts_test.go",
+          "test": "TestSetupOpenCodeRejectsUnsupportedVersionAndUnbuiltBundle"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_opencode_cli.py",
+        "name": "test_doctor_opencode_reports_plugin_and_skill",
+        "line": 338
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/integration_hosts_test.go",
+          "test": "TestOpenCodeDiagnosticsRequireActivationAndOwnedSkill"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_opencode_cli.py",
+        "name": "test_doctor_opencode_rejects_configured_but_inactive_plugin",
+        "line": 364
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/integration_hosts_test.go",
+          "test": "TestOpenCodeDiagnosticsRequireActivationAndOwnedSkill"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_pi_cli.py",
+        "name": "test_setup_pi_installs_the_native_package_and_reports_configuration",
+        "line": 41
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/integration_hosts_test.go",
+          "test": "TestSetupPiInstallsBeforeRemovingSupersededPackages"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_pi_cli.py",
+        "name": "test_setup_pi_refreshes_remote_source_and_replaces_previous_package",
+        "line": 58
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/integration_hosts_test.go",
+          "test": "TestSetupPiRefreshesRemoteCheckoutAndRemovesOnlySupersededUserPackage"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_pi_cli.py",
+        "name": "test_setup_pi_keeps_the_existing_package_when_refresh_installation_fails",
+        "line": 104
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/integration_hosts_test.go",
+          "test": "TestSetupPiInstallationFailurePreservesExistingPackage"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_pi_cli.py",
+        "name": "test_setup_pi_does_not_echo_source_credentials",
+        "line": 136
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/integration_hosts_test.go",
+          "test": "TestIntegrationGitSourcesAreCredentialFreeAndCanonical"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_pi_cli.py",
+        "name": "test_setup_pi_does_not_echo_git_clone_output",
+        "line": 149
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/integration_hosts_test.go",
+          "test": "TestIntegrationCheckoutCloneFailurePreservesExistingCheckoutAndRedactsOutput"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_pi_cli.py",
+        "name": "test_doctor_pi_reports_a_missing_cli",
+        "line": 165
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/integration_hosts_test.go",
+          "test": "TestHostDiagnosticsCoverUnavailableAndInactiveInstallations"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_pi_cli.py",
+        "name": "test_doctor_pi_reports_an_installed_package_as_json",
+        "line": 177
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/integration_hosts_test.go",
+          "test": "TestPiDiagnosticsReportInstalledPackageAsJSON"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_server.py",
+        "name": "test_settings_load_server_environment",
+        "line": 88
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "server/config_test.go",
+          "test": "TestLoadConfigMatchesFrozenServerEnvironment"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_server.py",
+        "name": "test_env_example_loads_server_settings",
+        "line": 146
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "server/config_test.go",
+          "test": "TestEnvExampleLoadsServerSettings"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_server.py",
+        "name": "test_server_settings_select_oceanbase",
+        "line": 164
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "server/config_test.go",
+          "test": "TestLoadConfigSelectsOceanBase"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_server.py",
+        "name": "test_server_settings_select_embedded_seekdb",
+        "line": 175
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "server/config_test.go",
+          "test": "TestLoadConfigSelectsEmbeddedSeekDB"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_server.py",
+        "name": "test_server_settings_default_blank_embedded_seekdb_path",
+        "line": 189
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "server/config_test.go",
+          "test": "TestLoadConfigDefaultsBlankAndAcceptsExplicitSeekDBPath"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_server.py",
+        "name": "test_server_settings_override_embedded_seekdb_path",
+        "line": 201
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "server/config_test.go",
+          "test": "TestLoadConfigDefaultsBlankAndAcceptsExplicitSeekDBPath"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_server.py",
+        "name": "test_server_settings_reject_custom_embedded_seekdb_database",
+        "line": 213
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "server/config_test.go",
+          "test": "TestLoadConfigRejectsCustomSeekDBDatabase"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_server.py",
+        "name": "test_server_scheduler_uses_the_powercontext_data_directory",
+        "line": 222
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "server/application_test.go",
+          "test": "TestOpenApplicationSchedulerUsesPowerContextHome"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_server.py",
+        "name": "test_settings_load_bearer_authentication_without_exposing_token",
+        "line": 237
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "server/config_test.go",
+          "test": "TestAuthenticationConfigurationRedactsTokenAcrossRepresentations"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_server.py",
+        "name": "test_enabled_bearer_authentication_requires_a_token",
+        "line": 249
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "server/config_test.go",
+          "test": "TestLoadConfigRequiresBearerTokenWhenEnabled"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_server.py",
+        "name": "test_liveness_adds_a_server_owned_request_id",
+        "line": 254
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/httpapi/middleware_test.go",
+          "test": "TestWrapOwnsRequestID"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_server.py",
+        "name": "test_server_factory_optionally_requires_bearer_authentication",
+        "line": 272
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "server/http_test.go",
+          "test": "TestHTTPAuthenticationAndUnboundReadiness"
+        },
+        {
+          "kind": "go",
+          "file": "internal/httpapi/middleware_test.go",
+          "test": "TestWrapBearerPolicy"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_server.py",
+        "name": "test_readiness_reports_unavailable_bindings",
+        "line": 305
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "server/http_test.go",
+          "test": "TestHTTPReadinessMapsNotReadyAndDegradedStatuses"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_server.py",
+        "name": "test_readiness_keeps_degraded_bindings_in_traffic",
+        "line": 322
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "server/http_test.go",
+          "test": "TestHTTPReadinessMapsNotReadyAndDegradedStatuses"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_server.py",
+        "name": "test_server_factory_reports_database_failure_as_not_ready",
+        "line": 338
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "server/application_readiness_test.go",
+          "test": "TestApplicationReadinessMakesDatabaseFailureBlockingAndRedacted"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_server.py",
+        "name": "test_server_factory_reports_database_and_configured_generation_readiness",
+        "line": 366
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "server/application_readiness_test.go",
+          "test": "TestApplicationReadinessClassifiesConfiguredInferenceWithoutLeakingFailures"
+        },
+        {
+          "kind": "go",
+          "file": "server/application_readiness_test.go",
+          "test": "TestGenerationReadinessUsesRawMinimalProviderRequest"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_server.py",
+        "name": "test_server_factory_reports_generation_failure_as_degraded",
+        "line": 389
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "server/application_readiness_test.go",
+          "test": "TestApplicationReadinessClassifiesConfiguredInferenceWithoutLeakingFailures"
+        },
+        {
+          "kind": "go",
+          "file": "internal/modelprovider/openai_test.go",
+          "test": "TestOpenAISDKRetriesAreDisabledAndErrorsAreSanitized"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_server.py",
+        "name": "test_server_factory_caches_and_redacts_degraded_embedding_readiness",
+        "line": 417
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "server/application_test.go",
+          "test": "TestOpenApplicationReportsAndCachesConfiguredEmbeddingReadiness"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_server.py",
+        "name": "test_server_factory_reports_transient_embedding_failures_as_degraded",
+        "line": 457
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "server/application_readiness_test.go",
+          "test": "TestApplicationReadinessClassifiesConfiguredInferenceWithoutLeakingFailures"
+        },
+        {
+          "kind": "go",
+          "file": "internal/runtime/readiness_test.go",
+          "test": "TestDependencyProbeClassification"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_server.py",
+        "name": "test_server_provider_cache_shares_refreshes_and_retries_transient_failures_sooner",
+        "line": 485
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/runtime/readiness_test.go",
+          "test": "TestCachedProbeCollapsesRefreshAndUsesTransientTTL"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_server.py",
+        "name": "test_server_factory_reports_missing_embedding_api_prefix_as_degraded",
+        "line": 530
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "server/application_test.go",
+          "test": "TestOpenApplicationReportsMissingOpenAIEmbeddingAPIPrefixAsDegraded"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_server.py",
+        "name": "test_unhandled_errors_return_the_server_request_id",
+        "line": 594
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "server/logging_test.go",
+          "test": "TestHTTPFailureLogsApplicationAndTransportWithoutErrorContent"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_server.py",
+        "name": "test_prepare_context_rejects_memory_specific_tuning_fields",
+        "line": 606
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "server/http_test.go",
+          "test": "TestHTTPPrepareContextRejectsMemorySpecificTuningFields"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_server.py",
+        "name": "test_prepare_context_rejects_unicode_surrogates_without_crashing",
+        "line": 628
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "server/http_test.go",
+          "test": "TestHTTPPrepareContextRejectsInvalidUTF8WithoutEchoingInput"
+        },
+        {
+          "kind": "go",
+          "file": "internal/httpapi/middleware_test.go",
+          "test": "TestValidJSONUnicodeDistinguishesSurrogateEscapes"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_server.py",
+        "name": "test_prepare_context_rejects_invalid_request_without_input_field",
+        "line": 653
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "server/http_test.go",
+          "test": "TestHTTPPrepareContextRejectsMemorySpecificTuningFields"
+        },
+        {
+          "kind": "go",
+          "file": "server/http_test.go",
+          "test": "TestHTTPDecodeFailureUsesStableEnvelope"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_server.py",
+        "name": "test_stats_returns_inclusive_utc_periods_for_empty_scope",
+        "line": 677
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "server/application_test.go",
+          "test": "TestOpenApplicationStatsUsesInclusiveUTCPeriodsForEmptyScope"
+        },
+        {
+          "kind": "go",
+          "file": "api/v1/time_test.go",
+          "test": "TestEncodeDateTimeMatchesPythonUTCMicroseconds"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_server.py",
+        "name": "test_application_failure_log_uses_operation_context",
+        "line": 732
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "server/logging_test.go",
+          "test": "TestHTTPFailureLogsApplicationAndTransportWithoutErrorContent"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_server.py",
+        "name": "test_logging_failure_does_not_change_the_response",
+        "line": 750
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "server/logging_test.go",
+          "test": "TestLoggingPanicDoesNotChangeApplicationResponse"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_server_embedding.py",
+        "name": "test_embedding_settings_load_one_complete_environment_profile",
+        "line": 24
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "server/config_test.go",
+          "test": "TestLoadConfigEmbeddingProfileAndDefaultsMatchPython"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_server_embedding.py",
+        "name": "test_embedding_normalization_defaults_to_unit",
+        "line": 42
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "server/config_test.go",
+          "test": "TestLoadConfigEmbeddingProfileAndDefaultsMatchPython"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_server_embedding.py",
+        "name": "test_embedding_settings_reject_unknown_normalization",
+        "line": 47
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "server/config_test.go",
+          "test": "TestProcessConfigRejectsInvalidAndPartialEmbeddingProfiles"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_server_embedding.py",
+        "name": "test_embedding_settings_reject_partial_profiles",
+        "line": 62
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "server/config_test.go",
+          "test": "TestProcessConfigRejectsInvalidAndPartialEmbeddingProfiles"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_server_logging.py",
+        "name": "test_configured_console_logging_uses_uvicorn_display_name",
+        "line": 52
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/observability/logging/logger_test.go",
+          "test": "TestConsoleAndJSONLoggersUseStableComponentDisplayName"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_server_logging.py",
+        "name": "test_configured_json_logging_uses_uvicorn_display_name",
+        "line": 64
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/observability/logging/logger_test.go",
+          "test": "TestConsoleAndJSONLoggersUseStableComponentDisplayName"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_server_logging.py",
+        "name": "test_json_formatter_emits_stable_operational_fields",
+        "line": 74
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/observability/logging/logger_test.go",
+          "test": "TestJSONLoggerEmitsOnlyOperationalFields"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_server_logging.py",
+        "name": "test_server_access_log_uses_operation_id_and_skips_health",
+        "line": 99
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "server/logging_test.go",
+          "test": "TestHTTPAccessLogCorrelatesWithIngressSpanAndSkipsInfrastructure"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_server_logging.py",
+        "name": "test_server_warns_when_using_an_in_memory_database",
+        "line": 121
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "server/logging_test.go",
+          "test": "TestInMemoryMainDatabaseEmitsOneBoundedDataLossWarning"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_server_logging.py",
+        "name": "test_server_logging_settings_normalize_the_level",
+        "line": 141
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "server/config_test.go",
+          "test": "TestLoadConfigNormalizesLoggingSettings"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_server_metrics.py",
+        "name": "test_http_metrics_use_declared_operations_and_exclude_infrastructure",
+        "line": 53
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "server/http_test.go",
+          "test": "TestHTTPAndMCPMetricsUseBoundedOperationLabels"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_server_metrics.py",
+        "name": "test_metrics_endpoint_is_absent_when_disabled",
+        "line": 85
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "server/http_test.go",
+          "test": "TestMetricsEndpointIsAbsentWhenDisabled"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_server_metrics.py",
+        "name": "test_one_off_scope_ids_keep_runtime_scope_cache_bounded",
+        "line": 94
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/runtime/lifecycle_test.go",
+          "test": "TestScopeCacheObserverReportsDistinctActiveAndCachedScopes"
+        },
+        {
+          "kind": "go",
+          "file": "internal/observability/metrics/server_test.go",
+          "test": "TestRuntimeScopeMetricsHaveOnlyBoundedStateLabels"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_server_metrics.py",
+        "name": "test_mcp_metrics_count_one_logical_request_and_one_application_operation",
+        "line": 111
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "server/http_test.go",
+          "test": "TestHTTPAndMCPMetricsUseBoundedOperationLabels"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_server_metrics.py",
+        "name": "test_metrics_failure_does_not_change_application_behavior",
+        "line": 155
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/observability/metrics/server_test.go",
+          "test": "TestMetricsFailureDoesNotChangeApplicationBehavior"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_server_tracing.py",
+        "name": "test_http_and_application_spans_preserve_incoming_context",
+        "line": 52
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "server/tracing_test.go",
+          "test": "TestHTTPAndApplicationSpansPreserveW3CParentWithoutSensitiveAttributes"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_server_tracing.py",
+        "name": "test_client_span_injects_w3c_trace_context",
+        "line": 84
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "client/client_test.go",
+          "test": "TestClientSpanInjectsW3CTraceContext"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_server_tracing.py",
+        "name": "test_tracing_context_is_not_recorded_by_default",
+        "line": 125
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/observability/tracing/server_test.go",
+          "test": "TestDisabledTracingKeepsValidNonRecordingContext"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_server_tracing.py",
+        "name": "test_inference_instrumentation_follows_the_tracing_setting",
+        "line": 136
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "inference/tracing_test.go",
+          "test": "TestInferenceTracingFollowsProviderSamplingSetting"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_server_tracing.py",
+        "name": "test_inference_instrumentation_records_no_content",
+        "line": 146
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "inference/tracing_test.go",
+          "test": "TestInferenceSpanRecordsNoModelContent"
+        },
+        {
+          "kind": "go",
+          "file": "inference/tracing_test.go",
+          "test": "TestEmbeddingSpanNestsUnderActiveOperationWithoutRecordingTextOrVectors"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_server_tracing.py",
+        "name": "test_runtime_stage_records_attributes_and_inherits_current_span",
+        "line": 156
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/runtime/tracing_test.go",
+          "test": "TestScopedStagesAreBoundedAndLockStageEndsBeforeCriticalSection"
+        },
+        {
+          "kind": "go",
+          "file": "server/runtime_tracing_test.go",
+          "test": "TestRuntimeStageSpansInheritApplicationContextWithoutRawScope"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_server_tracing.py",
+        "name": "test_runtime_stage_records_failure_and_reraises_same_error",
+        "line": 185
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/runtime/tracing_test.go",
+          "test": "TestRuntimeStageClassifiesFailureAndCancellation"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_server_tracing.py",
+        "name": "test_runtime_stage_records_cancellation_and_reraises_same_error",
+        "line": 202
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/runtime/tracing_test.go",
+          "test": "TestRuntimeStageClassifiesFailureAndCancellation"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_server_tracing.py",
+        "name": "test_runtime_stage_isolates_tracer_failure",
+        "line": 218
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/runtime/tracing_test.go",
+          "test": "TestRuntimeStageTracerFailureDoesNotChangeOperation"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_server_tracing.py",
+        "name": "test_readiness_ignores_tracing_setup_failure",
+        "line": 233
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/runtime/tracing_test.go",
+          "test": "TestRuntimeStageTracerFailureDoesNotChangeOperation"
+        },
+        {
+          "kind": "go",
+          "file": "server/application_readiness_test.go",
+          "test": "TestConfiguredEmbeddingReadinessIsUntracedButRuntimeEmbeddingIsTraced"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_server_tracing.py",
+        "name": "test_tracing_export_requires_the_otlp_extra",
+        "line": 258
+      },
+      "mode": "go-port",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/observability/tracing/server_test.go",
+          "test": "TestEnabledTracingHasCompiledOTLPHTTPExporter"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_setup_select.py",
+        "name": "test_setup_without_subcommand_prints_help_and_installs_nothing",
+        "line": 89
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_setup_select.py",
+        "name": "test_setup_select_json_without_host_does_not_install",
+        "line": 100
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_setup_select.py",
+        "name": "test_setup_select_without_host_requires_host_on_a_non_tty",
+        "line": 110
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_setup_select.py",
+        "name": "test_setup_select_rejects_an_unknown_host_before_installing",
+        "line": 121
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_setup_select.py",
+        "name": "test_setup_select_installs_only_the_requested_hosts",
+        "line": 132
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_setup_select.py",
+        "name": "test_setup_select_continues_after_a_selected_host_fails",
+        "line": 160
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_setup_select.py",
+        "name": "test_setup_select_reports_an_unavailable_selected_host_and_continues",
+        "line": 188
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_setup_select.py",
+        "name": "test_setup_select_reports_a_successful_rerun_as_installed",
+        "line": 203
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_setup_select.py",
+        "name": "test_setup_select_reads_a_tty_selection_by_number",
+        "line": 215
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_setup_select.py",
+        "name": "test_setup_select_cancels_an_empty_tty_selection",
+        "line": 236
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_setup_select.py",
+        "name": "test_setup_select_rejects_an_invalid_tty_token_without_installing",
+        "line": 246
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_setup_select.py",
+        "name": "test_setup_select_deduplicates_repeated_host_flags",
+        "line": 257
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_setup_select.py",
+        "name": "test_setup_select_json_writes_the_matrix_without_a_prompt",
+        "line": 266
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_setup_select.py",
+        "name": "test_setup_select_passes_source_ref_and_host_specific_defaults",
+        "line": 280
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_setup_select.py",
+        "name": "test_setup_select_passes_server_and_scope_overrides_to_openclaw",
+        "line": 317
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_setup_select.py",
+        "name": "test_setup_select_fails_a_row_when_post_install_verification_fails",
+        "line": 350
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_setup_select.py",
+        "name": "test_setup_select_continues_after_post_install_verification_fails",
+        "line": 375
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_setup_select.py",
+        "name": "test_setup_select_prints_hermes_specific_next_step_only_when_installed",
+        "line": 392
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_setup_select.py",
+        "name": "test_setup_dsh_still_fails_closed_when_the_cli_is_missing",
+        "line": 403
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_setup_select.py",
+        "name": "test_parse_host_selection_accepts_names_and_reorders_to_the_catalog",
+        "line": 412
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_sources.py",
+        "name": "test_catalog_rejects_invalid_backend_results",
+        "line": 130
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "source/catalog_test.go",
+          "test": "TestCatalogRejectsInvalidBackendResults"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_sources.py",
+        "name": "test_source_catalog_supports_the_read_only_usage_flow",
+        "line": 144
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "source/catalog_test.go",
+          "test": "TestSourceServiceSupportsReadOnlyUsageFlow"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_sources.py",
+        "name": "test_catalog_rejects_persisted_sources_without_an_adapter",
+        "line": 194
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "source/catalog_test.go",
+          "test": "TestCatalogRejectsPersistedSourcesWithoutAdapter"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_sources.py",
+        "name": "test_catalog_routes_only_exact_input_and_source_classes",
+        "line": 210
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "source/catalog_test.go",
+          "test": "TestCatalogRoutesByExactConcreteType"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_sources.py",
+        "name": "test_adapter_results_and_declarations_are_checked_at_the_boundary",
+        "line": 241
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "source/catalog_test.go",
+          "test": "TestAdapterResultsAndDeclarationsAreCheckedAtBoundary"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_sources.py",
+        "name": "test_source_composition_rejects_unregistered_values_before_storage",
+        "line": 270
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "source/catalog_test.go",
+          "test": "TestSourceCompositionRejectsUnregisteredValuesBeforeStorage"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_system_cli.py",
+        "name": "test_server_defaults_to_persistent_user_storage",
+        "line": 34
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "server/config_test.go",
+          "test": "TestDefaultConfigUsesPersistentUserStorage"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_system_cli.py",
+        "name": "test_setup_codex_installs_from_a_remote_ref_and_prepares_storage",
+        "line": 49
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/system_contract_test.go",
+          "test": "TestSetupCodexRemoteRefPreparesStorageAndVerifiesPlugin"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_system_cli.py",
+        "name": "test_setup_codex_uses_an_absolute_local_marketplace_without_a_ref",
+        "line": 111
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/system_contract_test.go",
+          "test": "TestSetupCodexLocalMarketplaceOmitsRef"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_system_cli.py",
+        "name": "test_setup_claude_code_reports_mutations_then_installs_and_verifies",
+        "line": 151
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/integration_hosts_test.go",
+          "test": "TestSetupClaudeCodeIsTransactionalAndMergesSettings"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_system_cli.py",
+        "name": "test_setup_claude_code_rolls_back_only_new_objects_after_verification_failure",
+        "line": 233
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/integration_hosts_test.go",
+          "test": "TestSetupClaudeCodeRollsBackNewObjectsAfterVerificationFailure"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_system_cli.py",
+        "name": "test_setup_claude_code_preserves_preexisting_objects_on_failure",
+        "line": 262
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/integration_hosts_test.go",
+          "test": "TestClaudeCodeFailureRestoresPreexistingDisabledSettings"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_system_cli.py",
+        "name": "test_setup_claude_code_restores_a_preexisting_disabled_plugin_after_failure",
+        "line": 302
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/integration_hosts_test.go",
+          "test": "TestClaudeCodeFailureRestoresPreexistingDisabledSettings"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_system_cli.py",
+        "name": "test_setup_claude_code_rejects_a_conflicting_existing_marketplace_before_mutation",
+        "line": 368
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/integration_hosts_test.go",
+          "test": "TestClaudeCodeRejectsConflictingMarketplaceBeforeMutation"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_system_cli.py",
+        "name": "test_claude_marketplace_remote_ref_syntax",
+        "line": 401
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/integration_hosts_test.go",
+          "test": "TestClaudeMarketplaceSourceAndRefCompatibilityMatchPython"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_system_cli.py",
+        "name": "test_claude_marketplace_accepts_json_that_omits_the_configured_ref",
+        "line": 405
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/integration_hosts_test.go",
+          "test": "TestClaudeMarketplaceSourceAndRefCompatibilityMatchPython"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_system_cli.py",
+        "name": "test_setup_claude_code_normalizes_an_mcp_url_before_installing",
+        "line": 412
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/integration_hosts_test.go",
+          "test": "TestSetupClaudeCodeIsTransactionalAndMergesSettings"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_system_cli.py",
+        "name": "test_setup_claude_code_preserves_unrelated_settings_when_updating_options",
+        "line": 444
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/integration_hosts_test.go",
+          "test": "TestSetupClaudeCodeIsTransactionalAndMergesSettings"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_system_cli.py",
+        "name": "test_setup_claude_code_rejects_unsafe_server_urls_before_cli_writes",
+        "line": 495
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/integration_hosts_test.go",
+          "test": "TestSetupClaudeCodeRejectsUnsafeURLBeforeHostInspection"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_system_cli.py",
+        "name": "test_doctor_reports_each_check_and_exits_nonzero_on_failure",
+        "line": 517
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/system_contract_test.go",
+          "test": "TestDoctorJSONReportsEveryCheckAndReturnsFailure"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_system_cli.py",
+        "name": "test_default_doctor_checks_server_without_inspecting_codex",
+        "line": 561
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/system_contract_test.go",
+          "test": "TestDoctorChecksOnlyServerByDefault"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_system_cli.py",
+        "name": "test_default_doctor_skips_readiness_when_liveness_is_unreachable",
+        "line": 587
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/system_contract_test.go",
+          "test": "TestDoctorSkipsReadinessWhenLivenessIsUnreachable"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_system_cli.py",
+        "name": "test_default_doctor_preserves_not_ready_checks_in_human_and_json_output",
+        "line": 599
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/system_contract_test.go",
+          "test": "TestDoctorPreservesNotReadyChecks"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_system_cli.py",
+        "name": "test_default_doctor_preserves_degraded_checks_in_human_and_json_output",
+        "line": 640
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/system_contract_test.go",
+          "test": "TestDoctorPreservesDegradedChecks"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_system_cli.py",
+        "name": "test_doctor_codex_reports_missing_cli_and_skipped_plugin",
+        "line": 696
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/system_contract_test.go",
+          "test": "TestDoctorCodexReportsMissingCLI"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_system_cli.py",
+        "name": "test_doctor_codex_requires_an_enabled_powercontext_plugin",
+        "line": 720
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/system_contract_test.go",
+          "test": "TestDoctorCodexRequiresEnabledPlugin"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_system_cli.py",
+        "name": "test_doctor_claude_code_reports_missing_cli_and_skipped_plugin",
+        "line": 731
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/integration_hosts_test.go",
+          "test": "TestHostDiagnosticsCoverUnavailableAndInactiveInstallations"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_system_cli.py",
+        "name": "test_doctor_claude_code_requires_an_enabled_powercontext_plugin",
+        "line": 755
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/integration_hosts_test.go",
+          "test": "TestHostDiagnosticsCoverUnavailableAndInactiveInstallations"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_system_cli.py",
+        "name": "test_claude_runner_uses_the_resolved_executable",
+        "line": 766
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/integration_hosts_test.go",
+          "test": "TestSetupClaudeCodeIsTransactionalAndMergesSettings"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_system_cli.py",
+        "name": "test_setup_dsh_adds_plugin_from_a_local_checkout",
+        "line": 777
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/system_contract_test.go",
+          "test": "TestSetupDSHLocalCheckoutAndVerifiesPlugin"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_system_cli.py",
+        "name": "test_setup_dsh_fails_when_dsh_cli_is_missing",
+        "line": 811
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/system_contract_test.go",
+          "test": "TestSetupDSHReportsMissingCLI"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_system_cli.py",
+        "name": "test_doctor_dsh_reports_missing_cli_and_skipped_plugin",
+        "line": 825
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/system_contract_test.go",
+          "test": "TestDoctorDSHReportsMissingCLI"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_system_cli.py",
+        "name": "test_doctor_dsh_requires_the_installed_plugin",
+        "line": 851
+      },
+      "mode": "cross-layer",
+      "status": "mapped",
+      "source": "oracle-traceability",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/system_contract_test.go",
+          "test": "TestDoctorDSHRequiresInstalledPlugin"
+        }
+      ]
+    },
+    {
+      "python": {
+        "file": "tests/test_transport.py",
+        "name": "test_loopback_hosts_are_recognized",
+        "line": 87
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_transport.py",
+        "name": "test_non_loopback_hosts_are_rejected",
+        "line": 92
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_transport.py",
+        "name": "test_plaintext_non_loopback_detects_only_remote_http",
+        "line": 96
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_transport.py",
+        "name": "test_client_settings_reject_non_loopback_plaintext_urls",
+        "line": 106
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_transport.py",
+        "name": "test_client_settings_accept_loopback_or_tls_urls",
+        "line": 115
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_transport.py",
+        "name": "test_client_refuses_requests_over_non_loopback_plaintext",
+        "line": 119
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_transport.py",
+        "name": "test_client_refuses_a_bearer_token_over_non_loopback_plaintext",
+        "line": 128
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_transport.py",
+        "name": "test_client_allows_a_bearer_token_over_loopback_plaintext",
+        "line": 135
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_transport.py",
+        "name": "test_client_allows_a_trusted_caller_supplied_transport",
+        "line": 140
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_transport.py",
+        "name": "test_client_refuses_a_bearer_token_over_an_untrusted_caller_supplied_transport",
+        "line": 157
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_transport.py",
+        "name": "test_client_refuses_an_unauthenticated_untrusted_non_loopback_transport",
+        "line": 172
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_transport.py",
+        "name": "test_server_rejects_an_unauthenticated_non_loopback_bind",
+        "line": 183
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_transport.py",
+        "name": "test_server_allows_a_non_loopback_bind_with_authentication",
+        "line": 191
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_transport.py",
+        "name": "test_server_allows_a_non_loopback_bind_with_an_explicit_opt_in",
+        "line": 199
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_transport.py",
+        "name": "test_vendored_plugin_shares_the_loopback_host_set",
+        "line": 209
+      },
+      "mode": "cross-layer",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_transport.py",
+        "name": "test_vendored_plugin_matches_the_shared_plaintext_policy",
+        "line": 215
+      },
+      "mode": "cross-layer",
+      "status": "pending",
+      "source": "rules"
+    }
+  ]
+}

--- a/test/conformance/parity_contract_test.go
+++ b/test/conformance/parity_contract_test.go
@@ -188,6 +188,7 @@ func TestParityContractMatchesFrozenOracleWorkflow(t *testing.T) {
 		t.Fatal("migration-gates.yml has no frozen-oracle job")
 	}
 	checkout, verify := "", ""
+	targetCheckout, targetVerify := "", ""
 	for _, step := range job.Steps {
 		switch step.Name {
 		case "Check out frozen Python Oracle":
@@ -203,6 +204,19 @@ func TestParityContractMatchesFrozenOracleWorkflow(t *testing.T) {
 			if !validOracleIdentityCommand(step.Run, contract.FrozenReleaseOracle.Commit) {
 				t.Errorf("Verify Oracle identity step does not pin the contract frozen Oracle %q", contract.FrozenReleaseOracle.Commit)
 			}
+		case "Check out the active parity target":
+			targetCheckout = step.Name
+			if step.With.Repository != contract.Upstream.Repository {
+				t.Errorf("parity target checkout repository = %q, want the contract upstream %q", step.With.Repository, contract.Upstream.Repository)
+			}
+			if step.With.Ref != contract.ExactTargetSHA {
+				t.Errorf("parity target checkout ref = %q, want the contract exact target SHA %q", step.With.Ref, contract.ExactTargetSHA)
+			}
+		case "Verify parity target identity":
+			targetVerify = step.Name
+			if !strings.Contains(step.Run, contract.ExactTargetSHA) {
+				t.Errorf("Verify parity target identity step does not pin the contract exact target SHA %q", contract.ExactTargetSHA)
+			}
 		}
 	}
 	if checkout == "" {
@@ -210,6 +224,12 @@ func TestParityContractMatchesFrozenOracleWorkflow(t *testing.T) {
 	}
 	if verify == "" {
 		t.Error("frozen-oracle job has no 'Verify Oracle identity' step")
+	}
+	if targetCheckout == "" {
+		t.Error("frozen-oracle job has no 'Check out the active parity target' step")
+	}
+	if targetVerify == "" {
+		t.Error("frozen-oracle job has no 'Verify parity target identity' step")
 	}
 }
 

--- a/test/conformance/parity_contract_test.go
+++ b/test/conformance/parity_contract_test.go
@@ -86,9 +86,21 @@ func TestParityContractRejectsAmbiguousJSON(t *testing.T) {
 	}
 }
 
-func TestFrozenOracleWorkflowRejectsNonVerifyingIdentityStep(t *testing.T) {
-	if validOracleIdentityCommand("echo "+oracleCommit, oracleCommit) {
-		t.Error("accepted an Oracle identity step that only prints the expected commit")
+func TestWorkflowRejectsNonVerifyingIdentitySteps(t *testing.T) {
+	tests := []struct {
+		name         string
+		checkoutPath string
+		commit       string
+	}{
+		{name: "frozen Oracle", checkoutPath: "_oracle", commit: oracleCommit},
+		{name: "active parity target", checkoutPath: "_target", commit: "target-commit"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if validCheckoutIdentityCommand("echo "+test.commit, test.checkoutPath, test.commit) {
+				t.Errorf("accepted a non-verifying identity step for %s", test.checkoutPath)
+			}
+		})
 	}
 }
 
@@ -201,7 +213,7 @@ func TestParityContractMatchesFrozenOracleWorkflow(t *testing.T) {
 			}
 		case "Verify Oracle identity":
 			verify = step.Name
-			if !validOracleIdentityCommand(step.Run, contract.FrozenReleaseOracle.Commit) {
+			if !validCheckoutIdentityCommand(step.Run, "_oracle", contract.FrozenReleaseOracle.Commit) {
 				t.Errorf("Verify Oracle identity step does not pin the contract frozen Oracle %q", contract.FrozenReleaseOracle.Commit)
 			}
 		case "Check out the active parity target":
@@ -214,7 +226,7 @@ func TestParityContractMatchesFrozenOracleWorkflow(t *testing.T) {
 			}
 		case "Verify parity target identity":
 			targetVerify = step.Name
-			if !strings.Contains(step.Run, contract.ExactTargetSHA) {
+			if !validCheckoutIdentityCommand(step.Run, "_target", contract.ExactTargetSHA) {
 				t.Errorf("Verify parity target identity step does not pin the contract exact target SHA %q", contract.ExactTargetSHA)
 			}
 		}
@@ -260,7 +272,7 @@ func validGitHubRepositorySlug(slug string) bool {
 		strings.IndexFunc(slug, unicode.IsSpace) < 0
 }
 
-func validOracleIdentityCommand(command, commit string) bool {
-	want := `test "$(git -C _oracle rev-parse HEAD)" = ` + commit
+func validCheckoutIdentityCommand(command, checkoutPath, commit string) bool {
+	want := `test "$(git -C ` + checkoutPath + ` rev-parse HEAD)" = ` + commit
 	return strings.TrimSpace(command) == want
 }

--- a/test/conformance/parity_inventory_test.go
+++ b/test/conformance/parity_inventory_test.go
@@ -1,0 +1,177 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conformance_test
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+type parityInventoryEntry struct {
+	Python   tracedPythonTest `json:"python"`
+	Mode     string           `json:"mode"`
+	Status   string           `json:"status"`
+	Source   string           `json:"source"`
+	Evidence []traceEvidence  `json:"evidence"`
+}
+
+type parityInventory struct {
+	SchemaVersion       int                    `json:"schema_version"`
+	TargetCommit        string                 `json:"target_commit"`
+	OracleCommit        string                 `json:"oracle_commit"`
+	PythonTestFileCount int                    `json:"python_test_file_count"`
+	PythonTestCaseCount int                    `json:"python_test_case_count"`
+	MappedCaseCount     int                    `json:"mapped_case_count"`
+	PendingCaseCount    int                    `json:"pending_case_count"`
+	Entries             []parityInventoryEntry `json:"entries"`
+}
+
+// TestParityInventoryMatchesContract guards the 759-case active parity target
+// inventory: it must agree with parity-contract.json on identity, keep every
+// frozen Oracle mapping verbatim, assign a mode to every delta case, resolve
+// every mapped evidence reference, and pin the mapped/pending split so silent
+// regressions fail.
+func TestParityInventoryMatchesContract(t *testing.T) {
+	var contract struct {
+		Upstream struct {
+			Repository string `json:"repository"`
+		} `json:"upstream"`
+		FrozenOracle struct {
+			Commit string `json:"commit"`
+		} `json:"frozen_release_oracle"`
+		ExactTargetSHA      string `json:"exact_target_sha"`
+		TargetTestCaseCount int    `json:"target_test_case_count"`
+	}
+	decodeJSONFile(t, "parity-contract.json", &contract)
+	var inventory parityInventory
+	decodeJSONFile(t, "parity-inventory.json", &inventory)
+	var trace traceTable
+	decodeJSONFile(t, "traceability.json", &trace)
+
+	if inventory.SchemaVersion != 1 {
+		t.Fatalf("unsupported parity inventory schema %d", inventory.SchemaVersion)
+	}
+	if inventory.TargetCommit != contract.ExactTargetSHA {
+		t.Fatalf("inventory target = %s, contract exact target SHA = %s", inventory.TargetCommit, contract.ExactTargetSHA)
+	}
+	if inventory.OracleCommit != contract.FrozenOracle.Commit || inventory.OracleCommit != trace.OracleCommit {
+		t.Fatalf("inventory Oracle = %s, contract frozen Oracle = %s, traceability Oracle = %s",
+			inventory.OracleCommit, contract.FrozenOracle.Commit, trace.OracleCommit)
+	}
+	if inventory.PythonTestCaseCount != contract.TargetTestCaseCount || len(inventory.Entries) != contract.TargetTestCaseCount {
+		t.Fatalf("inventory cases = %d entries/%d declared, contract records %d",
+			len(inventory.Entries), inventory.PythonTestCaseCount, contract.TargetTestCaseCount)
+	}
+	if inventory.MappedCaseCount+inventory.PendingCaseCount != inventory.PythonTestCaseCount {
+		t.Fatalf("mapped %d + pending %d != %d cases",
+			inventory.MappedCaseCount, inventory.PendingCaseCount, inventory.PythonTestCaseCount)
+	}
+
+	frozen := make(map[string]traceEntry, len(trace.Entries))
+	for _, entry := range trace.Entries {
+		frozen[entry.Python.File+"#"+entry.Python.Name] = entry
+	}
+
+	root := filepath.Join("..", "..")
+	seen := make(map[string]struct{}, len(inventory.Entries))
+	files := make(map[string]struct{})
+	mapped, pending, inherited := 0, 0, 0
+	for index, entry := range inventory.Entries {
+		key := entry.Python.File + "#" + entry.Python.Name
+		if _, exists := seen[key]; exists {
+			t.Fatalf("duplicate inventory entry %s", key)
+		}
+		seen[key] = struct{}{}
+		files[entry.Python.File] = struct{}{}
+		if index > 0 {
+			previous := inventory.Entries[index-1].Python
+			if lessPythonTest(entry.Python, previous) {
+				t.Fatalf("inventory entries are not deterministically ordered at %s", key)
+			}
+		}
+		if entry.Mode != "go-port" && entry.Mode != "retained-host" && entry.Mode != "cross-layer" {
+			t.Fatalf("%s has invalid mode %q", key, entry.Mode)
+		}
+		switch entry.Status {
+		case "mapped":
+			mapped++
+			if len(entry.Evidence) == 0 {
+				t.Fatalf("%s is mapped but carries no evidence", key)
+			}
+		case "pending":
+			pending++
+			if len(entry.Evidence) != 0 {
+				t.Fatalf("%s is pending but carries evidence", key)
+			}
+		default:
+			t.Fatalf("%s has invalid status %q", key, entry.Status)
+		}
+		if frozenEntry, ok := frozen[key]; ok {
+			inherited++
+			if entry.Source != "oracle-traceability" {
+				t.Fatalf("%s is a frozen Oracle case but has source %q", key, entry.Source)
+			}
+			if entry.Status != "mapped" || entry.Mode != frozenEntry.Mode {
+				t.Fatalf("%s lost its frozen mapping: mode %q (frozen %q), status %q",
+					key, entry.Mode, frozenEntry.Mode, entry.Status)
+			}
+			if !sameEvidence(entry.Evidence, frozenEntry.Evidence) {
+				t.Fatalf("%s changed its frozen evidence set", key)
+			}
+		} else if entry.Source != "rules" {
+			t.Fatalf("%s is a delta case but has source %q", key, entry.Source)
+		}
+		for _, evidence := range entry.Evidence {
+			assertEvidenceResolves(t, root, key, evidence)
+		}
+	}
+	if inherited != len(trace.Entries) {
+		t.Fatalf("inventory inherited %d frozen Oracle cases, traceability declares %d", inherited, len(trace.Entries))
+	}
+	if mapped != inventory.MappedCaseCount || pending != inventory.PendingCaseCount {
+		t.Fatalf("counted mapped %d/pending %d, summary says %d/%d",
+			mapped, pending, inventory.MappedCaseCount, inventory.PendingCaseCount)
+	}
+	if len(files) != inventory.PythonTestFileCount {
+		t.Fatalf("inventory covers %d files, summary says %d", len(files), inventory.PythonTestFileCount)
+	}
+}
+
+func lessPythonTest(left, right tracedPythonTest) bool {
+	if left.File != right.File {
+		return left.File < right.File
+	}
+	if left.Line != right.Line {
+		return left.Line < right.Line
+	}
+	return left.Name < right.Name
+}
+
+func sameEvidence(actual, expected []traceEvidence) bool {
+	if len(actual) != len(expected) {
+		return false
+	}
+	remaining := make(map[traceEvidence]int, len(expected))
+	for _, item := range expected {
+		remaining[item]++
+	}
+	for _, item := range actual {
+		remaining[item]--
+		if remaining[item] < 0 {
+			return false
+		}
+	}
+	return true
+}

--- a/tools/parity-inventory-generate/main.go
+++ b/tools/parity-inventory-generate/main.go
@@ -1,0 +1,436 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Command parity-inventory-generate builds the 759-case Python test
+// inventory at the active parity target recorded in
+// test/conformance/parity-contract.json. It walks an upstream checkout that
+// must sit exactly at the target commit, merges the frozen Oracle mappings
+// inherited from traceability.json with the delta mode assignments from
+// parity-inventory-rules.json, and emits a deterministic
+// test/conformance/parity-inventory.json. Evidence references are resolved
+// against real test declarations before output is accepted.
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+type parityContract struct {
+	SchemaVersion int `json:"schema_version"`
+	Upstream      struct {
+		Repository    string `json:"repository"`
+		URL           string `json:"url"`
+		DefaultBranch string `json:"default_branch"`
+	} `json:"upstream"`
+	FrozenOracle struct {
+		Commit            string `json:"commit"`
+		Baseline          string `json:"baseline"`
+		EvidenceDirectory string `json:"evidence_directory"`
+	} `json:"frozen_release_oracle"`
+	ExactTargetSHA      string `json:"exact_target_sha"`
+	TargetTestCaseCount int    `json:"target_test_case_count"`
+	ActiveParityTarget  string `json:"active_parity_target"`
+}
+
+type traceabilityEntry struct {
+	Python   pythonTest `json:"python"`
+	Mode     string     `json:"mode"`
+	Evidence []evidence `json:"evidence"`
+}
+
+type traceabilityTable struct {
+	OracleCommit string              `json:"oracle_commit"`
+	Entries      []traceabilityEntry `json:"entries"`
+}
+
+type pythonTest struct {
+	File string `json:"file"`
+	Name string `json:"name"`
+	Line int    `json:"line"`
+}
+
+type evidence struct {
+	Kind string `json:"kind"`
+	File string `json:"file"`
+	Test string `json:"test"`
+}
+
+type ruleSet struct {
+	SchemaVersion int                 `json:"schema_version"`
+	Comment       string              `json:"comment"`
+	Files         map[string]fileRule `json:"files"`
+}
+
+type fileRule struct {
+	Mode   string              `json:"mode"`
+	Reason string              `json:"reason"`
+	Cases  map[string]caseRule `json:"cases,omitempty"`
+}
+
+type caseRule struct {
+	Mode     string   `json:"mode,omitempty"`
+	Reason   string   `json:"reason,omitempty"`
+	Evidence []string `json:"evidence,omitempty"`
+}
+
+type inventoryEntry struct {
+	Python   pythonTest `json:"python"`
+	Mode     string     `json:"mode"`
+	Status   string     `json:"status"`
+	Source   string     `json:"source"`
+	Evidence []evidence `json:"evidence,omitempty"`
+}
+
+type inventory struct {
+	SchemaVersion       int              `json:"schema_version"`
+	TargetCommit        string           `json:"target_commit"`
+	OracleCommit        string           `json:"oracle_commit"`
+	PythonTestFileCount int              `json:"python_test_file_count"`
+	PythonTestCaseCount int              `json:"python_test_case_count"`
+	MappedCaseCount     int              `json:"mapped_case_count"`
+	PendingCaseCount    int              `json:"pending_case_count"`
+	Entries             []inventoryEntry `json:"entries"`
+}
+
+var (
+	goTestDeclaration = regexp.MustCompile(`^func\s+(Test[A-Za-z0-9_]+)\s*\(`)
+	pyTestDeclaration = regexp.MustCompile(`^\s*(?:async\s+)?def\s+(test_[A-Za-z0-9_]+)\s*\(`)
+	pyCaseScanner     = regexp.MustCompile(`^\s*(?:async\s+)?def\s+(test_[A-Za-z0-9_]+)\s*\(`)
+)
+
+const (
+	modeGoPort       = "go-port"
+	modeRetainedHost = "retained-host"
+	modeCrossLayer   = "cross-layer"
+	statusMapped     = "mapped"
+	statusPending    = "pending"
+	sourceOracle     = "oracle-traceability"
+	sourceRules      = "rules"
+)
+
+func main() {
+	contractPath := flag.String("contract", "test/conformance/parity-contract.json", "parity contract")
+	traceabilityPath := flag.String("traceability", "test/conformance/traceability.json", "frozen Oracle traceability table")
+	rulesPath := flag.String("rules", "test/conformance/parity-inventory-rules.json", "parity inventory rules")
+	outputPath := flag.String("output", "test/conformance/parity-inventory.json", "generated parity inventory")
+	upstream := flag.String("upstream", "", "upstream Python checkout pinned at the contract target SHA (required)")
+	root := flag.String("root", ".", "Go repository root")
+	check := flag.Bool("check", false, "verify generated output without rewriting")
+	flag.Parse()
+	if err := run(*root, *contractPath, *traceabilityPath, *rulesPath, *outputPath, *upstream, *check); err != nil {
+		fmt.Fprintln(os.Stderr, "parity-inventory-generate:", err)
+		os.Exit(1)
+	}
+}
+
+func run(root, contractPath, traceabilityPath, rulesPath, outputPath, upstream string, check bool) error {
+	var contract parityContract
+	if err := readJSON(filepath.Join(root, contractPath), &contract); err != nil {
+		return fmt.Errorf("read parity contract: %w", err)
+	}
+	if contract.SchemaVersion != 1 || contract.ExactTargetSHA == "" || contract.FrozenOracle.Commit == "" {
+		return fmt.Errorf("parity contract is missing the target SHA or frozen Oracle commit")
+	}
+	if upstream == "" {
+		return errors.New("-upstream is required: pass an upstream checkout pinned at the contract target SHA")
+	}
+	head, err := upstreamHead(upstream)
+	if err != nil {
+		return err
+	}
+	if head != contract.ExactTargetSHA {
+		return fmt.Errorf("upstream checkout HEAD = %s, want contract target %s", head, contract.ExactTargetSHA)
+	}
+
+	var trace traceabilityTable
+	if err := readJSONLoose(filepath.Join(root, traceabilityPath), &trace); err != nil {
+		return fmt.Errorf("read traceability table: %w", err)
+	}
+	if trace.OracleCommit != contract.FrozenOracle.Commit {
+		return fmt.Errorf("traceability Oracle commit = %s, contract frozen Oracle = %s", trace.OracleCommit, contract.FrozenOracle.Commit)
+	}
+	inherited := make(map[string]traceabilityEntry, len(trace.Entries))
+	for _, entry := range trace.Entries {
+		inherited[entry.Python.File+"#"+entry.Python.Name] = entry
+	}
+
+	var rules ruleSet
+	if err := readJSON(filepath.Join(root, rulesPath), &rules); err != nil {
+		return fmt.Errorf("read inventory rules: %w", err)
+	}
+	if rules.SchemaVersion != 1 {
+		return fmt.Errorf("unsupported rules schema %d", rules.SchemaVersion)
+	}
+
+	cases, err := extractUpstreamCases(upstream)
+	if err != nil {
+		return err
+	}
+	if contract.TargetTestCaseCount != 0 && len(cases) != contract.TargetTestCaseCount {
+		return fmt.Errorf("upstream target inventory = %d cases, contract records %d; update the parity contract deliberately", len(cases), contract.TargetTestCaseCount)
+	}
+
+	entries := make([]inventoryEntry, 0, len(cases))
+	sourceFiles := make(map[string]struct{})
+	mapped, pending := 0, 0
+	usedRules := make(map[string]struct{})
+	for _, test := range cases {
+		sourceFiles[test.File] = struct{}{}
+		key := test.File + "#" + test.Name
+		if frozen, ok := inherited[key]; ok {
+			entries = append(entries, inventoryEntry{
+				Python: test, Mode: frozen.Mode, Status: statusMapped,
+				Source: sourceOracle, Evidence: frozen.Evidence,
+			})
+			mapped++
+			continue
+		}
+		fileRule, ok := rules.Files[test.File]
+		if !ok {
+			return fmt.Errorf("no inventory rule for delta file %s (case %s)", test.File, test.Name)
+		}
+		usedRules[test.File] = struct{}{}
+		mode := fileRule.Mode
+		var references []string
+		if override, ok := fileRule.Cases[test.Name]; ok {
+			if override.Mode != "" {
+				mode = override.Mode
+			}
+			references = override.Evidence
+		}
+		if !validMode(mode) {
+			return fmt.Errorf("%s has invalid mode %q", key, mode)
+		}
+		status := statusPending
+		resolved := make([]evidence, 0, len(references))
+		for _, reference := range references {
+			reference = strings.ReplaceAll(reference, "{python_test}", test.Name)
+			value, err := resolveEvidence(root, reference)
+			if err != nil {
+				return fmt.Errorf("%s: %w", key, err)
+			}
+			resolved = append(resolved, value)
+		}
+		if len(resolved) != 0 {
+			status = statusMapped
+			mapped++
+		} else {
+			pending++
+		}
+		entries = append(entries, inventoryEntry{
+			Python: test, Mode: mode, Status: status,
+			Source: sourceRules, Evidence: resolved,
+		})
+	}
+
+	for file, fileRule := range rules.Files {
+		if _, ok := usedRules[file]; !ok {
+			return fmt.Errorf("inventory rules contain unknown target file %s", file)
+		}
+		caseNames := make(map[string]struct{})
+		for _, test := range cases {
+			if test.File == file {
+				caseNames[test.Name] = struct{}{}
+			}
+		}
+		for name := range fileRule.Cases {
+			if _, ok := caseNames[name]; !ok {
+				return fmt.Errorf("%s has an override for unknown target case %s", file, name)
+			}
+			if _, frozen := inherited[file+"#"+name]; frozen {
+				return fmt.Errorf("%s#%s is a frozen Oracle case and must not appear in the inventory rules", file, name)
+			}
+		}
+	}
+
+	value := inventory{
+		SchemaVersion: 1, TargetCommit: contract.ExactTargetSHA, OracleCommit: contract.FrozenOracle.Commit,
+		PythonTestFileCount: len(sourceFiles), PythonTestCaseCount: len(entries),
+		MappedCaseCount: mapped, PendingCaseCount: pending,
+		Entries: entries,
+	}
+	payload, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return err
+	}
+	payload = append(payload, '\n')
+	fullOutput := filepath.Join(root, outputPath)
+	current, err := os.ReadFile(fullOutput)
+	if err == nil && bytes.Equal(current, payload) {
+		return nil
+	}
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	if check {
+		return fmt.Errorf("%s is stale; regenerate with tools/parity-inventory-generate", outputPath)
+	}
+	return os.WriteFile(fullOutput, payload, 0o644)
+}
+
+func validMode(mode string) bool {
+	return mode == modeGoPort || mode == modeRetainedHost || mode == modeCrossLayer
+}
+
+func upstreamHead(upstream string) (string, error) {
+	cmd := exec.Command("git", "-C", upstream, "rev-parse", "HEAD")
+	output, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("resolve upstream checkout HEAD: %w", err)
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
+// extractUpstreamCases walks tests/, integrations/, and e2e/ of the upstream
+// checkout and returns every Python test case in deterministic order,
+// matching the counting convention used for the frozen Oracle manifest.
+func extractUpstreamCases(upstream string) ([]pythonTest, error) {
+	var cases []pythonTest
+	for _, base := range []string{"tests", "integrations", "e2e"} {
+		basePath := filepath.Join(upstream, base)
+		err := filepath.WalkDir(basePath, func(path string, entry os.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if entry.IsDir() {
+				if entry.Name() == "__pycache__" || entry.Name() == "node_modules" {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+			if !strings.HasSuffix(entry.Name(), ".py") {
+				return nil
+			}
+			rel, err := filepath.Rel(upstream, path)
+			if err != nil {
+				return fmt.Errorf("resolve upstream path %s: %w", path, err)
+			}
+			found, err := scanPythonCases(path, filepath.ToSlash(rel))
+			if err != nil {
+				return err
+			}
+			cases = append(cases, found...)
+			return nil
+		})
+		if err != nil {
+			return nil, fmt.Errorf("walk upstream %s: %w", base, err)
+		}
+	}
+	sort.Slice(cases, func(i, j int) bool {
+		if cases[i].File != cases[j].File {
+			return cases[i].File < cases[j].File
+		}
+		if cases[i].Line != cases[j].Line {
+			return cases[i].Line < cases[j].Line
+		}
+		return cases[i].Name < cases[j].Name
+	})
+	if len(cases) == 0 {
+		return nil, fmt.Errorf("upstream checkout %s yielded no Python test cases", upstream)
+	}
+	return cases, nil
+}
+
+func scanPythonCases(path, rel string) ([]pythonTest, error) {
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read upstream test %s: %w", rel, err)
+	}
+	var found []pythonTest
+	scanner := bufio.NewScanner(bytes.NewReader(contents))
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	line := 0
+	for scanner.Scan() {
+		line++
+		match := pyCaseScanner.FindStringSubmatch(scanner.Text())
+		if len(match) == 2 {
+			found = append(found, pythonTest{File: rel, Name: match[1], Line: line})
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("scan upstream test %s: %w", rel, err)
+	}
+	return found, nil
+}
+
+func resolveEvidence(root, reference string) (evidence, error) {
+	kind, remainder, ok := strings.Cut(reference, ":")
+	if !ok || (kind != "go" && kind != "py" && kind != "ts") {
+		return evidence{}, fmt.Errorf("invalid evidence reference %q", reference)
+	}
+	path, testName, ok := strings.Cut(remainder, "#")
+	if !ok || path == "" || testName == "" || strings.Contains(testName, "#") {
+		return evidence{}, fmt.Errorf("invalid evidence reference %q", reference)
+	}
+	clean := filepath.Clean(filepath.FromSlash(path))
+	if filepath.IsAbs(clean) || clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
+		return evidence{}, fmt.Errorf("evidence path escapes repository: %q", path)
+	}
+	contents, err := os.ReadFile(filepath.Join(root, clean))
+	if err != nil {
+		return evidence{}, fmt.Errorf("read evidence %s: %w", path, err)
+	}
+	if !declaresTest(kind, contents, testName) {
+		return evidence{}, fmt.Errorf("%s does not declare %s test %q", path, kind, testName)
+	}
+	return evidence{Kind: kind, File: filepath.ToSlash(clean), Test: testName}, nil
+}
+
+func declaresTest(kind string, contents []byte, name string) bool {
+	if kind == "ts" {
+		text := string(contents)
+		return strings.Contains(text, "it('"+name+"'") || strings.Contains(text, `it("`+name+`"`)
+	}
+	pattern := goTestDeclaration
+	if kind == "py" {
+		pattern = pyTestDeclaration
+	}
+	scanner := bufio.NewScanner(bytes.NewReader(contents))
+	for scanner.Scan() {
+		match := pattern.FindStringSubmatch(scanner.Text())
+		if len(match) == 2 && match[1] == name {
+			return true
+		}
+	}
+	return false
+}
+
+func readJSON(path string, target any) error {
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	decoder := json.NewDecoder(bytes.NewReader(contents))
+	decoder.DisallowUnknownFields()
+	return decoder.Decode(target)
+}
+
+func readJSONLoose(path string, target any) error {
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(contents, target)
+}

--- a/tools/parity-inventory-generate/main.go
+++ b/tools/parity-inventory-generate/main.go
@@ -25,7 +25,9 @@ package main
 import (
 	"bufio"
 	"bytes"
-	"encoding/json"
+	"cmp"
+	"encoding/json/jsontext"
+	"encoding/json/v2"
 	"errors"
 	"flag"
 	"fmt"
@@ -33,7 +35,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
-	"sort"
+	"slices"
 	"strings"
 )
 
@@ -117,7 +119,6 @@ type inventory struct {
 var (
 	goTestDeclaration = regexp.MustCompile(`^func\s+(Test[A-Za-z0-9_]+)\s*\(`)
 	pyTestDeclaration = regexp.MustCompile(`^\s*(?:async\s+)?def\s+(test_[A-Za-z0-9_]+)\s*\(`)
-	pyCaseScanner     = regexp.MustCompile(`^\s*(?:async\s+)?def\s+(test_[A-Za-z0-9_]+)\s*\(`)
 )
 
 const (
@@ -271,7 +272,7 @@ func run(root, contractPath, traceabilityPath, rulesPath, outputPath, upstream s
 		MappedCaseCount: mapped, PendingCaseCount: pending,
 		Entries: entries,
 	}
-	payload, err := json.MarshalIndent(value, "", "  ")
+	payload, err := json.Marshal(&value, json.Deterministic(true), jsontext.WithIndent("  "))
 	if err != nil {
 		return err
 	}
@@ -338,14 +339,14 @@ func extractUpstreamCases(upstream string) ([]pythonTest, error) {
 			return nil, fmt.Errorf("walk upstream %s: %w", base, err)
 		}
 	}
-	sort.Slice(cases, func(i, j int) bool {
-		if cases[i].File != cases[j].File {
-			return cases[i].File < cases[j].File
+	slices.SortFunc(cases, func(left, right pythonTest) int {
+		if order := cmp.Compare(left.File, right.File); order != 0 {
+			return order
 		}
-		if cases[i].Line != cases[j].Line {
-			return cases[i].Line < cases[j].Line
+		if order := cmp.Compare(left.Line, right.Line); order != 0 {
+			return order
 		}
-		return cases[i].Name < cases[j].Name
+		return cmp.Compare(left.Name, right.Name)
 	})
 	if len(cases) == 0 {
 		return nil, fmt.Errorf("upstream checkout %s yielded no Python test cases", upstream)
@@ -364,7 +365,7 @@ func scanPythonCases(path, rel string) ([]pythonTest, error) {
 	line := 0
 	for scanner.Scan() {
 		line++
-		match := pyCaseScanner.FindStringSubmatch(scanner.Text())
+		match := pyTestDeclaration.FindStringSubmatch(scanner.Text())
 		if len(match) == 2 {
 			found = append(found, pythonTest{File: rel, Name: match[1], Line: line})
 		}
@@ -400,8 +401,14 @@ func resolveEvidence(root, reference string) (evidence, error) {
 
 func declaresTest(kind string, contents []byte, name string) bool {
 	if kind == "ts" {
-		text := string(contents)
-		return strings.Contains(text, "it('"+name+"'") || strings.Contains(text, `it("`+name+`"`)
+		scanner := bufio.NewScanner(bytes.NewReader(contents))
+		for scanner.Scan() {
+			line := strings.TrimSpace(scanner.Text())
+			if strings.HasPrefix(line, "it('"+name+"'") || strings.HasPrefix(line, `it("`+name+`"`) {
+				return true
+			}
+		}
+		return false
 	}
 	pattern := goTestDeclaration
 	if kind == "py" {
@@ -422,9 +429,7 @@ func readJSON(path string, target any) error {
 	if err != nil {
 		return err
 	}
-	decoder := json.NewDecoder(bytes.NewReader(contents))
-	decoder.DisallowUnknownFields()
-	return decoder.Decode(target)
+	return json.Unmarshal(contents, target, json.RejectUnknownMembers(true))
 }
 
 func readJSONLoose(path string, target any) error {

--- a/tools/parity-inventory-generate/main.go
+++ b/tools/parity-inventory-generate/main.go
@@ -165,8 +165,8 @@ func run(root, contractPath, traceabilityPath, rulesPath, outputPath, upstream s
 	}
 
 	var trace traceabilityTable
-	if err := readJSONLoose(filepath.Join(root, traceabilityPath), &trace); err != nil {
-		return fmt.Errorf("read traceability table: %w", err)
+	if loadErr := readJSONLoose(filepath.Join(root, traceabilityPath), &trace); loadErr != nil {
+		return fmt.Errorf("read traceability table: %w", loadErr)
 	}
 	if trace.OracleCommit != contract.FrozenOracle.Commit {
 		return fmt.Errorf("traceability Oracle commit = %s, contract frozen Oracle = %s", trace.OracleCommit, contract.FrozenOracle.Commit)
@@ -177,8 +177,8 @@ func run(root, contractPath, traceabilityPath, rulesPath, outputPath, upstream s
 	}
 
 	var rules ruleSet
-	if err := readJSON(filepath.Join(root, rulesPath), &rules); err != nil {
-		return fmt.Errorf("read inventory rules: %w", err)
+	if loadErr := readJSON(filepath.Join(root, rulesPath), &rules); loadErr != nil {
+		return fmt.Errorf("read inventory rules: %w", loadErr)
 	}
 	if rules.SchemaVersion != 1 {
 		return fmt.Errorf("unsupported rules schema %d", rules.SchemaVersion)
@@ -227,9 +227,9 @@ func run(root, contractPath, traceabilityPath, rulesPath, outputPath, upstream s
 		resolved := make([]evidence, 0, len(references))
 		for _, reference := range references {
 			reference = strings.ReplaceAll(reference, "{python_test}", test.Name)
-			value, err := resolveEvidence(root, reference)
-			if err != nil {
-				return fmt.Errorf("%s: %w", key, err)
+			value, resolveErr := resolveEvidence(root, reference)
+			if resolveErr != nil {
+				return fmt.Errorf("%s: %w", key, resolveErr)
 			}
 			resolved = append(resolved, value)
 		}

--- a/tools/parity-inventory-generate/main_test.go
+++ b/tools/parity-inventory-generate/main_test.go
@@ -1,0 +1,66 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestReadJSONRejectsAmbiguousDocuments(t *testing.T) {
+	tests := []struct {
+		name     string
+		contents string
+	}{
+		{name: "duplicate member", contents: `{"schema_version": 999, "schema_version": 1}`},
+		{name: "unknown member", contents: `{"schema_version": 1, "future_semantics": true}`},
+		{name: "trailing value", contents: `{"schema_version": 1} {}`},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "document.json")
+			if err := os.WriteFile(path, []byte(test.contents), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			var document struct {
+				SchemaVersion int `json:"schema_version"`
+			}
+			if err := readJSON(path, &document); err == nil {
+				t.Error("accepted ambiguous JSON document")
+			}
+		})
+	}
+}
+
+func TestDeclaresTestRequiresTypeScriptCall(t *testing.T) {
+	tests := []struct {
+		name     string
+		contents string
+		want     bool
+	}{
+		{name: "single quoted call", contents: "  it('records evidence', () => {})", want: true},
+		{name: "double quoted call", contents: `it("records evidence", () => {})`, want: true},
+		{name: "comment", contents: "// it('records evidence', () => {})", want: false},
+		{name: "disabled alias", contents: "xit('records evidence', () => {})", want: false},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := declaresTest("ts", []byte(test.contents), "records evidence"); got != test.want {
+				t.Errorf("declaresTest() = %t, want %t", got, test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Inventory all 759 Python tests at the active parity target, closing #44 (WP1 item: "Inventory all 759 tests at the target SHA and map every case to case-specific Go, cross-layer, or retained-host evidence").

**Stacked on #43** (base: `wp1-parity-contract`) — the inventory identity is anchored in `parity-contract.json`.

- `test/conformance/parity-inventory.json` (generated): all 759 cases at target SHA `f2ec1f7` with file/name/line. The 622 frozen Oracle cases inherit their `traceability.json` mappings **verbatim** (status `mapped`); each of the 137 delta cases carries a deliberate mode — `go-port` (71), `retained-host` (61), `cross-layer` (5) — with status `pending` until the owning port lands (e.g. WP2 for the 21-case transport surface).
- `tools/parity-inventory-generate`: verifies the upstream checkout sits exactly at the contract target SHA via `git rev-parse HEAD`, extracts cases from `tests/` + `integrations/` + `e2e/` (the repository's own counting convention), merges frozen mappings with `parity-inventory-rules.json`, resolves every evidence reference against real test declarations, and emits deterministic output.
- `test/conformance/parity_inventory_test.go`: fails on target/Oracle identity drift vs `parity-contract.json`, count drift, lost or altered frozen mappings, mapped entries without resolvable evidence, pending entries carrying evidence, invalid modes, or moved mapped/pending counts.
- `parity-inventory-rules.json`: per-file mode assignment with a written reason for every delta area (WP2 transport, setup/doctor CLI, Hermes, LangChain, Pydantic AI, WorkBuddy, Bub trust).
- CI: the `frozen-oracle` job now also checks out the active parity target (identity-verified) and runs `parity-inventory-generate -check`, so the committed inventory is proven byte-for-byte reproducible from the true upstream on every PR. The parity contract workflow guard from #43 is extended to the new checkout.

## Why pending is explicit rather than silently unmapped

The measured delta (verified against a local upstream checkout): 137 new cases, 0 removed. Almost none of these areas have Go-side or retained-host evidence in this repository yet — `tests/test_transport.py` *is* the WP2 surface (#5). The inventory therefore records each delta case's owning mode and pins the 622/137 mapped/pending split; parity progress becomes a reviewed rules diff that moves cases from `pending` to `mapped` instead of an untracked discussion.

## Negative proof

The drift test was demonstrated to catch all three drift classes: dropping a case (count mismatch), flipping `pending`→`mapped` without evidence, and altering a frozen case's inherited mode — each fails with a precise message, and the restored inventory passes. The generator was also verified to reject an upstream checkout at any commit other than the contract target.

## Validation

Run with the local Go 1.27 toolchain on the exact PR head:

- `go run ./tools/parity-inventory-generate -upstream ../powercontext` then `-check` — byte-identical regeneration
- `go test -count=1 ./test/conformance/` — ok (full suite)
- `go vet ./test/conformance/ ./tools/parity-inventory-generate/` — clean
- `make license-check` — 784 valid, 0 invalid
- `actionlint` — no findings
- `git diff --check` — clean
