### PR TITLE
ci: reject quality worktree side effects

### DIFF
--- a/.github/workflows/migration-gates.yml
+++ b/.github/workflows/migration-gates.yml
@@ -55,6 +55,14 @@ jobs:
       - name: Build the standard Docker image
         run: docker build --pull --target powercontext -t powercontext:ci .
 
+      - name: Verify repository cleanliness after quality checks
+        if: always()
+        shell: bash
+        run: |
+          git diff --exit-code
+          git status --short
+          test -z "$(git status --porcelain)"
+
   portable-sdk:
     name: Portable SDK cross-builds
     runs-on: ubuntu-24.04

--- a/.github/workflows/migration-gates.yml
+++ b/.github/workflows/migration-gates.yml
@@ -61,7 +61,11 @@ jobs:
         run: |
           status="$(git status --porcelain)"
           if test -n "$status"; then
-            printf '%s\n' "$status"
+            count="$(printf '%s\n' "$status" | wc -l | tr -d '[:space:]')"
+            printf '%s\n' "$status" | sed -n '1,100p'
+            if test "$count" -gt 100; then
+              printf '... %s additional paths omitted\n' "$((count - 100))"
+            fi
             exit 1
           fi
 

--- a/.github/workflows/migration-gates.yml
+++ b/.github/workflows/migration-gates.yml
@@ -59,9 +59,11 @@ jobs:
         if: always()
         shell: bash
         run: |
-          git diff --exit-code
-          git status --short
-          test -z "$(git status --porcelain)"
+          status="$(git status --porcelain)"
+          if test -n "$status"; then
+            printf '%s\n' "$status"
+            exit 1
+          fi
 
   portable-sdk:
     name: Portable SDK cross-builds

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -183,6 +183,10 @@ source / artifact / trigger / inference
   environment variables in preflight guards with explicit defaults and run
   real failed-pipeline and missing-variable probes on every supported Make
   runtime; source-text checks alone do not prove the execution contract.
+- When an always-run CI cleanliness step must diagnose tracked and untracked
+  side effects, capture one porcelain status before deciding success; never put
+  a fail-fast dirty-tree command ahead of the diagnostic. Verify the parsed
+  workflow contract rejects the wrong job, condition, shell, command, or order.
 - When a governance parser exempts a GitHub Actions reusable-workflow caller
   from ordinary-job requirements, require a nonblank `uses` reference and
   reject every keyword outside GitHub's supported caller-job set. Verify the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -185,8 +185,9 @@ source / artifact / trigger / inference
   runtime; source-text checks alone do not prove the execution contract.
 - When an always-run CI cleanliness step must diagnose tracked and untracked
   side effects, capture one porcelain status before deciding success; never put
-  a fail-fast dirty-tree command ahead of the diagnostic. Verify the parsed
-  workflow contract rejects the wrong job, condition, shell, command, or order.
+  a fail-fast dirty-tree command ahead of the diagnostic. Print only a bounded
+  prefix plus the omitted-path count. Verify both the parsed workflow contract
+  and real clean, staged, unstaged, untracked, and over-limit repositories.
 - When a governance parser exempts a GitHub Actions reusable-workflow caller
   from ordinary-job requirements, require a nonblank `uses` reference and
   reject every keyword outside GitHub's supported caller-job set. Verify the

--- a/tools/release/workflow_test.go
+++ b/tools/release/workflow_test.go
@@ -161,6 +161,26 @@ func TestMigrationQualityRunsModuleIntegrity(t *testing.T) {
 	t.Fatal("migration-gates.yml quality job does not execute make module-integrity")
 }
 
