### PR TITLE
feat(integrations): align retained adapters with the shared transport trust policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -227,3 +227,10 @@ source / artifact / trigger / inference
   the final RoundTripper. Verify an unsafe override fails before the underlying
   transport runs, and allow an HTTP-labelled non-loopback route only when the
   caller supplies the client and explicitly vouches for transport security.
+- When a shared policy is vendored into isolated adapters that cannot import
+  it, align every copy in the same change and pin each copy with a drift guard
+  that drives the shared test vectors through the adapter's production entry
+  point. Pair environment-dependent behavioral probes with always-on
+  source-structure assertions so the guard still fires where an adapter
+  dependency is unavailable, and verify the guard by reverting one vendored
+  copy and watching it fail.

--- a/integrations/claude-code/plugins/powercontext/claude_code_settings.py
+++ b/integrations/claude-code/plugins/powercontext/claude_code_settings.py
@@ -16,13 +16,28 @@
 
 from __future__ import annotations
 
+import ipaddress
 import os
 from dataclasses import dataclass
 from urllib.parse import urlsplit, urlunsplit
 
+# Kept in lockstep with powercontext.transport.LOOPBACK_HOSTS; the plugin ships
+# isolated and cannot import powercontext.
 _LOOPBACK_HOSTS = frozenset({"127.0.0.1", "::1", "localhost"})
 _TRUE_VALUES = frozenset({"1", "true", "yes", "on"})
 _FALSE_VALUES = frozenset({"0", "false", "no", "off"})
+
+
+def _is_loopback_host(host: str) -> bool:
+    """Mirror ``powercontext.transport.is_loopback_host`` for the isolated plugin."""
+
+    normalized = host.strip().lower()
+    if normalized in _LOOPBACK_HOSTS:
+        return True
+    try:
+        return ipaddress.ip_address(normalized).is_loopback
+    except ValueError:
+        return False
 
 
 @dataclass(frozen=True, slots=True)
@@ -145,7 +160,7 @@ def _http_base_url(value: str) -> str:
         raise ValueError("PowerContext Server URL must use HTTP or HTTPS")  # noqa: TRY003
     if parsed.query or parsed.fragment:
         raise ValueError("PowerContext Server URL must not contain a query or fragment")  # noqa: TRY003
-    if parsed.scheme == "http" and parsed.hostname.lower() not in _LOOPBACK_HOSTS:
+    if parsed.scheme == "http" and not _is_loopback_host(parsed.hostname):
         raise ValueError("unencrypted PowerContext URLs must be loopback addresses")  # noqa: TRY003
     path = parsed.path.rstrip("/")
     if path.endswith("/mcp"):

--- a/integrations/codex/plugins/powercontext/settings.py
+++ b/integrations/codex/plugins/powercontext/settings.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import ipaddress
 from pathlib import Path
 from typing import Any, Literal
 from urllib.parse import urlsplit, urlunsplit
@@ -26,8 +27,22 @@ from pydantic_settings import BaseSettings, PydanticBaseSettingsSource, Settings
 from typing_extensions import override
 
 _MCP_CONFIGURATION_PATH = Path(__file__).with_name(".mcp.json")
+# Kept in lockstep with powercontext.transport.LOOPBACK_HOSTS; the plugin ships
+# isolated and cannot import powercontext, so tests pin the two copies together.
 _LOOPBACK_HOSTS = frozenset({"127.0.0.1", "::1", "localhost"})
 _AUTHORIZATION_ENVIRONMENT = {"Authorization": "POWERCONTEXT_CODEX_AUTHORIZATION"}
+
+
+def _is_loopback_host(host: str) -> bool:
+    """Mirror ``powercontext.transport.is_loopback_host`` for the isolated plugin."""
+
+    normalized = host.strip().lower()
+    if normalized in _LOOPBACK_HOSTS:
+        return True
+    try:
+        return ipaddress.ip_address(normalized).is_loopback
+    except ValueError:
+        return False
 
 
 class _McpEndpoint(BaseModel):
@@ -156,7 +171,7 @@ def _http_base_url(mcp_url: str) -> str:
         raise ValueError("PowerContext MCP URL must use HTTP or HTTPS")  # noqa: TRY003
     if parsed.query or parsed.fragment:
         raise ValueError("PowerContext MCP URL must not contain a query or fragment")  # noqa: TRY003
