### PR TITLE
test: map WP2 transport parity evidence

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -222,14 +222,25 @@ func TestClientRejectsPlaintextNonLoopbackByDefault(t *testing.T) {
 		return response(http.StatusOK, capabilitiesJSON), nil
 	})}
 	for _, test := range []struct {
-		name    string
-		options Options
+		name      string
+		serverURL string
+		options   Options
 	}{
-		{name: "owned transport without token"},
-		{name: "owned transport with token", options: Options{BearerToken: "probe-token"}},
-		{name: "caller transport without token", options: Options{HTTPClient: callerTransport}},
+		{name: "owned transport without token", serverURL: "http://memory.example"},
+		{name: "private network host", serverURL: "http://192.168.1.10:8000"},
 		{
-			name: "caller transport with token",
+			name:      "owned transport with token",
+			serverURL: "http://memory.example",
+			options:   Options{BearerToken: "probe-token"},
+		},
+		{
+			name:      "caller transport without token",
+			serverURL: "http://memory.example",
+			options:   Options{HTTPClient: callerTransport},
+		},
+		{
+			name:      "caller transport with token",
+			serverURL: "http://memory.example",
 			options: Options{
 				BearerToken: "probe-token",
 				HTTPClient:  callerTransport,
@@ -237,9 +248,45 @@ func TestClientRejectsPlaintextNonLoopbackByDefault(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			_, err := New("http://memory.example", test.options)
+			_, err := New(test.serverURL, test.options)
 			if err == nil || !IsConfigurationError(err) {
 				t.Fatalf("New() error = %v, want configuration error", err)
+			}
+		})
+	}
+}
+
+func TestClientAllowsLoopbackPlaintext(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		name        string
+		serverURL   string
+		bearerToken string
+	}{
+		{name: "IPv4 loopback with bearer", serverURL: "http://127.0.0.1:8000", bearerToken: "probe-token"},
+		{name: "localhost loopback", serverURL: "http://localhost:8000"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var authorization string
+			client, err := New(test.serverURL, Options{
+				BearerToken: test.bearerToken,
+				HTTPClient: &http.Client{Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+					authorization = request.Header.Get("Authorization")
+					return response(http.StatusOK, capabilitiesJSON), nil
+				})},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := client.GetCapabilities(t.Context()); err != nil {
+				t.Fatal(err)
+			}
+			wantAuthorization := ""
+			if test.bearerToken != "" {
+				wantAuthorization = "Bearer " + test.bearerToken
+			}
+			if authorization != wantAuthorization {
+				t.Fatalf("Authorization = %q, want %q", authorization, wantAuthorization)
 			}
 		})
 	}
