### PR TITLE
ci: verify explicit Go module integrity

### DIFF
--- a/.github/workflows/migration-gates.yml
+++ b/.github/workflows/migration-gates.yml
@@ -27,8 +27,8 @@ jobs:
       - name: Verify generated contracts
         run: make check-generated
 
-      - name: Verify owned Go module inventory
-        run: make module-inventory
+      - name: Verify owned Go module integrity
+        run: make module-integrity
 
       - name: Verify formatting
         run: make fmt-check

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -212,7 +212,7 @@ source / artifact / trigger / inference
   drift, and pin an `apidiff` build that uses the same `x/tools` export format
   as the writer. Verify deterministic regeneration on Windows and Linux and
   prove that removing a real exported identifier fails the public API gate.
-- When a CI Makefile target iterates over a platform or package matrix, verify
+- When a CI Makefile target iterates over a platform, package, or owned-module matrix, verify
   a successful fake command observes every required entry and intended
   environment. Make a non-final entry fail, then verify the target exits
   nonzero without running later entries.

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ PUBLIC_API_PACKAGES := \
 	$(MODULE_PATH)/source \
 	$(MODULE_PATH)/trigger
 
-.PHONY: help lint-tools lint lint-fix api-compat-tools api-baseline api-compat generate check-generated module-check module-inventory contract-test license-check license-fix license-dependencies fmt fmt-check vet build-all coverage coverage-check governance-check \
+.PHONY: help lint-tools lint lint-fix api-compat-tools api-baseline api-compat generate check-generated module-check module-inventory module-integrity contract-test license-check license-fix license-dependencies fmt fmt-check vet build-all coverage coverage-check governance-check \
 	test unit-test e2e-test test-sqlite test-race test-full test-oceanbase-live real-provider-test \
 	pi-test docs-sync docs-test docs-build harness-sync harness-check harness-compose-check \
 	harness-compose-acceptance harness-compose-down build build-full smoke smoke-full check \
@@ -142,6 +142,14 @@ module-check: ## Verify tidy readonly module metadata and checksums.
 
 module-inventory: ## Verify every owned Go module has an explicit inventory entry.
 	$(GO) run ./tools/module-integrity -inventory "$(MODULE_INVENTORY)"
+
+module-integrity: lint-tools module-inventory ## Verify root and downstream Go module metadata, builds, and lint.
+	$(MAKE) module-check
+	$(MAKE) lint
+	GOWORK=off $(GO) -C "$(DOWNSTREAM_DIR)" mod tidy -diff
+	GOWORK=off $(GO) -C "$(DOWNSTREAM_DIR)" mod verify
+	GOWORK=off $(GO) -C "$(DOWNSTREAM_DIR)" build -mod=readonly ./...
+	cd "$(DOWNSTREAM_DIR)" && "$(GOLANGCI_LINT)" run --config "$(CURDIR)/.golangci.yml"
 
 contract-test: check-generated ## Test the generated OpenAPI transport contract.
 	CGO_ENABLED=1 $(GO) test -tags '$(STANDARD_TAGS)' \

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ PORTABLE_TARGETS := linux/amd64 linux/arm64 darwin/amd64 darwin/arm64
 DOWNSTREAM_DIR := test/downstream
 DOWNSTREAM_BINARY := $(CURDIR)/bin/powercontext-downstream$(shell $(GO) env GOEXE)
 MODULE_INVENTORY := test/module-inventory.json
+OWNED_MODULES := . $(DOWNSTREAM_DIR)
 MODULE_PATH := github.com/ob-labs/powercontext-go
 API_BASELINE := test/api-compat/pre-release.apidiff
 API_BASELINE_GENERATOR ?= $(GO) run ./tools/api-baseline
@@ -143,13 +144,21 @@ module-check: ## Verify tidy readonly module metadata and checksums.
 module-inventory: ## Verify every owned Go module has an explicit inventory entry.
 	$(GO) run ./tools/module-integrity -inventory "$(MODULE_INVENTORY)"
 
