### PR TITLE
fix: harden transport policy diagnostics and CLI overrides

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -234,10 +234,14 @@ source / artifact / trigger / inference
   the final RoundTripper. Verify an unsafe override fails before the underlying
   transport runs, and allow an HTTP-labelled non-loopback route only when the
   caller supplies the client and explicitly vouches for transport security.
+  Return a typed refusal that preserves configuration-error matching, names the
+  non-loopback policy, and never includes the rejected URL in its representations.
 - When a cross-field security policy depends on environment values plus CLI
-  overrides, merge every explicit override before the final validation. Verify
-  both directions: a safe override repairs an unsafe environment value, and an
-  unsafe override cannot replace a safe environment value without failing.
+  overrides, preserve whether each override was explicitly present, reject
+  explicit blank values as operator input, and merge valid overrides before the
+  final validation. Verify both directions: a safe override repairs an unsafe
+  environment value, and an unsafe override cannot replace a safe environment
+  value without failing.
 - When isolated host adapters vendor the same transport policy, drive every
   configuration and directly constructible client boundary from one shared
   host-vector fixture. Verify the complete IPv4 `127.0.0.0/8` range, IPv6

--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ front of the Server; controlled networks or deployments with upstream TLS may
 instead opt in explicitly with
 `POWERCONTEXT_SERVER_ALLOW_UNAUTHENTICATED_NON_LOOPBACK=true`.
 
+The Go Client likewise rejects plaintext HTTP to a non-loopback Server unless
+the caller supplies its own `http.Client` and explicitly sets
+`TrustTransportSecurity` for a separately secured transport.
+
 Useful verification targets:
 
 ```sh

--- a/client/client.go
+++ b/client/client.go
@@ -98,7 +98,7 @@ func New(serverURL string, options Options) (*Client, error) {
 		return nil, err
 	}
 	if !options.trustsTransportSecurity() && transportpolicy.IsPlaintextNonLoopback(endpoint) {
-		return nil, &ConfigurationError{Field: "server_url"}
+		return nil, &PlaintextNonLoopbackError{}
 	}
 	transport, err := clientTransport(options)
 	if err != nil {
@@ -142,6 +142,23 @@ func (e *ConfigurationError) GoString() string {
 		return "(*client.ConfigurationError)(nil)"
 	}
 	return fmt.Sprintf("&client.ConfigurationError{Field:%q}", e.Field)
+}
+
+// PlaintextNonLoopbackError reports that the Client refused plaintext HTTP to
+// a non-loopback host. It excludes the rejected URL from every representation
+// and unwraps to ConfigurationError for compatibility with existing callers.
+type PlaintextNonLoopbackError struct{}
+
+func (*PlaintextNonLoopbackError) Error() string {
+	return "PowerContext Client refuses plaintext HTTP to a non-loopback host without an explicit secure-transport vouch"
+}
+
+func (*PlaintextNonLoopbackError) GoString() string {
+	return "&client.PlaintextNonLoopbackError{}"
+}
+
+func (*PlaintextNonLoopbackError) Unwrap() error {
+	return &ConfigurationError{Field: "server_url"}
 }
 
 type bearerSource struct{ token string }
@@ -205,7 +222,7 @@ type transportPolicyRoundTripper struct {
 
 func (t transportPolicyRoundTripper) RoundTrip(request *http.Request) (*http.Response, error) {
 	if !t.trusted && transportpolicy.IsPlaintextNonLoopback(request.URL) {
-		return nil, &ConfigurationError{Field: "server_url"}
+		return nil, &PlaintextNonLoopbackError{}
 	}
 	return t.next.RoundTrip(request)
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -253,6 +253,28 @@ func TestClientTrustOverrideRequiresCallerTransport(t *testing.T) {
 	}
 }
 
+func TestClientPlaintextNonLoopbackErrorNamesPolicyWithoutLeakingURL(t *testing.T) {
+	t.Parallel()
+	const rejectedHost = "private-memory.example"
+	_, err := New("http://"+rejectedHost, Options{BearerToken: "probe-token"})
+	if err == nil {
+		t.Fatal("New() accepted plaintext HTTP to a non-loopback host")
+	}
+	if _, ok := errors.AsType[*PlaintextNonLoopbackError](err); !ok {
+		t.Fatalf("New() error = %T %v, want PlaintextNonLoopbackError", err, err)
+	}
+	if !IsConfigurationError(err) {
+		t.Fatalf("IsConfigurationError(%T) = false, want compatibility with configuration errors", err)
+	}
+	rendered := fmt.Sprintf("%v\n%#v", err, err)
+	if !strings.Contains(rendered, "non-loopback") {
+		t.Fatalf("refusal = %q, want the upstream policy token", rendered)
+	}
+	if strings.Contains(rendered, rejectedHost) {
+		t.Fatalf("refusal leaked the rejected host: %q", rendered)
+	}
+}
+
 func TestClientAllowsExplicitlyTrustedCallerTransport(t *testing.T) {
 	t.Parallel()
 	client, err := New("http://memory.example", Options{
@@ -288,6 +310,9 @@ func TestClientRejectsPlaintextNonLoopbackPerRequestOverride(t *testing.T) {
 	_, err = client.GetCapabilities(v1.WithServerURL(t.Context(), override))
 	if err == nil || !IsConfigurationError(err) {
 		t.Fatalf("GetCapabilities() error = %v, want configuration error", err)
+	}
+	if _, ok := errors.AsType[*PlaintextNonLoopbackError](err); !ok {
+		t.Fatalf("GetCapabilities() error = %T %v, want PlaintextNonLoopbackError", err, err)
 	}
 	if requests != 0 {
 		t.Fatalf("requests = %d, want 0", requests)

--- a/internal/cli/python_contract_test.go
+++ b/internal/cli/python_contract_test.go
@@ -236,6 +236,28 @@ func TestServerCommandRejectsUnauthenticatedNonLoopbackHostOverride(t *testing.T
 	}
 }
 
+func TestServerCommandRejectsBlankHostOverride(t *testing.T) {
+	for _, host := range []string{"", " "} {
+		t.Run(fmt.Sprintf("host=%q", host), func(t *testing.T) {
+			called := false
+			runner := func(context.Context, *commandState, server.ProcessConfig) error {
+				called = true
+				return nil
+			}
+			var stdout, stderr bytes.Buffer
+			command := newCommandWithDependencies(VersionInfo{Version: "test"}, &stdout, &stderr, nil, runner)
+			command.SetArgs([]string{"server", "run", "--host", host})
+			err := command.ExecuteContext(context.Background())
+			if err == nil || ExitCode(err) != 2 {
+				t.Fatalf("server run --host error = %v, exit = %d, want usage failure", err, ExitCode(err))
+			}
+			if called {
+				t.Fatal("server runner was called for a blank host")
+			}
+		})
+	}
+}
+
 func TestServerCommandLoopbackOverrideRepairsUnsafeEnvironment(t *testing.T) {
 	t.Setenv("POWERCONTEXT_SERVER_HTTP_HOST", "0.0.0.0")
 	t.Setenv("POWERCONTEXT_SERVER_AUTH_ENABLED", "false")

--- a/internal/cli/server_command.go
+++ b/internal/cli/server_command.go
@@ -21,6 +21,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -46,6 +47,10 @@ func newServerRunCommand(state *commandState) *cobra.Command {
 		RunE: func(command *cobra.Command, _ []string) error {
 			override := server.HTTPConfigOverride{}
 			if command.Flags().Changed("host") {
+				trimmedHost := strings.TrimSpace(host)
+				if trimmedHost == "" || host != trimmedHost {
+					return usageError(errors.New("server: --host must be a non-empty trimmed value"))
+				}
 				override.Host = new(host)
 			}
 			if command.Flags().Changed("port") {


### PR DESCRIPTION
## Tracking

- Tracking issue: #5
- Relationship: `Part of #5`

