### PR TITLE
ci: enforce focused revive checks

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -28,6 +28,7 @@ linters:
     - govet
     - ineffassign
     - misspell
+    - revive
     - staticcheck
     - unused
     - wastedassign
@@ -38,6 +39,25 @@ linters:
     govet:
       enable:
         - shadow
+    revive:
+      # Keep only rules that add focused signal beyond govet and staticcheck.
+      # Declaring the rule set explicitly also avoids the high-noise defaults.
+      confidence: 0.8
+      rules:
+        - name: blank-imports
+        - name: context-as-argument
+          arguments:
+            - allow-types-before: "*testing.T"
+        - name: forbidden-call-in-wg-go
+        - name: identical-branches
+        - name: identical-ifelseif-branches
+        - name: identical-ifelseif-conditions
+        - name: identical-switch-branches
+        - name: identical-switch-conditions
+        - name: inefficient-map-lookup
+        - name: redundant-build-tag
+        - name: redundant-test-main-exit
+        - name: unconditional-recursion
     staticcheck:
       checks:
         - all

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -48,7 +48,6 @@ linters:
         - name: context-as-argument
           arguments:
             - allow-types-before: "*testing.T"
-        - name: forbidden-call-in-wg-go
         - name: identical-branches
         - name: identical-ifelseif-branches
         - name: identical-ifelseif-conditions

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -194,6 +194,10 @@ source / artifact / trigger / inference
   steps by the complete required operation rather than substring presence.
   Keep a valid fixture plus a failing mutant for each boundary, and recheck the
   assumptions against the current official schema before changing the gate.
+- When enabling a syntax-only linter rule for a method or selector, inspect the
+  pinned analyzer implementation and prove it with a repository-shaped mutant
+  using the receiver and call forms present in production. Do not advertise a
+  rule whose matcher ordinary identifier or selector naming can bypass.
 - When a repository inventory prunes generated output while discovering owned
   files, scope name-based exclusions to explicit repository-relative roots
   unless that directory class is unowned at every depth. Verify an owned nested

--- a/internal/cli/integration_pi.go
+++ b/internal/cli/integration_pi.go
@@ -192,12 +192,12 @@ func removeSupersededPiPackages(
 			continue
 		}
 		remove := ""
-		if hasRemotePackageScheme(listing.source) {
+		removeSource := hasRemotePackageScheme(listing.source) ||
+			(listing.path == "" && filepath.IsAbs(listing.source))
+		if removeSource {
 			remove = listing.source
 		} else if listing.path != "" {
 			remove = listing.path
-		} else if filepath.IsAbs(listing.source) {
-			remove = listing.source
 		}
 		if remove != "" {
 			if _, err := commands.Run(ctx, executable, "remove", remove); err != nil {

--- a/internal/modelprovider/openai_profile.go
+++ b/internal/modelprovider/openai_profile.go
@@ -84,9 +84,7 @@ func routedProfileSupportsJSONObject(provider, model string) bool {
 	}
 	downstream, _, _ = strings.Cut(downstream, ":")
 	switch upstream {
-	case "openai":
-		return true
-	case "x-ai", "xai":
+	case "openai", "x-ai", "xai":
 		return true
 	case "google", "vertex":
 		return googleProfileSupportsJSONObject(downstream)

--- a/internal/runtime/tracing.go
+++ b/internal/runtime/tracing.go
@@ -58,7 +58,7 @@ func (r *Runtime) runStage(
 	if operation == nil {
 		return errors.New("runtime: stage operation must not be nil")
 	}
-	stageContext, span := safelyStartStage(r.tracing, ctx, name, attributes)
+	stageContext, span := safelyStartStage(ctx, r.tracing, name, attributes)
 	defer func() {
 		if recovered := recover(); recovered != nil {
 			panicErr := fmt.Errorf("runtime: stage operation panicked with %T", recovered)
@@ -79,8 +79,8 @@ func (r *Runtime) runStage(
 }
 
 func safelyStartStage(
-	tracing StageTracing,
 	ctx context.Context,
+	tracing StageTracing,
 	name string,
 	attributes map[string]TraceAttribute,
 ) (stageContext context.Context, span StageSpan) {

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -27,6 +27,7 @@ import (
 	"sync"
 	"time"
 
+	// Register the SQLite driver used by the scheduler store.
 	_ "github.com/mattn/go-sqlite3"
 )
 


### PR DESCRIPTION
## Tracking

- Tracking issue: #74
- Relationship: Closes #74; Part of #3

## Problem and rationale

The default revive scan reports 2,034 findings, including 1,982 exported-comment findings and 44 redefined built-in identifiers. Enabling the defaults would create substantial documentation and naming churn.

This change enables a smaller, explicit rule set focused on likely defects and clear maintenance problems.

## Changes

- Enable revive through the existing pinned golangci-lint configuration.
- Configure 11 explicit rules instead of inheriting the default rule set.
- Exclude `forbidden-call-in-wg-go`: revive v1.15.0 only matches a receiver identifier named `wg`, so it does not cover this repository's `group.Go` and `scheduler.wg.Go` forms.
- Allow `testing.T` before `context.Context` in test helpers.
- Merge two identical conditional branches.
- Move `context.Context` to the first parameter position in an internal helper.
- Document the scheduler's SQLite driver registration.
- Record the repository-shaped mutant requirement for future syntax-only linter rules.

## Behavior and compatibility

- User-visible behavior: None.
- Public API or protocol impact: None.
- Breaking changes or migration requirements: None.
- Explicit non-goals: Enabling `exported`, `redefines-builtin-id`, `forbidden-call-in-wg-go`, or the complete revive default rule set.

## Generated, dependency, and workflow impact

- [x] No generated contract changed.
- [x] No dependency changed.
- [x] No CI or release workflow changed; the existing lint job is reused.
- [x] No credentials or private content are included.

## Validation

```text
make lint
0 issues.

(cd test/downstream && GOWORK=off ../../.tools/bin/golangci-lint run --config ../../.golangci.yml)
0 issues.

GL_DEBUG=revive confirmed that only the 11 configured rules are enabled.

An allowed *testing.T/context.Context probe passed with 0 issues.
A misplaced context.Context probe failed with context-as-argument (revive).

go test -count=1 -tags sqlite_fts5 ./internal/cli ./internal/modelprovider ./internal/runtime ./internal/scheduler
passed.

A temporary merge with current origin/main completed without conflicts; root and downstream lint both passed, and the merge was aborted afterward.

git diff --check
passed.
```

- [x] `git diff --check`
- [x] `git status --short` was inspected after validation.
- [x] The main and downstream lint checks were run with the pinned tools.
- [x] The directly affected Go packages were tested.
- [x] The current-main merge tree was linted.
- [x] No unavailable check is represented as passing.

## AI usage

AI assistance was used to inspect the existing lint setup, classify the revive baseline, review the pinned analyzer implementations, and prepare the configuration changes. I reviewed the selected rules and final diff, reran the lint and targeted test commands, and verified both accepted and rejected probe behavior.