-module-integrity: lint-tools module-inventory ## Verify root and downstream Go module metadata, builds, and lint.
-	$(MAKE) module-check
-	$(MAKE) lint
-	GOWORK=off $(GO) -C "$(DOWNSTREAM_DIR)" mod tidy -diff
-	GOWORK=off $(GO) -C "$(DOWNSTREAM_DIR)" mod verify
-	GOWORK=off $(GO) -C "$(DOWNSTREAM_DIR)" build -mod=readonly ./...
-	cd "$(DOWNSTREAM_DIR)" && "$(GOLANGCI_LINT)" run --config "$(CURDIR)/.golangci.yml"
+module-integrity: module-inventory lint-tools ## Verify metadata, readonly build, tests, and lint for every owned Go module.
+	@set -eu; \
+	for module in $(OWNED_MODULES); do \
+		printf 'checking Go module %s\n' "$$module"; \
+		GOWORK=off $(GO) -C "$$module" mod tidy -diff; \
+		GOWORK=off $(GO) -C "$$module" mod verify; \
+		GOWORK=off $(GO) -C "$$module" build -mod=readonly ./...; \
+		if [ "$$module" = "$(DOWNSTREAM_DIR)" ]; then \
+			$(GO) build -tags '$(STANDARD_TAGS)' -o "$(DOWNSTREAM_BINARY)" ./cmd/powercontext; \
+			POWERCONTEXT_DOWNSTREAM_BINARY="$(DOWNSTREAM_BINARY)" GOWORK=off $(GO) -C "$$module" test -count=1 -mod=readonly ./...; \
+		else \
+			GOWORK=off $(GO) -C "$$module" test -count=1 -mod=readonly ./...; \
+		fi; \
+		(cd "$$module" && GOWORK=off "$(GOLANGCI_LINT)" run --config "$(CURDIR)/.golangci.yml"); \
+	done
 
 contract-test: check-generated ## Test the generated OpenAPI transport contract.
 	CGO_ENABLED=1 $(GO) test -tags '$(STANDARD_TAGS)' \

--- a/tools/release/makefile_test.go
+++ b/tools/release/makefile_test.go
@@ -40,9 +40,32 @@ func TestBareMakeListsSupportedTargets(t *testing.T) {
 	if defaultOutput != helpOutput {
 		t.Errorf("default Make output differs from help output\ndefault:\n%s\nhelp:\n%s", defaultOutput, helpOutput)
 	}
-	for _, target := range []string{"lint", "check", "check-portable", "api-compat", "generated-consumers", "module-inventory", "license-dependencies", "test", "build", "package-full", "governance-check"} {
+	for _, target := range []string{"lint", "check", "check-portable", "api-compat", "generated-consumers", "module-inventory", "module-integrity", "license-dependencies", "test", "build", "package-full", "governance-check"} {
 		if !strings.Contains(helpOutput, "  "+target+" ") {
 			t.Errorf("Make help output is missing %q\n%s", target, helpOutput)
+		}
+	}
+}
+
+func TestModuleIntegrityChecksTheExplicitDownstreamModule(t *testing.T) {
+	repository := filepath.Clean(filepath.Join("..", ".."))
+	command := exec.CommandContext(t.Context(), "make", "--dry-run", "module-integrity", "GO=go")
+	command.Dir = repository
+	output, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("make module-integrity dry-run failed: %v\n%s", err, output)
+	}
+	for _, want := range []string{
+		"go run ./tools/module-integrity -inventory \"test/module-inventory.json\"",
+		"go mod tidy -diff",
+		"go -C \"test/downstream\" mod tidy -diff",
+		"go -C \"test/downstream\" mod verify",
+		"go -C \"test/downstream\" build -mod=readonly ./...",
+		"cd \"test/downstream\" &&",
+		"run --config",
+	} {
+		if !strings.Contains(string(output), want) {
+			t.Fatalf("make module-integrity is missing %q:\n%s", want, output)
 		}
 	}
 }

--- a/tools/release/makefile_test.go
+++ b/tools/release/makefile_test.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/json/v2"
 	"errors"
 	"os"
 	"os/exec"
@@ -47,27 +48,176 @@ func TestBareMakeListsSupportedTargets(t *testing.T) {
 	}
 }
 
