### PR TITLE
ci: enforce gocyclo complexity gate

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,6 +24,7 @@ linters:
     - bodyclose
     - durationcheck
     - errcheck
+    - gocyclo
     - govet
     - ineffassign
     - misspell
@@ -32,6 +33,8 @@ linters:
     - wastedassign
     - whitespace
   settings:
+    gocyclo:
+      min-complexity: 50
     govet:
       enable:
         - shadow
@@ -45,6 +48,28 @@ linters:
         - -QF*
   exclusions:
     generated: strict
+    warn-unused: true
+    rules:
+      # Scheduler: the pickle compatibility parser branches by supported opcode.
+      # Remove this waiver when parsePickle is reduced below the threshold.
+      - path: ^internal/scheduler/pickle\.go$
+        linters:
+          - gocyclo
+        text: 'cyclomatic complexity 107 of func `parsePickle` is high \(> 50\)'
+
+      # Server: process configuration validation covers the complete option matrix.
+      # Remove this waiver when ProcessConfig.Validate is reduced below the threshold.
+      - path: ^server/config_validate\.go$
+        linters:
+          - gocyclo
+        text: 'cyclomatic complexity 62 of func `\(ProcessConfig\)\.Validate` is high \(> 50\)'
+
+      # End-to-end tests: this vertical slice intentionally verifies the full memory lifecycle.
+      # Remove this waiver when the scenario is split into functions below the threshold.
+      - path: ^test/e2e/http_memory_test\.go$
+        linters:
+          - gocyclo
+        text: 'cyclomatic complexity 206 of func `TestHTTPSourceAndMemorySQLiteVerticalSlice` is high \(> 50\)'
 
 formatters:
   enable:


### PR DESCRIPTION
## Tracking

- Tracking issue: #52
- Relationship: `Closes #52`; `Part of #3`

## Problem and rationale

Issue #52 tracks the WP0-B requirement to evaluate `gocyclo` with a measured, project-specific threshold before making it required.

The baseline was measured against the default `make lint` build context. Strictly identified generated files were excluded, and files requiring inactive build tags such as `sqlite_fts5` were not included.

### Measured baseline

- Nontrivial functions: 2,901
- Average nontrivial complexity: 6.13
- Complexity over 20: 70
- Complexity over 30: 25
- Complexity over 40: 8
- Complexity over 50: 3

A threshold of 50 provides an initial ratchet without requiring unrelated refactoring in the lint-policy change. Lower thresholds can be evaluated separately after the existing complexity debt is reduced.

## Changes

- Enable `gocyclo` through the existing pinned `golangci-lint`.
- Set `min-complexity` to 50.
- Keep the three existing findings as exact file, function, and complexity-specific waivers.
- Document the reason and removal condition for each waiver.
- Enable unused-exclusion warnings so stale waivers remain visible.
- Reuse the existing `make lint` target and CI lint job.

## Behavior and compatibility

- User-visible behavior: none.
- Public API or protocol impact: none.
- Breaking changes or migration requirements: none.
- Explicit non-goals: `revive`, broad source refactoring, generated API changes, tagged-build lint expansion, and new CI workflows.

New functions above the threshold will fail `make lint`. Changes to the recorded complexity of an existing waived function will also require review because the exact exclusion will no longer match.

## Generated, dependency, and workflow impact

- [x] No generated contract changed.
- [x] No dependency changed.
- [x] The existing lint gate becomes stricter; no workflow name, permission, timeout, or failure-artifact behavior changed.
- [x] No credential, private Source/Memory content, or production log is included.

## Validation

```text
.tools/bin/golangci-lint config verify
PASS

make lint
PASS: 0 issues

Temporary complexity-52 probe:
make lint
EXPECTED FAILURE:
cyclomatic complexity 52 of func `gocycloThresholdProbe` is high (> 50)

Probe removed:
make lint
PASS: 0 issues

git diff --check
PASS
```

- [x] `git diff --check`
- [x] `git status --short` was inspected after validation.
- [x] The configured threshold was verified with a temporary failing probe.
- [x] The temporary probe was removed and the final lint result is clean.
- [x] No check is represented as passing when it was not run.

Project builds and unit tests were not run because this change only updates the existing lint policy. The lint configuration and red/green threshold behavior were verified directly.

## AI usage

AI assistance was used to inspect the existing lint setup, measure the complexity baseline, and prepare the configuration change. The baseline was rerun locally, the scan boundaries were reviewed, and the final diff and lint behavior were independently verified.
