### PR TITLE
fix(client): enforce shared loopback transport policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -222,3 +222,8 @@ source / artifact / trigger / inference
 - When a Go function retains an outer error value, do not redeclare `err` in a
   nested short declaration. Use operation-specific names and verify the change
   with the pinned `make lint` policy, including `govet` shadow analysis.
+- When a Client supports per-request endpoint overrides or caller-supplied HTTP
+  clients, enforce the plaintext loopback policy both at construction and in
+  the final RoundTripper. Verify an unsafe override fails before the underlying
+  transport runs, and allow an HTTP-labelled non-loopback route only when the
+  caller supplies the client and explicitly vouches for transport security.

--- a/client/client.go
+++ b/client/client.go
@@ -33,6 +33,7 @@ import (
 
 	v1 "github.com/ob-labs/powercontext-go/api/v1"
 	requesttrace "github.com/ob-labs/powercontext-go/internal/observability/tracing"
+	"github.com/ob-labs/powercontext-go/internal/transportpolicy"
 )
 
 const DefaultTimeout = 10 * time.Second
@@ -41,21 +42,30 @@ const DefaultTimeout = 10 * time.Second
 // generated-client errors. A caller-supplied HTTP client is shallow-cloned and
 // is never mutated.
 type Options struct {
-	BearerToken    string               `json:"-"`
-	Timeout        time.Duration        `json:"timeout"`
-	HTTPClient     *http.Client         `json:"-"`
-	TracerProvider trace.TracerProvider `json:"-"`
-	MeterProvider  metric.MeterProvider `json:"-"`
+	BearerToken string        `json:"-"`
+	Timeout     time.Duration `json:"timeout"`
+	HTTPClient  *http.Client  `json:"-"`
+	// TrustTransportSecurity permits a caller-supplied HTTPClient to use an
+	// http:// label only when its transport is secured outside ordinary TCP,
+	// such as an in-process handler, Unix socket, or TLS-terminating proxy.
+	TrustTransportSecurity bool                 `json:"trust_transport_security"`
+	TracerProvider         trace.TracerProvider `json:"-"`
+	MeterProvider          metric.MeterProvider `json:"-"`
 }
 
 func (o Options) String() string   { return o.redactedString() }
 func (o Options) GoString() string { return o.redactedString() }