-func TestModuleIntegrityChecksTheExplicitDownstreamModule(t *testing.T) {
+func TestModuleIntegrityRunsEveryOwnedModule(t *testing.T) {
 	repository := filepath.Clean(filepath.Join("..", ".."))
-	command := exec.CommandContext(t.Context(), "make", "--dry-run", "module-integrity", "GO=go")
-	command.Dir = repository
-	output, err := command.CombinedOutput()
+	want := expectedModuleIntegrityCalls(t, repository)
+	got, output, err := runModuleIntegrityProbe(t, repository, "")
 	if err != nil {
-		t.Fatalf("make module-integrity dry-run failed: %v\n%s", err, output)
+		t.Fatalf("make module-integrity failed: %v\n%s", err, output)
 	}
-	for _, want := range []string{
-		"go run ./tools/module-integrity -inventory \"test/module-inventory.json\"",
-		"go mod tidy -diff",
-		"go -C \"test/downstream\" mod tidy -diff",
-		"go -C \"test/downstream\" mod verify",
-		"go -C \"test/downstream\" build -mod=readonly ./...",
-		"cd \"test/downstream\" &&",
-		"run --config",
-	} {
-		if !strings.Contains(string(output), want) {
-			t.Fatalf("make module-integrity is missing %q:\n%s", want, output)
+	if !slices.Equal(got, want) {
+		t.Fatalf("module-integrity calls:\n%s\nwant:\n%s", strings.Join(got, "\n"), strings.Join(want, "\n"))
+	}
+}
+
+func TestModuleIntegrityStopsAfterModuleVerificationFailure(t *testing.T) {
+	repository := filepath.Clean(filepath.Join("..", ".."))
+	want := expectedModuleIntegrityCalls(t, repository)
+	failure := "-C test/downstream mod verify"
+	failureIndex := slices.IndexFunc(want, func(call string) bool {
+		return strings.Contains(call, failure)
+	})
+	if failureIndex < 0 {
+		t.Fatalf("expected calls do not contain %q", failure)
+	}
+
+	got, output, err := runModuleIntegrityProbe(t, repository, failure)
+	if err == nil {
+		t.Fatalf("make module-integrity ignored a downstream verification failure:\n%s", output)
+	}
+	want = want[:failureIndex+1]
+	if !slices.Equal(got, want) {
+		t.Fatalf("calls after downstream verification failure:\n%s\nwant:\n%s", strings.Join(got, "\n"), strings.Join(want, "\n"))
+	}
+}
+
+func expectedModuleIntegrityCalls(t *testing.T, repository string) []string {
+	t.Helper()
+	payload, err := os.ReadFile(filepath.Join(repository, "test", "module-inventory.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var inventory struct {
+		SchemaVersion int `json:"schema_version"`
+		Modules       []struct {
+			Path string `json:"path"`
+		} `json:"modules"`
+	}
+	if decodeErr := json.Unmarshal(payload, &inventory, json.RejectUnknownMembers(true)); decodeErr != nil {
+		t.Fatal(decodeErr)
+	}
+	if inventory.SchemaVersion != 1 {
+		t.Fatalf("module inventory schema_version = %d, want 1", inventory.SchemaVersion)
+	}
+
+	repository, err = filepath.Abs(repository)
+	if err != nil {
+		t.Fatal(err)
+	}
+	repository = filepath.ToSlash(repository)
+	binary := repository + "/bin/powercontext-downstream"
+	calls := []string{"go|||run ./tools/module-integrity -inventory test/module-inventory.json"}
+	for _, module := range inventory.Modules {
+		calls = append(calls,
+			"go|off||-C "+module.Path+" mod tidy -diff",
+			"go|off||-C "+module.Path+" mod verify",
+			"go|off||-C "+module.Path+" build -mod=readonly ./...",
+		)
+		if module.Path == "test/downstream" {
+			calls = append(calls,
+				"go|||build -tags sqlite_fts5 -o "+binary+" ./cmd/powercontext",
+				"go|off|"+binary+"|-C "+module.Path+" test -count=1 -mod=readonly ./...",
+			)
+		} else {
+			calls = append(calls, "go|off||-C "+module.Path+" test -count=1 -mod=readonly ./...")
+		}
+		directory := repository
+		if module.Path != "." {
+			directory += "/" + module.Path
+		}
+		calls = append(calls, "lint|"+directory+"|run --config "+repository+"/.golangci.yml")
+	}
+	return calls
+}
+
+func runModuleIntegrityProbe(t *testing.T, repository, failure string) ([]string, []byte, error) {
+	t.Helper()
+	temporary := t.TempDir()
+	toolsBin := filepath.Join(temporary, "bin")
+	if err := os.MkdirAll(toolsBin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	callLog := filepath.Join(temporary, "calls.txt")
+	fakeGo := filepath.Join(temporary, "go")
+	const fakeGoScript = `#!/bin/sh
+set -eu
+
+case "${1:-} ${2:-}" in
+  "env GOEXE")
+    exit 0
+    ;;
+  "env GOVERSION")
+    printf 'go1.27.0\n'
+    exit 0
+    ;;
+esac
+
+printf 'go|%s|%s|%s\n' "${GOWORK:-}" "${POWERCONTEXT_DOWNSTREAM_BINARY:-}" "$*" >> "$CALL_LOG"
+case "$*" in
+  *"${FAIL_MATCH:-never-match}"*)
+    exit 23
+    ;;
+esac
+`
+	if err := os.WriteFile(fakeGo, []byte(fakeGoScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	linter := filepath.Join(toolsBin, "golangci-lint")
+	const linterScript = `#!/bin/sh
+set -eu
+printf 'lint|%s|%s\n' "$PWD" "$*" >> "$CALL_LOG"
+case "$PWD|$*" in
+  *"${FAIL_MATCH:-never-match}"*)
+    exit 24
+    ;;
+esac
+`
+	if err := os.WriteFile(linter, []byte(linterScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	stamp := filepath.Join(toolsBin, ".golangci-lint-v2.13.1-go1.27.0")
+	if err := os.WriteFile(stamp, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	command := exec.CommandContext(
+		t.Context(),
+		"make",
+		"--no-print-directory",
+		"module-integrity",
+		"GO="+filepath.ToSlash(fakeGo),
+		"TOOLS_BIN="+filepath.ToSlash(toolsBin),
+	)
+	command.Dir = repository
+	command.Env = append(
+		os.Environ(),
+		"CALL_LOG="+filepath.ToSlash(callLog),
+		"FAIL_MATCH="+failure,
+		"GOWORK=",
+		"POWERCONTEXT_DOWNSTREAM_BINARY=",
+	)
+	output, commandErr := command.CombinedOutput()
+	payload, err := os.ReadFile(callLog)
+	if err != nil {
+		t.Fatalf("read module-integrity call log: %v\n%s", err, output)
+	}
+	calls := strings.Split(strings.TrimSpace(strings.ReplaceAll(string(payload), `\`, "/")), "\n")
+	for index, call := range calls {
+		parts := strings.SplitN(call, "|", 3)
+		if len(parts) == 3 && parts[0] == "lint" {
+			parts[1] = normalizeShellPath(parts[1])
+			calls[index] = strings.Join(parts, "|")
 		}
 	}
+	return calls, output, commandErr
+}
+
+func normalizeShellPath(path string) string {
+	if runtime.GOOS == "windows" && len(path) >= 3 && path[0] == '/' && path[2] == '/' {
+		return strings.ToUpper(path[1:2]) + ":" + path[2:]
+	}
+	return path
 }
 
 func TestMakefileRejectsFailedPipelines(t *testing.T) {

--- a/tools/release/makefile_test.go
+++ b/tools/release/makefile_test.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"bytes"
+	"cmp"
 	"encoding/json/v2"
 	"errors"
 	"os"
@@ -87,11 +88,12 @@ func expectedModuleIntegrityCalls(t *testing.T, repository string) []string {
 	if err != nil {
 		t.Fatal(err)
 	}
+	type moduleEntry struct {
+		Path string `json:"path"`
+	}
 	var inventory struct {
-		SchemaVersion int `json:"schema_version"`
-		Modules       []struct {
-			Path string `json:"path"`
-		} `json:"modules"`
+		SchemaVersion int           `json:"schema_version"`
+		Modules       []moduleEntry `json:"modules"`
 	}
 	if decodeErr := json.Unmarshal(payload, &inventory, json.RejectUnknownMembers(true)); decodeErr != nil {
 		t.Fatal(decodeErr)
@@ -99,6 +101,9 @@ func expectedModuleIntegrityCalls(t *testing.T, repository string) []string {
 	if inventory.SchemaVersion != 1 {
 		t.Fatalf("module inventory schema_version = %d, want 1", inventory.SchemaVersion)
 	}
+	slices.SortFunc(inventory.Modules, func(left, right moduleEntry) int {
+		return cmp.Compare(left.Path, right.Path)
+	})
 
 	repository, err = filepath.Abs(repository)
 	if err != nil {

--- a/tools/release/workflow_test.go
+++ b/tools/release/workflow_test.go
@@ -132,7 +132,7 @@ func TestContinuousIntegrationPreservesPythonTopologyAndGoAssurance(t *testing.T
 	}
 }
 
-func TestMigrationQualityRunsModuleInventory(t *testing.T) {
+func TestMigrationQualityRunsModuleIntegrity(t *testing.T) {
 	repository := filepath.Clean(filepath.Join("..", ".."))
 	payload, err := os.ReadFile(filepath.Join(repository, ".github", "workflows", "migration-gates.yml"))
 	if err != nil {
@@ -154,11 +154,11 @@ func TestMigrationQualityRunsModuleInventory(t *testing.T) {
 		t.Fatal("migration-gates.yml has no quality job")
 	}
 	for _, step := range quality.Steps {
-		if step.Name == "Verify owned Go module inventory" && strings.TrimSpace(step.Run) == "make module-inventory" {
+		if step.Name == "Verify owned Go module integrity" && strings.TrimSpace(step.Run) == "make module-integrity" {
 			return
 		}
 	}
-	t.Fatal("migration-gates.yml quality job does not execute make module-inventory")
+	t.Fatal("migration-gates.yml quality job does not execute make module-integrity")
 }
 
 func TestMigrationGeneratedConsumersRunsFreshConsumerVerification(t *testing.T) {


### PR DESCRIPTION
## Tracking  - Tracking issue: #3 - Relationship: `Part of #3` (WP0-C module integrity)  ## Problem and rationale  The repository inventory validated module paths and checksum-file presence, but it did not provide one stable gate that runs the complete metadata, readonly build, test, and lint contract for every explicitly owned module. Root and downstream coverage was distributed across jobs, and a new inventory entry could drift away from the Make execution matrix.  The Epic rejects dynamic multi-module CI machinery while the project has one production module. This change therefore keeps the root and `test/downstream` paths explicit and proves that the Make matrix exactly matches `test/module-inventory.json`.  ## Changes  - Add the discoverable `make module-integrity` target. - Validate the module inventory before installing or running later tools. - For every inventoried module, run tidy/no-diff, `go mod verify`, readonly build, real tests, and the pinned root lint policy. - Prebuild the standard PowerContext Server before the downstream module's public workflow tests and pass its absolute path explicitly. - Replace the dry-run substring test with executable fake-Go/fake-linter probes that compare the complete call matrix with a path-sorted inventory, so JSON entry order remains non-semantic. - Make a non-final downstream `mod verify` failure stop the target before build, tests, or lint.
- Strengthen the learned Make matrix prevention rule to cover owned-module matrices. - Update migration assurance to call the stable module-integrity target without changing the existing job name, permissions, or timeout.  ## Behavior and compatibility  - User-visible behavior: none. - Public API or protocol impact: none. - Breaking changes or migration requirements: none. - Explicit non-goals: dynamic module discovery/matrices and replacement of the separate downstream public-consumer job; the new target is self-contained, while `downstream-compat` remains an independently named runtime signal.  ## Generated, dependency, and workflow impact  - [x] No generated contract changed. - [x] No dependency changed. - [x] One existing migration-assurance step now uses the stable target; job names, permissions, and timeout remain unchanged. - [x] No credential, private Source/Memory content, or unredacted production log is included.  ## Validation  Commands run after the review fixes:  ```text go test -count=1 ./tools/release -run '^(TestBareMakeListsSupportedTargets|TestModuleIntegrityRunsEveryOwnedModule|TestModuleIntegrityStopsAfterModuleVerificationFailure|TestMigrationQualityRunsModuleIntegrity)$' PASS  GOWORK=off go test -count=10 ./tools/release -run '^(TestModuleIntegrityRunsEveryOwnedModule|TestModuleIntegrityStopsAfterModuleVerificationFailure)$' PASS  go test -count=1 ./tools/module-integrity PASS make module-check PASS make module-inventory PASS go vet ./tools/release PASS .tools/bin/golangci-lint.exe run ./tools/release PASS: 0 issues make governance-check PASS make license-check PASS: 803 valid, 0 invalid, 199 ignored git diff --check PASS ```  Exact-Head GitHub validation:

- Head `ed267ffb8659fe509db3f6a0be0fea15ec1f1626`: 33/33 visible checks succeeded.
- The critical [Contract, race, fuzz, and module integrity run](https://github.com/ob-labs/powercontext-go/actions/runs/33285964644) succeeded; its `Verify owned Go module integrity` step completed successfully before the existing race, fuzz, tidy, and Docker gates finished.
The executable probe first failed against the earlier implementation because root readonly build and module tests were absent. It now proves the complete inventory-derived matrix and fail-fast behavior.  Windows-local limitation, not represented as passing:  - The complete real target reaches the root standard Server build required by the downstream tests, where the existing `internal/sqlstore/seekdb/loader.c` build-selection defect prevents Windows package loading. The focused Make probes, module metadata checks, vet, and pinned lint passed locally. Exact-Head Linux CI must prove the real self-contained target.  - [x] `git diff --check` - [x] `git status --short` was inspected after validation. - [x] Relevant module, lint, Make, workflow, formatting, and license checks were run. - [x] The unavailable Windows full-target check is identified above and is not represented as passing.  ## AI usage  AI assistance was used to implement and revise the bounded module-integrity gate. Independent exact-Head review found that the first version overclaimed completeness and used a non-discriminative dry-run test. The final Head addresses both findings with a self-contained matrix and executable failure probe and was independently re-reviewed after exact-Head CI completed. 