@@ -277,8 +324,11 @@ func TestClientPlaintextNonLoopbackErrorNamesPolicyWithoutLeakingURL(t *testing.
 
 func TestClientAllowsExplicitlyTrustedCallerTransport(t *testing.T) {
 	t.Parallel()
+	var authorization string
 	client, err := New("http://memory.example", Options{
-		HTTPClient: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		BearerToken: "probe-token",
+		HTTPClient: &http.Client{Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+			authorization = request.Header.Get("Authorization")
 			return response(http.StatusOK, capabilitiesJSON), nil
 		})},
 		TrustTransportSecurity: true,
@@ -288,6 +338,9 @@ func TestClientAllowsExplicitlyTrustedCallerTransport(t *testing.T) {
 	}
 	if _, err := client.GetCapabilities(t.Context()); err != nil {
 		t.Fatal(err)
+	}
+	if authorization != "Bearer probe-token" {
+		t.Fatalf("Authorization = %q, want %q", authorization, "Bearer probe-token")
 	}
 }
 

--- a/test/conformance/parity-inventory-rules.json
+++ b/test/conformance/parity-inventory-rules.json
@@ -94,13 +94,98 @@
       "mode": "go-port",
       "reason": "Shared loopback/plaintext transport policy across Client, CLI, and Server; the Go port of this policy is WP2.",
       "cases": {
+        "test_loopback_hosts_are_recognized": {
+          "evidence": [
+            "go:test/transport/policy_test.go#TestSharedLoopbackHostVectors"
+          ]
+        },
+        "test_non_loopback_hosts_are_rejected": {
+          "evidence": [
+            "go:test/transport/policy_test.go#TestSharedLoopbackHostVectors"
+          ]
+        },
+        "test_plaintext_non_loopback_detects_only_remote_http": {
+          "evidence": [
+            "go:test/transport/policy_test.go#TestSharedPlaintextURLVectors"
+          ]
+        },
+        "test_client_settings_reject_non_loopback_plaintext_urls": {
+          "evidence": [
+            "go:client/client_test.go#TestClientRejectsPlaintextNonLoopbackByDefault"
+          ]
+        },
+        "test_client_settings_accept_loopback_or_tls_urls": {
+          "evidence": [
+            "go:client/client_test.go#TestClientAllowsLoopbackPlaintext",
+            "go:client/client_test.go#TestClientSendsBearerAndPreservesCallerHTTPClient"
+          ]
+        },
+        "test_client_refuses_requests_over_non_loopback_plaintext": {
+          "evidence": [
+            "go:client/client_test.go#TestClientRejectsPlaintextNonLoopbackByDefault"
+          ]
+        },
+        "test_client_refuses_a_bearer_token_over_non_loopback_plaintext": {
+          "evidence": [
+            "go:client/client_test.go#TestClientRejectsPlaintextNonLoopbackByDefault"
+          ]
+        },
+        "test_client_allows_a_bearer_token_over_loopback_plaintext": {
+          "evidence": [
+            "go:client/client_test.go#TestClientAllowsLoopbackPlaintext"
+          ]
+        },
+        "test_client_allows_a_trusted_caller_supplied_transport": {
+          "evidence": [
+            "go:client/client_test.go#TestClientAllowsExplicitlyTrustedCallerTransport"
+          ]
+        },
+        "test_client_refuses_a_bearer_token_over_an_untrusted_caller_supplied_transport": {
+          "evidence": [
+            "go:client/client_test.go#TestClientRejectsPlaintextNonLoopbackByDefault"
+          ]
+        },
+        "test_client_refuses_an_unauthenticated_untrusted_non_loopback_transport": {
+          "evidence": [
+            "go:client/client_test.go#TestClientRejectsPlaintextNonLoopbackByDefault"
+          ]
+        },
+        "test_server_rejects_an_unauthenticated_non_loopback_bind": {
+          "evidence": [
+            "go:server/config_test.go#TestLoadConfigRejectsUnauthenticatedNonLoopbackBind"
+          ]
+        },
+        "test_server_allows_a_non_loopback_bind_with_authentication": {
+          "evidence": [
+            "go:server/config_test.go#TestLoadConfigAllowsAuthenticatedNonLoopbackBind"
+          ]
+        },
+        "test_server_allows_a_non_loopback_bind_with_an_explicit_opt_in": {
+          "evidence": [
+            "go:server/config_test.go#TestLoadConfigAllowsExplicitUnauthenticatedNonLoopbackBind"
+          ]
+        },
         "test_vendored_plugin_shares_the_loopback_host_set": {
           "mode": "cross-layer",
-          "reason": "Asserts retained plugins share the core loopback host set; crosses the Go core and retained adapters."
+          "reason": "Asserts retained plugins share the core loopback host set; crosses the Go core and retained adapters.",
+          "evidence": [
+            "go:test/transport/policy_test.go#TestSharedLoopbackHostVectors",
+            "py:integrations/codex/tests/test_contract.py#test_codex_settings_accept_shared_loopback_hosts",
+            "py:integrations/codex/tests/test_contract.py#test_codex_settings_reject_shared_non_loopback_plaintext_hosts",
+            "py:integrations/claude-code/tests/test_contract.py#test_settings_accept_shared_loopback_hosts",
+            "py:integrations/claude-code/tests/test_contract.py#test_settings_reject_shared_non_loopback_plaintext_hosts"
+          ]
         },
         "test_vendored_plugin_matches_the_shared_plaintext_policy": {
           "mode": "cross-layer",
-          "reason": "Asserts retained plugins match the core plaintext policy; crosses the Go core and retained adapters."
+          "reason": "Asserts retained plugins match the core plaintext policy; crosses the Go core and retained adapters.",
+          "evidence": [
+            "go:test/transport/policy_test.go#TestSharedPlaintextURLVectors",
+            "py:integrations/codex/tests/test_contract.py#test_codex_settings_accept_shared_loopback_hosts",
+            "py:integrations/codex/tests/test_contract.py#test_codex_settings_reject_shared_non_loopback_plaintext_hosts",
+            "py:integrations/claude-code/tests/test_contract.py#test_settings_accept_shared_loopback_hosts",
+            "py:integrations/claude-code/tests/test_contract.py#test_settings_reject_shared_non_loopback_plaintext_hosts"
+          ]
         }
       }
     }