+
+func (o Options) trustsTransportSecurity() bool {
+	return o.HTTPClient != nil && o.TrustTransportSecurity
+}
 
 func (o Options) LogValue() slog.Value {
 	return slog.GroupValue(
 		slog.Bool("token_configured", o.BearerToken != ""),
 		slog.Duration("timeout", o.Timeout),
 		slog.Bool("http_client_configured", o.HTTPClient != nil),
+		slog.Bool("trust_transport_security", o.TrustTransportSecurity),
 		slog.Bool("tracer_provider_configured", o.TracerProvider != nil),
 		slog.Bool("meter_provider_configured", o.MeterProvider != nil),
 	)
@@ -63,8 +73,9 @@ func (o Options) LogValue() slog.Value {
 
 func (o Options) redactedString() string {
 	return fmt.Sprintf(
-		"client.Options{token_configured:%t, timeout:%s, http_client_configured:%t, tracer_provider_configured:%t, meter_provider_configured:%t}",
-		o.BearerToken != "", o.Timeout, o.HTTPClient != nil, o.TracerProvider != nil, o.MeterProvider != nil,
+		"client.Options{token_configured:%t, timeout:%s, http_client_configured:%t, trust_transport_security:%t, tracer_provider_configured:%t, meter_provider_configured:%t}",
+		o.BearerToken != "", o.Timeout, o.HTTPClient != nil, o.TrustTransportSecurity,
+		o.TracerProvider != nil, o.MeterProvider != nil,
 	)
 }
 
@@ -82,9 +93,12 @@ var _ v1.Invoker = (*Client)(nil)
 // Server URLs may contain a path prefix but never credentials, query values, or
 // fragments.
 func New(serverURL string, options Options) (*Client, error) {
-	normalized, err := normalizeServerURL(serverURL)
+	endpoint, err := normalizeServerURL(serverURL)
 	if err != nil {
 		return nil, err
+	}
+	if !options.trustsTransportSecurity() && transportpolicy.IsPlaintextNonLoopback(endpoint) {
+		return nil, &ConfigurationError{Field: "server_url"}
 	}
 	transport, err := clientTransport(options)
 	if err != nil {
@@ -95,7 +109,7 @@ func New(serverURL string, options Options) (*Client, error) {
 	if options.MeterProvider != nil {
 		generatedOptions = append(generatedOptions, v1.WithMeterProvider(options.MeterProvider))
 	}
-	raw, err := v1.NewClient(normalized, bearerSource{token: options.BearerToken}, generatedOptions...)
+	raw, err := v1.NewClient(endpoint.String(), bearerSource{token: options.BearerToken}, generatedOptions...)
 	if err != nil {
 		return nil, &ConfigurationError{Field: "server_url"}
 	}
@@ -139,23 +153,23 @@ func (s bearerSource) BearerAuth(context.Context, v1.OperationName) (v1.BearerAu
 	return v1.BearerAuth{Token: s.token}, nil
 }
 
-func normalizeServerURL(value string) (string, error) {
+func normalizeServerURL(value string) (*url.URL, error) {
 	if strings.TrimSpace(value) == "" {
-		return "", &ConfigurationError{Field: "server_url"}
+		return nil, &ConfigurationError{Field: "server_url"}
 	}
 	parsed, err := url.Parse(value)
 	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
-		return "", &ConfigurationError{Field: "server_url"}
+		return nil, &ConfigurationError{Field: "server_url"}
 	}
 	if parsed.Scheme != "http" && parsed.Scheme != "https" {
-		return "", &ConfigurationError{Field: "server_url"}
+		return nil, &ConfigurationError{Field: "server_url"}
 	}
 	if parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" {
-		return "", &ConfigurationError{Field: "server_url"}
+		return nil, &ConfigurationError{Field: "server_url"}
 	}
 	parsed.Path = strings.TrimRight(parsed.Path, "/")
 	parsed.RawPath = strings.TrimRight(parsed.RawPath, "/")
-	return parsed.String(), nil
+	return parsed, nil
 }
 
 func clientTransport(options Options) (*http.Client, error) {
@@ -178,7 +192,22 @@ func clientTransport(options Options) (*http.Client, error) {
 		result.Transport = http.DefaultTransport
 	}
 	result.Transport = traceContextRoundTripper{next: result.Transport}
+	result.Transport = transportPolicyRoundTripper{
+		next: result.Transport, trusted: options.trustsTransportSecurity(),
+	}
 	return &result, nil
+}
+
+type transportPolicyRoundTripper struct {
+	next    http.RoundTripper
+	trusted bool
+}
+
+func (t transportPolicyRoundTripper) RoundTrip(request *http.Request) (*http.Response, error) {
+	if !t.trusted && transportpolicy.IsPlaintextNonLoopback(request.URL) {
+		return nil, &ConfigurationError{Field: "server_url"}
+	}
+	return t.next.RoundTrip(request)
 }
 
 type traceContextRoundTripper struct{ next http.RoundTripper }
@@ -402,6 +431,6 @@ func decodeDetails(value v1.NilErrorDetailDetails) map[string]any {
 // IsConfigurationError reports configuration failures without requiring users
 // to import generated transport packages.
 func IsConfigurationError(err error) bool {
-	var target *ConfigurationError
-	return errors.As(err, &target)
+	_, ok := errors.AsType[*ConfigurationError](err)
+	return ok
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -46,7 +47,7 @@ func repeatValue[T any](value T, count int) []T {
 
 func TestClientRejectsUndeclaredSuccessStatus(t *testing.T) {
 	t.Parallel()
-	client, err := New("http://powercontext.test", Options{HTTPClient: &http.Client{
+	client, err := New("https://powercontext.test", Options{HTTPClient: &http.Client{
 		Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
 			return response(http.StatusOK, `{"status":"accepted","source":{"name":"content","source_id":"turn-1"},"position":1}`), nil
 		}),
@@ -69,7 +70,7 @@ func TestClientRejectsUndeclaredSuccessStatus(t *testing.T) {
 func TestClientValidatesRequestsBeforeTransport(t *testing.T) {
 	t.Parallel()
 	transportCalled := false
-	client, err := New("http://powercontext.test", Options{HTTPClient: &http.Client{
+	client, err := New("https://powercontext.test", Options{HTTPClient: &http.Client{
 		Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
 			transportCalled = true
 			return response(http.StatusInternalServerError, ""), nil
@@ -107,7 +108,7 @@ func TestClientValidatesRequestsBeforeTransport(t *testing.T) {
 func TestClientRejectsCombinedCandidateEvidenceBeforeTransport(t *testing.T) {
 	t.Parallel()
 	transportCalled := false
-	client, err := New("http://powercontext.test", Options{HTTPClient: &http.Client{
+	client, err := New("https://powercontext.test", Options{HTTPClient: &http.Client{
 		Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
 			transportCalled = true
 			return response(http.StatusCreated, `{}`), nil
@@ -157,7 +158,7 @@ func TestClientRejectsCombinedCandidateEvidenceInSuccessResponse(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	client, err := New("http://powercontext.test", Options{HTTPClient: &http.Client{
+	client, err := New("https://powercontext.test", Options{HTTPClient: &http.Client{
 		Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
 			result := response(http.StatusCreated, string(payload))
 			result.Header.Set(requestIDHeader, "0123456789abcdef")
@@ -190,7 +191,7 @@ func TestClientRejectsCombinedCandidateEvidenceInSuccessResponse(t *testing.T) {
 
 func TestClientPreservesDeclaredServerErrorContext(t *testing.T) {
 	t.Parallel()
-	client, err := New("http://powercontext.test", Options{HTTPClient: &http.Client{
+	client, err := New("https://powercontext.test", Options{HTTPClient: &http.Client{
 		Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
 			result := response(http.StatusServiceUnavailable, `{"error":{"code":"runtime_not_ready","message":"The Runtime is not ready.","details":{"component":"memory"}}}`)
 			result.Header.Set(requestIDHeader, "request-123")
@@ -215,6 +216,84 @@ func TestClientPreservesDeclaredServerErrorContext(t *testing.T) {
 	}
 }
 
+func TestClientRejectsPlaintextNonLoopbackByDefault(t *testing.T) {
+	t.Parallel()
+	callerTransport := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return response(http.StatusOK, capabilitiesJSON), nil
+	})}
+	for _, test := range []struct {
+		name    string
+		options Options
+	}{
+		{name: "owned transport without token"},
+		{name: "owned transport with token", options: Options{BearerToken: "probe-token"}},
+		{name: "caller transport without token", options: Options{HTTPClient: callerTransport}},
+		{
+			name: "caller transport with token",
+			options: Options{
+				BearerToken: "probe-token",
+				HTTPClient:  callerTransport,
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := New("http://memory.example", test.options)
+			if err == nil || !IsConfigurationError(err) {
+				t.Fatalf("New() error = %v, want configuration error", err)
+			}
+		})
+	}
+}
+
+func TestClientTrustOverrideRequiresCallerTransport(t *testing.T) {
+	t.Parallel()
+	_, err := New("http://memory.example", Options{TrustTransportSecurity: true})
+	if err == nil || !IsConfigurationError(err) {
+		t.Fatalf("New() error = %v, want configuration error", err)
+	}
+}
+
+func TestClientAllowsExplicitlyTrustedCallerTransport(t *testing.T) {
+	t.Parallel()
+	client, err := New("http://memory.example", Options{
+		HTTPClient: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return response(http.StatusOK, capabilitiesJSON), nil
+		})},
+		TrustTransportSecurity: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.GetCapabilities(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestClientRejectsPlaintextNonLoopbackPerRequestOverride(t *testing.T) {
+	t.Parallel()
+	requests := 0
+	client, err := New("https://powercontext.test", Options{
+		HTTPClient: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			requests++
+			return response(http.StatusOK, capabilitiesJSON), nil
+		})},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	override, err := url.Parse("http://memory.example")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = client.GetCapabilities(v1.WithServerURL(t.Context(), override))
+	if err == nil || !IsConfigurationError(err) {
+		t.Fatalf("GetCapabilities() error = %v, want configuration error", err)
+	}
+	if requests != 0 {
+		t.Fatalf("requests = %d, want 0", requests)
+	}
+}
+
 func TestClientSendsBearerAndPreservesCallerHTTPClient(t *testing.T) {
 	t.Parallel()
 	var authorization string
@@ -222,7 +301,7 @@ func TestClientSendsBearerAndPreservesCallerHTTPClient(t *testing.T) {
 		authorization = request.Header.Get("Authorization")
 		return response(http.StatusOK, capabilitiesJSON), nil
 	})}
-	client, err := New("http://powercontext.test/root/", Options{
+	client, err := New("https://powercontext.test/root/", Options{
 		BearerToken: "server-secret", HTTPClient: original,
 	})
 	if err != nil {
@@ -246,7 +325,7 @@ func TestClientSendsBearerAndPreservesCallerHTTPClient(t *testing.T) {
 func TestClientWithoutTokenOmitsAuthorization(t *testing.T) {
 	t.Parallel()
 	var authorizationPresent bool
-	client, err := New("http://powercontext.test", Options{HTTPClient: &http.Client{
+	client, err := New("https://powercontext.test", Options{HTTPClient: &http.Client{
 		Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
 			_, authorizationPresent = request.Header["Authorization"]
 			return response(http.StatusOK, capabilitiesJSON), nil
@@ -265,7 +344,7 @@ func TestClientWithoutTokenOmitsAuthorization(t *testing.T) {
 
 func TestClientKeepsGenericServerErrorForInvalidErrorBody(t *testing.T) {
 	t.Parallel()
-	client, err := New("http://powercontext.test", Options{HTTPClient: &http.Client{
+	client, err := New("https://powercontext.test", Options{HTTPClient: &http.Client{
 		Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
 			result := response(http.StatusInternalServerError, "Internal Server Error")
 			result.Header.Set("Content-Type", "text/plain")
@@ -287,7 +366,7 @@ func TestClientKeepsGenericServerErrorForInvalidErrorBody(t *testing.T) {
 
 func TestClientRejectsInvalidSuccessResponse(t *testing.T) {
 	t.Parallel()
-	client, err := New("http://powercontext.test", Options{HTTPClient: &http.Client{
+	client, err := New("https://powercontext.test", Options{HTTPClient: &http.Client{
 		Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
 			result := response(http.StatusOK, `{"status":"ok","unexpected":true}`)
 			result.Header.Set(requestIDHeader, "request-123")
@@ -310,7 +389,7 @@ func TestClientRejectsInvalidSuccessResponse(t *testing.T) {
 func TestClientWrapsHTTPTransportFailure(t *testing.T) {
 	t.Parallel()
 	connectionError := errors.New("connection refused")
-	client, err := New("http://powercontext.test", Options{HTTPClient: &http.Client{
+	client, err := New("https://powercontext.test", Options{HTTPClient: &http.Client{
 		Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
 			return nil, connectionError
 		}),
@@ -331,7 +410,7 @@ func TestClientWrapsHTTPTransportFailure(t *testing.T) {
 func TestClientRendersAndDownloadsHandoffReportWithoutMutatingRequest(t *testing.T) {
 	t.Parallel()
 	var downloadFlags []bool
-	client, err := New("http://powercontext.test", Options{HTTPClient: &http.Client{
+	client, err := New("https://powercontext.test", Options{HTTPClient: &http.Client{
 		Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
 			body, readErr := io.ReadAll(request.Body)
 			if readErr != nil {
@@ -376,7 +455,7 @@ func TestClientDownloadPreservesCanonicalJSONBytes(t *testing.T) {
 	t.Parallel()
 	digest := "sha256:" + strings.Repeat("a", 64)
 	canonical := []byte(`{"format":"json","report":{},"markdown":null,"selection_digest":"` + digest + `","report_digest":"` + digest + `"}`)
-	client, err := New("http://powercontext.test", Options{HTTPClient: &http.Client{
+	client, err := New("https://powercontext.test", Options{HTTPClient: &http.Client{
 		Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
 			return response(http.StatusOK, string(canonical)), nil
 		}),
@@ -407,7 +486,7 @@ func TestClientSpanInjectsW3CTraceContext(t *testing.T) {
 		traceparent = request.Header.Get("traceparent")
 		return response(http.StatusOK, capabilitiesJSON), nil
 	})
-	client, err := New("http://powercontext.test", Options{
+	client, err := New("https://powercontext.test", Options{
 		HTTPClient: &http.Client{Transport: transport}, TracerProvider: provider,
 	})
 	if err != nil {
@@ -449,7 +528,7 @@ func TestClientRejectsRedirects(t *testing.T) {
 			return nil
 		},
 	}
-	client, err := New("http://powercontext.test", Options{HTTPClient: original})
+	client, err := New("https://powercontext.test", Options{HTTPClient: original})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/cli/python_contract_test.go
+++ b/internal/cli/python_contract_test.go
@@ -99,7 +99,7 @@ func TestCLIVersionReportsBuildVersion(t *testing.T) {
 }
 
 func TestCLIClientSettingsLoadEnvironmentAndExplicitURLOverride(t *testing.T) {
-	t.Setenv(clientURLVar, "http://memory.example/api/")
+	t.Setenv(clientURLVar, "https://memory.example/api/")
 	t.Setenv(clientTimeoutVar, "3.5")
 	t.Setenv(clientTokenVar, "")
 	var URLs []string
@@ -114,10 +114,10 @@ func TestCLIClientSettingsLoadEnvironmentAndExplicitURLOverride(t *testing.T) {
 	if _, _, err := executeContractCLI(t, httpClient, "live"); err != nil {
 		t.Fatal(err)
 	}
-	if _, _, err := executeContractCLI(t, httpClient, "--server-url", "http://override.example/root/", "live"); err != nil {
+	if _, _, err := executeContractCLI(t, httpClient, "--server-url", "https://override.example/root/", "live"); err != nil {
 		t.Fatal(err)
 	}
-	if fmt.Sprint(URLs) != "[http://memory.example/api/health/live http://override.example/root/health/live]" {
+	if fmt.Sprint(URLs) != "[https://memory.example/api/health/live https://override.example/root/health/live]" {
 		t.Fatalf("request URLs = %v", URLs)
 	}
 	if len(deadlineRemaining) != 2 {
@@ -143,7 +143,7 @@ func TestCLIClientSettingsRejectInvalidEnvironment(t *testing.T) {
 		}
 	})
 	t.Run("timeout", func(t *testing.T) {
-		t.Setenv(clientURLVar, "http://powercontext.test")
+		t.Setenv(clientURLVar, "https://powercontext.test")
 		t.Setenv(clientTimeoutVar, "0")
 		_, _, err := executeContractCLI(t, nil, "live")
 		if err == nil || err.Error() != "invalid POWERCONTEXT_CLIENT_TIMEOUT" {
@@ -164,7 +164,7 @@ func TestCLITimeoutFlagAcceptsSecondsAndGoDuration(t *testing.T) {
 	})}
 	for _, value := range []string{"3.5", "3500ms"} {
 		if _, _, err := executeContractCLI(t, httpClient,
-			"--server-url", "http://powercontext.test", "--timeout", value, "live"); err != nil {
+			"--server-url", "https://powercontext.test", "--timeout", value, "live"); err != nil {
 			t.Fatalf("--timeout %s: %v", value, err)
 		}
 	}
@@ -174,7 +174,7 @@ func TestCLITimeoutFlagAcceptsSecondsAndGoDuration(t *testing.T) {
 		}
 	}
 	for _, arguments := range [][]string{
-		{"--server-url", "http://powercontext.test", "--timeout", "NaN", "live"},
+		{"--server-url", "https://powercontext.test", "--timeout", "NaN", "live"},
 		{"--server-url", "", "live"},
 	} {
 		_, _, err := executeContractCLI(t, nil, arguments...)
@@ -242,7 +242,7 @@ func TestCLIReportsServerErrorWithRequestContext(t *testing.T) {
 		writer.WriteHeader(http.StatusServiceUnavailable)
 		_, _ = writer.Write([]byte("Service Unavailable"))
 	})
-	_, _, err := executeContractCLI(t, httpClient, "--server-url", "http://powercontext.test", "ready")
+	_, _, err := executeContractCLI(t, httpClient, "--server-url", "https://powercontext.test", "ready")
 	if err == nil || err.Error() != "PowerContext Server returned HTTP 503 (request ID: request-123)" {
 		t.Fatalf("error = %v", err)
 	}
@@ -253,7 +253,7 @@ func TestCLIPrintsHumanLivenessByDefault(t *testing.T) {
 		writer.Header().Set("Content-Type", "application/json")
 		_, _ = writer.Write([]byte(`{"status":"ok"}`))
 	})
-	stdout, _, err := executeContractCLI(t, httpClient, "--server-url", "http://powercontext.test", "live")
+	stdout, _, err := executeContractCLI(t, httpClient, "--server-url", "https://powercontext.test", "live")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -270,7 +270,7 @@ func TestStatsCommandBuildsRequestAndPrintsSummary(t *testing.T) {
 		_, _ = writer.Write([]byte(scopedStatsJSON))
 	})
 	stdout, _, err := executeContractCLI(t, httpClient,
-		"--server-url", "http://powercontext.test", "stats", "--scope-id", "project", "--period", "today")
+		"--server-url", "https://powercontext.test", "stats", "--scope-id", "project", "--period", "today")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -311,13 +311,13 @@ func TestCLIGenerationCommandsBuildTypedRequests(t *testing.T) {
 		_, _ = writer.Write([]byte(generatedNoOpJSON))
 	})
 	if _, _, err := executeContractCLI(t, httpClient,
-		"--server-url", "http://powercontext.test", "--json", "experience", "generate",
+		"--server-url", "https://powercontext.test", "--json", "experience", "generate",
 		"--scope-id", "project", "--source-ref", "content/task-1", "--source-ref", "content/task-2",
 		"--target", "experience/exp-1@2", "--reason", "incorporate the latest result"); err != nil {
 		t.Fatal(err)
 	}
 	if _, _, err := executeContractCLI(t, httpClient,
-		"--server-url", "http://powercontext.test", "--json", "skill", "generate",
+		"--server-url", "https://powercontext.test", "--json", "skill", "generate",
 		"--scope-id", "project", "--origin", "experience", "--artifact-ref", "experience/exp-2@1"); err != nil {
 		t.Fatal(err)
 	}
@@ -349,14 +349,14 @@ func TestCLICandidateRevisionCommandsBuildTypedProposals(t *testing.T) {
 		t.Fatal(err)
 	}
 	if _, _, err := executeContractCLI(t, httpClient,
-		"--server-url", "http://powercontext.test", "candidate", "revise", "experience",
+		"--server-url", "https://powercontext.test", "candidate", "revise", "experience",
 		"--scope-id", "project", "--expected-version", "1", "--situation", "Only one backend was tested.",
 		"--action", "Run the same scenario on both backends.", "--outcome", "Both backends passed.",
 		"--lesson", "Keep acceptance behavior backend-neutral.", "--source-ref", "content/task-1", "candidate-experience"); err != nil {
 		t.Fatal(err)
 	}
 	if _, _, err := executeContractCLI(t, httpClient,
-		"--server-url", "http://powercontext.test", "candidate", "revise", "skill",
+		"--server-url", "https://powercontext.test", "candidate", "revise", "skill",
 		"--scope-id", "project", "--expected-version", "2", "--name", "backend-validation",
 		"--description", "Validate storage backends consistently.", "--instructions-file", instructions,
 		"--validation", "SQLite passes.", "--validation", "OceanBase passes.",
@@ -434,7 +434,7 @@ func TestCLICandidateLifecycleCommandsBuildTypedRequests(t *testing.T) {
 	}
 	for _, arguments := range commands {
 		stdout, _, err := executeContractCLI(
-			t, httpClient, append([]string{"--server-url", "http://powercontext.test"}, arguments...)...,
+			t, httpClient, append([]string{"--server-url", "https://powercontext.test"}, arguments...)...,
 		)
 		if err != nil {
 			t.Fatalf("powercontext %v: %v", arguments, err)
@@ -489,7 +489,7 @@ func TestCLIExternalSkillImportPreservesIdentityAndIntent(t *testing.T) {
 	})
 	fingerprint := strings.Repeat("a", 64)
 	if _, _, err := executeContractCLI(t, httpClient,
-		"--server-url", "http://powercontext.test", "external-skill", "import", "--scope-id", "project",
+		"--server-url", "https://powercontext.test", "external-skill", "import", "--scope-id", "project",
 		"--fingerprint", fingerprint, "--mode", "fork", "codex:project:repository/friendly-python"); err != nil {
 		t.Fatal(err)
 	}
@@ -506,7 +506,7 @@ func TestCLIMapsOpenAPIRequestValidationToUsage(t *testing.T) {
 		return responseForCLI(request, http.StatusInternalServerError, ""), nil
 	})}
 	_, _, err := executeContractCLI(t, httpClient,
-		"--server-url", "http://powercontext.test", "external-skill", "import",
+		"--server-url", "https://powercontext.test", "external-skill", "import",
 		"--scope-id", "project", "--fingerprint", "too-short", "external-skill-id")
 	if err == nil || ExitCode(err) != 2 {
 		t.Fatalf("error = %v, exit = %d", err, ExitCode(err))
@@ -517,7 +517,7 @@ func TestCLIMapsOpenAPIRequestValidationToUsage(t *testing.T) {
 }
 
 func TestCLISkillExportUsesConfiguredAuthentication(t *testing.T) {
-	t.Setenv(clientURLVar, "http://powercontext.test")
+	t.Setenv(clientURLVar, "https://powercontext.test")
 	t.Setenv(clientTokenVar, "secret-token")
 	t.Setenv(clientTimeoutVar, "10")
 	var authorization string

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -59,7 +59,7 @@ func TestCapabilitiesUsesEnvironmentAndWritesHumanOutput(t *testing.T) {
 		}`))
 	})
 
-	t.Setenv(clientURLVar, "http://powercontext.test")
+	t.Setenv(clientURLVar, "https://powercontext.test")
 	t.Setenv(clientTokenVar, "secret-token")
 	t.Setenv(clientTimeoutVar, "2.5")
 	var stdout, stderr bytes.Buffer
@@ -88,7 +88,7 @@ func TestCapabilitiesFormatsServerErrorWithRequestID(t *testing.T) {
 
 	var stdout, stderr bytes.Buffer
 	root := newCommandWithHTTPClient(VersionInfo{Version: "test"}, &stdout, &stderr, httpClient)
-	root.SetArgs([]string{"--server-url", "http://powercontext.test", "capabilities"})
+	root.SetArgs([]string{"--server-url", "https://powercontext.test", "capabilities"})
 	err := root.ExecuteContext(context.Background())
 	if err == nil || err.Error() != "PowerContext Server returned HTTP 401 (unauthorized) (request ID: request-42)" {
 		t.Fatalf("ExecuteContext() error = %v", err)

--- a/internal/transportpolicy/policy.go
+++ b/internal/transportpolicy/policy.go
@@ -1,0 +1,47 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package transportpolicy defines the shared network transport trust rules
+// used by PowerContext process and client surfaces.
+package transportpolicy
+
+import (
+	"net/netip"
+	"net/url"
+	"strings"
+)
+
+// IsLoopbackHost reports whether host is localhost, IPv6 loopback, or an IPv4
+// literal in the complete 127.0.0.0/8 loopback range.
+func IsLoopbackHost(host string) bool {
+	normalized := strings.TrimSpace(host)
+	if unbracketed, ok := strings.CutPrefix(normalized, "["); ok {
+		var closed bool
+		normalized, closed = strings.CutSuffix(unbracketed, "]")
+		if !closed {
+			return false
+		}
+	}
+	if strings.EqualFold(normalized, "localhost") {
+		return true
+	}
+	address, err := netip.ParseAddr(normalized)
+	return err == nil && address.IsLoopback()
+}
+
+// IsPlaintextNonLoopback reports whether endpoint uses plaintext HTTP for a
+// host outside the loopback ranges trusted by PowerContext.
+func IsPlaintextNonLoopback(endpoint *url.URL) bool {
+	return endpoint != nil && endpoint.Scheme == "http" && !IsLoopbackHost(endpoint.Hostname())
+}

--- a/server/application_test.go
+++ b/server/application_test.go
@@ -127,7 +127,9 @@ func TestGoClientExercisesReviewHTTPRuntimeSQLiteVerticalSlice(t *testing.T) {
 		handler.ServeHTTP(recorder, request)
 		return recorder.Result(), nil
 	})}
-	sdk, err := pcclient.New("http://powercontext.test", pcclient.Options{HTTPClient: inProcessHTTPClient})
+	sdk, err := pcclient.New("http://powercontext.test", pcclient.Options{
+		HTTPClient: inProcessHTTPClient, TrustTransportSecurity: true,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -319,7 +321,9 @@ func TestGoClientGeneratesReviewedExperienceAndSkillCandidates(t *testing.T) {
 		handler.ServeHTTP(recorder, request)
 		return recorder.Result(), nil
 	})}
-	sdk, err := pcclient.New("http://powercontext.test", pcclient.Options{HTTPClient: httpClient})
+	sdk, err := pcclient.New("http://powercontext.test", pcclient.Options{
+		HTTPClient: httpClient, TrustTransportSecurity: true,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/transport/policy_test.go
+++ b/test/transport/policy_test.go
@@ -1,0 +1,85 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package transport_test
+
+import (
+	json "encoding/json/v2"
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ob-labs/powercontext-go/internal/transportpolicy"
+)
+
+type loopbackVectors struct {
+	Loopback    []string `json:"loopback"`
+	NonLoopback []string `json:"non_loopback"`
+}
+
+func TestSharedLoopbackHostVectors(t *testing.T) {
+	vectors := loadLoopbackVectors(t)
+	for _, host := range vectors.Loopback {
+		t.Run("loopback/"+host, func(t *testing.T) {
+			if !transportpolicy.IsLoopbackHost(host) {
+				t.Fatalf("IsLoopbackHost(%q) = false, want true", host)
+			}
+		})
+	}
+	for _, host := range vectors.NonLoopback {
+		t.Run("non-loopback/"+host, func(t *testing.T) {
+			if transportpolicy.IsLoopbackHost(host) {
+				t.Fatalf("IsLoopbackHost(%q) = true, want false", host)
+			}
+		})
+	}
+}
+
+func TestSharedPlaintextURLVectors(t *testing.T) {
+	vectors := loadLoopbackVectors(t)
+	for _, host := range vectors.Loopback {
+		t.Run("loopback/"+host, func(t *testing.T) {
+			endpoint := &url.URL{Scheme: "http", Host: host}
+			if transportpolicy.IsPlaintextNonLoopback(endpoint) {
+				t.Fatalf("IsPlaintextNonLoopback(%q) = true, want false", endpoint)
+			}
+		})
+	}
+	for _, host := range vectors.NonLoopback {
+		t.Run("non-loopback/"+host, func(t *testing.T) {
+			endpoint := &url.URL{Scheme: "http", Host: host}
+			if !transportpolicy.IsPlaintextNonLoopback(endpoint) {
+				t.Fatalf("IsPlaintextNonLoopback(%q) = false, want true", endpoint)
+			}
+			endpoint.Scheme = "https"
+			if transportpolicy.IsPlaintextNonLoopback(endpoint) {
+				t.Fatalf("IsPlaintextNonLoopback(%q) = true, want false", endpoint)
+			}
+		})
+	}
+}
+
+func loadLoopbackVectors(t *testing.T) loopbackVectors {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join("testdata", "loopback_hosts.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var vectors loopbackVectors
+	if err := json.Unmarshal(data, &vectors); err != nil {
+		t.Fatal(err)
+	}
+	return vectors
+}

--- a/test/transport/testdata/loopback_hosts.json
+++ b/test/transport/testdata/loopback_hosts.json
@@ -1,0 +1,20 @@
+{
+  "_comment": "Shared transport-policy host vectors. Go and retained adapter drift guards must agree that plaintext HTTP is trusted only for these loopback authorities, including the complete IPv4 127.0.0.0/8 range.",
+  "loopback": [
+    "127.0.0.0",
+    "127.0.0.1",
+    "127.0.0.2",
+    "127.1.2.3",
+    "127.255.255.255",
+    "localhost",
+    "LOCALHOST",
+    "[::1]"
+  ],
+  "non_loopback": [
+    "0.0.0.0",
+    "[::]",
+    "192.168.1.10",
+    "memory.example",
+    "[2001:db8::1]"
+  ]
+}


### PR DESCRIPTION
## Tracking

- Tracking issue: #5
- Relationship: `Part of #5`

## Problem and rationale

The public Go Client accepted plaintext HTTP endpoints outside loopback and could send Source or Memory request bodies without transport encryption. A constructor-only check would still be bypassable through ogen's per-request `v1.WithServerURL` override exposed by `Client.Raw()` and the promoted invoker methods.

This is the first independently reviewable WP2 change. It centralizes the Go loopback contract and enforces it at both Client construction and the final HTTP RoundTripper. Server, CLI bind policy, Docker behavior, and retained-adapter alignment remain separate follow-up PRs.

## Changes

- add `internal/transportpolicy` with shared `localhost`, IPv6 `::1`, and complete IPv4 `127.0.0.0/8` recognition;
- add repository-wide JSON loopback/non-loopback vectors for later adapter drift guards;
- reject every plaintext non-loopback Client endpoint by default, with or without a bearer token;
- add `client.Options.TrustTransportSecurity`, effective only with a caller-supplied `HTTPClient`;
- enforce the same policy in the final RoundTripper so per-request Server URL overrides cannot bypass it;
- mark existing in-process Server tests as explicitly trusted and move unrelated fake-network tests to HTTPS labels;
- add the required reusable bug-prevention rule to `AGENTS.md`.

## Behavior and compatibility

- User-visible behavior: `client.New` now rejects non-loopback `http://` Server URLs unless the caller supplies an HTTP client and explicitly vouches for its transport security.
- Public API or protocol impact: adds `client.Options.TrustTransportSecurity`; no OpenAPI or wire-contract change.
- Breaking changes or migration requirements: callers using remote plaintext HTTP must move to HTTPS or provide a separately secured caller-owned transport and set the explicit trust flag. Keyed `client.Options` literals remain source-compatible; external unkeyed literals must account for the new field.
- Explicit non-goals: Server bind policy, CLI host/port override policy, Docker configuration, documentation guides, and retained-adapter implementation changes.

## Generated, dependency, and workflow impact

- [x] No generated contract changed, or every required output was regenerated from its source.
- [x] No dependency changed, or `go.mod` and `go.sum` are complete and verified.
- [x] No CI or release contract changed, or stable job names, permissions, timeouts, and failure evidence were reviewed.
- [x] No credential, private Source/Memory content, or unredacted production log is included.

## Validation

The Linux gates ran in an exact-Base temporary WSL clone at `0cbd2559753adb0dafaa7a052a3a8a543b421eaa`; Ubuntu `libsqlite3-dev` was unpacked only into the temporary directory to provide headers, without changing the WSL system.

```text
Windows:
go test -count=1 ./client ./test/transport

Linux/WSL exact-Base patched clone:
go test -count=1 -tags sqlite_fts5 ./...
go test -count=1 -race ./client ./test/transport
make check-portable
make downstream-compat
make check-generated
make check
make lint
make license-check
git diff --check

Results:
- all Go packages passed with sqlite_fts5;
- Client and shared transport tests passed under the race detector;
- all four portable SDK targets built;
- the isolated downstream public consumer built and passed;
- generated files remained clean;
- module, formatting, vet, lint, license, and diff checks passed;
- golangci-lint: 0 issues;
- license-eye: 786 valid, 0 invalid, 193 ignored.
```

- [x] `git diff --check`
- [x] `git status --short` was inspected after validation.
- [x] Relevant generated, race, compatibility, process, adapter, documentation, or release checks were run.
- [x] Any skipped or unavailable check is identified above and is not represented as passing.

## AI usage

OpenAI Codex implemented the change. The submitted result was reviewed against #3, #5, the current Go 1.27 guidance, the authoritative upstream transport policy, and the Go-specific per-request URL override path. Regression tests were demonstrated red before implementation and the complete relevant repository gates were rerun after the final code change.