### PR TITLE
test: reject commented documentation commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -259,3 +259,7 @@ source / artifact / trigger / inference
   host-vector fixture. Verify the complete IPv4 `127.0.0.0/8` range, IPv6
   loopback, remote plaintext rejection, and each explicit trusted-transport
   exception in the adapter's native test suite.
+- When a documentation contract test extracts executable shell commands, stop
+  parsing at a shell comment before deciding that a command exists. Verify a
+  fully commented command cannot satisfy executable-documentation evidence and
+  that a valid command still reaches the real CLI boundary.

--- a/internal/cli/docs_contract_test.go
+++ b/internal/cli/docs_contract_test.go
@@ -86,6 +86,13 @@ func TestDocumentedServerRunCommandsStart(t *testing.T) {
 	}
 }
 
+func TestParseDocumentedServerRunRejectsCommentedCommand(t *testing.T) {
+	fields := strings.Fields("# ./bin/powercontext server run --host 0.0.0.0")
+	if _, ok := parseDocumentedServerRun(fields); ok {
+		t.Fatal("commented Server command was treated as executable documentation")
+	}
+}
+
 func readDocumentedServerRuns(t *testing.T) []documentedServerRun {
 	t.Helper()
 	payload, err := os.ReadFile(filepath.Join("..", "..", "README.md"))
@@ -111,6 +118,12 @@ func readDocumentedServerRuns(t *testing.T) []documentedServerRun {
 }
 
 func parseDocumentedServerRun(fields []string) (documentedServerRun, bool) {
+	for index, field := range fields {
+		if strings.HasPrefix(field, "#") {
+			fields = fields[:index]
+			break
+		}
+	}
 	environment := make(map[string]string)
 	index := 0
 	for index < len(fields) && documentedEnvToken.MatchString(fields[index]) {


### PR DESCRIPTION
## Tracking

- Tracking issue: #3
- Relationship: Part of #3
- Follow-up to merged PR #67

## Problem and rationale

The documentation parity test added in #67 tokenized shell blocks with strings.Fields and then searched forward for powercontext server run. A fully commented command such as # ./bin/powercontext server run --host 0.0.0.0 was therefore treated as executable evidence, so both mapped documentation cases could remain green after the runnable remote-bind example was disabled.

## Changes

- Stop parsing documented shell fields at the first shell-comment token.
- Add a focused regression test proving a commented Server command is rejected.
- Add the repository-required reusable bug-prevention rule.

## Regression proof

Before the fix:

```text
=== RUN   TestParseDocumentedServerRunRejectsCommentedCommand
docs_contract_test.go:92: commented Server command was treated as executable documentation
--- FAIL: TestParseDocumentedServerRunRejectsCommentedCommand
```

After the fix, the same regression and the real documented-command tests pass through the CLI configuration boundary.

## Behavior and compatibility

- Production CLI, Server, public API, OpenAPI, persistence, and generated contracts are unchanged.
- Documentation evidence can no longer be satisfied by a shell-commented command.
- No new dependency or general-purpose shell parser is introduced.

## Validation

```text
go test -count=1 ./internal/cli
PASS

go test -race -count=1 ./internal/cli
PASS

make lint
0 issues (clean LF clone)

make docs-test
No issues found; Build finished

git diff --check
PASS
```

The Windows checkout has pre-existing CRLF bytes in three untouched source files, so pinned lint was run in a clean LF clone with this exact two-file patch.

## AI usage

AI assistance was used to review #67, build the discriminative commented-command regression, implement the bounded repair, and verify the exact patch with package, race, lint, documentation, and diff gates.