--- a/test/conformance/parity-inventory-rules.json
+++ b/test/conformance/parity-inventory-rules.json
@@ -122,12 +122,14 @@
         },
         "test_client_refuses_requests_over_non_loopback_plaintext": {
           "evidence": [
-            "go:client/client_test.go#TestClientRejectsPlaintextNonLoopbackByDefault"
+            "go:client/client_test.go#TestClientRejectsPlaintextNonLoopbackByDefault",
+            "go:client/client_test.go#TestClientPlaintextNonLoopbackErrorNamesPolicyWithoutLeakingURL"
           ]
         },
         "test_client_refuses_a_bearer_token_over_non_loopback_plaintext": {
           "evidence": [
-            "go:client/client_test.go#TestClientRejectsPlaintextNonLoopbackByDefault"
+            "go:client/client_test.go#TestClientRejectsPlaintextNonLoopbackByDefault",
+            "go:client/client_test.go#TestClientPlaintextNonLoopbackErrorNamesPolicyWithoutLeakingURL"
           ]
         },
         "test_client_allows_a_bearer_token_over_loopback_plaintext": {
@@ -142,12 +144,14 @@
         },
         "test_client_refuses_a_bearer_token_over_an_untrusted_caller_supplied_transport": {
           "evidence": [
-            "go:client/client_test.go#TestClientRejectsPlaintextNonLoopbackByDefault"
+            "go:client/client_test.go#TestClientRejectsPlaintextNonLoopbackByDefault",
+            "go:client/client_test.go#TestClientPlaintextNonLoopbackErrorNamesPolicyWithoutLeakingURL"
           ]
         },
         "test_client_refuses_an_unauthenticated_untrusted_non_loopback_transport": {
           "evidence": [
-            "go:client/client_test.go#TestClientRejectsPlaintextNonLoopbackByDefault"
+            "go:client/client_test.go#TestClientRejectsPlaintextNonLoopbackByDefault",
+            "go:client/client_test.go#TestClientPlaintextNonLoopbackErrorNamesPolicyWithoutLeakingURL"
           ]
         },
         "test_server_rejects_an_unauthenticated_non_loopback_bind": {

--- a/test/conformance/parity-inventory.json
+++ b/test/conformance/parity-inventory.json
@@ -12370,6 +12370,11 @@
           "kind": "go",
           "file": "client/client_test.go",
           "test": "TestClientRejectsPlaintextNonLoopbackByDefault"
+        },
+        {
+          "kind": "go",
+          "file": "client/client_test.go",
+          "test": "TestClientPlaintextNonLoopbackErrorNamesPolicyWithoutLeakingURL"
         }
       ]
     },
@@ -12387,6 +12392,11 @@
           "kind": "go",
           "file": "client/client_test.go",
           "test": "TestClientRejectsPlaintextNonLoopbackByDefault"
+        },
+        {
+          "kind": "go",
+          "file": "client/client_test.go",
+          "test": "TestClientPlaintextNonLoopbackErrorNamesPolicyWithoutLeakingURL"
         }
       ]
     },
@@ -12438,6 +12448,11 @@
           "kind": "go",
           "file": "client/client_test.go",
           "test": "TestClientRejectsPlaintextNonLoopbackByDefault"
+        },
+        {
+          "kind": "go",
+          "file": "client/client_test.go",
+          "test": "TestClientPlaintextNonLoopbackErrorNamesPolicyWithoutLeakingURL"
         }
       ]
     },
@@ -12455,6 +12470,11 @@
           "kind": "go",
           "file": "client/client_test.go",
           "test": "TestClientRejectsPlaintextNonLoopbackByDefault"
+        },
+        {
+          "kind": "go",
+          "file": "client/client_test.go",
+          "test": "TestClientPlaintextNonLoopbackErrorNamesPolicyWithoutLeakingURL"
         }
       ]
     },

