### PR TITLE
fix: align seekdb native source build constraints

### DIFF
--- a/.github/workflows/windows-contract.yml
+++ b/.github/workflows/windows-contract.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Verify API baseline replacement on Windows
         run: go test -count=1 ./tools/api-baseline -run '^TestWriteBaselineReplacesExistingOutput$'
 
+      - name: Verify seekDB build selection on Windows
+        run: go test -count=1 ./tools/release -run '^TestSeekDBBuildConstraintsSelectImplementationAndNativeSourcesTogether$'
+
       - name: Verify LF attributes and frozen fixture hashes
         shell: pwsh
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,7 +140,9 @@ source / artifact / trigger / inference
   emit that support as a declared generated artifact and verify a fresh
   temporary module can tidy, verify, and test the complete output.
 - When a Go package has build-tagged implementation variants, keep its package
-  documentation in an untagged `doc.go`. Verify the package `Doc` field with
+  documentation in an untagged `doc.go` and give accompanying C, C++, or
+  assembly sources the same constraints as the Go implementation that owns
+  them. Verify `Doc`, `GoFiles`, `CgoFiles`, and native source fields with
   `go list -e` under every supported `GOOS` and CGO selection.
 - When a query checks `Rows.Err` before returning, its deferred cleanup must
   merge only `Rows.Close`; do not call a helper that reads `Rows.Err` again.

--- a/internal/sqlstore/seekdb/loader.c
+++ b/internal/sqlstore/seekdb/loader.c
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+//go:build cgo && (darwin || linux)
+
 #include "loader.h"
 
 #include <dlfcn.h>

--- a/tools/release/build_constraints_test.go
+++ b/tools/release/build_constraints_test.go
@@ -1,0 +1,105 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"encoding/json/v2"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"testing"
+)
+
+const seekDBPackageDoc = "Package seekdb loads and owns the embedded seekDB runtime used by the SQL store."
+
+type listedPackage struct {
+	Doc      string   `json:"Doc"`
+	GoFiles  []string `json:"GoFiles"`
+	CgoFiles []string `json:"CgoFiles"`
+	CFiles   []string `json:"CFiles"`
+	Error    *struct {
+		Err string `json:"Err"`
+	} `json:"Error"`
+}
+
+func TestSeekDBBuildConstraintsSelectImplementationAndNativeSourcesTogether(t *testing.T) {
+	tests := []struct {
+		name       string
+		goos       string
+		cgoEnabled string
+		wantNative bool
+	}{
+		{name: "linux native", goos: "linux", cgoEnabled: "1", wantNative: true},
+		{name: "darwin native", goos: "darwin", cgoEnabled: "1", wantNative: true},
+		{name: "linux stub without cgo", goos: "linux", cgoEnabled: "0"},
+		{name: "darwin stub without cgo", goos: "darwin", cgoEnabled: "0"},
+		{name: "windows stub with cgo", goos: "windows", cgoEnabled: "1"},
+		{name: "windows stub without cgo", goos: "windows", cgoEnabled: "0"},
+	}
+
+	repository := filepath.Clean(filepath.Join("..", ".."))
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			command := exec.CommandContext(
+				t.Context(),
+				"go",
+				"-C",
+				repository,
+				"list",
+				"-e",
+				"-json",
+				"./internal/sqlstore/seekdb",
+			)
+			command.Env = append(
+				os.Environ(),
+				"GOOS="+test.goos,
+				"GOARCH=amd64",
+				"CGO_ENABLED="+test.cgoEnabled,
+			)
+			output, err := command.CombinedOutput()
+			if err != nil {
+				t.Fatalf("go list: %v\n%s", err, output)
+			}
+			var pkg listedPackage
+			if decodeErr := json.Unmarshal(output, &pkg); decodeErr != nil {
+				t.Fatalf("decode go list output: %v", decodeErr)
+			}
+			if pkg.Error != nil {
+				t.Fatalf("go list package error: %s", pkg.Error.Err)
+			}
+			if pkg.Doc != seekDBPackageDoc {
+				t.Fatalf("package Doc = %q, want %q", pkg.Doc, seekDBPackageDoc)
+			}
+
+			if test.wantNative {
+				if !slices.Contains(pkg.CgoFiles, "seekdb.go") || !slices.Contains(pkg.CFiles, "loader.c") {
+					t.Fatalf("native files: CgoFiles=%v CFiles=%v", pkg.CgoFiles, pkg.CFiles)
+				}
+				if slices.Contains(pkg.GoFiles, "seekdb_stub.go") {
+					t.Fatalf("native build selected seekdb_stub.go: GoFiles=%v", pkg.GoFiles)
+				}
+				return
+			}
+
+			if !slices.Contains(pkg.GoFiles, "seekdb_stub.go") {
+				t.Fatalf("stub build did not select seekdb_stub.go: GoFiles=%v", pkg.GoFiles)
+			}
+			if slices.Contains(pkg.CgoFiles, "seekdb.go") || slices.Contains(pkg.CFiles, "loader.c") {
+				t.Fatalf("stub build retained native files: CgoFiles=%v CFiles=%v", pkg.CgoFiles, pkg.CFiles)
+			}
+		})
+	}
+}