## Problem and rationale

The core Client, Server, Docker, and retained-adapter transport policies have now landed independently through #48, #51, and #54. This PR was rebuilt on the current `main` so it no longer duplicates or replaces those implementations.

Two observable gaps remained:

- Client plaintext non-loopback refusals were exposed only as a generic `ConfigurationError`, losing the upstream `non-loopback` policy token and a dedicated error identity.
- `server run --host ""` treated an explicit empty value as if the flag were absent; a whitespace-only host surfaced as an ordinary process error instead of a CLI usage error.

## Changes

- add `client.PlaintextNonLoopbackError` for constructor and per-request URL-override refusals;
- keep `client.IsConfigurationError` compatibility through error unwrapping;
- keep every error representation free of the rejected URL while naming the `non-loopback` policy;
- reject explicit empty, whitespace-only, and surrounding-whitespace `--host` values as usage errors before configuration construction;
- document the caller-owned `http.Client` plus `TrustTransportSecurity` migration path;
- strengthen the reusable Client-error and explicit-override prevention rules.

## Behavior and compatibility

- Existing callers using `client.IsConfigurationError` continue to match the refusal.
- Callers may additionally use `errors.AsType[*client.PlaintextNonLoopbackError]`.
- No OpenAPI, wire, persistence, authentication, Docker, generated-contract, dependency, or retained-adapter implementation changes are included.

## Regression proof

- Before the Client fix, the new constructor test failed to compile because `PlaintextNonLoopbackError` did not exist.
- With the final RoundTripper temporarily returning the generic error, the per-request override test failed because the wrapped error did not contain `PlaintextNonLoopbackError`; restoring the typed refusal turned it green.
- Before the CLI fix, `--host ""` returned exit 0 and whitespace-only input returned exit 1; both now return usage exit 2 without invoking the Server runner.

## Validation

Submitted Head local evidence:

- `go test -count=1 ./client` — passed.
- `git diff --check origin/main...HEAD` — clean.

Additional pre-push validation of the same changed paths included complete `client` and `internal/cli` packages, focused Server/shared transport packages, targeted race tests, full vet, gofmt, license (790 valid, 0 invalid), strict docs build, and downstream public-consumer build/test. Pinned local golangci-lint reported zero findings but did not complete successfully because Windows lacked CGO typechecking and the WSL run reached its timeout; exact-Head CI is the authoritative lint result.

## AI usage

OpenAI Codex performed the rebase reconciliation, review, regression tests, and repairs. The final diff was checked against the fixed upstream target and the implementations already merged through #48, #51, and #54.