+func TestMigrationQualityRejectsWorktreeSideEffects(t *testing.T) {
+	repository := filepath.Clean(filepath.Join("..", ".."))
+	payload, err := os.ReadFile(filepath.Join(repository, ".github", "workflows", "migration-gates.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	contents := string(payload)
+	for _, value := range []string{
+		"Verify repository cleanliness after quality checks",
+		"if: always()",
+		"git diff --exit-code",
+		"git status --short",
+		"test -z \"$(git status --porcelain)\"",
+	} {
+		if !strings.Contains(contents, value) {
+			t.Fatalf("migration quality job is missing %q", value)
+		}
+	}
+}
+
 func TestMigrationGeneratedConsumersRunsFreshConsumerVerification(t *testing.T) {
 	repository := filepath.Clean(filepath.Join("..", ".."))
 	payload, err := os.ReadFile(filepath.Join(repository, ".github", "workflows", "migration-gates.yml"))

--- a/tools/release/workflow_test.go
+++ b/tools/release/workflow_test.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"fmt"
 	"io/fs"
 	"os"
 	"os/exec"
@@ -167,18 +168,86 @@ func TestMigrationQualityRejectsWorktreeSideEffects(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	contents := string(payload)
-	for _, value := range []string{
-		"Verify repository cleanliness after quality checks",
-		"if: always()",
-		"git diff --exit-code",
-		"git status --short",
-		"test -z \"$(git status --porcelain)\"",
-	} {
-		if !strings.Contains(contents, value) {
-			t.Fatalf("migration quality job is missing %q", value)
-		}
+	if err := validateMigrationQualityCleanliness(payload); err != nil {
+		t.Fatal(err)
 	}
+
+	mutations := []struct {
+		name string
+		old  string
+		new  string
+	}{
+		{name: "wrong job", old: "  quality:\n", new: "  renamed-quality:\n"},
+		{name: "wrong condition", old: "        if: always()\n", new: "        if: success()\n"},
+		{name: "wrong shell", old: "        shell: bash\n", new: "        shell: sh\n"},
+		{
+			name: "incomplete command",
+			old:  "          status=\"$(git status --porcelain)\"\n",
+			new:  "          status=\"\"\n",
+		},
+		{
+			name: "not final",
+			old:  "\n  portable-sdk:\n",
+			new: "\n      - name: Later quality step\n" +
+				"        run: true\n\n" +
+				"  portable-sdk:\n",
+		},
+	}
+	for _, mutation := range mutations {
+		t.Run(mutation.name, func(t *testing.T) {
+			contents := string(payload)
+			if !strings.Contains(contents, mutation.old) {
+				t.Fatalf("test mutation source %q is missing", mutation.old)
+			}
+			mutant := strings.Replace(contents, mutation.old, mutation.new, 1)
+			if err := validateMigrationQualityCleanliness([]byte(mutant)); err == nil {
+				t.Fatal("invalid migration quality cleanliness contract was accepted")
+			}
+		})
+	}
+}
+
+func validateMigrationQualityCleanliness(payload []byte) error {
+	type workflowStep struct {
+		Name  string `yaml:"name"`
+		If    string `yaml:"if"`
+		Shell string `yaml:"shell"`
+		Run   string `yaml:"run"`
+	}
+	var workflow struct {
+		Jobs map[string]struct {
+			Steps []workflowStep `yaml:"steps"`
+		} `yaml:"jobs"`
+	}
+	if err := yaml.Unmarshal(payload, &workflow); err != nil {
+		return fmt.Errorf("parse migration workflow: %w", err)
+	}
+	quality, ok := workflow.Jobs["quality"]
+	if !ok {
+		return fmt.Errorf("migration-gates.yml has no quality job")
+	}
+	if len(quality.Steps) == 0 {
+		return fmt.Errorf("migration-gates.yml quality job has no steps")
+	}
+
+	got := quality.Steps[len(quality.Steps)-1]
+	got.Run = strings.TrimSpace(got.Run)
+	want := workflowStep{
+		Name:  "Verify repository cleanliness after quality checks",
+		If:    "always()",
+		Shell: "bash",
+		Run: strings.TrimSpace(`
+status="$(git status --porcelain)"
+if test -n "$status"; then
+  printf '%s\n' "$status"
+  exit 1
+fi
+`),
+	}
+	if got != want {
+		return fmt.Errorf("migration-gates.yml final quality step = %#v, want %#v", got, want)
+	}
+	return nil
 }
 
 func TestMigrationGeneratedConsumersRunsFreshConsumerVerification(t *testing.T) {

--- a/tools/release/workflow_test.go
+++ b/tools/release/workflow_test.go
@@ -21,6 +21,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -162,6 +163,13 @@ func TestMigrationQualityRunsModuleIntegrity(t *testing.T) {
 	t.Fatal("migration-gates.yml quality job does not execute make module-integrity")
 }
 
+type migrationWorkflowStep struct {
+	Name  string `yaml:"name"`
+	If    string `yaml:"if"`
+	Shell string `yaml:"shell"`
+	Run   string `yaml:"run"`
+}
+
 func TestMigrationQualityRejectsWorktreeSideEffects(t *testing.T) {
 	repository := filepath.Clean(filepath.Join("..", ".."))
 	payload, err := os.ReadFile(filepath.Join(repository, ".github", "workflows", "migration-gates.yml"))
@@ -207,39 +215,131 @@ func TestMigrationQualityRejectsWorktreeSideEffects(t *testing.T) {
 	}
 }
 
-func validateMigrationQualityCleanliness(payload []byte) error {
-	type workflowStep struct {
-		Name  string `yaml:"name"`
-		If    string `yaml:"if"`
-		Shell string `yaml:"shell"`
-		Run   string `yaml:"run"`
+func TestMigrationQualityCleanlinessCommandReportsBoundedGitStatus(t *testing.T) {
+	repository := filepath.Clean(filepath.Join("..", ".."))
+	payload, err := os.ReadFile(filepath.Join(repository, ".github", "workflows", "migration-gates.yml"))
+	if err != nil {
+		t.Fatal(err)
 	}
-	var workflow struct {
-		Jobs map[string]struct {
-			Steps []workflowStep `yaml:"steps"`
-		} `yaml:"jobs"`
+	step, err := migrationQualityCleanlinessStep(payload)
+	if err != nil {
+		t.Fatal(err)
 	}
-	if err := yaml.Unmarshal(payload, &workflow); err != nil {
-		return fmt.Errorf("parse migration workflow: %w", err)
-	}
-	quality, ok := workflow.Jobs["quality"]
-	if !ok {
-		return fmt.Errorf("migration-gates.yml has no quality job")
-	}
-	if len(quality.Steps) == 0 {
-		return fmt.Errorf("migration-gates.yml quality job has no steps")
+	bash := workflowBash(t)
+
+	tests := []struct {
+		name         string
+		mutate       func(t *testing.T, root string)
+		wantDirty    bool
+		wantOutput   string
+		maximumLines int
+	}{
+		{name: "clean"},
+		{
+			name: "unstaged tracked file",
+			mutate: func(t *testing.T, root string) {
+				writeWorkflowFixture(t, filepath.Join(root, "tracked.txt"), "changed\n")
+			},
+			wantDirty:  true,
+			wantOutput: " M tracked.txt",
+		},
+		{
+			name: "staged tracked file",
+			mutate: func(t *testing.T, root string) {
+				writeWorkflowFixture(t, filepath.Join(root, "tracked.txt"), "changed\n")
+				runWorkflowGit(t, root, "add", "tracked.txt")
+			},
+			wantDirty:  true,
+			wantOutput: "M  tracked.txt",
+		},
+		{
+			name: "untracked file",
+			mutate: func(t *testing.T, root string) {
+				writeWorkflowFixture(t, filepath.Join(root, "untracked.txt"), "new\n")
+			},
+			wantDirty:  true,
+			wantOutput: "?? untracked.txt",
+		},
+		{
+			name: "bounded diagnostics",
+			mutate: func(t *testing.T, root string) {
+				for index := range 105 {
+					writeWorkflowFixture(t, filepath.Join(root, fmt.Sprintf("untracked-%03d.txt", index)), "new\n")
+				}
+			},
+			wantDirty:    true,
+			wantOutput:   "... 5 additional paths omitted",
+			maximumLines: 101,
+		},
 	}
 
-	got := quality.Steps[len(quality.Steps)-1]
-	got.Run = strings.TrimSpace(got.Run)
-	want := workflowStep{
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := initializeWorkflowGitRepository(t)
+			if test.mutate != nil {
+				test.mutate(t, root)
+			}
+			before := workflowGitStatus(t, root)
+			command := exec.CommandContext(t.Context(), bash, "-eu", "-o", "pipefail", "-c", step.Run)
+			command.Dir = root
+			output, commandErr := command.CombinedOutput()
+			after := workflowGitStatus(t, root)
+			if after != before {
+				t.Fatalf("cleanliness command changed repository status\nbefore:\n%s\nafter:\n%s", before, after)
+			}
+			if test.wantDirty && commandErr == nil {
+				t.Fatalf("cleanliness command accepted a dirty repository:\n%s", output)
+			}
+			if !test.wantDirty && commandErr != nil {
+				t.Fatalf("cleanliness command rejected a clean repository: %v\n%s", commandErr, output)
+			}
+			if test.wantOutput != "" && !strings.Contains(string(output), test.wantOutput) {
+				t.Fatalf("cleanliness output is missing %q:\n%s", test.wantOutput, output)
+			}
+			if test.maximumLines > 0 {
+				lines := strings.Split(strings.TrimSpace(string(output)), "\n")
+				if len(lines) > test.maximumLines {
+					t.Fatalf("cleanliness diagnostics have %d lines, want at most %d", len(lines), test.maximumLines)
+				}
+			}
+		})
+	}
+}
+
+func workflowBash(t *testing.T) string {
+	t.Helper()
+	if runtime.GOOS != "windows" {
+		return "bash"
+	}
+	command := exec.CommandContext(t.Context(), "git", "--exec-path")
+	output, err := command.Output()
+	if err != nil {
+		t.Fatalf("locate Git executable directory: %v", err)
+	}
+	bash := filepath.Clean(filepath.Join(strings.TrimSpace(string(output)), "..", "..", "..", "bin", "bash.exe"))
+	if _, statErr := os.Stat(bash); statErr != nil {
+		t.Fatalf("locate Git Bash at %s: %v", bash, statErr)
+	}
+	return bash
+}
+
+func validateMigrationQualityCleanliness(payload []byte) error {
+	got, err := migrationQualityCleanlinessStep(payload)
+	if err != nil {
+		return err
+	}
+	want := migrationWorkflowStep{
 		Name:  "Verify repository cleanliness after quality checks",
 		If:    "always()",
 		Shell: "bash",
 		Run: strings.TrimSpace(`
 status="$(git status --porcelain)"
 if test -n "$status"; then
-  printf '%s\n' "$status"
+  count="$(printf '%s\n' "$status" | wc -l | tr -d '[:space:]')"
+  printf '%s\n' "$status" | sed -n '1,100p'
+  if test "$count" -gt 100; then
+    printf '... %s additional paths omitted\n' "$((count - 100))"
+  fi
   exit 1
 fi
 `),
@@ -248,6 +348,65 @@ fi
 		return fmt.Errorf("migration-gates.yml final quality step = %#v, want %#v", got, want)
 	}
 	return nil
+}
+
+func migrationQualityCleanlinessStep(payload []byte) (migrationWorkflowStep, error) {
+	var workflow struct {
+		Jobs map[string]struct {
+			Steps []migrationWorkflowStep `yaml:"steps"`
+		} `yaml:"jobs"`
+	}
+	if err := yaml.Unmarshal(payload, &workflow); err != nil {
+		return migrationWorkflowStep{}, fmt.Errorf("parse migration workflow: %w", err)
+	}
+	quality, ok := workflow.Jobs["quality"]
+	if !ok {
+		return migrationWorkflowStep{}, fmt.Errorf("migration-gates.yml has no quality job")
+	}
+	if len(quality.Steps) == 0 {
+		return migrationWorkflowStep{}, fmt.Errorf("migration-gates.yml quality job has no steps")
+	}
+
+	got := quality.Steps[len(quality.Steps)-1]
+	got.Run = strings.TrimSpace(got.Run)
+	return got, nil
+}
+
+func initializeWorkflowGitRepository(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	runWorkflowGit(t, root, "init", "--quiet")
+	runWorkflowGit(t, root, "config", "user.email", "ci@example.invalid")
+	runWorkflowGit(t, root, "config", "user.name", "CI")
+	writeWorkflowFixture(t, filepath.Join(root, "tracked.txt"), "original\n")
+	runWorkflowGit(t, root, "add", "tracked.txt")
+	runWorkflowGit(t, root, "commit", "--quiet", "-m", "initial")
+	return root
+}
+
+func runWorkflowGit(t *testing.T, root string, arguments ...string) {
+	t.Helper()
+	command := exec.CommandContext(t.Context(), "git", append([]string{"-C", root}, arguments...)...)
+	if output, err := command.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v\n%s", arguments, err, output)
+	}
+}
+
+func workflowGitStatus(t *testing.T, root string) string {
+	t.Helper()
+	command := exec.CommandContext(t.Context(), "git", "-C", root, "status", "--porcelain")
+	output, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git status: %v\n%s", err, output)
+	}
+	return string(output)
+}
+
+func writeWorkflowFixture(t *testing.T, path, contents string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestMigrationGeneratedConsumersRunsFreshConsumerVerification(t *testing.T) {


### PR DESCRIPTION
## Tracking

- Tracking issue: #3
- Relationship: `Part of #3` (WP0 exit-gate cleanliness evidence)

## Problem and rationale

The quality job runs generator, module, formatter, vet, race/fuzz, and Docker checks, but previously had no final assertion that those documented validation commands leave the CI checkout clean. Generated-only diffs do not cover unrelated tracked, staged, unstaged, or untracked side effects.

## Changes

- add an `always()` cleanup-free repository cleanliness assertion as the final quality step;
- capture one complete porcelain status before deciding success so diagnostics are preserved even after an earlier quality failure;
- reject staged, unstaged, and untracked side effects without deleting, resetting, restoring, or cleaning any path;
- print at most 100 status lines plus the exact omitted-path count;
- keep a parsed workflow contract that rejects the wrong job, condition, shell, command, or step order;
- execute the parsed workflow script in real temporary Git repositories covering clean, staged, unstaged, untracked, and 105-path cases;
- compare porcelain status before/after every probe to prove the step is cleanup-free;
- strengthen the learned rule with bounded diagnostics and real Git-state verification.

## Behavior and compatibility

- User-visible behavior: none.
- Public API or protocol impact: none.
- Breaking changes or migration requirements: none.
- Explicit non-goals: deleting side effects or claiming every arbitrary developer command is clean; this verifies the complete documented quality-job command chain.

## Validation

Commands run after review fixes and rebase to main `764d29a`:

```text
go test -count=10 ./tools/release -run '^(TestMigrationQualityRejectsWorktreeSideEffects|TestMigrationQualityCleanlinessCommandReportsBoundedGitStatus)$'
PASS

.tools/bin/golangci-lint.exe run ./tools/release
PASS: 0 issues
go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
PASS
make governance-check
PASS
make license-check
PASS: 806 valid, 0 invalid, 199 ignored
git diff --check
PASS
```

The pre-fix behavior probe created 203 dirty paths and emitted all 203 lines. The new executable matrix proves:

- clean repository: exit 0, no diagnostic;
- unstaged tracked file: exit 1 with ` M` status;
- staged tracked file: exit 1 with `M ` status;
- untracked file: exit 1 with `??` status;
- 105 untracked files: exit 1, at most 101 output lines, and `... 5 additional paths omitted`;
- every case has byte-identical porcelain status before and after the script.

- [x] `git diff --check`
- [x] `git status --short` was inspected after validation.
- [x] Parsed workflow mutants, real Git-state probes, pinned lint, actionlint, governance, and license checks were run.

## AI usage

AI assistance implemented and revised the cleanup-free CI assertion. Independent review found unbounded diagnostics and source-text-only regression coverage on the first Head; the new Head adds bounded output, executable Git-state probes, no-delete proof, and was rebuilt on the current main. It will receive independent exact-Head re-review before merge.
