### PR TITLE
ci: audit dependency licenses across owned modules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -223,6 +223,9 @@ source / artifact / trigger / inference
   drift, and pin an `apidiff` build that uses the same `x/tools` export format
   as the writer. Verify deterministic regeneration on Windows and Linux and
   prove that removing a real exported identifier fails the public API gate.
+- When a dependency audit inspects owned Go module graphs, use readonly package
+  resolution and verify `go.mod` and `go.sum` remain unchanged; do not download
+  graph metadata in a way that expands a checked-in module manifest.
 - When a CI Makefile target iterates over a platform, package, or owned-module matrix, verify
   a successful fake command observes every required entry and intended
   environment. Make a non-final entry fail, then verify the target exits

--- a/Makefile
+++ b/Makefile
@@ -171,9 +171,9 @@ license-fix: ## Repair eligible source headers and recheck them.
 	$(LICENSE_EYE) -c .licenserc.yaml header fix
 	$(LICENSE_EYE) -c .licenserc.yaml header check
 
-license-dependencies: build ## Build bounded dependency-license evidence for the standard binary.
+license-dependencies: build ## Build dependency-license evidence for every owned Go module.
 	@$(RM) "$(LICENSE_DEPENDENCY_OUTPUT)"
-	$(GO) run ./tools/release licenses -binary bin/powercontext -edition standard -output "$(LICENSE_DEPENDENCY_OUTPUT)"
+	$(GO) run ./tools/release licenses -binary bin/powercontext -edition standard -output "$(LICENSE_DEPENDENCY_OUTPUT)" -modules "$(OWNED_MODULES)"
 
 fmt: lint-tools ## Format supported source with the pinned formatter set.
 	$(GOFMT) -w $$(find . -name '*.go' -not -path './vendor/*')

