### PR TITLE
test: map Bub transport parity evidence

### DIFF
--- a/integrations/bub/tests/test_transport_trust.py
+++ b/integrations/bub/tests/test_transport_trust.py
@@ -1,0 +1,118 @@
+# Copyright (c) 2026 OceanBase.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from powercontext_bub import plugin as plugin_module
+from powercontext_bub import tools as tools_module
+from powercontext_bub.client import PowerContextHTTPClient
+from powercontext_bub.plugin import STATE_KEY, PowerContextPlugin, PowerContextSettings
+
+
+def _plugin_with(
+    settings: PowerContextSettings,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> PowerContextPlugin:
+    monkeypatch.setattr(plugin_module, "ensure_config", lambda _: settings)
+    return PowerContextPlugin(SimpleNamespace(workspace=tmp_path))
+
+
+def _tool_settings(
+    plugin: PowerContextPlugin,
+    settings: PowerContextSettings,
+    monkeypatch: pytest.MonkeyPatch,
+) -> tools_module.ToolSettings:
+    monkeypatch.setattr(tools_module, "ensure_config", lambda _: settings)
+    state = plugin.load_state(message=None, session_id="session-1")
+    return tools_module._settings(SimpleNamespace(state=state))
+
+
+def test_plugin_refuses_a_plaintext_non_loopback_server_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    settings = PowerContextSettings(base_url="http://host-gateway:8000", scope_id="test:scope")
+    plugin = _plugin_with(settings, monkeypatch, tmp_path)
+
+    with pytest.raises(ValueError, match="loopback"):
+        plugin._client()
+
+
+def test_trusting_the_transport_supplies_the_client_an_explicit_vouched_transport(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    settings = PowerContextSettings(
+        base_url="http://host-gateway:8000",
+        scope_id="test:scope",
+        trust_transport_security=True,
+    )
+    plugin = _plugin_with(settings, monkeypatch, tmp_path)
+
+    assert isinstance(plugin._client(), PowerContextHTTPClient)
+
+
+def test_load_state_carries_the_transport_vouch_to_tool_settings(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    refusing = _plugin_with(
+        PowerContextSettings(base_url="http://host-gateway:8000", scope_id="test:scope"),
+        monkeypatch,
+        tmp_path,
+    )
+    assert refusing.load_state(message=None, session_id="session-1")[STATE_KEY]["trust_transport_security"] is False
+
+    vouched = _plugin_with(
+        PowerContextSettings(
+            base_url="http://host-gateway:8000",
+            scope_id="test:scope",
+            trust_transport_security=True,
+        ),
+        monkeypatch,
+        tmp_path,
+    )
+    assert vouched.load_state(message=None, session_id="session-1")[STATE_KEY]["trust_transport_security"] is True
+
+
+def test_tools_refuse_a_plaintext_non_loopback_server_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    settings = PowerContextSettings(base_url="http://host-gateway:8000", scope_id="test:scope")
+    plugin = _plugin_with(settings, monkeypatch, tmp_path)
+
+    with pytest.raises(ValueError, match="loopback"):
+        tools_module._client(_tool_settings(plugin, settings, monkeypatch))
+
+
+def test_tools_honour_the_operator_transport_vouch(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    settings = PowerContextSettings(
+        base_url="http://host-gateway:8000",
+        scope_id="test:scope",
+        trust_transport_security=True,
+    )
+    plugin = _plugin_with(settings, monkeypatch, tmp_path)
+
+    client = tools_module._client(_tool_settings(plugin, settings, monkeypatch))
+
+    assert isinstance(client, PowerContextHTTPClient)

--- a/test/conformance/parity-inventory-rules.json
+++ b/test/conformance/parity-inventory-rules.json
@@ -4,7 +4,34 @@
   "files": {
     "e2e/bub/tests/test_bub_transport_trust.py": {
       "mode": "retained-host",
-      "reason": "Bub plugin transport trust behavior; evidence will live in the retained Bub adapter tests once WP2 aligns the shared loopback vectors."
+      "reason": "Bub plugin transport trust behavior owned by the retained Bub adapter.",
+      "cases": {
+        "test_plugin_refuses_a_plaintext_non_loopback_server_by_default": {
+          "evidence": [
+            "py:integrations/bub/tests/test_transport_trust.py#test_plugin_refuses_a_plaintext_non_loopback_server_by_default"
+          ]
+        },
+        "test_trusting_the_transport_supplies_the_client_an_explicit_vouched_transport": {
+          "evidence": [
+            "py:integrations/bub/tests/test_transport_trust.py#test_trusting_the_transport_supplies_the_client_an_explicit_vouched_transport"
+          ]
+        },
+        "test_load_state_carries_the_transport_vouch_to_tool_settings": {
+          "evidence": [
+            "py:integrations/bub/tests/test_transport_trust.py#test_load_state_carries_the_transport_vouch_to_tool_settings"
+          ]
+        },
+        "test_tools_refuse_a_plaintext_non_loopback_server_by_default": {
+          "evidence": [
+            "py:integrations/bub/tests/test_transport_trust.py#test_tools_refuse_a_plaintext_non_loopback_server_by_default"
+          ]
+        },
+        "test_tools_honour_the_operator_transport_vouch": {
+          "evidence": [
+            "py:integrations/bub/tests/test_transport_trust.py#test_tools_honour_the_operator_transport_vouch"
+          ]
+        }
+      }
     },
     "e2e/bub/tests/test_harbor_agent.py": {
       "mode": "retained-host",

--- a/test/conformance/parity-inventory.json
+++ b/test/conformance/parity-inventory.json
@@ -4,8 +4,8 @@
   "oracle_commit": "3a6cb0151670eaff7dc0293466edd673124e80da",
   "python_test_file_count": 127,
   "python_test_case_count": 759,
-  "mapped_case_count": 645,
-  "pending_case_count": 114,
+  "mapped_case_count": 650,
+  "pending_case_count": 109,
   "entries": [
     {
       "python": {
@@ -31,8 +31,15 @@
         "line": 38
       },
       "mode": "retained-host",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/bub/tests/test_transport_trust.py",
+          "test": "test_plugin_refuses_a_plaintext_non_loopback_server_by_default"
+        }
+      ]
     },
     {
       "python": {
@@ -41,8 +48,15 @@
         "line": 81
       },
       "mode": "retained-host",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/bub/tests/test_transport_trust.py",
+          "test": "test_trusting_the_transport_supplies_the_client_an_explicit_vouched_transport"
+        }
+      ]
     },
     {
       "python": {
@@ -51,8 +65,15 @@
         "line": 107
       },
       "mode": "retained-host",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/bub/tests/test_transport_trust.py",
+          "test": "test_load_state_carries_the_transport_vouch_to_tool_settings"
+        }
+      ]
     },
     {
       "python": {
@@ -61,8 +82,15 @@
         "line": 127
       },
       "mode": "retained-host",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/bub/tests/test_transport_trust.py",
+          "test": "test_tools_refuse_a_plaintext_non_loopback_server_by_default"
+        }
+      ]
     },
     {
       "python": {
@@ -71,8 +99,15 @@
         "line": 139
       },
       "mode": "retained-host",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/bub/tests/test_transport_trust.py",
+          "test": "test_tools_honour_the_operator_transport_vouch"
+        }
+      ]
     },
     {
       "python": {


### PR DESCRIPTION
## Tracking

- Tracking issue: #3
- Relationship: `Part of #3` (WP1 active-target parity evidence)

## Problem and rationale

The active parity inventory still left all five cases from `e2e/bub/tests/test_bub_transport_trust.py` pending even though the retained Bub adapter already implements the shared transport policy. Existing tests covered the low-level Bub Client vectors but did not give case-specific evidence for the plugin constructor, plugin state, and tools client boundaries.

## Changes

- Add five retained-host tests matching the active-target Bub transport cases by name.
- Exercise real `PowerContextSettings`, plugin construction, plugin state, tools settings, and `PowerContextHTTPClient` construction.
- Keep the only monkeypatch at Bub's `ensure_config` framework boundary; no internal Client mock is used.
- Map all five upstream cases and regenerate the 759-case inventory from `645 mapped / 114 pending` to `650 mapped / 109 pending`.

## Discriminative proof

Temporary mutants were applied and restored before the final commit:

- disabling plaintext remote rejection made the plugin refusal test fail because no `ValueError` was raised;
- dropping the plugin Client vouch made the plugin trust test fail at Client construction;
- dropping the vouch from plugin state made both the state assertion and tools chain fail;
- dropping the vouch in the tools Client boundary made the tools trust test fail.

These mutants prove the tests distinguish each transport propagation boundary instead of only restating configuration values.

## Behavior and compatibility

- Production behavior: unchanged.
- Public API, OpenAPI, persistence, and generated contracts: unchanged.
- Security defaults: unchanged; plaintext non-loopback routes still fail closed unless the operator vouches for transport security.
- Explicit non-goal: the remaining 109 active-target cases stay pending for later WP1 slices.

## Validation

```text
uv run --project integrations/bub --locked --with pytest pytest integrations/bub/tests -q
16 passed, 28 subtests passed

go test -count=1 ./tools/parity-inventory-generate
PASS

go run ./tools/parity-inventory-generate -upstream <exact f2ec1f75 checkout> -check
PASS

make license-check
805 valid, 0 invalid

git diff --check -- <three submitted files>
PASS
```

## AI usage

AI assistance was used to add and verify the retained-host parity evidence. The tests use real settings, state, tools, and Client objects and were independently checked with four restored mutants, the locked Bub environment, exact-target inventory regeneration, and license validation.