### PR TITLE
test: map CLI transport parity evidence

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -242,6 +242,10 @@ source / artifact / trigger / inference
   final validation. Verify both directions: a safe override repairs an unsafe
   environment value, and an unsafe override cannot replace a safe environment
   value without failing.
+- When a CLI converts a typed configuration failure into a usage error, keep
+  the underlying error matchable and name concrete operator remediation without
+  exposing configured values. Verify exit code 2 and that execution never
+  reaches the operation runner.
 - When isolated host adapters vendor the same transport policy, drive every
   configuration and directly constructible client boundary from one shared
   host-vector fixture. Verify the complete IPv4 `127.0.0.0/8` range, IPv6

--- a/internal/cli/python_contract_test.go
+++ b/internal/cli/python_contract_test.go
@@ -236,6 +236,28 @@ func TestServerCommandRejectsUnauthenticatedNonLoopbackHostOverride(t *testing.T
 	}
 }
 
+func TestServerCommandReportsFriendlyErrorWhenAuthTokenMissing(t *testing.T) {
+	t.Setenv("POWERCONTEXT_SERVER_AUTH_ENABLED", "true")
+	t.Setenv("POWERCONTEXT_SERVER_AUTH_TOKEN", "")
+	called := false
+	runner := func(context.Context, *commandState, server.ProcessConfig) error {
+		called = true
+		return nil
+	}
+	var stdout, stderr bytes.Buffer
+	command := newCommandWithDependencies(VersionInfo{Version: "test"}, &stdout, &stderr, nil, runner)
+	command.SetArgs([]string{"server", "run"})
+	err := command.ExecuteContext(context.Background())
+	if err == nil || ExitCode(err) != 2 ||
+		!strings.Contains(err.Error(), "POWERCONTEXT_SERVER_AUTH_TOKEN") ||
+		!strings.Contains(err.Error(), "POWERCONTEXT_SERVER_AUTH_ENABLED=false") {
+		t.Fatalf("error = %v, exit = %d", err, ExitCode(err))
+	}
+	if called {
+		t.Fatal("invalid authentication configuration reached the runner")
+	}
+}
+
 func TestServerCommandRejectsBlankHostOverride(t *testing.T) {
 	for _, host := range []string{"", " "} {
 		t.Run(fmt.Sprintf("host=%q", host), func(t *testing.T) {

--- a/internal/cli/server_command.go
+++ b/internal/cli/server_command.go
@@ -61,6 +61,12 @@ func newServerRunCommand(state *commandState) *cobra.Command {
 				if _, ok := errors.AsType[*server.UnauthenticatedNonLoopbackBindError](err); ok {
 					return usageError(err)
 				}
+				if _, ok := errors.AsType[*server.AuthenticationTokenRequiredError](err); ok {
+					return usageError(fmt.Errorf(
+						"server: set POWERCONTEXT_SERVER_AUTH_TOKEN or POWERCONTEXT_SERVER_AUTH_ENABLED=false: %w",
+						err,
+					))
+				}
 				return err
 			}
 			runner := state.serverRun

--- a/server/config_test.go
+++ b/server/config_test.go
@@ -348,7 +348,9 @@ func TestLoadConfigRequiresBearerTokenWhenEnabled(t *testing.T) {
 	t.Setenv(PowerContextHomeEnv, t.TempDir())
 	t.Setenv("POWERCONTEXT_SERVER_AUTH_ENABLED", "true")
 	t.Setenv("POWERCONTEXT_SERVER_AUTH_TOKEN", "")
-	if _, err := LoadConfig(); err == nil || !strings.Contains(err.Error(), "bearer token is required") {
+	_, err := LoadConfig()
+	if _, ok := errors.AsType[*AuthenticationTokenRequiredError](err); !ok ||
+		!strings.Contains(err.Error(), "bearer token is required") {
 		t.Fatalf("authentication error = %v", err)
 	}
 }

--- a/server/config_validate.go
+++ b/server/config_validate.go
@@ -41,6 +41,14 @@ func (*UnauthenticatedNonLoopbackBindError) Error() string {
 		"POWERCONTEXT_SERVER_ALLOW_UNAUTHENTICATED_NON_LOOPBACK=true to opt in"
 }
 
+// AuthenticationTokenRequiredError reports enabled bearer authentication
+// without the token required to authenticate requests.
+type AuthenticationTokenRequiredError struct{}
+
+func (*AuthenticationTokenRequiredError) Error() string {
+	return "server: bearer token is required when authentication is enabled"
+}
+
 func (c ProcessConfig) Validate() error {
 	if strings.TrimSpace(c.HTTP.Host) == "" || c.HTTP.Port < 1 || c.HTTP.Port > 65_535 {
 		return errors.New("server: HTTP host and port are invalid")
@@ -49,7 +57,7 @@ func (c ProcessConfig) Validate() error {
 		return err
 	}
 	if c.Auth.Enabled && c.Auth.Token == "" {
-		return errors.New("server: bearer token is required when authentication is enabled")
+		return &AuthenticationTokenRequiredError{}
 	}
 	if !c.Auth.Enabled && !c.AllowUnauthenticatedNonLoopback && !transportpolicy.IsLoopbackHost(c.HTTP.Host) {
 		return &UnauthenticatedNonLoopbackBindError{}

--- a/test/conformance/parity-inventory-rules.json
+++ b/test/conformance/parity-inventory-rules.json
@@ -60,7 +60,25 @@
     },
     "tests/test_cli.py": {
       "mode": "go-port",
-      "reason": "CLI server command transport overrides; the CLI is Go (internal/cli) and the behavior is part of the WP2 transport surface."
+      "reason": "CLI server command transport overrides; the CLI is Go (internal/cli) and the behavior is part of the WP2 transport surface.",
+      "cases": {
+        "test_server_command_rejects_an_unauthenticated_non_loopback_host_override": {
+          "evidence": [
+            "go:internal/cli/python_contract_test.go#TestServerCommandRejectsUnauthenticatedNonLoopbackHostOverride"
+          ]
+        },
+        "test_server_command_reports_a_friendly_error_when_auth_lacks_a_token": {
+          "evidence": [
+            "go:server/config_test.go#TestLoadConfigRequiresBearerTokenWhenEnabled",
+            "go:internal/cli/python_contract_test.go#TestServerCommandReportsFriendlyErrorWhenAuthTokenMissing"
+          ]
+        },
+        "test_server_command_lets_a_loopback_override_repair_an_unsafe_environment_host": {
+          "evidence": [
+            "go:internal/cli/python_contract_test.go#TestServerCommandLoopbackOverrideRepairsUnsafeEnvironment"
+          ]
+        }
+      }
     },
     "tests/test_cli_workbuddy.py": {
       "mode": "go-port",

--- a/test/conformance/parity-inventory.json
+++ b/test/conformance/parity-inventory.json
@@ -4,8 +4,8 @@
   "oracle_commit": "3a6cb0151670eaff7dc0293466edd673124e80da",
   "python_test_file_count": 127,
   "python_test_case_count": 759,
-  "mapped_case_count": 638,
-  "pending_case_count": 121,
+  "mapped_case_count": 641,
+  "pending_case_count": 118,
   "entries": [
     {
       "python": {
@@ -7783,8 +7783,15 @@
         "line": 246
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/python_contract_test.go",
+          "test": "TestServerCommandRejectsUnauthenticatedNonLoopbackHostOverride"
+        }
+      ]
     },
     {
       "python": {
@@ -7793,8 +7800,20 @@
         "line": 269
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "server/config_test.go",
+          "test": "TestLoadConfigRequiresBearerTokenWhenEnabled"
+        },
+        {
+          "kind": "go",
+          "file": "internal/cli/python_contract_test.go",
+          "test": "TestServerCommandReportsFriendlyErrorWhenAuthTokenMissing"
+        }
+      ]
     },
     {
       "python": {
@@ -7803,8 +7822,15 @@
         "line": 291
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/python_contract_test.go",
+          "test": "TestServerCommandLoopbackOverrideRepairsUnsafeEnvironment"
+        }
+      ]
     },
     {
       "python": {


### PR DESCRIPTION
## Tracking

- Part of #3 (WP1 parity evidence after WP2)

## Problem

Three active-target cases in `tests/test_cli.py` remained pending. Two already had direct Go evidence. The third exposed a real behavior gap: when Server authentication was enabled without a token, `server run` returned an ordinary process error (exit 1) instead of an actionable usage error (exit 2).

## Changes

- add typed `server.AuthenticationTokenRequiredError` while preserving the existing stable error text;
- map that typed configuration failure at the CLI boundary to usage exit 2;
- name both operator remediation paths: set `POWERCONTEXT_SERVER_AUTH_TOKEN` or set `POWERCONTEXT_SERVER_AUTH_ENABLED=false`;
- verify invalid configuration never reaches the Server runner;
- map all three target CLI cases to concrete Go tests;
- regenerate parity inventory from 638 mapped / 121 pending to 641 mapped / 118 pending;
- strengthen the reusable typed-configuration-to-usage-error prevention rule.

## RED / GREEN proof

RED Head `91c015a` ran on Linux CI. `make unit-test` failed only at `TestServerCommandReportsFriendlyErrorWhenAuthTokenMissing`:

```text
error = server: bearer token is required when authentication is enabled, exit = 1
```

The final Head adds the typed error and CLI mapping. The same Linux `tests` job is required to turn green before merge.

## Local validation

- exact upstream target regeneration and `parity-inventory-generate -check` passed;
- `tests/test_cli.py`: 19 selected / 19 mapped / 0 pending;
- inventory: 641 mapped / 118 pending;
- parity generator tests and vet passed;
- pinned formatter on changed Go files passed;
- `git diff --check` passed;
- license check: 799 valid / 0 invalid.

Windows cannot execute the complete CLI package locally because CGO mode lacks `sqlite3.h` and CGO-disabled mode has no sqlitevec implementation. Linux exact-Head CI is the execution authority and is not represented here as already passing.

## Scope

No OpenAPI, persistence format, authentication mechanism, dependency, Docker, adapter, or unrelated CLI behavior changes.