### PR TITLE
fix(integrations): align shared transport policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -238,3 +238,8 @@ source / artifact / trigger / inference
   overrides, merge every explicit override before the final validation. Verify
   both directions: a safe override repairs an unsafe environment value, and an
   unsafe override cannot replace a safe environment value without failing.
+- When isolated host adapters vendor the same transport policy, drive every
+  configuration and directly constructible client boundary from one shared
+  host-vector fixture. Verify the complete IPv4 `127.0.0.0/8` range, IPv6
+  loopback, remote plaintext rejection, and each explicit trusted-transport
+  exception in the adapter's native test suite.

--- a/integrations/bub/README.md
+++ b/integrations/bub/README.md
@@ -36,11 +36,17 @@ validated by Pydantic before the plugin starts.
 | `POWERCONTEXT_BUB_API_TOKEN` | unset | Optional PowerContext Server bearer token |
 | `POWERCONTEXT_BUB_SCOPE_ID` | workspace-derived | Durable scope shared by Bub sessions |
 | `POWERCONTEXT_BUB_TIMEOUT` | `10` | Client timeout in seconds |
+| `POWERCONTEXT_BUB_TRUST_TRANSPORT_SECURITY` | `false` | Explicitly trust an HTTP-labelled controlled or TLS-terminated transport |
 | `POWERCONTEXT_BUB_MAX_BYTES` | `8000` | Maximum prepared-context size |
 | `POWERCONTEXT_BUB_CAPTURE_EVENTS` | `false` | Capture completed Bub events as Content Sources |
 | `POWERCONTEXT_BUB_CAPTURE_CHECKPOINT_EVERY` | `5` | Flush Memory after this many captured events |
 | `POWERCONTEXT_BUB_CAPTURE_MAX_BYTES` | `8192` | Maximum UTF-8 bytes stored for one captured event |
 | `POWERCONTEXT_BUB_CAPTURE_LOG` | unset | Optional JSONL evidence path; records metadata but not event content |
+
+Plain HTTP is accepted only for loopback hosts, including the complete
+`127.0.0.0/8` range. Set `POWERCONTEXT_BUB_TRUST_TRANSPORT_SECURITY=true` only
+when the configured HTTP label routes over a controlled network or a transport
+that terminates TLS outside the adapter.
 
 Captured tool arguments redact values under credential-like keys. Known credential environment values are also
 removed from serialized event content. Keep the PowerContext scope and optional capture log protected because normal

--- a/integrations/bub/src/powercontext_bub/client.py
+++ b/integrations/bub/src/powercontext_bub/client.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import asyncio
+import ipaddress
 import json
 from collections.abc import Mapping
 from time import monotonic
@@ -79,8 +80,15 @@ _URL_OPENER = build_opener(_RejectRedirects)
 class PowerContextHTTPClient:
     """The narrow five-operation client required by the Bub integration."""
 
-    def __init__(self, base_url: str, *, token: str | None = None, timeout: float = 10.0) -> None:
-        self._base_url = _http_base_url(base_url)
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        token: str | None = None,
+        timeout: float = 10.0,
+        trust_transport_security: bool = False,
+    ) -> None:
+        self._base_url = _http_base_url(base_url, trust_transport_security=trust_transport_security)
         if timeout <= 0:
             raise ValueError("PowerContext timeout must be positive")
         if token is not None and (not token or any(character.isspace() for character in token)):
@@ -192,13 +200,25 @@ def _set_response_timeout(response: _Response, timeout: float) -> None:
         settimeout(timeout)
 
 
-def _http_base_url(value: str) -> str:
+def _http_base_url(value: str, *, trust_transport_security: bool = False) -> str:
     parsed = urlsplit(value.rstrip("/"))
     if parsed.scheme not in {"http", "https"} or parsed.hostname is None:
         raise ValueError("PowerContext base URL must use HTTP or HTTPS")
     if parsed.username is not None or parsed.password is not None or parsed.query or parsed.fragment:
         raise ValueError("PowerContext base URL must not contain credentials, query data, or a fragment")
+    if parsed.scheme == "http" and not trust_transport_security and not _is_loopback_host(parsed.hostname):
+        raise ValueError("unencrypted PowerContext URLs must be loopback addresses")
     return urlunsplit((parsed.scheme, parsed.netloc, parsed.path.rstrip("/"), "", ""))