--- a/tools/release/license_inventory.go
+++ b/tools/release/license_inventory.go
@@ -56,9 +56,7 @@ func runLicenseInventory(arguments []string, output io.Writer) error {
 		(options.Edition != "standard" && options.Edition != "full") {
 		return errors.New("licenses requires binary, output, and standard or full edition")
 	}
-	for _, value := range strings.Fields(modules) {
-		options.Modules = append(options.Modules, value)
-	}
+	options.Modules = append(options.Modules, strings.Fields(modules)...)
 	repository, err := filepath.Abs(options.Repository)
 	if err != nil {
 		return err
@@ -71,8 +69,8 @@ func runLicenseInventory(arguments []string, output io.Writer) error {
 	if err != nil {
 		return err
 	}
-	if err := collectModuleGraphLicenses(&manifest, repository, options.Modules); err != nil {
-		return err
+	if collectErr := collectModuleGraphLicenses(&manifest, repository, options.Modules); collectErr != nil {
+		return collectErr
 	}
 	encoded, err := json.Marshal(&manifest, jsontext.WithIndent("  "))
 	if err != nil {

--- a/tools/release/license_inventory.go
+++ b/tools/release/license_inventory.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 type licenseInventoryOptions struct {
@@ -29,6 +30,7 @@ type licenseInventoryOptions struct {
 	Edition    string
 	Output     string
 	Repository string
+	Modules    []string
 }
 
 type licenseInventoryResult struct {
@@ -45,12 +47,17 @@ func runLicenseInventory(arguments []string, output io.Writer) error {
 	flags.StringVar(&options.Edition, "edition", "standard", "standard or full")
 	flags.StringVar(&options.Output, "output", "", "new dependency-license manifest path")
 	flags.StringVar(&options.Repository, "repository", ".", "repository root")
+	var modules string
+	flags.StringVar(&modules, "modules", "", "space-separated owned Go module directories beyond the root binary")
 	if err := flags.Parse(arguments); err != nil {
 		return err
 	}
 	if flags.NArg() != 0 || options.Binary == "" || options.Output == "" ||
 		(options.Edition != "standard" && options.Edition != "full") {
 		return errors.New("licenses requires binary, output, and standard or full edition")
+	}
+	for _, value := range strings.Fields(modules) {
+		options.Modules = append(options.Modules, value)
 	}
 	repository, err := filepath.Abs(options.Repository)
 	if err != nil {
@@ -62,6 +69,9 @@ func runLicenseInventory(arguments []string, output io.Writer) error {
 	}
 	manifest, _, err := collectLicenses(options.Binary, repository, options.Edition, assets)
 	if err != nil {
+		return err
+	}
+	if err := collectModuleGraphLicenses(&manifest, repository, options.Modules); err != nil {
 		return err
 	}
 	encoded, err := json.Marshal(&manifest, jsontext.WithIndent("  "))

--- a/tools/release/licenses.go
+++ b/tools/release/licenses.go
@@ -127,6 +127,89 @@ func collectLicenses(
 	return dependencies, []byte(notices.String()), nil
 }
 
+func collectModuleGraphLicenses(manifest *dependencyManifest, repository string, modules []string) error {
+	moduleCache, err := goModuleCache(repository)
+	if err != nil {
+		return err
+	}
+	seen := make(map[string]struct{}, len(manifest.Modules))
+	for _, record := range manifest.Modules {
+		seen[record.Path+"\x00"+record.Version+"\x00"+record.Replacement] = struct{}{}
+	}
+	for _, modulePath := range modules {
+		if modulePath == "." {
+			continue
+		}
+		dependencies, err := moduleGraphDependencies(repository, modulePath)
+		if err != nil {
+			return err
+		}
+		for _, dependency := range dependencies {
+			if dependency.Version == "" || (dependency.Replace != nil && dependency.Replace.Version == "") {
+				continue
+			}
+			directory, replacement, err := moduleDirectory(dependency, moduleCache, repository)
+			if err != nil {
+				return err
+			}
+			key := dependency.Path + "\x00" + dependency.Version + "\x00" + replacement
+			if _, exists := seen[key]; exists {
+				continue
+			}
+			licenses, err := findLicenseFiles(directory)
+			if err != nil {
+				return fmt.Errorf("%s %s: %w", dependency.Path, dependency.Version, err)
+			}
+			record := dependencyRecord{Path: dependency.Path, Version: dependency.Version, Replacement: replacement}
+			for _, licensePath := range licenses {
+				contents, err := readBoundedFile(licensePath, maxLicenseBytes)
+				if err != nil {
+					return err
+				}
+				hash := sha256.Sum256(contents)
+				record.Licenses = append(record.Licenses, licenseRecord{Name: filepath.Base(licensePath), SHA256: hex.EncodeToString(hash[:])})
+			}
+			manifest.Modules = append(manifest.Modules, record)
+			seen[key] = struct{}{}
+		}
+	}
+	sort.Slice(manifest.Modules, func(left, right int) bool {
+		if manifest.Modules[left].Path == manifest.Modules[right].Path {
+			return manifest.Modules[left].Version < manifest.Modules[right].Version
+		}
+		return manifest.Modules[left].Path < manifest.Modules[right].Path
+	})
+	return nil
+}
+
+func moduleGraphDependencies(repository, modulePath string) ([]*debug.Module, error) {
+	command := exec.Command("go", "-C", modulePath, "list", "-deps", "-test", "-f", "{{if .Module}}{{.Module.Path}}|{{.Module.Version}}|{{if .Module.Replace}}{{.Module.Replace.Path}}|{{.Module.Replace.Version}}{{end}}{{end}}", "./...")
+	command.Dir = repository
+	output, err := command.Output()
+	if err != nil {
+		return nil, fmt.Errorf("list module graph for %s: %w", modulePath, err)
+	}
+	var result []*debug.Module
+	for _, line := range strings.Split(strings.TrimSpace(string(output)), "\n") {
+		if line == "" {
+			continue
+		}
+		fields := strings.Split(line, "|")
+		if len(fields) < 2 || fields[0] == "" {
+			return nil, fmt.Errorf("module graph for %s contains malformed entry", modulePath)
+		}
+		dependency := &debug.Module{Path: fields[0], Version: fields[1]}
+		if len(fields) >= 3 && fields[2] != "" {
+			dependency.Replace = &debug.Module{Path: fields[2]}
+			if len(fields) >= 4 {
+				dependency.Replace.Version = fields[3]
+			}
+		}
+		result = append(result, dependency)
+	}
+	return result, nil
+}
+
 func goModuleCache(repository string) (string, error) {
 	command := exec.Command("go", "env", "GOMODCACHE")
 	command.Dir = repository

--- a/tools/release/main_test.go
+++ b/tools/release/main_test.go
@@ -41,6 +41,7 @@ func TestLicenseInventoryWritesBoundedDependencyEvidence(t *testing.T) {
 	var stdout bytes.Buffer
 	if inventoryErr := runLicenseInventory([]string{
 		"-binary", binary, "-edition", "standard", "-output", output, "-repository", repository,
+		"-modules", "test/downstream",
 	}, &stdout); inventoryErr != nil {
 		t.Fatal(inventoryErr)
 	}


### PR DESCRIPTION
## Tracking

- Tracking issue: #3
- Relationship: `Part of #3` (WP0-C dependency-license assurance)

## Problem and rationale

`license-dependencies` derived evidence from the standard root binary only. That did not prove that external dependencies reached through every explicitly owned module, including the isolated downstream consumer, had license evidence. A direct graph audit initially exposed unused module-graph residue and a module-download side effect that expanded go.sum; both are incorrect audit boundaries.

## Changes

- Extend the `licenses` command with explicit owned-module inputs.
- For non-root owned modules, inspect the actual `go list -deps -test` compilation closure and merge any external license evidence into the existing manifest.
- Skip the root module because the release binary build info remains its authoritative runtime dependency source.
- Skip local replacements while preserving versioned external replacements.
- Pass `OWNED_MODULES` from `make license-dependencies`.
- Add regression coverage through the real downstream consumer graph.
- Add a prevention rule requiring readonly graph inspection with no go.mod/go.sum side effect.

## Behavior and compatibility

- User-visible behavior: none.
- Public API or protocol impact: none.
- Breaking changes or migration requirements: none.
- Explicit non-goals: unused `go list -m all` graph residue is not treated as a shipped dependency; release archive/package smoke remains covered by existing release verification.

## Validation

```text
go test -count=1 ./tools/release -run TestLicenseInventoryWritesBoundedDependencyEvidence
PASS
- root binary evidence
- actual test/downstream dependency closure
- no go.sum side effect

make license-check
PASS: 807 valid, 0 invalid

actionlint v1.7.12
PASS

git diff --check
PASS
```

- [x] `git diff --check`
- [x] `git status --short` was inspected after validation.
- [x] Focused dependency-license and license-header checks were run.

## AI usage

AI assistance was used to extend the dependency-license audit. The downstream graph, missing-license failure mode, module metadata side effect, and final readonly consumer graph path were independently exercised locally.