### PR TITLE
ci: enforce focused revive checks

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -28,6 +28,7 @@ linters:
     - govet
     - ineffassign
     - misspell
+    - revive
     - staticcheck
     - unused
     - wastedassign
@@ -38,6 +39,25 @@ linters:
     govet:
       enable:
         - shadow
+    revive:
+      # Keep only rules that add focused signal beyond govet and staticcheck.
+      # Declaring the rule set explicitly also avoids the high-noise defaults.
+      confidence: 0.8
+      rules:
+        - name: blank-imports
+        - name: context-as-argument
+          arguments:
+            - allow-types-before: "*testing.T"
+        - name: forbidden-call-in-wg-go
+        - name: identical-branches
+        - name: identical-ifelseif-branches
+        - name: identical-ifelseif-conditions
+        - name: identical-switch-branches
+        - name: identical-switch-conditions
+        - name: inefficient-map-lookup
+        - name: redundant-build-tag
+        - name: redundant-test-main-exit
+        - name: unconditional-recursion
     staticcheck:
       checks:
         - all

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -48,7 +48,6 @@ linters:
         - name: context-as-argument
           arguments:
             - allow-types-before: "*testing.T"
-        - name: forbidden-call-in-wg-go
         - name: identical-branches
         - name: identical-ifelseif-branches
         - name: identical-ifelseif-conditions

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -199,6 +199,10 @@ source / artifact / trigger / inference
   steps by the complete required operation rather than substring presence.
   Keep a valid fixture plus a failing mutant for each boundary, and recheck the
   assumptions against the current official schema before changing the gate.
+- When enabling a syntax-only linter rule for a method or selector, inspect the
+  pinned analyzer implementation and prove it with a repository-shaped mutant
+  using the receiver and call forms present in production. Do not advertise a
+  rule whose matcher ordinary identifier or selector naming can bypass.
 - When a repository inventory prunes generated output while discovering owned
   files, scope name-based exclusions to explicit repository-relative roots
   unless that directory class is unowned at every depth. Verify an owned nested

--- a/internal/cli/integration_pi.go
+++ b/internal/cli/integration_pi.go
@@ -192,12 +192,12 @@ func removeSupersededPiPackages(
 			continue
 		}
 		remove := ""
