### PR TITLE
test: consume fresh traceability output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,8 +134,8 @@ check-generated: ## Verify generated contracts and traceability outputs are clea
 	$(GO) run ./tools/traceability-generate -check
 	git diff --exit-code -- openapi api/v1 client/invoker_gen.go internal/mcpapi/schemas_gen.go integrations/dsh/plugins/powercontext/src/operations.generated.ts
 
-generated-consumers: ## Generate and test fresh Go consumers from public generator CLIs.
-	GOWORK=off $(GO) test -count=1 ./tools/generated-consumers
+generated-consumers: lint-tools ## Generate, test, and lint fresh consumers from public generator CLIs.
+	POWERCONTEXT_GOLANGCI_LINT="$(GOLANGCI_LINT)" GOWORK=off $(GO) test -count=1 ./tools/generated-consumers
 
 module-check: ## Verify tidy readonly module metadata and checksums.
 	$(GO) mod tidy -diff

--- a/tools/generated-consumers/main_test.go
+++ b/tools/generated-consumers/main_test.go
@@ -64,58 +64,139 @@ func TestGeneratedRememberMemorySchema(t *testing.T) {
 const generatedTraceabilityConsumerTest = `package generatedconsumer
 
 import (
-	"encoding/json"
+	"encoding/json/v2"
+	"fmt"
 	"os"
+	"slices"
 	"testing"
 )
 
+type traceabilityTable struct {
+	SchemaVersion               int                 ` + "`json:\"schema_version\"`" + `
+	OracleCommit                string              ` + "`json:\"oracle_commit\"`" + `
+	PythonTestFileCount         int                 ` + "`json:\"python_test_file_count\"`" + `
+	PythonTestCaseCount         int                 ` + "`json:\"python_test_case_count\"`" + `
+	CaseSpecificEvidenceCount   int                 ` + "`json:\"case_specific_evidence_count\"`" + `
+	FileSupportingEvidenceCount int                 ` + "`json:\"file_supporting_evidence_count\"`" + `
+	CaseSpecificEvidenceMinimum int                 ` + "`json:\"case_specific_evidence_minimum\"`" + `
+	Entries                     []traceabilityEntry ` + "`json:\"entries\"`" + `
+}
+
+type traceabilityEntry struct {
+	Python        pythonIdentity         ` + "`json:\"python\"`" + `
+	Mode          string                 ` + "`json:\"mode\"`" + `
+	EvidenceLevel string                 ` + "`json:\"evidence_level\"`" + `
+	Evidence      []traceabilityEvidence ` + "`json:\"evidence\"`" + `
+}
+
+type pythonIdentity struct {
+	File string ` + "`json:\"file\"`" + `
+	Name string ` + "`json:\"name\"`" + `
+	Line int    ` + "`json:\"line\"`" + `
+}
+
+type traceabilityEvidence struct {
+	Kind string ` + "`json:\"kind\"`" + `
+	File string ` + "`json:\"file\"`" + `
+	Test string ` + "`json:\"test\"`" + `
+}
+
 func TestGeneratedTraceabilityTable(t *testing.T) {
-	payload, err := os.ReadFile("traceability.json")
-	if err != nil {
-		t.Fatal(err)
+	payload, readErr := os.ReadFile("traceability.json")
+	if readErr != nil {
+		t.Fatal(readErr)
 	}
-	var table map[string]json.RawMessage
-	if err := json.Unmarshal(payload, &table); err != nil {
-		t.Fatal(err)
+	table, decodeErr := decodeTraceabilityTable(payload)
+	if decodeErr != nil {
+		t.Fatalf("decode traceability table: %v", decodeErr)
 	}
-	var schemaVersion, pythonTestCaseCount, caseSpecificEvidenceCount int
-	if err := json.Unmarshal(table["schema_version"], &schemaVersion); err != nil {
-		t.Fatal(err)
+	if validateErr := validateTraceabilityTable(table); validateErr != nil {
+		t.Fatal(validateErr)
 	}
-	if schemaVersion != 2 {
-		t.Fatalf("schema version = %d, want 2", schemaVersion)
+}
+
+func TestTraceabilityEntryValidationRejectsIncompleteValues(t *testing.T) {
+	valid := traceabilityEntry{
+		Python:        pythonIdentity{File: "tests/test_example.py", Name: "test_example", Line: 10},
+		Mode:          "go-port",
+		EvidenceLevel: "case-specific",
+		Evidence:      []traceabilityEvidence{{Kind: "go", File: "example_test.go", Test: "TestExample"}},
 	}
-	var oracleCommit string
-	if err := json.Unmarshal(table["oracle_commit"], &oracleCommit); err != nil {
-		t.Fatal(err)
+	tests := []struct {
+		name   string
+		mutate func(*traceabilityEntry)
+	}{
+		{name: "missing Python identity", mutate: func(entry *traceabilityEntry) { entry.Python.Name = "" }},
+		{name: "invalid mode", mutate: func(entry *traceabilityEntry) { entry.Mode = "unknown" }},
+		{name: "invalid evidence level", mutate: func(entry *traceabilityEntry) { entry.EvidenceLevel = "file-supporting" }},
+		{name: "missing evidence", mutate: func(entry *traceabilityEntry) { entry.Evidence = nil }},
+		{name: "incomplete evidence", mutate: func(entry *traceabilityEntry) { entry.Evidence[0].File = "" }},
 	}
-	if oracleCommit != "3a6cb0151670eaff7dc0293466edd673124e80da" {
-		t.Fatalf("oracle commit = %q", oracleCommit)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			entry := valid
+			entry.Evidence = slices.Clone(valid.Evidence)
+			test.mutate(&entry)
+			if validateErr := validateTraceabilityEntry(entry); validateErr == nil {
+				t.Fatal("validation unexpectedly succeeded")
+			}
+		})
 	}
-	for key, target := range map[string]*int{
-		"python_test_case_count": &pythonTestCaseCount,
-		"case_specific_evidence_count": &caseSpecificEvidenceCount,
-	} {
-		if err := json.Unmarshal(table[key], target); err != nil {
-			t.Fatal(err)
+}
+
+func decodeTraceabilityTable(payload []byte) (traceabilityTable, error) {
+	var table traceabilityTable
+	if decodeErr := json.Unmarshal(payload, &table, json.RejectUnknownMembers(true)); decodeErr != nil {
+		return traceabilityTable{}, decodeErr
+	}
+	return table, nil
+}
+
+func validateTraceabilityTable(table traceabilityTable) error {
+	if table.SchemaVersion != 2 {
+		return fmt.Errorf("schema version = %d, want 2", table.SchemaVersion)
+	}
+	if table.OracleCommit != "3a6cb0151670eaff7dc0293466edd673124e80da" {
+		return fmt.Errorf("oracle commit = %q", table.OracleCommit)
+	}
+	if table.PythonTestFileCount != 109 || table.PythonTestCaseCount != 622 ||
+		table.CaseSpecificEvidenceCount != 622 || table.FileSupportingEvidenceCount != 0 ||
+		table.CaseSpecificEvidenceMinimum != 622 {
+		return fmt.Errorf("traceability summary is inconsistent")
+	}
+	if len(table.Entries) != table.PythonTestCaseCount {
+		return fmt.Errorf("traceability entries = %d, want %d", len(table.Entries), table.PythonTestCaseCount)
+	}
+	for index, entry := range table.Entries {
+		if entryErr := validateTraceabilityEntry(entry); entryErr != nil {
+			return fmt.Errorf("entry %d: %w", index, entryErr)
 		}
 	}
-	var entries []map[string]json.RawMessage
-	if err := json.Unmarshal(table["entries"], &entries); err != nil {
-		t.Fatal(err)
+	return nil
+}
+
+func validateTraceabilityEntry(entry traceabilityEntry) error {
+	if entry.Python.File == "" || entry.Python.Name == "" || entry.Python.Line <= 0 {
+		return fmt.Errorf("Python identity is incomplete")
 	}
-	if len(entries) != pythonTestCaseCount || caseSpecificEvidenceCount != len(entries) {
-		t.Fatalf("traceability counts are inconsistent")
+	if !slices.Contains([]string{"cross-layer", "go-port", "retained-host"}, entry.Mode) {
+		return fmt.Errorf("mode = %q", entry.Mode)
 	}
-	for _, entry := range entries {
-		var evidence []json.RawMessage
-		if err := json.Unmarshal(entry["evidence"], &evidence); err != nil {
-			t.Fatal(err)
+	if entry.EvidenceLevel != "case-specific" {
+		return fmt.Errorf("evidence level = %q", entry.EvidenceLevel)
+	}
+	if len(entry.Evidence) == 0 {
+		return fmt.Errorf("evidence is empty")
+	}
+	for index, evidence := range entry.Evidence {
+		if !slices.Contains([]string{"go", "py", "ts"}, evidence.Kind) {
+			return fmt.Errorf("evidence %d kind = %q", index, evidence.Kind)
 		}
-		if len(evidence) == 0 {
-			t.Fatal("traceability entry has no evidence")
+		if evidence.File == "" || evidence.Test == "" {
+			return fmt.Errorf("evidence %d is incomplete", index)
 		}
 	}
+	return nil
 }
 `
 
@@ -177,12 +258,137 @@ func TestTraceabilityGeneratorProducesGoldenConsumableTable(t *testing.T) {
 	)
 
 	compareFile(t, filepath.Join(repository, "test", "conformance", "traceability.json"), generated)
+	prepareTraceabilityConsumer(t, consumer)
+	runGo(t, consumer, "test", "-count=1", "./...")
+	runGo(t, consumer, "vet", "./...")
+	runConsumerLint(t, repository, consumer)
+}
+
+func TestTraceabilityConsumerRejectsSchemaMutants(t *testing.T) {
+	repository := repositoryRoot(t)
+	payload, readErr := os.ReadFile(filepath.Join(repository, "test", "conformance", "traceability.json"))
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	tests := []struct {
+		name       string
+		mutate     func([]byte) []byte
+		wantOutput string
+	}{
+		{
+			name: "unknown top-level field",
+			mutate: func(payload []byte) []byte {
+				return replaceOnce(t, payload, []byte("{"), []byte(`{"unexpected":true,`))
+			},
+			wantOutput: "decode traceability table",
+		},
+		{
+			name: "duplicate top-level field",
+			mutate: func(payload []byte) []byte {
+				return replaceOnce(t, payload, []byte(`"schema_version": 2,`), []byte(`"schema_version": 2, "schema_version": 2,`))
+			},
+			wantOutput: "decode traceability table",
+		},
+		{
+			name: "unknown entry field",
+			mutate: func(payload []byte) []byte {
+				return replaceOnce(t, payload, []byte(`"python": {`), []byte(`"unexpected": true, "python": {`))
+			},
+			wantOutput: "decode traceability table",
+		},
+		{
+			name: "missing evidence field",
+			mutate: func(payload []byte) []byte {
+				return replaceOnce(t, payload, []byte(`"evidence": [`), []byte(`"missing_evidence": [`))
+			},
+			wantOutput: "decode traceability table",
+		},
+		{
+			name: "empty evidence object",
+			mutate: func(payload []byte) []byte {
+				return clearFirstJSONStringValue(t, payload, "kind")
+			},
+			wantOutput: "evidence 0 kind",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			consumer := t.TempDir()
+			mutated := test.mutate(slices.Clone(payload))
+			generated := filepath.Join(consumer, "traceability.json")
+			writeFile(t, generated, string(mutated))
+			prepareTraceabilityConsumer(t, consumer)
+			runGoExpectFailure(t, consumer, test.wantOutput, "test", "-count=1", "./...")
+		})
+	}
+}
+
+func prepareTraceabilityConsumer(t *testing.T, consumer string) {
+	t.Helper()
 	writeFile(t, filepath.Join(consumer, "go.mod"), "module example.com/powercontext-traceability-consumer\n\ngo 1.27.0\n")
 	writeFile(t, filepath.Join(consumer, "consumer_test.go"), generatedTraceabilityConsumerTest)
-
 	runGo(t, consumer, "mod", "tidy")
 	runGo(t, consumer, "mod", "verify")
-	runGo(t, consumer, "test", "-count=1", "./...")
+}
+
+func replaceOnce(t *testing.T, payload, old, replacement []byte) []byte {
+	t.Helper()
+	mutated := bytes.Replace(payload, old, replacement, 1)
+	if bytes.Equal(mutated, payload) {
+		t.Fatalf("traceability payload does not contain %q", old)
+	}
+	return mutated
+}
+
+func clearFirstJSONStringValue(t *testing.T, payload []byte, key string) []byte {
+	t.Helper()
+	prefix := []byte(`"` + key + `": "`)
+	start := bytes.Index(payload, prefix)
+	if start < 0 {
+		t.Fatalf("traceability payload does not contain string field %q", key)
+	}
+	valueStart := start + len(prefix)
+	valueEnd := bytes.IndexByte(payload[valueStart:], '"')
+	if valueEnd < 0 {
+		t.Fatalf("traceability field %q has no closing quote", key)
+	}
+	mutated := slices.Clone(payload[:valueStart])
+	return append(mutated, payload[valueStart+valueEnd:]...)
+}
+
+func runGoExpectFailure(t *testing.T, directory, wantOutput string, arguments ...string) {
+	t.Helper()
+	command := exec.CommandContext(t.Context(), "go", arguments...)
+	command.Dir = directory
+	command.Env = append(os.Environ(), "GOWORK=off")
+	output, err := command.CombinedOutput()
+	if err == nil {
+		t.Fatalf("Go command unexpectedly succeeded:\n%s", output)
+	}
+	if !bytes.Contains(output, []byte(wantOutput)) {
+		t.Fatalf("Go command output is missing %q:\n%s", wantOutput, output)
+	}
+}
+
+func runConsumerLint(t *testing.T, repository, consumer string) {
+	t.Helper()
+	linter := os.Getenv("POWERCONTEXT_GOLANGCI_LINT")
+	if linter == "" {
+		return
+	}
+	config := filepath.Join(repository, ".golangci.yml")
+	for _, arguments := range [][]string{
+		{"fmt", "--diff", "--config", config},
+		{"run", "--config", config},
+	} {
+		command := exec.CommandContext(t.Context(), linter, arguments...)
+		command.Dir = consumer
+		command.Env = append(os.Environ(), "GOWORK=off")
+		output, err := command.CombinedOutput()
+		if err != nil {
+			t.Fatalf("check generated consumer with %v: %v\n%s", arguments, err, output)
+		}
+	}
 }
 
 func repositoryRoot(t *testing.T) string {

--- a/tools/generated-consumers/main_test.go
+++ b/tools/generated-consumers/main_test.go
@@ -61,6 +61,64 @@ func TestGeneratedRememberMemorySchema(t *testing.T) {
 }
 `
 
+const generatedTraceabilityConsumerTest = `package generatedconsumer
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+)
+
+func TestGeneratedTraceabilityTable(t *testing.T) {
+	payload, err := os.ReadFile("traceability.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var table map[string]json.RawMessage
+	if err := json.Unmarshal(payload, &table); err != nil {
+		t.Fatal(err)
+	}
+	var schemaVersion, pythonTestCaseCount, caseSpecificEvidenceCount int
+	if err := json.Unmarshal(table["schema_version"], &schemaVersion); err != nil {
+		t.Fatal(err)
+	}
+	if schemaVersion != 2 {
+		t.Fatalf("schema version = %d, want 2", schemaVersion)
+	}
+	var oracleCommit string
+	if err := json.Unmarshal(table["oracle_commit"], &oracleCommit); err != nil {
+		t.Fatal(err)
+	}
+	if oracleCommit != "3a6cb0151670eaff7dc0293466edd673124e80da" {
+		t.Fatalf("oracle commit = %q", oracleCommit)
+	}
+	for key, target := range map[string]*int{
+		"python_test_case_count": &pythonTestCaseCount,
+		"case_specific_evidence_count": &caseSpecificEvidenceCount,
+	} {
+		if err := json.Unmarshal(table[key], target); err != nil {
+			t.Fatal(err)
+		}
+	}
+	var entries []map[string]json.RawMessage
+	if err := json.Unmarshal(table["entries"], &entries); err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != pythonTestCaseCount || caseSpecificEvidenceCount != len(entries) {
+		t.Fatalf("traceability counts are inconsistent")
+	}
+	for _, entry := range entries {
+		var evidence []json.RawMessage
+		if err := json.Unmarshal(entry["evidence"], &evidence); err != nil {
+			t.Fatal(err)
+		}
+		if len(evidence) == 0 {
+			t.Fatal("traceability entry has no evidence")
+		}
+	}
+}
+`
+
 func TestOpenAPIGeneratorProducesGoldenBuildableConsumer(t *testing.T) {
 	repository := repositoryRoot(t)
 	consumer := t.TempDir()
@@ -99,6 +157,28 @@ func TestMCPSchemaGeneratorProducesGoldenBuildableConsumer(t *testing.T) {
 	compareFile(t, filepath.Join(repository, "internal", "mcpapi", "schemas_gen.go"), generated)
 	writeFile(t, filepath.Join(consumer, "go.mod"), "module example.com/powercontext-generated-mcp\n\ngo 1.27.0\n")
 	writeFile(t, filepath.Join(consumer, "schemas_gen_test.go"), generatedMCPSchemaConsumerTest)
+
+	runGo(t, consumer, "mod", "tidy")
+	runGo(t, consumer, "mod", "verify")
+	runGo(t, consumer, "test", "-count=1", "./...")
+}
+
+func TestTraceabilityGeneratorProducesGoldenConsumableTable(t *testing.T) {
+	repository := repositoryRoot(t)
+	consumer := t.TempDir()
+	generated := filepath.Join(consumer, "traceability.json")
+
+	runGo(t, repository,
+		"run", "./tools/traceability-generate",
+		"-root", repository,
+		"-manifest", filepath.Join(repository, "test", "conformance", "testdata", "python-v0.0.2", "manifest.json"),
+		"-rules", filepath.Join(repository, "test", "conformance", "traceability-rules.json"),
+		"-output", generated,
+	)
+
+	compareFile(t, filepath.Join(repository, "test", "conformance", "traceability.json"), generated)
+	writeFile(t, filepath.Join(consumer, "go.mod"), "module example.com/powercontext-traceability-consumer\n\ngo 1.27.0\n")
+	writeFile(t, filepath.Join(consumer, "consumer_test.go"), generatedTraceabilityConsumerTest)
 
 	runGo(t, consumer, "mod", "tidy")
 	runGo(t, consumer, "mod", "verify")

--- a/tools/release/makefile_test.go
+++ b/tools/release/makefile_test.go
@@ -368,7 +368,8 @@ func TestGeneratedConsumersTargetRunsFreshConsumerVerification(t *testing.T) {
 	if err != nil {
 		t.Fatalf("make generated-consumers dry-run failed: %v\n%s", err, output)
 	}
-	if !strings.Contains(string(output), "go test -count=1 ./tools/generated-consumers") {
+	if !strings.Contains(string(output), "POWERCONTEXT_GOLANGCI_LINT=") ||
+		!strings.Contains(string(output), "go test -count=1 ./tools/generated-consumers") {
 		t.Fatalf("make generated-consumers does not run the uncached fresh-consumer check:\n%s", output)
 	}
 }


### PR DESCRIPTION
## Tracking

- Tracking issue: #3
- Relationship: `Part of #3` (WP0-C generator consumer integrity)

## Problem and rationale

The generated-consumers job proved fresh OpenAPI and MCP outputs, but did not execute the public traceability generator into an empty output location or prove that its JSON table remains independently consumable under a strict schema contract.

## Changes

- generate traceability output through `go run ./tools/traceability-generate` into a fresh temporary directory;
- compare the complete generated JSON bytes with the reviewed traceability golden;
- create an independent Go 1.27 module that consumes the generated JSON;
- use `encoding/json/v2` typed structs with `RejectUnknownMembers(true)`, which also rejects duplicate object members;
- validate the frozen Oracle identity, exact `109 / 622 / 622 / 0 / 622` summary, all entry identities/modes/evidence levels, and every evidence kind/file/test;
- run real golden mutants for unknown top-level, duplicate top-level, unknown nested, missing evidence, and empty evidence-object cases and require the independent module to fail;
- run the fresh consumer through `go test`, `go vet`, pinned gofumpt/goimports formatting, and the pinned golangci policy;
- pass the repository-local pinned linter into the existing generated-consumers target and lock that Make contract with a regression test.

## Behavior and compatibility

- User-visible behavior: none.
- Public API or protocol impact: none.
- Breaking changes or migration requirements: none.
- Explicit non-goals: release packaging and retained Python/TypeScript adapter generators remain separate WP0-C work.

## Generated, dependency, and workflow impact

- [x] No checked-in generated output changed.
- [x] No dependency changed.
- [x] The existing generated-consumers job keeps its stable name and now installs/uses the same pinned lint tool as local validation.
- [x] No credential, private Source/Memory content, or unredacted production log is included.

## Validation

Commands run after the review fixes and rebase to main `307367f`:

```text
make generated-consumers
PASS
- OpenAPI fresh API consumer
- MCP schema fresh consumer
- traceability fresh typed JSON consumer
- pinned formatter and lint on the traceability consumer

go test -count=3 ./tools/generated-consumers -run '^TestTraceabilityConsumerRejectsSchemaMutants$'
PASS

go test -count=1 ./tools/release -run '^TestGeneratedConsumersTargetRunsFreshConsumerVerification$'
PASS

go vet ./tools/generated-consumers ./tools/release
PASS
.tools/bin/golangci-lint.exe run ./tools/generated-consumers ./tools/release
PASS: 0 issues
make module-check
PASS
make governance-check
PASS
make license-check
PASS: 805 valid, 0 invalid, 199 ignored
git diff --check
PASS
```

Review-failure proof from the previous Head:

- v1 map decoding accepted unknown and incomplete schema structure;
- runtime-generated code shadowed the retained `err` value and root lint could not see the string source;
- the first pinned fresh-consumer lint run correctly failed on a gofumpt difference, after which the template itself was formatted and the formatter/linter both passed.

- [x] `git diff --check`
- [x] `git status --short` was inspected after validation.
- [x] Public generator entrypoint, exact golden, strict schema mutants, independent module tests, vet, formatting, and lint all ran.

## AI usage

AI assistance added and revised the fresh traceability consumer. Independent review found a fail-open JSON parser and hidden err-shadow violation on the first Head; the new Head replaces both with strict Go 1.27 decoding, discriminative mutants, operation-specific errors, and pinned fresh-module formatting/lint. The rebased exact Head will be independently re-reviewed before merge.