+
+
+def _is_loopback_host(host: str) -> bool:
+    normalized = host.strip().lower()
+    if normalized == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(normalized).is_loopback
+    except ValueError:
+        return False
 
 
 __all__ = [

--- a/integrations/bub/src/powercontext_bub/plugin.py
+++ b/integrations/bub/src/powercontext_bub/plugin.py
@@ -72,6 +72,7 @@ class PowerContextSettings(Settings):
     capture_checkpoint_every: int = Field(default=5, ge=1, le=100)
     capture_max_bytes: int = Field(default=8192, ge=512, le=32768)
     capture_log: Path | None = None
+    trust_transport_security: bool = False
 
 
 class PowerContextPlugin:
@@ -91,6 +92,7 @@ class PowerContextPlugin:
                 "base_url": self.base_url,
                 "scope_id": self.scope_id,
                 "timeout": self.settings.timeout,
+                "trust_transport_security": self.settings.trust_transport_security,
                 "capture_sequence": 0,
                 "captured_events": 0,
                 "captured_position": 0,
@@ -300,7 +302,12 @@ class PowerContextPlugin:
 
     def _client(self) -> PowerContextHTTPClient:
         token = None if self.settings.api_token is None else self.settings.api_token.get_secret_value()
-        return PowerContextHTTPClient(self.base_url, token=token, timeout=self.settings.timeout)
+        return PowerContextHTTPClient(
+            self.base_url,
+            token=token,
+            timeout=self.settings.timeout,
+            trust_transport_security=self.settings.trust_transport_security,
+        )
 
     def _write_capture_record(self, *, event: str, status: str, **values: Any) -> None:
         if self.settings.capture_log is None:

--- a/integrations/bub/src/powercontext_bub/tools.py
+++ b/integrations/bub/src/powercontext_bub/tools.py
@@ -32,6 +32,7 @@ class ToolSettings(TypedDict):
     scope_id: str
     timeout: float
     token: str | None
+    trust_transport_security: bool
 
 
 class SearchInput(BaseModel):
@@ -125,5 +126,8 @@ def _settings(context: Any) -> ToolSettings:
 
 def _client(settings: ToolSettings) -> PowerContextHTTPClient:
     return PowerContextHTTPClient(
-        settings["base_url"], token=settings["token"], timeout=settings["timeout"]
+        settings["base_url"],
+        token=settings["token"],
+        timeout=settings["timeout"],
+        trust_transport_security=settings["trust_transport_security"],
     )

--- a/integrations/bub/tests/test_client.py
+++ b/integrations/bub/tests/test_client.py
@@ -23,6 +23,11 @@ from pathlib import Path
 from types import ModuleType
 from unittest import mock
 
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+_TRANSPORT_VECTORS = json.loads(
+    (REPOSITORY_ROOT / "test" / "transport" / "testdata" / "loopback_hosts.json").read_text(encoding="utf-8")
+)
+
 
 def _load_client() -> ModuleType:
     path = Path(__file__).resolve().parents[1] / "src" / "powercontext_bub" / "client.py"
@@ -172,6 +177,20 @@ class ValidationTests(unittest.TestCase):
         for token in ["", " leading", "trailing ", "two words", "token\r\nInjected: yes"]:
             with self.subTest(token=token), self.assertRaises(ValueError):
                 client.PowerContextHTTPClient("http://127.0.0.1:8000", token=token)
+
+    def test_transport_policy_matches_shared_loopback_vectors(self) -> None:
+        for host in _TRANSPORT_VECTORS["loopback"]:
+            with self.subTest(kind="loopback", host=host):
+                client.PowerContextHTTPClient(f"http://{host}:8000")
+        for host in _TRANSPORT_VECTORS["non_loopback"]:
+            with self.subTest(kind="non-loopback", host=host), self.assertRaises(ValueError):
+                client.PowerContextHTTPClient(f"http://{host}:8000")
+
+    def test_explicit_transport_trust_allows_controlled_non_loopback_http(self) -> None:
+        client.PowerContextHTTPClient(
+            "http://memory.example:8000",
+            trust_transport_security=True,
+        )
 
     def test_integer_validation_rejects_bool_and_search_score_examples_are_finite(self) -> None:
         with self.assertRaises(client.InvalidResponseError):

--- a/integrations/claude-code/plugins/powercontext/README.md
+++ b/integrations/claude-code/plugins/powercontext/README.md
@@ -16,6 +16,9 @@ The plugin defaults to `http://127.0.0.1:8000`. Its Hook and MCP transport share
 enabled. Prompt capture can be disabled through the plugin's `capture_prompts`
 option or by setting `POWERCONTEXT_CLAUDE_CAPTURE_PROMPTS=false`.
 
+Plain HTTP is accepted only for loopback hosts, including IPv6 `::1` and the
+complete IPv4 `127.0.0.0/8` range. Every remote Server URL must use HTTPS.
+
 The Hook fails open on transport, authentication, contract, and capture errors.
 MCP remains available for explicit Memory maintenance and the inspected
 Handoff lifecycle when the Server is reachable.

--- a/integrations/claude-code/plugins/powercontext/claude_code_settings.py
+++ b/integrations/claude-code/plugins/powercontext/claude_code_settings.py
@@ -16,11 +16,11 @@
 
 from __future__ import annotations
 
+import ipaddress
 import os
 from dataclasses import dataclass
 from urllib.parse import urlsplit, urlunsplit
 
-_LOOPBACK_HOSTS = frozenset({"127.0.0.1", "::1", "localhost"})
 _TRUE_VALUES = frozenset({"1", "true", "yes", "on"})
 _FALSE_VALUES = frozenset({"0", "false", "no", "off"})
 
@@ -145,12 +145,22 @@ def _http_base_url(value: str) -> str:
         raise ValueError("PowerContext Server URL must use HTTP or HTTPS")  # noqa: TRY003
     if parsed.query or parsed.fragment:
         raise ValueError("PowerContext Server URL must not contain a query or fragment")  # noqa: TRY003
-    if parsed.scheme == "http" and parsed.hostname.lower() not in _LOOPBACK_HOSTS:
+    if parsed.scheme == "http" and not _is_loopback_host(parsed.hostname):
         raise ValueError("unencrypted PowerContext URLs must be loopback addresses")  # noqa: TRY003
     path = parsed.path.rstrip("/")
     if path.endswith("/mcp"):
         path = path.removesuffix("/mcp")
     return urlunsplit((parsed.scheme, parsed.netloc, path, "", "")).rstrip("/")
+
+
+def _is_loopback_host(host: str) -> bool:
+    normalized = host.strip().lower()
+    if normalized == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(normalized).is_loopback
+    except ValueError:
+        return False
 
 
 __all__ = ["ClaudeCodePluginSettings"]

--- a/integrations/claude-code/tests/test_contract.py
+++ b/integrations/claude-code/tests/test_contract.py
@@ -28,6 +28,9 @@ import pytest
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
 PLUGIN_ROOT = REPOSITORY_ROOT / "integrations" / "claude-code" / "plugins" / "powercontext"
+_TRANSPORT_VECTORS = json.loads(
+    (REPOSITORY_ROOT / "test" / "transport" / "testdata" / "loopback_hosts.json").read_text(encoding="utf-8")
+)
 _WINDOWS_DRIVE_PATH = re.compile(r"(?:^|[\"'\s(=])[A-Za-z]:[\\/]", re.MULTILINE)
 _WINDOWS_UNC_PATH = re.compile(r"(?:^|[\"'\s(=])\\\\[A-Za-z0-9_.-]+\\[A-Za-z0-9_$.-]+", re.MULTILINE)
 
@@ -177,6 +180,17 @@ def test_scope_reads_the_shared_git_private_workstream_binding(scope_module: Mod
 def test_settings_reject_unsafe_server_urls(settings_module: ModuleType, value: str) -> None:
     with pytest.raises(ValueError):
         settings_module.ClaudeCodePluginSettings(server_url=value)
+
+
+@pytest.mark.parametrize("host", _TRANSPORT_VECTORS["loopback"])
+def test_settings_accept_shared_loopback_hosts(settings_module: ModuleType, host: str) -> None:
+    settings_module.ClaudeCodePluginSettings(server_url=f"http://{host}:8000")
+
+
+@pytest.mark.parametrize("host", _TRANSPORT_VECTORS["non_loopback"])
+def test_settings_reject_shared_non_loopback_plaintext_hosts(settings_module: ModuleType, host: str) -> None:
+    with pytest.raises(ValueError):
+        settings_module.ClaudeCodePluginSettings(server_url=f"http://{host}:8000")
 
 
 def test_environment_override_controls_prompt_capture(

--- a/integrations/codex/plugins/powercontext/README.md
+++ b/integrations/codex/plugins/powercontext/README.md
@@ -63,7 +63,8 @@ the hook: the hook validates its PowerContext MCP URL and derives the HTTP API
 base by removing the final `/mcp` path segment. Change that file before
 installing the plugin when the loopback default is not appropriate. MCP URLs
 cannot contain credentials, query strings, or fragments; plain HTTP is accepted
-only for loopback hosts.
+only for loopback hosts, including IPv6 `::1` and the complete IPv4
+`127.0.0.0/8` range. Every remote Server URL must use HTTPS.
 
 The hook strictly validates `powercontext.prepared-context.v1`, rejects redirects,
 caps response bodies at 1 MiB, and applies both per-request and shared wall-clock

--- a/integrations/codex/plugins/powercontext/settings.py
+++ b/integrations/codex/plugins/powercontext/settings.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import ipaddress
 from pathlib import Path
 from typing import Any, Literal
 from urllib.parse import urlsplit, urlunsplit
@@ -26,7 +27,6 @@ from pydantic_settings import BaseSettings, PydanticBaseSettingsSource, Settings
 from typing_extensions import override
 
 _MCP_CONFIGURATION_PATH = Path(__file__).with_name(".mcp.json")
-_LOOPBACK_HOSTS = frozenset({"127.0.0.1", "::1", "localhost"})
 _AUTHORIZATION_ENVIRONMENT = {"Authorization": "POWERCONTEXT_CODEX_AUTHORIZATION"}
 
 
@@ -156,13 +156,23 @@ def _http_base_url(mcp_url: str) -> str:
         raise ValueError("PowerContext MCP URL must use HTTP or HTTPS")  # noqa: TRY003
     if parsed.query or parsed.fragment:
         raise ValueError("PowerContext MCP URL must not contain a query or fragment")  # noqa: TRY003
-    if parsed.scheme == "http" and parsed.hostname.lower() not in _LOOPBACK_HOSTS:
+    if parsed.scheme == "http" and not _is_loopback_host(parsed.hostname):
         raise ValueError("unencrypted PowerContext MCP URLs must be loopback addresses")  # noqa: TRY003
     mcp_path = parsed.path.rstrip("/")
     if not mcp_path.endswith("/mcp"):
         raise ValueError("PowerContext MCP URL path must end with /mcp")  # noqa: TRY003
     base_path = mcp_path.removesuffix("/mcp")
     return urlunsplit((parsed.scheme, parsed.netloc, base_path, "", "")).rstrip("/")
+
+
+def _is_loopback_host(host: str) -> bool:
+    normalized = host.strip().lower()
+    if normalized == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(normalized).is_loopback
+    except ValueError:
+        return False
 
 
 __all__ = ["CodexPluginSettings"]

--- a/integrations/codex/tests/test_contract.py
+++ b/integrations/codex/tests/test_contract.py
@@ -22,7 +22,11 @@ from types import ModuleType
 import pytest
 from pydantic import ValidationError
 
-PLUGIN_ROOT = Path(__file__).resolve().parents[3] / "integrations" / "codex" / "plugins" / "powercontext"
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+PLUGIN_ROOT = REPOSITORY_ROOT / "integrations" / "codex" / "plugins" / "powercontext"
+_TRANSPORT_VECTORS = json.loads(
+    (REPOSITORY_ROOT / "test" / "transport" / "testdata" / "loopback_hosts.json").read_text(encoding="utf-8")
+)
 
 
 @pytest.mark.parametrize(
@@ -169,6 +173,17 @@ def test_codex_settings_reject_unsafe_or_ambiguous_mcp_urls(
 ) -> None:
     with pytest.raises(ValueError):
         settings_module._http_base_url(value)
+
+
+@pytest.mark.parametrize("host", _TRANSPORT_VECTORS["loopback"])
+def test_codex_settings_accept_shared_loopback_hosts(settings_module: ModuleType, host: str) -> None:
+    settings_module._http_base_url(f"http://{host}:8000/mcp")
+
+
+@pytest.mark.parametrize("host", _TRANSPORT_VECTORS["non_loopback"])
+def test_codex_settings_reject_shared_non_loopback_plaintext_hosts(settings_module: ModuleType, host: str) -> None:
+    with pytest.raises(ValueError):
+        settings_module._http_base_url(f"http://{host}:8000/mcp")
 
 
 def test_codex_settings_normalize_the_mcp_path_to_http_base(

--- a/integrations/dsh/plugins/powercontext/README.md
+++ b/integrations/dsh/plugins/powercontext/README.md
@@ -27,3 +27,6 @@ make js-api-generate-check
 ```
 
 Environment overrides use the `POWERCONTEXT_DSH_` prefix for `BASE_URL`, `AUTHORIZATION`, `SCOPE_ID`, `CAPTURE_PROMPTS`, and `FLUSH_ON_CAPTURE`. `timeoutMs`, `requestTimeoutMs`, `maxBytes`, and `flushMaxCalls` are plugin patch settings. Context returned by recall is labelled as untrusted history. An unavailable Server never blocks normal Harness work. The plugin directory must contain a built `lib/index.js`.
+
+Plain HTTP is accepted only for loopback hosts, including the complete
+`127.0.0.0/8` range. Every remote Server URL must use HTTPS.

--- a/integrations/dsh/plugins/powercontext/lib/index.js
+++ b/integrations/dsh/plugins/powercontext/lib/index.js
@@ -403,6 +403,25 @@ const OPERATIONS = {
 const OPERATION_IDS = Object.keys(OPERATIONS);
 
 //#endregion
+//#region src/transport.ts
+function isLoopbackHost(hostname) {
+	const normalized = hostname.toLowerCase().replace(/^\[|\]$/g, "");
+	return normalized === "localhost" || normalized === "::1" || /^127(?:\.\d{1,3}){3}$/.test(normalized);
+}
+function normalizePowerContextBaseUrl(value, name$1) {
+	let url;
+	try {
+		url = new URL(value);
+	} catch {
+		throw new Error(`${name$1} must be a valid HTTP(S) URL`);
+	}
+	if (!["http:", "https:"].includes(url.protocol)) throw new Error(`${name$1} must use HTTP or HTTPS`);
+	if (url.username || url.password || url.search || url.hash) throw new Error(`${name$1} must not contain credentials, a query, or a fragment`);
+	if (url.protocol === "http:" && !isLoopbackHost(url.hostname)) throw new Error(`${name$1} must use HTTPS outside loopback`);
+	return url.toString().replace(/\/+$/, "");
+}
+
+//#endregion
 //#region src/client.ts
 function combineSignals(signals) {
 	const present$1 = signals.filter(Boolean);
@@ -489,7 +508,7 @@ var PowerContextClient = class {
 	requestTimeoutMs;
 	fetchImpl;
 	constructor(options) {
-		this.baseUrl = options.baseUrl.replace(/\/+$/, "");
+		this.baseUrl = normalizePowerContextBaseUrl(options.baseUrl, "PowerContext base URL");
 		this.authorization = options.authorization;
 		this.requestTimeoutMs = options.requestTimeoutMs;
 		this.fetchImpl = options.fetch ?? fetch;
@@ -975,9 +994,6 @@ function envBoolean(env, name$1) {
 		"off"
 	].includes(value)) return false;
 }
-function stripSlash(url) {
-	return url.replace(/\/+$/, "");
-}
 function optionalText(value) {
 	const trimmed = value?.trim();
 	return trimmed ? trimmed : void 0;
@@ -986,7 +1002,7 @@ function resolveConfig(config = {}, env = process.env) {
 	const maxBytes = config.maxBytes ?? DEFAULTS.maxBytes;
 	if (maxBytes < 512 || maxBytes > 32768) throw new Error("maxBytes must be between 512 and 32768");
 	return {
-		baseUrl: stripSlash(envString(env, "POWERCONTEXT_DSH_BASE_URL") ?? config.baseUrl ?? DEFAULTS.baseUrl),
+		baseUrl: normalizePowerContextBaseUrl(envString(env, "POWERCONTEXT_DSH_BASE_URL") ?? config.baseUrl ?? DEFAULTS.baseUrl, "POWERCONTEXT_DSH_BASE_URL"),
 		authorization: envString(env, "POWERCONTEXT_DSH_AUTHORIZATION") ?? optionalText(config.authorization),
 		scopeId: envString(env, "POWERCONTEXT_DSH_SCOPE_ID") ?? optionalText(config.scopeId),
 		timeoutMs: config.timeoutMs ?? DEFAULTS.timeoutMs,

--- a/integrations/dsh/plugins/powercontext/src/client.ts
+++ b/integrations/dsh/plugins/powercontext/src/client.ts
@@ -25,6 +25,7 @@ import {
   UnknownOperationError,
 } from './errors.ts'
 import { OPERATIONS, type OperationId, type OperationSpec } from './operations.generated.ts'
+import { normalizePowerContextBaseUrl } from './transport.ts'
 
 export type JsonObject = Record<string, unknown>
 export type FetchFn = (input: string, init: RequestInit) => Promise<Response>
@@ -134,7 +135,7 @@ export class PowerContextClient {
   private readonly fetchImpl: FetchFn
 
   constructor(options: ClientOptions) {
-    this.baseUrl = options.baseUrl.replace(/\/+$/, '')
+    this.baseUrl = normalizePowerContextBaseUrl(options.baseUrl, 'PowerContext base URL')
     this.authorization = options.authorization
     this.requestTimeoutMs = options.requestTimeoutMs
     this.fetchImpl = options.fetch ?? fetch

--- a/integrations/dsh/plugins/powercontext/src/config.ts
+++ b/integrations/dsh/plugins/powercontext/src/config.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import { normalizePowerContextBaseUrl } from './transport.ts'
+
 export interface PluginConfig {
   baseUrl?: string
   authorization?: string
@@ -63,10 +65,6 @@ function envBoolean(env: NodeJS.ProcessEnv, name: string): boolean | undefined {
   return undefined
 }
 
-function stripSlash(url: string): string {
-  return url.replace(/\/+$/, '')
-}
-
 function optionalText(value: string | undefined): string | undefined {
   const trimmed = value?.trim()
   return trimmed ? trimmed : undefined
@@ -81,7 +79,10 @@ export function resolveConfig(
     throw new Error('maxBytes must be between 512 and 32768')
   }
   return {
-    baseUrl: stripSlash(envString(env, 'POWERCONTEXT_DSH_BASE_URL') ?? config.baseUrl ?? DEFAULTS.baseUrl),
+    baseUrl: normalizePowerContextBaseUrl(
+      envString(env, 'POWERCONTEXT_DSH_BASE_URL') ?? config.baseUrl ?? DEFAULTS.baseUrl,
+      'POWERCONTEXT_DSH_BASE_URL',
+    ),
     authorization: envString(env, 'POWERCONTEXT_DSH_AUTHORIZATION') ?? optionalText(config.authorization),
     scopeId: envString(env, 'POWERCONTEXT_DSH_SCOPE_ID') ?? optionalText(config.scopeId),
     timeoutMs: config.timeoutMs ?? DEFAULTS.timeoutMs,

--- a/integrations/dsh/plugins/powercontext/src/transport.ts
+++ b/integrations/dsh/plugins/powercontext/src/transport.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+function isLoopbackHost(hostname: string): boolean {
+  const normalized = hostname.toLowerCase().replace(/^\[|\]$/g, '')
+  return normalized === 'localhost'
+    || normalized === '::1'
+    || /^127(?:\.\d{1,3}){3}$/.test(normalized)
+}
+
+export function normalizePowerContextBaseUrl(value: string, name: string): string {
+  let url: URL
+  try {
+    url = new URL(value)
+  } catch {
+    throw new Error(`${name} must be a valid HTTP(S) URL`)
+  }
+  if (!['http:', 'https:'].includes(url.protocol)) {
+    throw new Error(`${name} must use HTTP or HTTPS`)
+  }
+  if (url.username || url.password || url.search || url.hash) {
+    throw new Error(`${name} must not contain credentials, a query, or a fragment`)
+  }
+  if (url.protocol === 'http:' && !isLoopbackHost(url.hostname)) {
+    throw new Error(`${name} must use HTTPS outside loopback`)
+  }
+  return url.toString().replace(/\/+$/, '')
+}

--- a/integrations/dsh/plugins/powercontext/tests/client.spec.ts
+++ b/integrations/dsh/plugins/powercontext/tests/client.spec.ts
@@ -136,7 +136,7 @@ describe('PowerContextClient', () => {
     const { OPERATION_IDS, OPERATIONS } = await import('../src/operations.generated.ts')
     const seen: Array<{ method: string; url: string; hasBody: boolean }> = []
     const client = new PowerContextClient({
-      baseUrl: 'http://example.test',
+      baseUrl: 'https://example.test',
       requestTimeoutMs: 1000,
       fetch: async (url, init) => {
         seen.push({ method: String(init?.method), url, hasBody: Boolean(init?.body) })
@@ -151,7 +151,7 @@ describe('PowerContextClient', () => {
     OPERATION_IDS.forEach((id, index) => {
       const spec = OPERATIONS[id]
       expect(seen[index].method).toBe(spec.method)
-      expect(seen[index].url.startsWith(`http://example.test${spec.path}`)).toBe(true)
+      expect(seen[index].url.startsWith(`https://example.test${spec.path}`)).toBe(true)
       expect(seen[index].hasBody).toBe(spec.method === 'POST' && spec.location === 'body')
     })
   })

--- a/integrations/dsh/plugins/powercontext/tests/commands.spec.ts
+++ b/integrations/dsh/plugins/powercontext/tests/commands.spec.ts
@@ -96,12 +96,12 @@ describe('config env overrides', () => {
     const resolved = resolveConfig(
       { baseUrl: 'http://127.0.0.1:8000', capturePrompts: true },
       {
-        POWERCONTEXT_DSH_BASE_URL: 'http://example.local:9000/',
+        POWERCONTEXT_DSH_BASE_URL: 'https://example.local:9000/',
         POWERCONTEXT_DSH_SCOPE_ID: 'project:from-env',
         POWERCONTEXT_DSH_CAPTURE_PROMPTS: 'false',
       },
     )
-    expect(resolved.baseUrl).toBe('http://example.local:9000')
+    expect(resolved.baseUrl).toBe('https://example.local:9000')
     expect(resolved.scopeId).toBe('project:from-env')
     expect(resolved.capturePrompts).toBe(false)
   })

--- a/integrations/dsh/plugins/powercontext/tests/transport-policy.spec.ts
+++ b/integrations/dsh/plugins/powercontext/tests/transport-policy.spec.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+import { PowerContextClient } from '../src/client.ts'
+import { resolveConfig } from '../src/config.ts'
+
+type TransportVectors = { loopback: string[]; non_loopback: string[] }
+
+const vectors = JSON.parse(readFileSync(
+  new URL('../../../../../test/transport/testdata/loopback_hosts.json', import.meta.url),
+  'utf8',
+)) as TransportVectors
+
+describe('DSH transport policy', () => {
+  it.each(vectors.loopback)('accepts plaintext loopback host %s', (host) => {
+    const baseUrl = `http://${host}:8000`
+    expect(() => resolveConfig({}, { POWERCONTEXT_DSH_BASE_URL: baseUrl })).not.toThrow()
+    expect(() => new PowerContextClient({ baseUrl, requestTimeoutMs: 1000 })).not.toThrow()
+  })
+
+  it.each(vectors.non_loopback)('rejects plaintext non-loopback host %s', (host) => {
+    const baseUrl = `http://${host}:8000`
+    expect(() => resolveConfig({}, { POWERCONTEXT_DSH_BASE_URL: baseUrl })).toThrow(/HTTPS|loopback/)
+    expect(() => new PowerContextClient({ baseUrl, requestTimeoutMs: 1000 })).toThrow(/HTTPS|loopback/)
+  })
+
+  it('accepts HTTPS outside loopback', () => {
+    expect(resolveConfig({}, { POWERCONTEXT_DSH_BASE_URL: 'https://memory.example:8000' }).baseUrl)
+      .toBe('https://memory.example:8000')
+  })
+})

--- a/integrations/hermes/README.md
+++ b/integrations/hermes/README.md
@@ -91,6 +91,9 @@ Environment variables override file values:
 | `POWERCONTEXT_HERMES_BASE_URL` | PowerContext server URL |
 | `POWERCONTEXT_HERMES_AUTHORIZATION` | Complete authorization header, e.g. `Bearer <token>` |
 | `POWERCONTEXT_HERMES_TOKEN` | Token shorthand; used when `AUTHORIZATION` is absent |
+
+Plain HTTP is accepted only for loopback hosts, including the complete
+`127.0.0.0/8` range. Every remote Server URL must use HTTPS.
 | `POWERCONTEXT_HERMES_SCOPE_ID` | Explicit scope or scope template |
 | `POWERCONTEXT_HERMES_MAX_BYTES` | Maximum prepared context size, 512–32768 |
 | `POWERCONTEXT_HERMES_TIMEOUT` | HTTP request timeout in seconds |

--- a/integrations/hermes/plugins/powercontext/client.py
+++ b/integrations/hermes/plugins/powercontext/client.py
@@ -16,11 +16,13 @@
 
 from __future__ import annotations
 
+import ipaddress
 import json
 from collections.abc import Callable
 from http.client import HTTPResponse
 from typing import TYPE_CHECKING, Any, TypeVar
 from urllib.error import HTTPError, URLError
+from urllib.parse import urlsplit, urlunsplit
 from urllib.request import HTTPRedirectHandler, Request, build_opener
 
 if TYPE_CHECKING:
@@ -60,6 +62,27 @@ class _NoRedirectHandler(HTTPRedirectHandler):
 Transport = Callable[[Request, float], HTTPResponse]
 
 
+def _http_base_url(value: str) -> str:
+    parsed = urlsplit(value.rstrip("/"))
+    if parsed.scheme not in {"http", "https"} or parsed.hostname is None:
+        raise ValueError("PowerContext base URL must use HTTP or HTTPS")
+    if parsed.username is not None or parsed.password is not None or parsed.query or parsed.fragment:
+        raise ValueError("PowerContext base URL must not contain credentials, query data, or a fragment")
+    if parsed.scheme == "http" and not _is_loopback_host(parsed.hostname):
+        raise ValueError("unencrypted PowerContext URLs must be loopback addresses")
+    return urlunsplit((parsed.scheme, parsed.netloc, parsed.path.rstrip("/"), "", ""))
+
+
+def _is_loopback_host(host: str) -> bool:
+    normalized = host.strip().lower()
+    if normalized == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(normalized).is_loopback
+    except ValueError:
+        return False
+
+
 class PowerContextClient:
     """HTTP facade for the PowerContext operations used by Hermes."""
 
@@ -71,7 +94,7 @@ class PowerContextClient:
         timeout: float = 5.0,
         transport: Transport | None = None,
     ) -> None:
