### PR TITLE
test: bound cleanup target deletions

### DIFF
--- a/tools/release/makefile_test.go
+++ b/tools/release/makefile_test.go
@@ -63,6 +63,7 @@ func TestDependencySecurityScansTheStandardSourceClosure(t *testing.T) {
 		}
 	}
 }
+
 func TestCleanRemovesOnlyKnownLocalOutputs(t *testing.T) {
 	repository, absoluteErr := filepath.Abs(filepath.Clean(filepath.Join("..", "..")))
 	if absoluteErr != nil {
@@ -92,7 +93,7 @@ func TestCleanRemovesOnlyKnownLocalOutputs(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(root, "keep", "sentinel")); err != nil {
 		t.Fatalf("make clean removed unrelated sentinel: %v", err)
-}
+	}
 }
 
 func TestModuleIntegrityRunsEveryOwnedModule(t *testing.T) {

--- a/tools/release/makefile_test.go
+++ b/tools/release/makefile_test.go
@@ -61,8 +61,8 @@ func TestDependencySecurityScansTheStandardSourceClosure(t *testing.T) {
 		if !strings.Contains(string(output), want) {
 			t.Fatalf("make dependency-security is missing %q:\n%s", want, output)
 		}
+	}
 }
-
 func TestCleanRemovesOnlyKnownLocalOutputs(t *testing.T) {
 	repository, absoluteErr := filepath.Abs(filepath.Clean(filepath.Join("..", "..")))
 	if absoluteErr != nil {

--- a/tools/release/makefile_test.go
+++ b/tools/release/makefile_test.go
@@ -61,7 +61,38 @@ func TestDependencySecurityScansTheStandardSourceClosure(t *testing.T) {
 		if !strings.Contains(string(output), want) {
 			t.Fatalf("make dependency-security is missing %q:\n%s", want, output)
 		}
+}
+
+func TestCleanRemovesOnlyKnownLocalOutputs(t *testing.T) {
+	repository, absoluteErr := filepath.Abs(filepath.Clean(filepath.Join("..", "..")))
+	if absoluteErr != nil {
+		t.Fatal(absoluteErr)
 	}
+	root := t.TempDir()
+	for _, directory := range []string{"bin", "dist", "coverage", "site", "keep"} {
+		path := filepath.Join(root, directory)
+		if mkdirErr := os.Mkdir(path, 0o755); mkdirErr != nil {
+			t.Fatal(mkdirErr)
+		}
+		if writeErr := os.WriteFile(filepath.Join(path, "sentinel"), []byte(directory), 0o600); writeErr != nil {
+			t.Fatal(writeErr)
+		}
+	}
+
+	command := exec.CommandContext(t.Context(), "make", "-f", filepath.Join(repository, "Makefile"), "clean")
+	command.Dir = root
+	output, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("make clean failed: %v\n%s", err, output)
+	}
+	for _, directory := range []string{"bin", "dist", "coverage", "site"} {
+		if _, err := os.Stat(filepath.Join(root, directory)); !os.IsNotExist(err) {
+			t.Fatalf("make clean kept %s: %v", directory, err)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(root, "keep", "sentinel")); err != nil {
+		t.Fatalf("make clean removed unrelated sentinel: %v", err)
+}
 }
 
 func TestModuleIntegrityRunsEveryOwnedModule(t *testing.T) {


### PR DESCRIPTION
## Tracking

- Tracking issue: #3
- Relationship: `Part of #3` (WP0-C cleanup contract)

## Problem and rationale

The cleanup target deletes local build outputs, but no behavior-level regression proof established that it remains bounded to the known output directories. A source-text assertion would not prove the Make recipe's real deletion behavior.

## Changes

- Add a temporary-directory test that invokes the real repository Makefile's `clean` target.
- Prove that `bin`, `dist`, `coverage`, and `site` are removed.
- Prove that an unrelated sibling sentinel survives.
- Keep the test compliant with the repository's pinned shadow and formatting policies.

## Behavior and compatibility

- User-visible behavior: none.
- Public API or protocol impact: none.
- Breaking changes or migration requirements: none.
- Explicit non-goals: no cleanup recipe behavior changed; the test does not run against or modify a developer worktree.

## Validation

The following commands were run against the submitted Head content:

```text
go test ./tools/release -run '^TestCleanRemovesOnlyKnownLocalOutputs$' -count=1
PASS

go test ./...
PASS

make test-race
PASS

make lint
PASS: 0 issues

make check
PASS

make license-check
PASS: 807 valid, 0 invalid

git diff --check
PASS
```

- [x] The real Make cleanup behavior was exercised in an isolated temporary directory.
- [x] The changed test passed the repository's pinned formatter, linter, vet, standard test, and race-test gates.
- [x] `git status --short` was inspected after validation.

## AI usage

AI assistance was used to add, review, and format the isolated cleanup regression test. Verification exercised the real Makefile and inspected the exact command output and final diff without touching the developer worktree.