-    if parsed.scheme == "http" and parsed.hostname.lower() not in _LOOPBACK_HOSTS:
+    if parsed.scheme == "http" and not _is_loopback_host(parsed.hostname):
         raise ValueError("unencrypted PowerContext MCP URLs must be loopback addresses")  # noqa: TRY003
     mcp_path = parsed.path.rstrip("/")
     if not mcp_path.endswith("/mcp"):

--- a/integrations/pi/plugins/powercontext/src/config.ts
+++ b/integrations/pi/plugins/powercontext/src/config.ts
@@ -67,8 +67,23 @@ function envInteger(
   return value
 }
 
+function isIpv4Loopback(host: string): boolean {
+  const octets = host.split('.')
+  if (octets.length !== 4) return false
+  if (!octets.every((octet) => /^\d{1,3}$/.test(octet) && Number(octet) <= 255)) return false
+  // The whole 127.0.0.0/8 block is loopback, not just 127.0.0.1.
+  return octets[0] === '127'
+}
+
 function isLoopback(hostname: string): boolean {
-  return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '[::1]'
+  // Mirror the shared `is_loopback_host` transport contract (src/powercontext/transport.py): trim,
+  // lowercase, drop the IPv6 brackets that URL.hostname keeps, then accept `localhost`, the whole
+  // IPv4 127.0.0.0/8 block, and IPv6 ::1. Drift here is pinned by transport-policy.spec.ts, which
+  // shares its host vectors with the Python drift guard.
+  const normalized = hostname.trim().toLowerCase().replace(/^\[/, '').replace(/\]$/, '')
+  if (!normalized) return false
+  if (normalized === 'localhost' || normalized === '::1') return true
+  return isIpv4Loopback(normalized)
 }
 
 function normalizeBaseUrl(value: string): string {

--- a/integrations/pi/plugins/powercontext/tests/transport-policy.spec.ts
+++ b/integrations/pi/plugins/powercontext/tests/transport-policy.spec.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { resolveConfig } from '../src/config.ts'
+
+// Single source of truth shared with the Go transport drift guard (test/transport). Both suites
+// drive the SAME host vectors through their production entry points, so a plugin that drifts from
+// the shared 127.0.0.0/8 loopback contract fails in at least one language.
+const vectorsPath = fileURLToPath(
+  new URL('../../../../../test/transport/testdata/loopback_hosts.json', import.meta.url),
+)
+const vectors = JSON.parse(readFileSync(vectorsPath, 'utf8')) as {
+  loopback: string[]
+  non_loopback: string[]
+}
+
+describe('Pi transport policy', () => {
+  it.each(vectors.loopback)('trusts a plaintext loopback bind for %s', (host) => {
+    // WHATWG URL lowercases the host, so the normalized baseUrl echoes the lowercased authority.
+    const config = resolveConfig({ POWERCONTEXT_PI_BASE_URL: `http://${host}:8000` })
+    expect(config.baseUrl).toBe(`http://${host.toLowerCase()}:8000`)
+  })
+
+  it.each(vectors.non_loopback)('refuses a plaintext non-loopback bind for %s', (host) => {
+    expect(() => resolveConfig({ POWERCONTEXT_PI_BASE_URL: `http://${host}:8000` })).toThrow(
+      /must use HTTPS outside loopback/,
+    )
+  })
+})

--- a/test/transport/vendored_adapters_test.go
+++ b/test/transport/vendored_adapters_test.go
@@ -1,0 +1,173 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package transport_test
+
+import (
+	"bytes"
+	json "encoding/json/v2"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/ob-labs/powercontext-go/internal/transportpolicy"
+)
+
+// The retained Python adapters (Codex, Claude Code) ship isolated: they cannot
+// import the shared policy, so each vendors a copy of the loopback contract.
+// These guards pin every vendored copy to the shared vectors so drift in any
+// one implementation fails here instead of silently weakening the policy. The
+// Pi adapter is pinned the same way by its own Vitest suite
+// (integrations/pi/plugins/powercontext/tests/transport-policy.spec.ts), which
+// consumes the same vectors file.
+var vendoredPythonAdapters = map[string]string{
+	"codex":       filepath.Join("..", "..", "integrations", "codex", "plugins", "powercontext", "settings.py"),
+	"claude-code": filepath.Join("..", "..", "integrations", "claude-code", "plugins", "powercontext", "claude_code_settings.py"),
+}
+
+// vendoredAdapterProbe loads one vendored adapter by path and drives the
+// shared host vectors through its production _http_base_url entry point. It
+// exits 3 when the adapter cannot be imported (for example the Codex adapter's
+// pydantic dependency is absent), which the Go side treats as a skip -- the
+// same defensive semantics as the upstream Python drift guard's skipif.
+const vendoredAdapterProbe = `
+import importlib.util
+import json
+import sys
+
+path = sys.argv[1]
+hosts = json.load(sys.stdin)
+
+module_name = "vendored_adapter_drift_guard"
+spec = importlib.util.spec_from_file_location(module_name, path)
+module = importlib.util.module_from_spec(spec)
+# Register before executing: a slotted dataclass (the Claude Code adapter)
+# resolves its own module via sys.modules during class creation.
+sys.modules[module_name] = module
+try:
+    spec.loader.exec_module(module)
+except Exception as error:
+    print(repr(error), file=sys.stderr)
+    sys.exit(3)
+
+accepted = {}
+for host in hosts:
+    try:
+        module._http_base_url(f"http://{host}:8000/mcp")
+        accepted[host] = True
+    except ValueError:
+        accepted[host] = False
+
+print(json.dumps({"loopback_hosts": sorted(module._LOOPBACK_HOSTS), "accepted": accepted}))
+`
+
+type vendoredAdapterVerdict struct {
+	LoopbackHosts []string        `json:"loopback_hosts"`
+	Accepted      map[string]bool `json:"accepted"`
+}
+
+func probeVendoredAdapter(t *testing.T, adapterPath string, hosts []string) vendoredAdapterVerdict {
+	t.Helper()
+	python, err := exec.LookPath("python3")
+	if err != nil {
+		t.Skip("python3 is unavailable; skipping the behavioral drift guard (upstream skip semantics)")
+	}
+	payload, err := json.Marshal(hosts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	command := exec.Command(python, "-c", vendoredAdapterProbe, adapterPath)
+	command.Stdin = bytes.NewReader(payload)
+	var stdout, stderr bytes.Buffer
+	command.Stdout = &stdout
+	command.Stderr = &stderr
+	err = command.Run()
+	if exitError, ok := err.(*exec.ExitError); ok && exitError.ExitCode() == 3 {
+		t.Skipf("vendored adapter cannot be imported in this environment (upstream skip semantics): %s",
+			strings.TrimSpace(stderr.String()))
+	}
+	if err != nil {
+		t.Fatalf("probing %s: %v\n%s", adapterPath, err, stderr.String())
+	}
+	var verdict vendoredAdapterVerdict
+	if err := json.Unmarshal(stdout.Bytes(), &verdict); err != nil {
+		t.Fatalf("decoding the probe output for %s: %v\n%s", adapterPath, err, stdout.String())
+	}
+	return verdict
+}
+
+// TestVendoredPythonAdaptersKeepTheSharedPolicyCheck is the always-on half of
+// the guard: even where python3 or an adapter dependency is unavailable, the
+// vendored source must keep the shared 127.0.0.0/8 check and must not revert
+// to the pre-policy exact-match host list.
+func TestVendoredPythonAdaptersKeepTheSharedPolicyCheck(t *testing.T) {
+	for name, adapterPath := range vendoredPythonAdapters {
+		t.Run(name, func(t *testing.T) {
+			source, err := os.ReadFile(adapterPath)
+			if err != nil {
+				t.Fatalf("reading the vendored adapter: %v", err)
+			}
+			text := string(source)
+			for _, required := range []string{
+				"def _is_loopback_host(",
+				"ipaddress.ip_address(",
+				"not _is_loopback_host(parsed.hostname)",
+			} {
+				if !strings.Contains(text, required) {
+					t.Errorf("vendored adapter is missing %q; it must mirror the shared 127.0.0.0/8 loopback contract", required)
+				}
+			}
+			if strings.Contains(text, "hostname.lower() not in _LOOPBACK_HOSTS") {
+				t.Error("vendored adapter reverted to the exact-match loopback check; the rest of 127.0.0.0/8 must stay trusted")
+			}
+		})
+	}
+}
+
+func TestVendoredPythonAdaptersShareTheLoopbackHostSet(t *testing.T) {
+	want := []string{"127.0.0.1", "::1", "localhost"}
+	for name, adapterPath := range vendoredPythonAdapters {
+		t.Run(name, func(t *testing.T) {
+			verdict := probeVendoredAdapter(t, adapterPath, []string{"127.0.0.1"})
+			if !slices.Equal(verdict.LoopbackHosts, want) {
+				t.Fatalf("vendored _LOOPBACK_HOSTS = %v, want the shared set %v", verdict.LoopbackHosts, want)
+			}
+		})
+	}
+}
+
+func TestVendoredPythonAdaptersMatchTheSharedPlaintextPolicy(t *testing.T) {
+	vectors := loadLoopbackVectors(t)
+	hosts := slices.Concat(vectors.Loopback, vectors.NonLoopback)
+	for name, adapterPath := range vendoredPythonAdapters {
+		t.Run(name, func(t *testing.T) {
+			verdict := probeVendoredAdapter(t, adapterPath, hosts)
+			for _, host := range hosts {
+				sharedRejects := transportpolicy.IsPlaintextNonLoopback(&url.URL{Scheme: "http", Host: host + ":8000"})
+				accepted, ok := verdict.Accepted[host]
+				if !ok {
+					t.Fatalf("the probe returned no verdict for host %q", host)
+				}
+				if accepted == sharedRejects {
+					t.Errorf("host %q: vendored adapter accepted = %t, but the shared policy rejects = %t",
+						host, accepted, sharedRejects)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Part of #49 and the WP2 umbrella #5.

The retained host adapters still shipped their **pre-policy vendored copies**: they trusted plaintext HTTP only for the exact hosts `127.0.0.1` / `localhost` / `[::1]` and refused the rest of the IPv4 loopback range that the shared contract accepts. This PR ports the upstream `127.0.0.0/8` loopback contract (`ob-labs/powercontext#1344`, parity target `f2ec1f7`) into the three drifted adapters and pins every vendored copy with drift guards driven by the shared vectors at `test/transport/testdata/loopback_hosts.json`.

## Changes

- **`integrations/codex/.../settings.py`** and **`integrations/claude-code/.../claude_code_settings.py`**: gain `_is_loopback_host` mirroring the shared `ipaddress`-based contract; `_http_base_url` now accepts the complete `127.0.0.0/8` block (verbatim upstream port; diffs vs upstream were exactly this upgrade).
- **`integrations/pi/.../src/config.ts`**: `isLoopback` now trims, lowercases, strips IPv6 brackets, and accepts the full `127.0.0.0/8` block via the new `isIpv4Loopback` (verbatim upstream port).
- **`integrations/pi/.../tests/transport-policy.spec.ts`** (new): Vitest drift guard driving the shared vectors through the production `resolveConfig` entry point; runs in CI via `make pi-test`.
- **`test/transport/vendored_adapters_test.go`** (new): Go drift guard pinning both vendored Python adapters against the same vectors —
  - always-on source-structure assertions (fire even where python3 or an adapter dependency is unavailable),
  - behavioral probes through each adapter's production `_http_base_url`, with upstream-style defensive skips (`pydantic` absent → Codex probe skips, exactly like the upstream `skipif`),
  - `_LOOPBACK_HOSTS` set-equality pin.
- **`AGENTS.md`**: learned rule for vendored-policy drift guards.

## Verification

- **Mutation proof for every guard**: reverting any of the three vendored copies to the exact-match check fails its guard on precisely `127.0.0.0`, `127.0.0.2`, `127.1.2.3`, `127.255.255.255` (observed for Codex and Claude Code via the Go guard, and for Pi via the Vitest guard); restoring upstream returns all green.
- `go test ./test/transport/` — pass (including behavioral probes with a `pydantic`-provisioned interpreter).
- Pi Vitest `transport-policy.spec.ts` — 13/13 pass; `tsc --noEmit` clean.
- Gates: `make license-check` (0 invalid), `fmt-check`, `vet`, `lint` (0 issues), `unit-test` — all green.

## Notes

- **OpenCode adapter deliberately unchanged**: it is byte-identical to upstream `f2ec1f7`, which has not upgraded it (initial integration commit only). Aligning it here would *create* drift with the accepted upstream target behavior. Bub/LangGraph/Hermes/DSH/OpenClaw carry no vendored transport-policy logic in either repository; LangChain/WorkBuddy/pydantic-ai are not retained here.
- **Pre-existing local flake (not from this PR)**: `tests/e2e/package.spec.ts` (real Pi CLI spawn) intermittently hits its 5 s test timeout under full-suite parallel load on this machine; it also fails the same way on a pristine `origin/main` worktree and passes standalone. CI is the arbiter.
- The `.env.example` / operator-docs part of #5 (documenting `POWERCONTEXT_SERVER_ALLOW_UNAUTHENTICATED_NON_LOOPBACK`) follows once #46 lands, since the variable only exists after that merge.