--- a/tools/release/workflow_test.go
+++ b/tools/release/workflow_test.go
@@ -280,7 +280,7 @@ func TestMigrationAPICompatRunsThePinnedPublicBaseline(t *testing.T) {
 	}
 }
 
-func TestWindowsContractExercisesAPIBaselineReplacement(t *testing.T) {
+func TestWindowsContractExercisesTargetedGoRegressions(t *testing.T) {
 	repository := filepath.Clean(filepath.Join("..", ".."))
 	payload, err := os.ReadFile(filepath.Join(repository, ".github", "workflows", "windows-contract.yml"))
 	if err != nil {
@@ -302,7 +302,7 @@ func TestWindowsContractExercisesAPIBaselineReplacement(t *testing.T) {
 	if !ok {
 		t.Fatal("windows-contract.yml has no windows-contract job")
 	}
-	setupIndex, testIndex := -1, -1
+	setupIndex, apiTestIndex, seekDBTestIndex := -1, -1, -1
 	for index, step := range job.Steps {
 		switch step.Name {
 		case "Set up the Go environment":
@@ -311,12 +311,21 @@ func TestWindowsContractExercisesAPIBaselineReplacement(t *testing.T) {
 			}
 		case "Verify API baseline replacement on Windows":
 			if strings.TrimSpace(step.Run) == "go test -count=1 ./tools/api-baseline -run '^TestWriteBaselineReplacesExistingOutput$'" {
-				testIndex = index
+				apiTestIndex = index
+			}
+		case "Verify seekDB build selection on Windows":
+			if strings.TrimSpace(step.Run) == "go test -count=1 ./tools/release -run '^TestSeekDBBuildConstraintsSelectImplementationAndNativeSourcesTogether$'" {
+				seekDBTestIndex = index
 			}
 		}
 	}
-	if setupIndex < 0 || testIndex <= setupIndex {
-		t.Fatalf("Windows API baseline steps = setup %d, test %d, want ordered setup and replacement test", setupIndex, testIndex)
+	if setupIndex < 0 || apiTestIndex <= setupIndex || seekDBTestIndex <= apiTestIndex {
+		t.Fatalf(
+			"Windows targeted Go steps = setup %d, API %d, seekDB %d, want ordered setup and regression tests",
+			setupIndex,
+			apiTestIndex,
+			seekDBTestIndex,
+		)
 	}
 }
 


### PR DESCRIPTION
## Tracking

- Tracking issue: #3
- Relationship: `Part of #3` (WP0-C build-tag and validation integrity)

## Problem and rationale

`internal/sqlstore/seekdb` selects its typed stub on Windows even when CGO is enabled, but the accompanying `loader.c` had no matching build constraint. Go therefore retained the C source after excluding the only cgo Go implementation and reported:

```text
C source files not allowed when not using cgo or SWIG: loader.c
```

This broke `go list`, scoped vet, and the documented `make check` path before they could reach later packages. Go 1.27 explicitly supports build constraints in non-Go source files, so the smallest repair is to give `loader.c` the same ownership boundary as `seekdb.go` and lock the complete file selection matrix.

## Changes

- add `//go:build cgo && (darwin || linux)` to `loader.c`;
- add an executable `go list -e -json` regression covering Linux, Darwin, and Windows with CGO on/off;
- verify package documentation and exact Go/cgo/C file selection rather than compilation alone;
- run the regression in the existing Windows contract workflow after Go setup;
- extend the workflow contract test to require both targeted Windows Go regressions in order;
- strengthen the existing AGENTS build-variant rule so companion native sources must share their owning Go implementation's constraints.

## Behavior and compatibility

- User-visible behavior: none on supported Linux/macOS native paths; Windows package loading now reaches the deliberate typed unsupported stub.
- Public API or protocol impact: none.
- Breaking changes or migration requirements: none.
- Explicit non-goals: Windows binary support, installing Windows SQLite development headers, changing seekDB runtime behavior, or modifying unrelated sqlitevec CGO packaging.

## Generated, dependency, and workflow impact

- [x] No generated contract changed.
- [x] No dependency changed.
- [x] The existing `windows-contract` job gains one focused package-selection regression; its stable name, permissions, runner, and timeout are unchanged.
- [x] No credential, private Source/Memory content, or unredacted production log is included.

## Validation

Commands run against Head `43e1f3f`:

```text
go test -count=50 ./tools/release -run '^TestSeekDBBuildConstraintsSelectImplementationAndNativeSourcesTogether$'
PASS

go test -count=1 ./tools/release -run '^(TestSeekDBBuildConstraintsSelectImplementationAndNativeSourcesTogether|TestWindowsContractExercisesTargetedGoRegressions)$'
PASS

go vet ./tools/release
PASS
GOOS=windows GOARCH=amd64 CGO_ENABLED=1 go vet ./internal/sqlstore/seekdb
PASS
.tools/bin/golangci-lint.exe run ./tools/release ./internal/sqlstore/seekdb
PASS: 0 issues
go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
PASS
make governance-check
PASS
make license-check
PASS: 806 valid, 0 invalid, 199 ignored
git diff --check
PASS
```

Failure-before-fix proof:

```text
TestSeekDBBuildConstraintsSelectImplementationAndNativeSourcesTogether/windows_stub_with_cgo
C source files not allowed when not using cgo or SWIG: loader.c
```

After the fix, Windows with CGO enabled reports `doc.go` and `seekdb_stub.go`, no package Error, no CFiles, and `loader.c` under `IgnoredOtherFiles`.

`make check` was rerun. `go mod tidy -diff`, `go mod verify`, and pinned formatting passed; full `go vet ./...` progressed beyond the repaired seekDB package and then failed in the separate `internal/sqlstore/sqlitevec` package because this Windows machine does not provide `sqlite3.h`. That unrelated native-header limitation is not represented as passing and is intentionally outside this PR.

- [x] `git diff --check`
- [x] `git status --short` was inspected after validation.
- [x] Relevant package-selection, workflow, vet, lint, governance, and license checks were run.
- [x] The remaining Windows-local sqlitevec header limitation is identified above and is not represented as passing.

## AI usage

Codex reproduced the package-load failure, verified the current Go 1.27 build-constraint contract from the installed toolchain and official `golang/go` source, implemented the native-source constraint, and added discriminative cross-target regression coverage. The exact Head will receive an independent read-only review before merge.
