### PR TITLE
ci: add bounded dependency update automation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,42 @@
+# Copyright (c) 2026 OceanBase.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 4
+    groups:
+      go-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "tuesday"
+    open-pull-requests-limit: 4
+    groups:
+      actions-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,14 @@ versions are the formatting authority; no mutable global linter installation is 
 Run `make coverage` when a change affects executable Go behavior. It uses race-enabled atomic coverage and rejects a
 material regression from the recorded baseline.
 
+## Dependency updates
+
+Dependabot checks Go modules every Monday and GitHub Actions every Tuesday. Minor and patch updates are grouped within
+each ecosystem; major updates remain separate so their compatibility impact is reviewable. The configuration limits
+the number of open version-update pull requests and follows the live default branch instead of naming a historical
+target branch. Dependency pull requests must not be auto-merged; they must pass the repository's normal review and CI
+contracts.
+
 ## Code and generated contracts
 
 - Match the existing package boundaries, names, and error model. Avoid unrelated refactors or speculative extension

--- a/tools/governance-check/main.go
+++ b/tools/governance-check/main.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 
 	"gopkg.in/yaml.v2"
@@ -84,6 +85,35 @@ func (option *issueOption) UnmarshalYAML(unmarshal func(any) error) error {
 type issueConfig struct {
 	BlankIssuesEnabled *bool `yaml:"blank_issues_enabled"`
 	ContactLinks       []any `yaml:"contact_links"`
+}
+
+type dependabotConfig struct {
+	Version int                `yaml:"version"`
+	Updates []dependabotUpdate `yaml:"updates"`
+}
+
+type dependabotUpdate struct {
+	PackageEcosystem      string                     `yaml:"package-ecosystem"`
+	Directory             string                     `yaml:"directory"`
+	Schedule              dependabotSchedule         `yaml:"schedule"`
+	OpenPullRequestsLimit int                        `yaml:"open-pull-requests-limit"`
+	Groups                map[string]dependabotGroup `yaml:"groups"`
+}
+
+type dependabotSchedule struct {
+	Interval string `yaml:"interval"`
+	Day      string `yaml:"day"`
+}
+
+type dependabotGroup struct {
+	Patterns    []string `yaml:"patterns"`
+	UpdateTypes []string `yaml:"update-types"`
+}
+
+type dependabotExpectation struct {
+	Ecosystem string
+	Day       string
+	Group     string
 }
 
 type workflowContract struct {
@@ -162,6 +192,9 @@ func checkRepository(root string) error {
 		return err
 	}
 	if err := checkIssueConfig(root); err != nil {
+		return err
+	}
+	if err := checkDependabotConfig(root); err != nil {
 		return err
 	}
 	return checkWorkflowContracts(root)
@@ -276,6 +309,68 @@ func checkIssueConfig(root string) error {
 	}
 	if config.ContactLinks == nil {
 		return fmt.Errorf("%s must declare contact_links, even when empty", name)
+	}
+	return nil
+}
+
+func checkDependabotConfig(root string) error {
+	const name = ".github/dependabot.yml"
+	contents, err := readRepositoryFile(root, name)
+	if err != nil {
+		return err
+	}
+	var config dependabotConfig
+	if err := yaml.UnmarshalStrict(contents, &config); err != nil {
+		return fmt.Errorf("%s is invalid: %w", name, err)
+	}
+	if config.Version != 2 {
+		return fmt.Errorf("%s must use version 2", name)
+	}
+	expectations := []dependabotExpectation{
+		{Ecosystem: "gomod", Day: "monday", Group: "go-minor-patch"},
+		{Ecosystem: "github-actions", Day: "tuesday", Group: "actions-minor-patch"},
+	}
+	if len(config.Updates) != len(expectations) {
+		return fmt.Errorf("%s must configure exactly gomod and github-actions", name)
+	}
+	updates := make(map[string][]dependabotUpdate, len(config.Updates))
+	for _, update := range config.Updates {
+		updates[update.PackageEcosystem] = append(updates[update.PackageEcosystem], update)
+	}
+	for _, expectation := range expectations {
+		matches := updates[expectation.Ecosystem]
+		if len(matches) != 1 {
+			return fmt.Errorf("package ecosystem %q must be configured exactly once", expectation.Ecosystem)
+		}
+		if err := checkDependabotUpdate(matches[0], expectation); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func checkDependabotUpdate(update dependabotUpdate, expectation dependabotExpectation) error {
+	if update.Directory != "/" {
+		return fmt.Errorf("package ecosystem %q must monitor directory %q", expectation.Ecosystem, "/")
+	}
+	if update.Schedule.Interval != "weekly" {
+		return fmt.Errorf("package ecosystem %q must use a weekly schedule", expectation.Ecosystem)
+	}
+	if update.Schedule.Day != expectation.Day {
+		return fmt.Errorf("package ecosystem %q must run on %s", expectation.Ecosystem, expectation.Day)
+	}
+	if update.OpenPullRequestsLimit < 1 || update.OpenPullRequestsLimit > 5 {
+		return fmt.Errorf("package ecosystem %q must limit open pull requests to 1 through 5", expectation.Ecosystem)
+	}
+	group, ok := update.Groups[expectation.Group]
+	if !ok || len(update.Groups) != 1 {
+		return fmt.Errorf("package ecosystem %q must define group %q", expectation.Ecosystem, expectation.Group)
+	}
+	if len(group.Patterns) != 1 || group.Patterns[0] != "*" {
+		return fmt.Errorf("group %q must match every dependency", expectation.Group)
+	}
+	if len(group.UpdateTypes) != 2 || !slices.Contains(group.UpdateTypes, "minor") || !slices.Contains(group.UpdateTypes, "patch") {
+		return fmt.Errorf("group %q must contain only minor and patch updates", expectation.Group)
 	}
 	return nil
 }

--- a/tools/governance-check/main_test.go
+++ b/tools/governance-check/main_test.go
@@ -61,6 +61,83 @@ func TestCheckRepositoryEnforcesGovernanceContract(t *testing.T) {
 			wantError: "least-privilege permissions",
 		},
 		{
+			name: "missing dependency automation",
+			mutate: func(t *testing.T, root string) {
+				if err := os.Remove(filepath.Join(root, ".github", "dependabot.yml")); err != nil {
+					t.Fatal(err)
+				}
+			},
+			wantError: "read .github/dependabot.yml",
+		},
+		{
+			name: "duplicate dependency ecosystem",
+			mutate: func(t *testing.T, root string) {
+				replaceFixtureText(t, root, ".github/dependabot.yml", `package-ecosystem: "github-actions"`, `package-ecosystem: "gomod"`)
+			},
+			wantError: `package ecosystem "gomod" must be configured exactly once`,
+		},
+		{
+			name: "dependency ecosystem outside repository root",
+			mutate: func(t *testing.T, root string) {
+				replaceFixtureText(t, root, ".github/dependabot.yml", `directory: "/"`, `directory: "/tools"`)
+			},
+			wantError: `package ecosystem "gomod" must monitor directory "/"`,
+		},
+		{
+			name: "dependency updates more frequent than weekly",
+			mutate: func(t *testing.T, root string) {
+				replaceFixtureText(t, root, ".github/dependabot.yml", `interval: "weekly"`, `interval: "daily"`)
+			},
+			wantError: `package ecosystem "gomod" must use a weekly schedule`,
+		},
+		{
+			name: "unbounded dependency pull requests",
+			mutate: func(t *testing.T, root string) {
+				replaceFixtureText(t, root, ".github/dependabot.yml", "open-pull-requests-limit: 4", "open-pull-requests-limit: 20")
+			},
+			wantError: `package ecosystem "gomod" must limit open pull requests to 1 through 5`,
+		},
+		{
+			name: "dependency updates without grouping",
+			mutate: func(t *testing.T, root string) {
+				replaceFixtureText(t, root, ".github/dependabot.yml", `    groups:
+      go-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+`, "")
+			},
+			wantError: `package ecosystem "gomod" must define group "go-minor-patch"`,
+		},
+		{
+			name: "dependency group includes major updates",
+			mutate: func(t *testing.T, root string) {
+				replaceFixtureText(t, root, ".github/dependabot.yml", `          - "patch"`, `          - "major"`)
+			},
+			wantError: `group "go-minor-patch" must contain only minor and patch updates`,
+		},
+		{
+			name: "dependency automation with unknown field",
+			mutate: func(t *testing.T, root string) {
+				appendFixtureFile(t, root, ".github/dependabot.yml", "unknown: true\n")
+			},
+			wantError: ".github/dependabot.yml is invalid",
+		},
+		{
+			name: "dependency automation with duplicate field",
+			mutate: func(t *testing.T, root string) {
+				replaceFixtureText(t, root, ".github/dependabot.yml", `    directory: "/"
+    schedule:
+`, `    directory: "/"
+    directory: "/"
+    schedule:
+`)
+			},
+			wantError: ".github/dependabot.yml is invalid",
+		},
+		{
 			name: "valid reusable workflow caller",
 			mutate: func(t *testing.T, root string) {
 				writeFixtureFile(t, root, ".github/workflows/main.yml", reusableWorkflowCaller())
@@ -264,8 +341,41 @@ func writeGovernanceFixture(t *testing.T) string {
 		"problem", "contract_surface", "outcome", "compatibility", "scope", "non_goals", "alternatives", "evidence", "confirmations",
 	}))
 	writeFixtureFile(t, root, ".github/ISSUE_TEMPLATE/config.yml", "blank_issues_enabled: false\ncontact_links: []\n")
+	writeFixtureFile(t, root, ".github/dependabot.yml", validDependabotConfig())
 	writeFixtureFile(t, root, ".github/workflows/main.yml", validWorkflow(true))
 	return root
+}
+
+func validDependabotConfig() string {
+	return `version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 4
+    groups:
+      go-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "tuesday"
+    open-pull-requests-limit: 4
+    groups:
+      actions-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+`
 }
 
 func validPullRequestTemplate(includeRelationship bool) string {


### PR DESCRIPTION
## Tracking

- Tracking issue: #3
- Relationship: `Part of #3`

## Problem and rationale

WP0-B requires dependency automation for Go modules and GitHub Actions with bounded grouping, a reviewable cadence, and normal CI execution. The repository had no Dependabot or equivalent configuration. This change adds only that missing maintenance contract and extends the existing governance gate so drift cannot silently disable or unbound it.

## Changes

- add weekly Dependabot updates for the root Go module and GitHub Actions;
- group minor and patch updates per ecosystem while leaving major updates as separate reviewable pull requests;
- cap open version-update pull requests at four per ecosystem and follow the live default branch;
- make `governance-check` reject missing, duplicate, unknown, mis-scoped, ungrouped, over-frequent, or unbounded configurations;
- document that dependency pull requests use normal review and CI and must not be auto-merged.

## Behavior and compatibility

- User-visible behavior: Dependabot may open bounded dependency-update pull requests on the documented weekly cadence.
- Public API or protocol impact: none.
- Breaking changes or migration requirements: none.
- Explicit non-goals: dependency-review, govulncheck, auto-merge, dependency upgrades, release-note automation, and changes to existing workflow job names.

## Generated, dependency, and workflow impact

- [x] No generated contract changed, or every required output was regenerated from its source.
- [x] No dependency changed, or `go.mod` and `go.sum` are complete and verified.
- [x] No CI or release workflow changed; the existing stable `governance-contract` job validates the new configuration.
- [x] No credential, private Source/Memory content, or unredacted production log is included.

## Validation

Commands run against Head `3364dfd32d8aaf912ceff5f0cf6480eacb2af825`:

```text
go test -count=1 ./tools/governance-check
make governance-check
go vet ./tools/governance-check
.tools/bin/golangci-lint.exe run ./tools/governance-check
go test -race -count=1 ./tools/governance-check
make license-check
make docs-test
go test -count=10 ./tools/governance-check
git diff --check
```

All commands above passed. The tests were first run before implementation and eight invalid Dependabot configurations failed because the old checker returned nil; the same cases pass after the implementation. `make license-check` inspected 1002 files with 803 valid, 0 invalid, and 199 ignored. `make docs-test` completed with no issues.

`make check` was also attempted. `go mod tidy -diff`, `go mod verify`, and the pinned formatter passed, but the full Windows `go vet ./...` step is unavailable because `internal/sqlstore/seekdb/loader.c` is present while the Windows build selects the non-CGO stub. This pre-existing host/platform failure is not represented as passing; the changed package passed targeted vet and lint, and the pull-request Linux CI must prove the full repository gate.

- [x] `git diff --check`
- [x] `git status --short` was inspected after validation.
- [x] Relevant governance, race, lint, license, and documentation checks were run.
- [x] The unavailable Windows full-repository vet check is identified above and is not represented as passing.

## AI usage

Codex implemented the configuration, strict governance checks, tests, documentation, and validation. The submitted behavior was checked against the current GitHub Dependabot options reference, exercised with discriminative invalid-config mutants, and will receive an independent exact-Head review before merge.