--- a/test/conformance/parity-inventory.json
+++ b/test/conformance/parity-inventory.json
@@ -4,8 +4,8 @@
   "oracle_commit": "3a6cb0151670eaff7dc0293466edd673124e80da",
   "python_test_file_count": 127,
   "python_test_case_count": 759,
-  "mapped_case_count": 622,
-  "pending_case_count": 137,
+  "mapped_case_count": 638,
+  "pending_case_count": 121,
   "entries": [
     {
       "python": {
@@ -12273,8 +12273,15 @@
         "line": 87
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "test/transport/policy_test.go",
+          "test": "TestSharedLoopbackHostVectors"
+        }
+      ]
     },
     {
       "python": {
@@ -12283,8 +12290,15 @@
         "line": 92
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "test/transport/policy_test.go",
+          "test": "TestSharedLoopbackHostVectors"
+        }
+      ]
     },
     {
       "python": {
@@ -12293,8 +12307,15 @@
         "line": 96
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "test/transport/policy_test.go",
+          "test": "TestSharedPlaintextURLVectors"
+        }
+      ]
     },
     {
       "python": {
@@ -12303,8 +12324,15 @@
         "line": 106
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "client/client_test.go",
+          "test": "TestClientRejectsPlaintextNonLoopbackByDefault"
+        }
+      ]
     },
     {
       "python": {
@@ -12313,8 +12341,20 @@
         "line": 115
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "client/client_test.go",
+          "test": "TestClientAllowsLoopbackPlaintext"
+        },
+        {
+          "kind": "go",
+          "file": "client/client_test.go",
+          "test": "TestClientSendsBearerAndPreservesCallerHTTPClient"
+        }
+      ]
     },
     {
       "python": {
@@ -12323,8 +12363,15 @@
         "line": 119
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "client/client_test.go",
+          "test": "TestClientRejectsPlaintextNonLoopbackByDefault"
+        }
+      ]
     },
     {
       "python": {
@@ -12333,8 +12380,15 @@
         "line": 128
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "client/client_test.go",
+          "test": "TestClientRejectsPlaintextNonLoopbackByDefault"
+        }
+      ]
     },
     {
       "python": {
@@ -12343,8 +12397,15 @@
         "line": 135
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "client/client_test.go",
+          "test": "TestClientAllowsLoopbackPlaintext"
+        }
+      ]
     },
     {
       "python": {
@@ -12353,8 +12414,15 @@
         "line": 140
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "client/client_test.go",
+          "test": "TestClientAllowsExplicitlyTrustedCallerTransport"
+        }
+      ]
     },
     {
       "python": {
@@ -12363,8 +12431,15 @@
         "line": 157
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "client/client_test.go",
+          "test": "TestClientRejectsPlaintextNonLoopbackByDefault"
+        }
+      ]
     },
     {
       "python": {
@@ -12373,8 +12448,15 @@
         "line": 172
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "client/client_test.go",
+          "test": "TestClientRejectsPlaintextNonLoopbackByDefault"
+        }
+      ]
     },
     {
       "python": {
@@ -12383,8 +12465,15 @@
         "line": 183
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "server/config_test.go",
+          "test": "TestLoadConfigRejectsUnauthenticatedNonLoopbackBind"
+        }
+      ]
     },
     {
       "python": {
@@ -12393,8 +12482,15 @@
         "line": 191
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "server/config_test.go",
+          "test": "TestLoadConfigAllowsAuthenticatedNonLoopbackBind"
+        }
+      ]
     },
     {
       "python": {
@@ -12403,8 +12499,15 @@
         "line": 199
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "server/config_test.go",
+          "test": "TestLoadConfigAllowsExplicitUnauthenticatedNonLoopbackBind"
+        }
+      ]
     },
     {
       "python": {
@@ -12413,8 +12516,35 @@
         "line": 209
       },
       "mode": "cross-layer",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "test/transport/policy_test.go",
+          "test": "TestSharedLoopbackHostVectors"
+        },
+        {
+          "kind": "py",
+          "file": "integrations/codex/tests/test_contract.py",
+          "test": "test_codex_settings_accept_shared_loopback_hosts"
+        },
+        {
+          "kind": "py",
+          "file": "integrations/codex/tests/test_contract.py",
+          "test": "test_codex_settings_reject_shared_non_loopback_plaintext_hosts"
+        },
+        {
+          "kind": "py",
+          "file": "integrations/claude-code/tests/test_contract.py",
+          "test": "test_settings_accept_shared_loopback_hosts"
+        },
+        {
+          "kind": "py",
+          "file": "integrations/claude-code/tests/test_contract.py",
+          "test": "test_settings_reject_shared_non_loopback_plaintext_hosts"
+        }
+      ]
     },
     {
       "python": {
@@ -12423,8 +12553,35 @@
         "line": 215
       },
       "mode": "cross-layer",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "test/transport/policy_test.go",
+          "test": "TestSharedPlaintextURLVectors"
+        },
+        {
+          "kind": "py",
+          "file": "integrations/codex/tests/test_contract.py",
+          "test": "test_codex_settings_accept_shared_loopback_hosts"
+        },
+        {
+          "kind": "py",
+          "file": "integrations/codex/tests/test_contract.py",
+          "test": "test_codex_settings_reject_shared_non_loopback_plaintext_hosts"
+        },
+        {
+          "kind": "py",
+          "file": "integrations/claude-code/tests/test_contract.py",
+          "test": "test_settings_accept_shared_loopback_hosts"
+        },
+        {
+          "kind": "py",
+          "file": "integrations/claude-code/tests/test_contract.py",
+          "test": "test_settings_reject_shared_non_loopback_plaintext_hosts"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Tracking

- Part of #3 (WP1 parity evidence after WP2)
- Updates #44

## Problem

WP2 transport behavior has landed through #48, #51, #54, and #46, but all 16 cases in the active target's `tests/test_transport.py` still remained `pending` in the parity inventory. The repository therefore understated current parity even though the shared Client, Server, and retained-adapter evidence existed.

## Changes

- map all 16 upstream transport-policy cases to concrete Go or retained-adapter tests;
- add focused public Client coverage for plaintext loopback endpoints, including bearer propagation;
- extend the existing rejection matrix with the upstream private-network host vector;
- verify authenticated traffic still reaches an explicitly trusted caller transport;
- regenerate the active parity inventory from the exact target SHA.

The generated summary moves from 622 mapped / 137 pending to 638 mapped / 121 pending. The other 743 inventory entries are byte-semantically unchanged.

## Scope

This PR changes only:

- `client/client_test.go`
- `test/conformance/parity-inventory-rules.json`
- generated `test/conformance/parity-inventory.json`

It does not change Client, Server, adapter, OpenAPI, persistence, dependency, or runtime behavior. It preserves the typed `client.PlaintextNonLoopbackError` and CLI override behavior merged by #46.

## Regression and drift proof

- With the new rules referencing the missing positive Client test, the generator failed because `TestClientAllowsLoopbackPlaintext` was not declared.
- After adding the focused test, the committed inventory still failed `-check` as stale.
- Regeneration from upstream target `f2ec1f75e5e1b46ad0626ab8390801b88966b6f5` produced 638 mapped / 121 pending, and the same `-check` then passed.
- A semantic Base/Head comparison confirmed exactly 16 changed inventory entries, all from `tests/test_transport.py`, all mapped with resolvable evidence.

## Validation

- `go test -count=1 ./client ./test/transport ./tools/parity-inventory-generate` — passed.
- `go vet ./client ./test/transport ./tools/parity-inventory-generate` — passed.
- `golangci-lint run ./client` using the repository-pinned binary — 0 issues.
- parity inventory regeneration and `-check` against the exact upstream target — passed.
- Codex shared loopback/non-loopback adapter vectors — 13 passed.
- Claude Code shared loopback/non-loopback adapter vectors — 13 passed.
- `git diff --check` — passed.

Repository-wide `make lint` could not complete on the local Windows toolchain because SeekDB's C loader was typechecked with CGO unavailable; it reported 0 lint issues before exiting with that environment error. Full conformance similarly requires the CI native/CGO environment. Exact-Head CI remains required and is not represented here as already passing.

## AI usage

OpenAI Codex performed the live-state reconciliation, evidence mapping, focused test change, regeneration, and validation. Existing dirty work in the primary checkout was not modified or overwritten.