-        self.base_url = base_url.rstrip("/")
+        self.base_url = _http_base_url(base_url)
         self.authorization = authorization.strip() if authorization else None
         self.timeout = timeout
         self._opener = build_opener(_NoRedirectHandler())

--- a/integrations/hermes/tests/test_provider.py
+++ b/integrations/hermes/tests/test_provider.py
@@ -26,6 +26,10 @@ from typing import Any
 import pytest
 
 HERMES_ROOT = Path(__file__).parents[3] / "integrations" / "hermes"
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+_TRANSPORT_VECTORS = json.loads(
+    (REPOSITORY_ROOT / "test" / "transport" / "testdata" / "loopback_hosts.json").read_text(encoding="utf-8")
+)
 _HERMES_MODULE_NAMES = (
     "plugins.powercontext",
     "plugins.powercontext.client",
@@ -126,6 +130,16 @@ class FakeClient:
     def get_capabilities(self):
         self.calls.append(("get_capabilities", (), {}))
         return {"memory_extraction": self.memory_extraction}
+
+
+def test_client_matches_shared_transport_vectors(hermes_modules) -> None:
+    del hermes_modules
+    client_module = importlib.import_module("plugins.powercontext.client")
+    for host in _TRANSPORT_VECTORS["loopback"]:
+        client_module.PowerContextClient(f"http://{host}:8000")
+    for host in _TRANSPORT_VECTORS["non_loopback"]:
+        with pytest.raises(ValueError):
+            client_module.PowerContextClient(f"http://{host}:8000")
 
 
 @pytest.fixture

--- a/integrations/langgraph/README.md
+++ b/integrations/langgraph/README.md
@@ -84,6 +84,11 @@ Configuration is read through pydantic-settings with the prefix `POWERCONTEXT_LA
 | `POWERCONTEXT_LANGGRAPH_BASE_URL` | `http://127.0.0.1:8000` | PowerContext Server URL |
 | `POWERCONTEXT_LANGGRAPH_TOKEN` | unset | Bearer token forwarded to the PowerContext Go Server |
 | `POWERCONTEXT_LANGGRAPH_SCOPE_ID` | derived | Durable scope shared across runs |
+
+Plain HTTP is accepted only for loopback hosts, including the complete
+`127.0.0.0/8` range. Every remote Server URL must use HTTPS. A caller that
+installs an in-process, Unix-socket, or TLS-terminating shared HTTP client must
+also pass `trust_transport_security=True` to `shared_http_client`.
 | `POWERCONTEXT_LANGGRAPH_TIMEOUT` | `10` | Client timeout in seconds |
 | `POWERCONTEXT_LANGGRAPH_MAX_BYTES` | `8000` | Prepared-context size limit |
 

--- a/integrations/langgraph/src/powercontext_langgraph/client.py
+++ b/integrations/langgraph/src/powercontext_langgraph/client.py
@@ -22,6 +22,7 @@ HTTP operations the adapter consumes.
 from __future__ import annotations
 
 import asyncio
+import ipaddress
 import json
 import math
 from collections.abc import Iterator
@@ -51,7 +52,7 @@ _USER_AGENT = "powercontext-langgraph/0.0.1"
 
 # A shared HTTP client lets a long-running deployment reuse one connection pool across nodes and tools, and lets
 # tests provide an in-process transport. Per-operation clients borrow it and never close it.
-_SHARED_HTTP_CLIENT: ContextVar[httpx.AsyncClient | None] = ContextVar(
+_SHARED_HTTP_CLIENT: ContextVar[tuple[httpx.AsyncClient, bool] | None] = ContextVar(
     "powercontext_langgraph_http_client", default=None
 )
 
@@ -262,7 +263,7 @@ def resolve_config(
     ):
         raise ValueError("PowerContext token must be a non-empty bearer token")
     return ResolvedConfig(
-        base_url=_http_base_url(scope.base_url or resolved_settings.base_url),
+        base_url=_normalize_http_base_url(scope.base_url or resolved_settings.base_url),
         scope_id=resolve_scope_id(scope.scope_id or resolved_settings.scope_id),
         token=token,
         timeout=timeout,
@@ -284,8 +285,10 @@ class PowerContextClient:
         token: str | None = None,
         timeout: float = 10.0,
         http_client: httpx.AsyncClient | None = None,
+        trust_transport_security: bool = False,
     ) -> None:
-        self._base_url = _http_base_url(base_url)
+        transport_trusted = http_client is not None and trust_transport_security
+        self._base_url = _http_base_url(base_url, trust_transport_security=transport_trusted)
         if timeout <= 0:
             raise ValueError("PowerContext timeout must be positive")
         if token is not None and (
@@ -375,19 +378,24 @@ class PowerContextClient:
 def open_client(config: ResolvedConfig) -> PowerContextClient:
     """Open a per-operation client, borrowing a shared pool when installed."""
 
-    return PowerContextClient(
-        config.base_url,
-        token=config.token,
-        timeout=config.timeout,
-        http_client=_SHARED_HTTP_CLIENT.get(),
-    )
+    shared = _SHARED_HTTP_CLIENT.get()
+    if shared is not None:
+        client, trust_transport_security = shared
+        return PowerContextClient(
+            config.base_url,
+            token=config.token,
+            timeout=config.timeout,
+            http_client=client,
+            trust_transport_security=trust_transport_security,
+        )
+    return PowerContextClient(config.base_url, token=config.token, timeout=config.timeout)
 
 
 @contextmanager
-def shared_http_client(client: httpx.AsyncClient) -> Iterator[None]:
-    """Install a shared connection pool for the duration of a block."""
+def shared_http_client(client: httpx.AsyncClient, *, trust_transport_security: bool = False) -> Iterator[None]:
+    """Install a shared connection pool and its explicit transport-security vouch."""
 
-    token = _SHARED_HTTP_CLIENT.set(client)
+    token = _SHARED_HTTP_CLIENT.set((client, trust_transport_security))
     try:
         yield
     finally:
@@ -423,7 +431,7 @@ def _validate(model: type[_WireModel], value: dict[str, Any]):
         ) from error
 
 
-def _http_base_url(value: str) -> str:
+def _normalize_http_base_url(value: str) -> str:
     parsed = urlsplit(value.rstrip("/"))
     if parsed.scheme not in {"http", "https"} or parsed.hostname is None:
         raise ValueError("PowerContext base URL must use HTTP or HTTPS")
@@ -437,6 +445,24 @@ def _http_base_url(value: str) -> str:
             "PowerContext base URL must not contain credentials, query data, or a fragment"
         )
     return urlunsplit((parsed.scheme, parsed.netloc, parsed.path.rstrip("/"), "", ""))
+
+
+def _http_base_url(value: str, *, trust_transport_security: bool = False) -> str:
+    normalized = _normalize_http_base_url(value)
+    parsed = urlsplit(normalized)
+    if parsed.scheme == "http" and not trust_transport_security and not _is_loopback_host(parsed.hostname or ""):
+        raise ValueError("unencrypted PowerContext URLs must be loopback addresses")
+    return normalized
+
+
+def _is_loopback_host(host: str) -> bool:
+    normalized = host.strip().lower()
+    if normalized == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(normalized).is_loopback
+    except ValueError:
+        return False
 
 
 __all__ = [

--- a/integrations/langgraph/tests/test_recall.py
+++ b/integrations/langgraph/tests/test_recall.py
@@ -92,10 +92,14 @@ def _run(
         async with httpx.AsyncClient(
             transport=transport, base_url="http://testserver"
         ) as http_client:
-            client = PowerContextClient("http://testserver", http_client=http_client)
+            client = PowerContextClient(
+                "http://testserver",
+                http_client=http_client,
+                trust_transport_security=True,
+            )
             from powercontext_langgraph.client import shared_http_client
 
-            with shared_http_client(http_client):
+            with shared_http_client(http_client, trust_transport_security=True):
                 await scenario(client)
 
     asyncio.run(driver())

--- a/integrations/langgraph/tests/test_tools.py
+++ b/integrations/langgraph/tests/test_tools.py
@@ -55,7 +55,7 @@ def _run(
         async with httpx.AsyncClient(
             transport=transport, base_url="http://testserver"
         ) as http_client:
-            with shared_http_client(http_client):
+            with shared_http_client(http_client, trust_transport_security=True):
                 await scenario()
 
     asyncio.run(driver())

--- a/integrations/langgraph/tests/test_transport.py
+++ b/integrations/langgraph/tests/test_transport.py
@@ -1,0 +1,82 @@
+# Copyright (c) 2026 OceanBase.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+
+pytest.importorskip("powercontext_langgraph")
+
+from powercontext_langgraph.client import (
+    PowerContextClient,
+    ResolvedConfig,
+    open_client,
+    shared_http_client,
+)
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+_TRANSPORT_VECTORS = json.loads(
+    (REPOSITORY_ROOT / "test" / "transport" / "testdata" / "loopback_hosts.json").read_text(encoding="utf-8")
+)
+
+
+@pytest.mark.parametrize("host", _TRANSPORT_VECTORS["loopback"])
+def test_client_accepts_shared_loopback_hosts(host: str) -> None:
+    client = PowerContextClient(f"http://{host}:8000")
+    asyncio.run(client.aclose())
+
+
+@pytest.mark.parametrize("host", _TRANSPORT_VECTORS["non_loopback"])
+def test_client_rejects_shared_non_loopback_plaintext_hosts(host: str) -> None:
+    with pytest.raises(ValueError):
+        PowerContextClient(f"http://{host}:8000")
+
+
+def test_client_requires_an_explicit_vouch_for_a_caller_supplied_transport() -> None:
+    transport = httpx.AsyncClient(transport=httpx.MockTransport(lambda _request: httpx.Response(200)))
+    try:
+        with pytest.raises(ValueError):
+            PowerContextClient("http://memory.example:8000", http_client=transport)
+        client = PowerContextClient(
+            "http://memory.example:8000",
+            http_client=transport,
+            trust_transport_security=True,
+        )
+        asyncio.run(client.aclose())
+    finally:
+        asyncio.run(transport.aclose())
+
+
+def test_shared_http_client_keeps_transport_untrusted_by_default() -> None:
+    transport = httpx.AsyncClient(transport=httpx.MockTransport(lambda _request: httpx.Response(200)))
+    config = ResolvedConfig(
+        base_url="http://memory.example:8000",
+        scope_id="project:transport-policy",
+        token=None,
+        timeout=1.0,
+        max_bytes=8000,
+    )
+    try:
+        with shared_http_client(transport), pytest.raises(ValueError):
+            open_client(config)
+        with shared_http_client(transport, trust_transport_security=True):
+            client = open_client(config)
+            asyncio.run(client.aclose())
+    finally:
+        asyncio.run(transport.aclose())

--- a/integrations/openclaw/README.md
+++ b/integrations/openclaw/README.md
@@ -100,9 +100,9 @@ chmod 600 ~/.openclaw/.env
 openclaw gateway restart
 ```
 
-Do not put credentials in the endpoint. The current configuration accepts both HTTP and HTTPS URLs; use plain HTTP
-only for a trusted loopback Server and use HTTPS for every remote Server. This is an operator security requirement,
-not a restriction currently enforced by the CLI or plugin.
+Do not put credentials in the endpoint. The plugin accepts plain HTTP only for
+loopback hosts, including the complete `127.0.0.0/8` range, and rejects every
+remote HTTP endpoint. Use HTTPS for every remote Server.
 
 ## Verify the installation
 

--- a/integrations/openclaw/plugins/memory-powercontext/dist/index.js
+++ b/integrations/openclaw/plugins/memory-powercontext/dist/index.js
@@ -37,13 +37,19 @@ function readPluginConfig(config, fallback) {
 function boundedInteger(value, fallback, min, max) {
 	return typeof value === "number" && Number.isInteger(value) ? Math.min(max, Math.max(min, value)) : fallback;
 }
+function isLoopbackHost(hostname) {
+	const normalized = hostname.toLowerCase().replace(/^\[|\]$/gu, "");
+	return normalized === "localhost" || normalized === "::1" || /^127(?:\.\d{1,3}){3}$/u.test(normalized);
+}
 function normalizeEndpoint(value) {
 	if (typeof value !== "string") return;
 	const endpoint = value.trim().replace(/\/+$/u, "");
 	if (!/^https?:\/\//iu.test(endpoint)) return;
 	try {
 		const parsed = new URL(endpoint);
-		return parsed.username || parsed.password ? void 0 : endpoint;
+		if (parsed.username || parsed.password) return;
+		if (parsed.protocol === "http:" && !isLoopbackHost(parsed.hostname)) return;
+		return endpoint;
 	} catch {
 		return;
 	}

--- a/integrations/openclaw/plugins/memory-powercontext/src/config.test.ts
+++ b/integrations/openclaw/plugins/memory-powercontext/src/config.test.ts
@@ -15,8 +15,32 @@
  */
 
 
+import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 import { resolvePowerContextConfig, resolvePowerContextScope } from "./config.js";
+
+type TransportVectors = { loopback: string[]; non_loopback: string[] };
+
+const vectors = JSON.parse(
+  readFileSync(new URL("../../../../../test/transport/testdata/loopback_hosts.json", import.meta.url), "utf8"),
+) as TransportVectors;
+
+describe("PowerContext transport policy", () => {
+  it.each(vectors.loopback)("accepts plaintext loopback host %s", (host) => {
+    const endpoint = `http://${host}:8000`;
+    expect(resolvePowerContextConfig(undefined, { endpoint }).endpoint).toBeDefined();
+  });
+
+  it.each(vectors.non_loopback)("rejects plaintext non-loopback host %s", (host) => {
+    const endpoint = `http://${host}:8000`;
+    expect(resolvePowerContextConfig(undefined, { endpoint }).endpoint).toBeUndefined();
+  });
+
+  it("accepts HTTPS outside loopback", () => {
+    expect(resolvePowerContextConfig(undefined, { endpoint: "https://memory.example:8000" }).endpoint)
+      .toBe("https://memory.example:8000");
+  });
+});
 
 describe("PowerContext scope resolution", () => {
   it("isolates agents without using a raw session key", () => {

--- a/integrations/openclaw/plugins/memory-powercontext/src/config.ts
+++ b/integrations/openclaw/plugins/memory-powercontext/src/config.ts
@@ -53,6 +53,13 @@ function boundedInteger(value: unknown, fallback: number, min: number, max: numb
     : fallback;
 }
 
+function isLoopbackHost(hostname: string): boolean {
+  const normalized = hostname.toLowerCase().replace(/^\[|\]$/gu, "");
+  return normalized === "localhost"
+    || normalized === "::1"
+    || /^127(?:\.\d{1,3}){3}$/u.test(normalized);
+}
+
 function normalizeEndpoint(value: unknown): string | undefined {
   if (typeof value !== "string") {
     return undefined;
@@ -63,7 +70,13 @@ function normalizeEndpoint(value: unknown): string | undefined {
   }
   try {
     const parsed = new URL(endpoint);
-    return parsed.username || parsed.password ? undefined : endpoint;
+    if (parsed.username || parsed.password) {
+      return undefined;
+    }
+    if (parsed.protocol === "http:" && !isLoopbackHost(parsed.hostname)) {
+      return undefined;
+    }
+    return endpoint;
   } catch {
     return undefined;
   }

--- a/integrations/openclaw/plugins/memory-powercontext/src/lifecycle.test.ts
+++ b/integrations/openclaw/plugins/memory-powercontext/src/lifecycle.test.ts
@@ -32,7 +32,7 @@ function createLifecycleHarness() {
   const contextQueries: string[] = [];
   let memoryExtraction = true;
   const config = resolvePowerContextConfig(undefined, {
-    endpoint: "http://powercontext.test",
+    endpoint: "https://powercontext.test",
     scopeMode: "project",
   });
   const client = {

--- a/integrations/openclaw/plugins/memory-powercontext/src/manager.test.ts
+++ b/integrations/openclaw/plugins/memory-powercontext/src/manager.test.ts
@@ -42,7 +42,7 @@ describe("PowerContext memory manager", () => {
     } as unknown as PowerContextClient;
     const manager = new PowerContextMemoryManager(
       "main",
-      () => resolvePowerContextConfig(undefined, { endpoint: "http://powercontext.test" }),
+      () => resolvePowerContextConfig(undefined, { endpoint: "https://powercontext.test" }),
       client,
       () => true,
     );
@@ -72,7 +72,7 @@ describe("PowerContext memory manager", () => {
       },
     } as unknown as PowerContextClient;
     const config = resolvePowerContextConfig(undefined, {
-      endpoint: "http://powercontext.test",
+      endpoint: "https://powercontext.test",
       scopeMode: "project",
     });
     const manager = new PowerContextMemoryManager("main", () => config, client, () => true);

--- a/integrations/openclaw/plugins/memory-powercontext/src/tools.test.ts
+++ b/integrations/openclaw/plugins/memory-powercontext/src/tools.test.ts
@@ -41,7 +41,7 @@ describe("PowerContext tools", () => {
     } as OpenClawPluginToolContext;
     const deps = {
       client,
-      getConfig: () => resolvePowerContextConfig(undefined, { endpoint: "http://powercontext.test" }),
+      getConfig: () => resolvePowerContextConfig(undefined, { endpoint: "https://powercontext.test" }),
       isPrivateSession: () => true,
     };
 
@@ -59,7 +59,7 @@ describe("PowerContext tools", () => {
     } as OpenClawPluginToolContext;
     const deps = {
       client,
-      getConfig: () => resolvePowerContextConfig(undefined, { endpoint: "http://powercontext.test" }),
+      getConfig: () => resolvePowerContextConfig(undefined, { endpoint: "https://powercontext.test" }),
       isPrivateSession: () => true,
     };
 
@@ -83,7 +83,7 @@ describe("PowerContext tools", () => {
     const manager = {} as never;
     const deps = {
       client,
-      getConfig: () => resolvePowerContextConfig(undefined, { endpoint: "http://powercontext.test" }),
+      getConfig: () => resolvePowerContextConfig(undefined, { endpoint: "https://powercontext.test" }),
       isPrivateSession: () => true,
       managerFor: () => manager,
     };
@@ -106,7 +106,7 @@ describe("PowerContext tools", () => {
     } as OpenClawPluginToolContext;
     const deps = {
       client,
-      getConfig: () => resolvePowerContextConfig(undefined, { endpoint: "http://powercontext.test" }),
+      getConfig: () => resolvePowerContextConfig(undefined, { endpoint: "https://powercontext.test" }),
       isPrivateSession: () => true,
     };
     const tool = createMemorySearchTool(context, deps);
@@ -129,7 +129,7 @@ describe("PowerContext tools", () => {
     } as OpenClawPluginToolContext;
     const deps = {
       client,
-      getConfig: () => resolvePowerContextConfig(undefined, { endpoint: "http://powercontext.test" }),
+      getConfig: () => resolvePowerContextConfig(undefined, { endpoint: "https://powercontext.test" }),
       isPrivateSession: () => true,
     };
     const tool = createMemoryGetTool(context, deps);

--- a/integrations/opencode/plugins/powercontext/README.md
+++ b/integrations/opencode/plugins/powercontext/README.md
@@ -21,4 +21,7 @@ The project scope comes from the normalized Git remote, falling back to a hash o
 `AUTHORIZATION`, `CAPTURE_PROMPTS`, `FLUSH_ON_CAPTURE`, `REQUEST_TIMEOUT_MS`, `HTTP_BUDGET_MS`, `MAX_BYTES`, and
 `FLUSH_MAX_CALLS`.
 
+Plain HTTP is accepted only for loopback hosts, including the complete
+`127.0.0.0/8` range. Every remote Server URL must use HTTPS.
+
 OpenCode 1.18.21 or newer in the 1.x line is required. Server failures are fail-open and never block normal work.

--- a/integrations/opencode/plugins/powercontext/lib/index.js
+++ b/integrations/opencode/plugins/powercontext/lib/index.js
@@ -390,6 +390,25 @@ const OPERATIONS = {
 const OPERATION_IDS = Object.keys(OPERATIONS);
 
 //#endregion
+//#region src/transport.ts
+function isLoopbackHost(hostname) {
+	const normalized = hostname.toLowerCase().replace(/^\[|\]$/g, "");
+	return normalized === "localhost" || normalized === "::1" || /^127(?:\.\d{1,3}){3}$/.test(normalized);
+}
+function normalizePowerContextBaseUrl(value, name) {
+	let url;
+	try {
+		url = new URL(value);
+	} catch {
+		throw new Error(`${name} must be a valid HTTP(S) URL`);
+	}
+	if (!["http:", "https:"].includes(url.protocol)) throw new Error(`${name} must use HTTP or HTTPS`);
+	if (url.username || url.password || url.search || url.hash) throw new Error(`${name} must not contain credentials, a query, or a fragment`);
+	if (url.protocol === "http:" && !isLoopbackHost(url.hostname)) throw new Error(`${name} must use HTTPS outside loopback`);
+	return url.toString().replace(/\/+$/, "");
+}
+
+//#endregion
 //#region src/client.ts
 function combineSignals(signals) {
 	if (signals.length === 1) return signals[0];
@@ -457,9 +476,13 @@ function queryString(payload) {
 	return encoded ? `?${encoded}` : "";
 }
 var PowerContextClient = class {
+	options;
 	fetchImpl;
 	constructor(options) {
-		this.options = options;
+		this.options = {
+			...options,
+			baseUrl: normalizePowerContextBaseUrl(options.baseUrl, "PowerContext base URL")
+		};
 		this.fetchImpl = options.fetch ?? fetch;
 	}
 	async request(id, payload, signal) {
@@ -564,21 +587,7 @@ function envInteger(env, name, fallback, minimum, maximum) {
 	return value;
 }
 function normalizeBaseUrl(value) {
-	let url;
-	try {
-		url = new URL(value);
-	} catch {
-		throw new Error("POWERCONTEXT_OPENCODE_BASE_URL must be a valid HTTP(S) URL");
-	}
-	if (!["http:", "https:"].includes(url.protocol)) throw new Error("POWERCONTEXT_OPENCODE_BASE_URL must use HTTP or HTTPS");
-	if (url.username || url.password || url.search || url.hash) throw new Error("POWERCONTEXT_OPENCODE_BASE_URL must not contain credentials, a query, or a fragment");
-	const loopback = [
-		"localhost",
-		"127.0.0.1",
-		"[::1]"
-	].includes(url.hostname);
-	if (url.protocol === "http:" && !loopback) throw new Error("POWERCONTEXT_OPENCODE_BASE_URL must use HTTPS outside loopback");
-	return url.toString().replace(/\/+$/, "");
+	return normalizePowerContextBaseUrl(value, "POWERCONTEXT_OPENCODE_BASE_URL");
 }
 function resolveConfig(env = process.env) {
 	const requestTimeoutMs = envInteger(env, "POWERCONTEXT_OPENCODE_REQUEST_TIMEOUT_MS", DEFAULTS.requestTimeoutMs, 50, 3e4);

--- a/integrations/opencode/plugins/powercontext/src/client.ts
+++ b/integrations/opencode/plugins/powercontext/src/client.ts
@@ -24,6 +24,7 @@ import {
   UnknownOperationError,
 } from './errors.ts'
 import { OPERATIONS, type OperationId, type OperationSpec } from './operations.generated.ts'
+import { normalizePowerContextBaseUrl } from './transport.ts'
 
 export type JsonObject = Record<string, unknown>
 export type FetchFn = (input: string, init: RequestInit) => Promise<Response>
@@ -117,9 +118,14 @@ function queryString(payload: JsonObject | undefined): string {
 }
 
 export class PowerContextClient {
+  private readonly options: ClientOptions
   private readonly fetchImpl: FetchFn
 
-  constructor(private readonly options: ClientOptions) {
+  constructor(options: ClientOptions) {
+    this.options = {
+      ...options,
+      baseUrl: normalizePowerContextBaseUrl(options.baseUrl, 'PowerContext base URL'),
+    }
     this.fetchImpl = options.fetch ?? fetch
   }
 

--- a/integrations/opencode/plugins/powercontext/src/config.ts
+++ b/integrations/opencode/plugins/powercontext/src/config.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import { normalizePowerContextBaseUrl } from './transport.ts'
+
 export interface ResolvedConfig {
   baseUrl: string
   scopeId: string | undefined
@@ -62,23 +64,7 @@ function envInteger(env: NodeJS.ProcessEnv, name: string, fallback: number, mini
 }
 
 function normalizeBaseUrl(value: string): string {
-  let url: URL
-  try {
-    url = new URL(value)
-  } catch {
-    throw new Error('POWERCONTEXT_OPENCODE_BASE_URL must be a valid HTTP(S) URL')
-  }
-  if (!['http:', 'https:'].includes(url.protocol)) {
-    throw new Error('POWERCONTEXT_OPENCODE_BASE_URL must use HTTP or HTTPS')
-  }
-  if (url.username || url.password || url.search || url.hash) {
-    throw new Error('POWERCONTEXT_OPENCODE_BASE_URL must not contain credentials, a query, or a fragment')
-  }
-  const loopback = ['localhost', '127.0.0.1', '[::1]'].includes(url.hostname)
-  if (url.protocol === 'http:' && !loopback) {
-    throw new Error('POWERCONTEXT_OPENCODE_BASE_URL must use HTTPS outside loopback')
-  }
-  return url.toString().replace(/\/+$/, '')
+  return normalizePowerContextBaseUrl(value, 'POWERCONTEXT_OPENCODE_BASE_URL')
 }
 
 export function resolveConfig(env: NodeJS.ProcessEnv = process.env): ResolvedConfig {

--- a/integrations/opencode/plugins/powercontext/src/transport.ts
+++ b/integrations/opencode/plugins/powercontext/src/transport.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+function isLoopbackHost(hostname: string): boolean {
+  const normalized = hostname.toLowerCase().replace(/^\[|\]$/g, '')
+  return normalized === 'localhost'
+    || normalized === '::1'
+    || /^127(?:\.\d{1,3}){3}$/.test(normalized)
+}
+
+export function normalizePowerContextBaseUrl(value: string, name: string): string {
+  let url: URL
+  try {
+    url = new URL(value)
+  } catch {
+    throw new Error(`${name} must be a valid HTTP(S) URL`)
+  }
+  if (!['http:', 'https:'].includes(url.protocol)) {
+    throw new Error(`${name} must use HTTP or HTTPS`)
+  }
+  if (url.username || url.password || url.search || url.hash) {
+    throw new Error(`${name} must not contain credentials, a query, or a fragment`)
+  }
+  if (url.protocol === 'http:' && !isLoopbackHost(url.hostname)) {
+    throw new Error(`${name} must use HTTPS outside loopback`)
+  }
+  return url.toString().replace(/\/+$/, '')
+}

--- a/integrations/opencode/plugins/powercontext/tests/transport-policy.spec.ts
+++ b/integrations/opencode/plugins/powercontext/tests/transport-policy.spec.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+import { PowerContextClient } from '../src/client.ts'
+import { resolveConfig } from '../src/config.ts'
+
+type TransportVectors = { loopback: string[]; non_loopback: string[] }
+
+const vectors = JSON.parse(readFileSync(
+  new URL('../../../../../test/transport/testdata/loopback_hosts.json', import.meta.url),
+  'utf8',
+)) as TransportVectors
+
+describe('OpenCode transport policy', () => {
+  it.each(vectors.loopback)('accepts plaintext loopback host %s', (host) => {
+    const baseUrl = `http://${host}:8000`
+    expect(() => resolveConfig({ POWERCONTEXT_OPENCODE_BASE_URL: baseUrl })).not.toThrow()
+    expect(() => new PowerContextClient({ baseUrl, requestTimeoutMs: 1000 })).not.toThrow()
+  })
+
+  it.each(vectors.non_loopback)('rejects plaintext non-loopback host %s', (host) => {
+    const baseUrl = `http://${host}:8000`
+    expect(() => resolveConfig({ POWERCONTEXT_OPENCODE_BASE_URL: baseUrl })).toThrow(/HTTPS|loopback/)
+    expect(() => new PowerContextClient({ baseUrl, requestTimeoutMs: 1000 })).toThrow(/HTTPS|loopback/)
+  })
+
+  it('accepts HTTPS outside loopback', () => {
+    expect(resolveConfig({ POWERCONTEXT_OPENCODE_BASE_URL: 'https://memory.example:8000' }).baseUrl)
+      .toBe('https://memory.example:8000')
+  })
+})

--- a/integrations/pi/plugins/powercontext/README.md
+++ b/integrations/pi/plugins/powercontext/README.md
@@ -15,3 +15,6 @@ Start `powercontext server run`, then open a new Pi session in the project. The 
 Use `POWERCONTEXT_PI_BASE_URL`, `POWERCONTEXT_PI_SCOPE_ID`, and `POWERCONTEXT_PI_CAPTURE_PROMPTS` to adjust the
 connection, scope, and automatic prompt capture. See the repository documentation for the full configuration and
 security behavior.
+
+Plain HTTP is accepted only for loopback hosts, including the complete
+`127.0.0.0/8` range. Every remote Server URL must use HTTPS.

--- a/integrations/pi/plugins/powercontext/src/client.ts
+++ b/integrations/pi/plugins/powercontext/src/client.ts
@@ -24,6 +24,7 @@ import {
   UnknownOperationError,
 } from './errors.ts'
 import { OPERATIONS, type OperationId, type OperationSpec } from './operations.generated.ts'
+import { normalizePowerContextBaseUrl } from './transport.ts'
 
 export type JsonObject = Record<string, unknown>
 export type FetchFn = (input: string, init: RequestInit) => Promise<Response>
@@ -132,7 +133,7 @@ export class PowerContextClient {
   private readonly fetchImpl: FetchFn
 
   constructor(options: ClientOptions) {
-    this.baseUrl = options.baseUrl.replace(/\/+$/, '')
+    this.baseUrl = normalizePowerContextBaseUrl(options.baseUrl, 'PowerContext base URL')
     this.authorization = options.authorization
     this.requestTimeoutMs = options.requestTimeoutMs
     this.fetchImpl = options.fetch ?? fetch

--- a/integrations/pi/plugins/powercontext/src/config.ts
+++ b/integrations/pi/plugins/powercontext/src/config.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import { normalizePowerContextBaseUrl } from './transport.ts'
+
 export interface ResolvedConfig {
   baseUrl: string
   scopeId: string | undefined
@@ -67,27 +69,8 @@ function envInteger(
   return value
 }
 
-function isLoopback(hostname: string): boolean {
-  return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '[::1]'
-}
-
 function normalizeBaseUrl(value: string): string {
-  let url: URL
-  try {
-    url = new URL(value)
-  } catch {
-    throw new Error('POWERCONTEXT_PI_BASE_URL must be a valid HTTP(S) URL')
-  }
-  if (!['http:', 'https:'].includes(url.protocol)) {
-    throw new Error('POWERCONTEXT_PI_BASE_URL must use HTTP or HTTPS')
-  }
-  if (url.username || url.password || url.search || url.hash) {
-    throw new Error('POWERCONTEXT_PI_BASE_URL must not contain credentials, a query, or a fragment')
-  }
-  if (url.protocol === 'http:' && !isLoopback(url.hostname)) {
-    throw new Error('POWERCONTEXT_PI_BASE_URL must use HTTPS outside loopback')
-  }
-  return url.toString().replace(/\/+$/, '')
+  return normalizePowerContextBaseUrl(value, 'POWERCONTEXT_PI_BASE_URL')
 }
 
 export function resolveConfig(env: NodeJS.ProcessEnv = process.env): ResolvedConfig {

--- a/integrations/pi/plugins/powercontext/src/transport.ts
+++ b/integrations/pi/plugins/powercontext/src/transport.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+function isLoopbackHost(hostname: string): boolean {
+  const normalized = hostname.toLowerCase().replace(/^\[|\]$/g, '')
+  return normalized === 'localhost'
+    || normalized === '::1'
+    || /^127(?:\.\d{1,3}){3}$/.test(normalized)
+}
+
+export function normalizePowerContextBaseUrl(value: string, name: string): string {
+  let url: URL
+  try {
+    url = new URL(value)
+  } catch {
+    throw new Error(`${name} must be a valid HTTP(S) URL`)
+  }
+  if (!['http:', 'https:'].includes(url.protocol)) {
+    throw new Error(`${name} must use HTTP or HTTPS`)
+  }
+  if (url.username || url.password || url.search || url.hash) {
+    throw new Error(`${name} must not contain credentials, a query, or a fragment`)
+  }
+  if (url.protocol === 'http:' && !isLoopbackHost(url.hostname)) {
+    throw new Error(`${name} must use HTTPS outside loopback`)
+  }
+  return url.toString().replace(/\/+$/, '')
+}

--- a/integrations/pi/plugins/powercontext/tests/transport-policy.spec.ts
+++ b/integrations/pi/plugins/powercontext/tests/transport-policy.spec.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+import { PowerContextClient } from '../src/client.ts'
+import { resolveConfig } from '../src/config.ts'
+
+type TransportVectors = { loopback: string[]; non_loopback: string[] }
+
+const vectors = JSON.parse(readFileSync(
+  new URL('../../../../../test/transport/testdata/loopback_hosts.json', import.meta.url),
+  'utf8',
+)) as TransportVectors
+
+describe('Pi transport policy', () => {
+  it.each(vectors.loopback)('accepts plaintext loopback host %s', (host) => {
+    const baseUrl = `http://${host}:8000`
+    expect(() => resolveConfig({ POWERCONTEXT_PI_BASE_URL: baseUrl })).not.toThrow()
+    expect(() => new PowerContextClient({ baseUrl, requestTimeoutMs: 1000 })).not.toThrow()
+  })
+
+  it.each(vectors.non_loopback)('rejects plaintext non-loopback host %s', (host) => {
+    const baseUrl = `http://${host}:8000`
+    expect(() => resolveConfig({ POWERCONTEXT_PI_BASE_URL: baseUrl })).toThrow(/HTTPS|loopback/)
+    expect(() => new PowerContextClient({ baseUrl, requestTimeoutMs: 1000 })).toThrow(/HTTPS|loopback/)
+  })
+
+  it('accepts HTTPS outside loopback', () => {
+    expect(resolveConfig({ POWERCONTEXT_PI_BASE_URL: 'https://memory.example:8000' }).baseUrl)
+      .toBe('https://memory.example:8000')
+  })
+})


### PR DESCRIPTION
## Tracking

- Tracking issue: #5
- Relationship: `Part of #5`

## Problem and rationale

The retained adapters had divergent transport policy. Codex, Claude Code, Pi, and OpenCode recognized only a small named-host set and rejected valid addresses elsewhere in `127.0.0.0/8`; Bub, Hermes, LangGraph, DSH, and OpenClaw could accept plaintext non-loopback endpoints at one or more configuration or directly constructible client boundaries.

This is the third independently reviewable WP2 change. Each isolated adapter retains its own runtime implementation, but every implementation is pinned to the shared host vectors introduced by #48.

## Changes

- consume `test/transport/testdata/loopback_hosts.json` from each adapter's native test suite;
- recognize `localhost`, IPv6 `::1`, and the complete IPv4 `127.0.0.0/8` loopback range;
- reject plaintext non-loopback endpoints in Bub, Claude Code, Codex, DSH, Hermes, LangGraph, OpenClaw, OpenCode, and Pi;
- enforce the policy at directly constructible DSH, OpenCode, Pi, Bub, Hermes, and LangGraph client boundaries, not only configuration parsing;
- add Bub's explicit `POWERCONTEXT_BUB_TRUST_TRANSPORT_SECURITY` operator vouch;
- require LangGraph caller-supplied shared HTTP clients to opt in explicitly before an HTTP-labelled non-loopback transport is trusted;
- update DSH, OpenCode, and OpenClaw checked-in build outputs;
- update adapter-native documentation and the reusable drift-prevention rule.

## Behavior and compatibility

- Plain HTTP remains valid for every shared loopback vector, including `127.0.0.0`, `127.0.0.2`, `127.1.2.3`, and `127.255.255.255`.
- Remote HTTP now fails closed; remote Servers must use HTTPS.
- Bub controlled-network/TLS-terminated deployments must set `POWERCONTEXT_BUB_TRUST_TRANSPORT_SECURITY=true` explicitly.
- LangGraph in-process, Unix-socket, or TLS-terminating shared clients must pass `trust_transport_security=True` to `shared_http_client`.
- Public OpenAPI, Go Client, and Server behavior are unchanged in this PR; those WP2 slices landed in #48 and #51.
- LangChain and WorkBuddy are not present in the current Go repository and remain WP4 work. Future adapters must consume the same shared vectors.

## Generated, dependency, and workflow impact

- [x] DSH `lib/index.js`, OpenCode `lib/index.js`, and OpenClaw `dist/index.js` were regenerated from their source changes.
- [x] No OpenAPI or generated operation table changed; `make check-generated` passed.
- [x] No dependency or lockfile changed.
- [x] No CI or release workflow changed.
- [x] No credential, private Source/Memory content, or unredacted production log is included.

## Validation

```text
Python adapters:
- Bub: 11 passed, 28 subtests passed
- Codex: 57 passed
- Claude Code: 50 passed locally; the one omitted Windows-only command probe requires a `python3` executable and remains covered by Linux CI
- Hermes: 24 passed
- LangGraph: 47 passed; final transport-only rerun: 15 passed

TypeScript transport suites after rebase:
- DSH: 14 passed
- OpenCode: 14 passed
- Pi: 14 passed
- OpenClaw config/transport: 16 passed

Expanded TypeScript evidence:
- OpenCode: typecheck passed, 34 tests passed, build passed
- Pi: typecheck passed, 42 tests passed; the real Pi CLI package E2E exceeded its fixed 5-second timeout on Windows
- OpenClaw: typecheck passed, 25 tests passed, build passed; one suite was blocked because local Node 24.13.1 embeds SQLite 3.51.2, which OpenClaw rejects for its upstream WAL-reset safety issue
- DSH: generated operations check and build passed; 73 tests passed, while one Windows child-process exit-state assertion remained platform-specific

Repository gates:
- make check-generated: passed
- make license-check: 797 valid, 0 invalid, 195 ignored
- git diff --check: passed
- local docs-test environment installation stalled without a test failure; exact-Head check-docs remains required before merge
```

The Windows-only gaps above are not represented as passing. The submitted Head must complete the Linux Host adapters job, Pi package job, check-docs, generated/build diff checks, and the rest of the repository CI before merge.

## AI usage

OpenAI Codex implemented the change. Each native test suite first demonstrated its existing policy drift, then passed after the minimal adapter-local implementation. The final commit was rebased onto `d240b033b2245f346ab8d95dc9bbbf1580b2322b`, and all nine transport suites were rerun against the rebased tree.