### PR TITLE
test: map documentation transport parity evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,15 @@ front of the Server; controlled networks or deployments with upstream TLS may
 instead opt in explicitly with
 `POWERCONTEXT_SERVER_ALLOW_UNAUTHENTICATED_NON_LOOPBACK=true`.
 
+For an authenticated non-loopback bind behind a TLS terminator, replace the
+example token before starting the Server:
+
+```sh
+POWERCONTEXT_SERVER_AUTH_ENABLED=true \
+POWERCONTEXT_SERVER_AUTH_TOKEN='replace-with-a-strong-token' \
+./bin/powercontext server run --host 0.0.0.0
+```
+
 The Go Client likewise rejects plaintext HTTP to a non-loopback Server unless
 the caller supplies its own `http.Client` and explicitly sets
 `TrustTransportSecurity` for a separately secured transport.

--- a/internal/cli/docs_contract_test.go
+++ b/internal/cli/docs_contract_test.go
@@ -1,0 +1,156 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/ob-labs/powercontext-go/server"
+)
+
+var (
+	documentedShellBlock = regexp.MustCompile("(?s)```(?:sh|bash)\\r?\\n(.*?)```")
+	documentedEnvToken   = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*=`)
+)
+
+type documentedServerRun struct {
+	environment map[string]string
+	arguments   []string
+	host        string
+	port        string
+}
+
+func TestRemoteAccessDocumentationIncludesNonLoopbackServerCommand(t *testing.T) {
+	commands := readDocumentedServerRuns(t)
+	for _, command := range commands {
+		if command.host == "0.0.0.0" {
+			return
+		}
+	}
+	t.Fatal("README.md does not document a non-loopback Server command")
+}
+
+func TestDocumentedServerRunCommandsStart(t *testing.T) {
+	clearServerEnvironment(t)
+	for _, documented := range readDocumentedServerRuns(t) {
+		t.Run(documented.host+":"+documented.port, func(t *testing.T) {
+			for name, value := range documented.environment {
+				t.Setenv(name, value)
+			}
+			t.Setenv(server.PowerContextHomeEnv, t.TempDir())
+
+			called := false
+			var received server.ProcessConfig
+			runner := func(_ context.Context, _ *commandState, config server.ProcessConfig) error {
+				called = true
+				received = config
+				return nil
+			}
+			var stdout, stderr bytes.Buffer
+			command := newCommandWithDependencies(VersionInfo{Version: "test"}, &stdout, &stderr, nil, runner)
+			command.SetArgs(documented.arguments)
+			if err := command.ExecuteContext(t.Context()); err != nil {
+				t.Fatalf("documented command failed: %v", err)
+			}
+			if !called {
+				t.Fatal("documented command did not reach the Server runner")
+			}
+			port, err := strconv.Atoi(documented.port)
+			if err != nil {
+				t.Fatalf("documented port %q is not numeric: %v", documented.port, err)
+			}
+			if received.HTTP.Host != documented.host || received.HTTP.Port != port {
+				t.Fatalf("Server address = %s:%d, want %s:%d", received.HTTP.Host, received.HTTP.Port, documented.host, port)
+			}
+		})
+	}
+}
+
+func readDocumentedServerRuns(t *testing.T) []documentedServerRun {
+	t.Helper()
+	payload, err := os.ReadFile(filepath.Join("..", "..", "README.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	commands := make([]documentedServerRun, 0)
+	for _, match := range documentedShellBlock.FindAllStringSubmatch(string(payload), -1) {
+		block := strings.ReplaceAll(match[1], "\\\r\n", " ")
+		block = strings.ReplaceAll(block, "\\\n", " ")
+		for line := range strings.SplitSeq(block, "\n") {
+			fields := strings.Fields(line)
+			command, ok := parseDocumentedServerRun(fields)
+			if ok {
+				commands = append(commands, command)
+			}
+		}
+	}
+	if len(commands) == 0 {
+		t.Fatal("README.md does not contain a documented Server command")
+	}
+	return commands
+}
+
+func parseDocumentedServerRun(fields []string) (documentedServerRun, bool) {
+	environment := make(map[string]string)
+	index := 0
+	for index < len(fields) && documentedEnvToken.MatchString(fields[index]) {
+		name, value, _ := strings.Cut(fields[index], "=")
+		environment[name] = strings.Trim(value, `'"`)
+		index++
+	}
+	for index+2 < len(fields) {
+		if path.Base(fields[index]) == "powercontext" && fields[index+1] == "server" && fields[index+2] == "run" {
+			arguments := fields[index+1:]
+			host := documentedOption(arguments, "--host", "127.0.0.1")
+			port := documentedOption(arguments, "--port", "8000")
+			return documentedServerRun{environment: environment, arguments: arguments, host: host, port: port}, true
+		}
+		index++
+	}
+	return documentedServerRun{}, false
+}
+
+func documentedOption(arguments []string, name, fallback string) string {
+	for index, argument := range arguments {
+		if argument == name && index+1 < len(arguments) {
+			return arguments[index+1]
+		}
+	}
+	return fallback
+}
+
+func clearServerEnvironment(t *testing.T) {
+	t.Helper()
+	for _, item := range os.Environ() {
+		name, value, ok := strings.Cut(item, "=")
+		if !ok || !strings.HasPrefix(name, "POWERCONTEXT_SERVER_") {
+			continue
+		}
+		if err := os.Unsetenv(name); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() {
+			_ = os.Setenv(name, value)
+		})
+	}
+}