-		if hasRemotePackageScheme(listing.source) {
+		removeSource := hasRemotePackageScheme(listing.source) ||
+			(listing.path == "" && filepath.IsAbs(listing.source))
+		if removeSource {
 			remove = listing.source
 		} else if listing.path != "" {
 			remove = listing.path
-		} else if filepath.IsAbs(listing.source) {
-			remove = listing.source
 		}
 		if remove != "" {
 			if _, err := commands.Run(ctx, executable, "remove", remove); err != nil {

--- a/internal/modelprovider/openai_profile.go
+++ b/internal/modelprovider/openai_profile.go
@@ -84,9 +84,7 @@ func routedProfileSupportsJSONObject(provider, model string) bool {
 	}
 	downstream, _, _ = strings.Cut(downstream, ":")
 	switch upstream {
-	case "openai":
-		return true
-	case "x-ai", "xai":
+	case "openai", "x-ai", "xai":
 		return true
 	case "google", "vertex":
 		return googleProfileSupportsJSONObject(downstream)

--- a/internal/runtime/tracing.go
+++ b/internal/runtime/tracing.go
@@ -58,7 +58,7 @@ func (r *Runtime) runStage(
 	if operation == nil {
 		return errors.New("runtime: stage operation must not be nil")
 	}
-	stageContext, span := safelyStartStage(r.tracing, ctx, name, attributes)
+	stageContext, span := safelyStartStage(ctx, r.tracing, name, attributes)
 	defer func() {
 		if recovered := recover(); recovered != nil {
 			panicErr := fmt.Errorf("runtime: stage operation panicked with %T", recovered)
@@ -79,8 +79,8 @@ func (r *Runtime) runStage(
 }
 
 func safelyStartStage(
-	tracing StageTracing,
 	ctx context.Context,
+	tracing StageTracing,
 	name string,
 	attributes map[string]TraceAttribute,
 ) (stageContext context.Context, span StageSpan) {

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -27,6 +27,7 @@ import (
 	"sync"
 	"time"
 
+	// Register the SQLite driver used by the scheduler store.
 	_ "github.com/mattn/go-sqlite3"
 )
 


### PR DESCRIPTION
## Tracking

- Tracking issue: #74
- Relationship: `Closes #74`; `Part of #3` (WP0-B focused lint evaluation)
- Supersedes #75 after rebuilding the contributor's commit on current main. The original commit author `duanyuanzhe <1342558165@qq.com>` is preserved.

## Problem and rationale

The default revive scan reports 2,034 findings, dominated by 1,982 exported-comment and 44 redefined-built-in findings. Enabling revive defaults would create documentation and naming churn rather than focused defect signal.

This replacement enables an explicit 11-rule set on current main. It intentionally excludes `forbidden-call-in-wg-go`: pinned revive v1.15.0 matches only the literal receiver spelling `wg.Go`/`wg.Done`, while this repository uses `group.Go` and `scheduler.wg.Go`. A repository-shaped mutant proved the rule reports `wg.Go` but misses both production forms, so advertising it would provide false assurance.

## Changes

- enable revive through the existing pinned golangci-lint configuration;
- configure 11 explicit rules instead of inheriting defaults;
- allow `testing.T` before `context.Context` in test helpers;
- omit the syntax-only WaitGroup rule whose receiver matcher does not cover this repository;
- merge two behavior-identical conditional/switch branches;
- move `context.Context` to the first parameter of an internal helper;
- document the scheduler SQLite blank import;
- add an AGENTS rule requiring repository-shaped mutants before enabling syntax-only selector rules.

## Behavior and compatibility

- User-visible behavior: none.
- Public API or protocol impact: none.
- Breaking changes or migration requirements: none.
- Explicit non-goals: enabling `exported`, `redefines-builtin-id`, the complete revive defaults, or renaming production WaitGroups to satisfy a brittle analyzer.

## Generated, dependency, and workflow impact

- [x] No generated contract changed.
- [x] No dependency or workflow changed; the existing stable lint job is reused.
- [x] No broad path exclusion or lint waiver was added.
- [x] No credentials or private content are included.

## Validation

Evidence from original exact Head #75:

```text
33/33 exact-Head checks completed success
make lint: 0 issues
root and test/downstream use the same pinned golangci-lint v2.13.1 policy
GL_DEBUG=revive: defaults disabled; only explicit rules enabled
context-as-argument mutant: actionable failure
```

Replacement validation on current main `ab128a1`:

```text
go test -count=1 ./internal/modelprovider ./internal/runtime
PASS
make module-check
PASS
make governance-check
PASS
make license-check
PASS: 807 valid, 0 invalid, 199 ignored
git diff --check
PASS
```

Pinned-analyzer discriminative mutant from independent review:

```text
wg.Go(func() { panic(...) })           -> reported
 group.Go(func() { panic(...) })       -> missed
scheduler.wg.Go(func() { panic(...) }) -> missed
```

The full Windows root lint/test path is not represented as passing because this machine lacks the native SQLite header/toolchain shape used by Linux CI. The replacement exact Head must obtain a fresh current-base CI result before merge.

- [x] `git diff --check`
- [x] `git status --short` was inspected after validation.
- [x] Focused tests, module/governance/license gates, original exact-Head CI, and pinned analyzer mutants were reviewed.

## AI usage

AI assistance reviewed #75, reproduced the pinned analyzer's receiver-name limitation, preserved the contributor-authored semantic commit, removed the ineffective rule, added a prevention rule, and rebuilt the branch on current main. This replacement will receive fresh exact-Head CI and independent review before merge.
