### PR TITLE
test: map Bub source install parity evidence

### DIFF
--- a/integrations/bub/tests/test_packaging.py
+++ b/integrations/bub/tests/test_packaging.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2026 OceanBase.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import json
+import re
+import tomllib
+from importlib.metadata import distribution
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+REQUIREMENT_NAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*")
+
+
+def test_source_checkout_install_uses_local_adapter_without_python_sdk_override() -> None:
+    direct_url_payload = distribution("powercontext-bub").read_text("direct_url.json")
+    assert direct_url_payload is not None
+    direct_url = json.loads(direct_url_payload)
+    assert direct_url["url"].rstrip("/") == PROJECT_ROOT.as_uri()
+    assert direct_url["dir_info"]["editable"] is True
+
+    project = tomllib.loads((PROJECT_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    dependency_names = {_requirement_name(requirement) for requirement in project["project"]["dependencies"]}
+    assert "powercontext" not in dependency_names
+
+
+def _requirement_name(requirement: str) -> str:
+    match = REQUIREMENT_NAME.match(requirement)
+    assert match is not None, f"invalid requirement {requirement!r}"
+    return match.group().lower().replace("_", "-")

--- a/test/conformance/parity-inventory-rules.json
+++ b/test/conformance/parity-inventory-rules.json
@@ -35,7 +35,14 @@
     },
     "e2e/bub/tests/test_harbor_agent.py": {
       "mode": "retained-host",
-      "reason": "Bub harbor agent installation behavior owned by the retained Bub adapter."
+      "reason": "Bub source-checkout installation behavior adapted to the Go Server architecture without the retired Python SDK dependency.",
+      "cases": {
+        "test_install_bub_command_overrides_release_floor_for_mounted_source": {
+          "evidence": [
+            "py:integrations/bub/tests/test_packaging.py#test_source_checkout_install_uses_local_adapter_without_python_sdk_override"
+          ]
+        }
+      }
     },
     "tests/e2e/test_pydantic_ai_chain.py": {
       "mode": "cross-layer",

--- a/test/conformance/parity-inventory.json
+++ b/test/conformance/parity-inventory.json
@@ -4,8 +4,8 @@
   "oracle_commit": "3a6cb0151670eaff7dc0293466edd673124e80da",
   "python_test_file_count": 127,
   "python_test_case_count": 759,
-  "mapped_case_count": 650,
-  "pending_case_count": 109,
+  "mapped_case_count": 651,
+  "pending_case_count": 108,
   "entries": [
     {
       "python": {
@@ -177,8 +177,15 @@
         "line": 30
       },
       "mode": "retained-host",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/bub/tests/test_packaging.py",
+          "test": "test_source_checkout_install_uses_local_adapter_without_python_sdk_override"
+        }
+      ]
     },
     {
       "python": {


### PR DESCRIPTION
## Tracking

- Tracking issue: #3
- Relationship: `Part of #3` (WP1 active-target parity evidence)

## Problem and rationale

The active parity inventory retained one pending Bub source-checkout installation case from `e2e/bub/tests/test_harbor_agent.py`. Upstream Python needs a `powercontext[client]` source override to bypass its release floor. The Go architecture deliberately removes that dependency: the retained Bub adapter talks to the Go Server through its own HTTP client and must install directly from the mounted adapter source without resolving the retired Python SDK.

## Changes

- Verify the installed `powercontext-bub` distribution is an editable installation from the current `integrations/bub` source directory.
- Verify the adapter's root dependency manifest contains no `powercontext` Python distribution requirement.
- Map the upstream mounted-source override case to this Go-adapted packaging evidence.
- Regenerate the 759-case inventory from `650 mapped / 109 pending` to `651 mapped / 108 pending`.

## Discriminative proof

A temporary manifest mutant added `powercontext[client]>=0.0.2`. Running the packaging test with the existing environment and `--no-sync` failed on the intended contract assertion:

```text
assert 'powercontext' not in {'bub', 'powercontext', 'pydantic-settings'}
```

The manifest was restored before final validation and is not changed by this PR.

## Behavior and compatibility

- Production behavior and dependencies: unchanged.
- Public API, OpenAPI, persistence, and generated contracts: unchanged.
- Architectural adaptation: preserves the Go Server boundary instead of reintroducing the retired public Python SDK.
- Explicit non-goal: the remaining 108 WP1 cases stay pending for their owning WP3/WP4 feature slices.

## Validation

```text
uv run --project integrations/bub --locked --with pytest pytest integrations/bub/tests -q
17 passed, 28 subtests passed

go test -count=1 ./tools/parity-inventory-generate
PASS

go run ./tools/parity-inventory-generate -upstream <exact f2ec1f75 checkout> -check
PASS

make license-check
806 valid, 0 invalid

git diff --check -- <three submitted files>
PASS
```

## AI usage

AI assistance was used to add and verify this Go-adapted packaging evidence. The final test reads the real installed distribution metadata and root manifest, and was checked with a restored dependency mutant, the locked Bub environment, exact-target inventory generation, and license validation.