--- a/test/conformance/parity-inventory-rules.json
+++ b/test/conformance/parity-inventory-rules.json
@@ -102,7 +102,19 @@
     },
     "tests/test_docs_remote_access_contract.py": {
       "mode": "go-port",
-      "reason": "Documentation contract for non-loopback binds owned by this repository."
+      "reason": "Documentation contract for non-loopback binds owned by this repository.",
+      "cases": {
+        "test_docs_expose_a_non_loopback_bind_command": {
+          "evidence": [
+            "go:internal/cli/docs_contract_test.go#TestRemoteAccessDocumentationIncludesNonLoopbackServerCommand"
+          ]
+        },
+        "test_documented_server_run_command_starts": {
+          "evidence": [
+            "go:internal/cli/docs_contract_test.go#TestDocumentedServerRunCommandsStart"
+          ]
+        }
+      }
     },
     "tests/test_doctor_integrations.py": {
       "mode": "go-port",

--- a/test/conformance/parity-inventory.json
+++ b/test/conformance/parity-inventory.json
@@ -4,8 +4,8 @@
   "oracle_commit": "3a6cb0151670eaff7dc0293466edd673124e80da",
   "python_test_file_count": 127,
   "python_test_case_count": 759,
-  "mapped_case_count": 643,
-  "pending_case_count": 116,
+  "mapped_case_count": 645,
+  "pending_case_count": 114,
   "entries": [
     {
       "python": {
@@ -8507,8 +8507,15 @@
         "line": 103
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/docs_contract_test.go",
+          "test": "TestRemoteAccessDocumentationIncludesNonLoopbackServerCommand"
+        }
+      ]
     },
     {
       "python": {
@@ -8517,8 +8524,15 @@
         "line": 110
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/docs_contract_test.go",
+          "test": "TestDocumentedServerRunCommandsStart"
+        }
+      ]
     },
     {
       "python": {


### PR DESCRIPTION
## Tracking

- Tracking issue: #3
- Relationship: `Part of #3` (WP1 active-target parity evidence)

## Problem and rationale

The active parity inventory still left both cases from `tests/test_docs_remote_access_contract.py` pending. The repository documented the remote-bind policy in prose but did not provide a copy-pasteable non-loopback `server run` command, and documentation builds did not prove that a documented command survives the real CLI policy checks.

## Changes

- Add an authenticated `0.0.0.0` Server example for deployments behind a TLS terminator.
- Extract documented `powercontext server run` commands from README shell blocks and execute them through the real Go CLI configuration path with only their documented `POWERCONTEXT_SERVER_*` environment.
- Assert the documented address reaches the Server runner.
- Map both upstream documentation cases and regenerate the 759-case inventory from `643 mapped / 116 pending` to `645 mapped / 114 pending`.

## Regression proof

RED before the documentation change:

```text
--- FAIL: TestRemoteAccessDocumentationIncludesNonLoopbackServerCommand
README.md does not document a non-loopback Server command
```

Discriminative unsafe-command mutant:

```text
--- FAIL: TestDocumentedServerRunCommandsStart/0.0.0.0:8000
server: refusing to bind an unauthenticated Server to a non-loopback address
```

The final authenticated command passes the same real CLI entry point and reaches the injected Server process boundary with `0.0.0.0:8000`.

## Behavior and compatibility

- User-visible behavior: README now contains an executable authenticated remote-bind example.
- Public API, OpenAPI, persistence, and generated transport behavior: unchanged.
- Security default: unchanged; unauthenticated non-loopback binds still fail closed.
- Explicit non-goals: Bub and the remaining 114 WP1 parity cases remain separate slices.

## Validation

```text
go test -count=1 ./internal/cli ./tools/parity-inventory-generate ./test/conformance
PASS in a fresh LF Linux checkout

go run ./tools/parity-inventory-generate -upstream <exact f2ec1f75 checkout> -check
PASS

make lint
0 issues

make check-generated
PASS

make module-check
all modules verified

make license-check
804 valid, 0 invalid

git diff --check
PASS
```

The original Windows working checkout retains CRLF bytes in several frozen JSON fixtures created before the LF attributes landed, so its conformance hash test is not represented as passing. The same current diff passed conformance in a fresh LF checkout; no frozen fixture was modified.

## AI usage

AI assistance was used to implement and verify this parity-evidence slice. The final tests were exercised through the real CLI configuration entry point, a failing unauthenticated mutant, exact-target inventory regeneration, fresh-LF conformance, pinned lint, generated checks, module verification, and license validation.