### PR TITLE
test: map Docker transport parity evidence

### DIFF
--- a/internal/cli/docker_contract_test.go
+++ b/internal/cli/docker_contract_test.go
@@ -1,0 +1,75 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/ob-labs/powercontext-go/server"
+)
+
+func TestDockerImageServerCommandStartsWithDeclaredEnvironment(t *testing.T) {
+	payload, err := os.ReadFile(filepath.Join("..", "..", "Dockerfile"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	pattern := regexp.MustCompile(`(?m)^\s*(?:ENV\s+)?(POWERCONTEXT_SERVER_[A-Z0-9_]+)=([^\s\\]+)`)
+	environment := make(map[string]string)
+	for _, match := range pattern.FindAllStringSubmatch(string(payload), -1) {
+		environment[match[1]] = match[2]
+	}
+	for _, item := range os.Environ() {
+		name, value, ok := strings.Cut(item, "=")
+		if !ok || !strings.HasPrefix(name, "POWERCONTEXT_SERVER_") {
+			continue
+		}
+		if err := os.Unsetenv(name); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() {
+			_ = os.Setenv(name, value)
+		})
+	}
+	for name, value := range environment {
+		t.Setenv(name, value)
+	}
+	t.Setenv(server.PowerContextHomeEnv, t.TempDir())
+
+	called := false
+	var received server.ProcessConfig
+	runner := func(_ context.Context, _ *commandState, config server.ProcessConfig) error {
+		called = true
+		received = config
+		return nil
+	}
+	var stdout, stderr bytes.Buffer
+	command := newCommandWithDependencies(VersionInfo{Version: "test"}, &stdout, &stderr, nil, runner)
+	command.SetArgs([]string{"server", "run"})
+	if err := command.ExecuteContext(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	if !called {
+		t.Fatal("Docker Server configuration did not reach the runner")
+	}
+	if received.HTTP.Host != "0.0.0.0" || received.HTTP.Port != 8000 || !received.AllowUnauthenticatedNonLoopback {
+		t.Fatalf("Docker Server config = %#v", received)
+	}
+}

--- a/test/conformance/parity-inventory-rules.json
+++ b/test/conformance/parity-inventory-rules.json
@@ -86,7 +86,19 @@
     },
     "tests/test_docker_contract.py": {
       "mode": "go-port",
-      "reason": "Dockerfile and container invocation contract owned by this repository."
+      "reason": "Dockerfile and container invocation contract owned by this repository.",
+      "cases": {
+        "test_dockerfile_pins_the_bind_environment_under_test": {
+          "evidence": [
+            "go:server/docker_contract_test.go#TestDockerImageDeclaresControlledNonLoopbackBind"
+          ]
+        },
+        "test_documented_container_invocation_starts_out_of_the_box": {
+          "evidence": [
+            "go:internal/cli/docker_contract_test.go#TestDockerImageServerCommandStartsWithDeclaredEnvironment"
+          ]
+        }
+      }
     },
     "tests/test_docs_remote_access_contract.py": {
       "mode": "go-port",

--- a/test/conformance/parity-inventory.json
+++ b/test/conformance/parity-inventory.json
@@ -4,8 +4,8 @@
   "oracle_commit": "3a6cb0151670eaff7dc0293466edd673124e80da",
   "python_test_file_count": 127,
   "python_test_case_count": 759,
-  "mapped_case_count": 641,
-  "pending_case_count": 118,
+  "mapped_case_count": 643,
+  "pending_case_count": 116,
   "entries": [
     {
       "python": {
@@ -8473,8 +8473,15 @@
         "line": 47
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "server/docker_contract_test.go",
+          "test": "TestDockerImageDeclaresControlledNonLoopbackBind"
+        }
+      ]
     },
     {
       "python": {
@@ -8483,8 +8490,15 @@
         "line": 53
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/docker_contract_test.go",
+          "test": "TestDockerImageServerCommandStartsWithDeclaredEnvironment"
+        }
+      ]
     },
     {
       "python": {


### PR DESCRIPTION
## Tracking

- Part of #3 (WP1 parity evidence after WP2)

## Problem

The active target adds two `tests/test_docker_contract.py` cases, but both remained pending after the Docker transport policy landed. Existing Go coverage proved the Dockerfile environment loads into a valid Server config, but no public CLI test reproduced the documented container invocation with no command-line overrides.

## Changes

- add a CLI contract test that reads the real root Dockerfile `POWERCONTEXT_SERVER_*` environment;
- isolate the test from ambient Server environment variables and restore them after execution;
- execute the real `server run` command with no CLI overrides;
- verify the configuration reaches the process runner as `0.0.0.0:8000` with the explicit unauthenticated non-loopback opt-in;
- map both upstream Docker cases to concrete Server/CLI tests;
- regenerate inventory from 641 mapped / 118 pending to 643 mapped / 116 pending.

## Validation

- exact target regeneration and `parity-inventory-generate -check` passed;
- Docker target cases: 2 selected / 2 mapped / 0 pending;
- parity generator tests passed;
- pinned formatter on the new Go test passed;
- `git diff --check` passed;
- license check: 800 valid / 0 invalid.

The complete `internal/cli` package cannot run on the local Windows environment because native SQLite headers are unavailable. Exact-Head Linux CI is required to execute the new public CLI contract before merge.

## Scope

No production code, OpenAPI, Dockerfile, configuration semantics, dependencies, adapters, persistence formats, or unrelated tests change.