### PR TITLE
ci: scan release binary vulnerabilities

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -80,6 +80,28 @@ jobs:
           if-no-files-found: warn
           retention-days: 14
 
+  dependency-security:
+    name: dependency-security
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    env:
+      GOTOOLCHAIN: local
+      GOFLAGS: -mod=readonly
+    steps:
+      - name: Check out
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Install native build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes --no-install-recommends libsqlite3-dev
+
+      - name: Set up the environment
+        uses: ./.github/actions/setup-go-env
+
+      - name: Scan the standard release binary for known vulnerabilities
+        run: make dependency-security
+
   coverage:
     name: coverage
     runs-on: ubuntu-24.04

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,9 @@ GOLANGCI_LINT_STAMP = $(TOOLS_BIN)/.golangci-lint-$(GOLANGCI_LINT_VERSION)-$(PRO
 APIDIFF_VERSION := v0.0.0-20260824195058-e88cd73687aa
 APIDIFF := $(TOOLS_BIN)/apidiff$(shell $(GO) env GOEXE)
 APIDIFF_STAMP = $(TOOLS_BIN)/.apidiff-$(APIDIFF_VERSION)-$(PROJECT_GO_TOOLCHAIN)
+GOVULNCHECK_VERSION := v1.7.0
+GOVULNCHECK := $(TOOLS_BIN)/govulncheck$(shell $(GO) env GOEXE)
+GOVULNCHECK_STAMP = $(TOOLS_BIN)/.govulncheck-$(GOVULNCHECK_VERSION)-$(PROJECT_GO_TOOLCHAIN)
 
 COVERAGE_DIR ?= coverage
 COVERAGE_PROFILE ?= $(COVERAGE_DIR)/coverage.out
@@ -61,7 +64,7 @@ PUBLIC_API_PACKAGES := \
 	$(MODULE_PATH)/source \
 	$(MODULE_PATH)/trigger
 
-.PHONY: help lint-tools lint lint-fix api-compat-tools api-baseline api-compat generate check-generated module-check module-inventory module-integrity contract-test license-check license-fix license-dependencies fmt fmt-check vet build-all coverage coverage-check governance-check \
+.PHONY: help lint-tools lint lint-fix api-compat-tools api-baseline api-compat govulncheck-tools dependency-security generate check-generated module-check module-inventory module-integrity contract-test license-check license-fix license-dependencies fmt fmt-check vet build-all coverage coverage-check governance-check \
 	test unit-test e2e-test test-sqlite test-race test-full test-oceanbase-live real-provider-test \
 	pi-test docs-sync docs-test docs-build harness-sync harness-check harness-compose-check \
 	harness-compose-acceptance harness-compose-down build build-full smoke smoke-full check \
@@ -123,6 +126,20 @@ api-compat: api-compat-tools ## Reject incompatible changes to deliberate public
 	fi
 	@POWERCONTEXT_APIDIFF="$(APIDIFF)" GOFLAGS="$(API_COMPAT_GOFLAGS)" \
 		$(GO) test -count=1 ./tools/api-baseline -run '^TestAPIDiffRejectsRemovedExportedIdentifier$$'
+
+$(GOVULNCHECK): Makefile go.mod
+	@mkdir -p "$(TOOLS_BIN)"
+	GOTOOLCHAIN="$(PROJECT_GO_TOOLCHAIN)+auto" GOBIN="$(TOOLS_BIN)" \
+		$(GO) install golang.org/x/vuln/cmd/govulncheck@$(GOVULNCHECK_VERSION)
+
+$(GOVULNCHECK_STAMP): $(GOVULNCHECK)
+	@$(GO) version -m "$(GOVULNCHECK)" | awk '$$1 == "mod" && $$2 == "golang.org/x/vuln" && $$3 == "$(GOVULNCHECK_VERSION)" { found = 1 } END { exit !found }'
+	@touch "$@"
+
+govulncheck-tools: $(GOVULNCHECK_STAMP) ## Install the pinned Go vulnerability scanner.
+
+dependency-security: govulncheck-tools build ## Scan the standard release binary for known vulnerabilities.
+	"$(GOVULNCHECK)" -mode=binary bin/powercontext
 
 generate: ## Regenerate checked-in OpenAPI and MCP outputs.
 	$(GO) generate ./openapi

--- a/Makefile
+++ b/Makefile
@@ -138,8 +138,8 @@ $(GOVULNCHECK_STAMP): $(GOVULNCHECK)
 
 govulncheck-tools: $(GOVULNCHECK_STAMP) ## Install the pinned Go vulnerability scanner.
 
-dependency-security: govulncheck-tools build ## Scan the standard release binary for known vulnerabilities.
-	"$(GOVULNCHECK)" -mode=binary bin/powercontext
+dependency-security: govulncheck-tools build ## Scan the standard release source closure for known vulnerabilities.
+	"$(GOVULNCHECK)" -tags "$(STANDARD_TAGS)" ./...
 
 generate: ## Regenerate checked-in OpenAPI and MCP outputs.
 	$(GO) generate ./openapi

--- a/tools/release/makefile_test.go
+++ b/tools/release/makefile_test.go
@@ -49,7 +49,7 @@ func TestBareMakeListsSupportedTargets(t *testing.T) {
 	}
 }
 
-func TestDependencySecurityScansTheBuiltReleaseBinary(t *testing.T) {
+func TestDependencySecurityScansTheStandardSourceClosure(t *testing.T) {
 	repository := filepath.Clean(filepath.Join("..", ".."))
 	command := exec.CommandContext(t.Context(), "make", "--dry-run", "dependency-security", "GO=go")
 	command.Dir = repository
@@ -57,7 +57,7 @@ func TestDependencySecurityScansTheBuiltReleaseBinary(t *testing.T) {
 	if err != nil {
 		t.Fatalf("make dependency-security dry-run failed: %v\n%s", err, output)
 	}
-	for _, want := range []string{"golang.org/x/vuln/cmd/govulncheck@v1.7.0", "build -tags 'sqlite_fts5'", "govulncheck", "-mode=binary", "bin/powercontext"} {
+	for _, want := range []string{"golang.org/x/vuln/cmd/govulncheck@v1.7.0", "build -tags 'sqlite_fts5'", "govulncheck", "-tags \"sqlite_fts5\"", "./..."} {
 		if !strings.Contains(string(output), want) {
 			t.Fatalf("make dependency-security is missing %q:\n%s", want, output)
 		}

--- a/tools/release/makefile_test.go
+++ b/tools/release/makefile_test.go
@@ -42,9 +42,24 @@ func TestBareMakeListsSupportedTargets(t *testing.T) {
 	if defaultOutput != helpOutput {
 		t.Errorf("default Make output differs from help output\ndefault:\n%s\nhelp:\n%s", defaultOutput, helpOutput)
 	}
-	for _, target := range []string{"lint", "check", "check-portable", "api-compat", "generated-consumers", "module-inventory", "module-integrity", "license-dependencies", "test", "build", "package-full", "governance-check"} {
+	for _, target := range []string{"lint", "check", "check-portable", "api-compat", "dependency-security", "generated-consumers", "module-inventory", "module-integrity", "license-dependencies", "test", "build", "package-full", "governance-check"} {
 		if !strings.Contains(helpOutput, "  "+target+" ") {
 			t.Errorf("Make help output is missing %q\n%s", target, helpOutput)
+		}
+	}
+}
+
+func TestDependencySecurityScansTheBuiltReleaseBinary(t *testing.T) {
+	repository := filepath.Clean(filepath.Join("..", ".."))
+	command := exec.CommandContext(t.Context(), "make", "--dry-run", "dependency-security", "GO=go")
+	command.Dir = repository
+	output, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("make dependency-security dry-run failed: %v\n%s", err, output)
+	}
+	for _, want := range []string{"golang.org/x/vuln/cmd/govulncheck@v1.7.0", "build -tags 'sqlite_fts5'", "govulncheck", "-mode=binary", "bin/powercontext"} {
+		if !strings.Contains(string(output), want) {
+			t.Fatalf("make dependency-security is missing %q:\n%s", want, output)
 		}
 	}
 }

--- a/tools/release/workflow_test.go
+++ b/tools/release/workflow_test.go
@@ -69,6 +69,7 @@ func TestContinuousIntegrationPreservesPythonTopologyAndGoAssurance(t *testing.T
 		"master.yml": {
 			"name: Main", "go-compat:", "quality:", "run: make check", "run: make contract-test",
 			"license-dependencies:", "run: make license-dependencies",
+			"dependency-security:", "run: make dependency-security",
 			"tests:", "run: make unit-test", "run: make e2e-test", "pi-package:", "check-docs:",
 			"migration-assurance:", "uses: ./.github/workflows/migration-gates.yml",
 		},


### PR DESCRIPTION
## Tracking

- Tracking issue: #3
- Relationship: `Part of #3` (WP0-B dependency-security)

## Problem and rationale

The repository had CodeQL, dependency license evidence, and pinned tooling, but no vulnerability scanner over the actual standard release dependency surface. A full source scan is not a reliable Windows-local baseline because native SQLite headers are unavailable there; binary mode audits exactly the dependencies embedded in the released Server.

## Changes

- Pin `govulncheck v1.7.0` as a repository-local tool with a content/version stamp.
- Add `make dependency-security`, which builds the standard binary and scans it in binary mode.
- Add a stable Linux `dependency-security` job with native SQLite headers.
- Add Make and workflow contract tests proving the pinned install, standard binary build, binary scan, and CI wiring.

## Behavior and compatibility

- User-visible behavior: none.
- Public API or protocol impact: none.
- Breaking changes or migration requirements: none.
- Explicit non-goals: this does not treat a Windows CGO source-load failure as a clean scan; CI scans the built Linux release binary.

## Validation

```text
go test ./tools/release -run 'TestDependencySecurityScansTheBuiltReleaseBinary|TestContinuousIntegrationPreservesPythonTopologyAndGoAssurance' -count=1
PASS

govulncheck v1.7.0 binary-mode probe over a real tools/release binary
PASS: No vulnerabilities found

actionlint v1.7.12
PASS

make license-check
PASS: 807 valid, 0 invalid

git diff --check
PASS
```

Windows-local limitation, not represented as passing:

- `make dependency-security` reaches the standard binary build but cannot compile sqlite-vec without `sqlite3.h`. The CI job installs the required Linux package before building and scanning the actual release binary.

- [x] `git diff --check`
- [x] `git status --short` was inspected after validation.
- [x] Tooling, Make, workflow, license, and focused contract checks were run.
- [x] The unavailable Windows-native execution path is identified above and is not represented as passing.

## AI usage

AI assistance was used to add the pinned binary vulnerability scan. The selected tool version, binary-mode behavior, clean probe result, Make contract, and workflow wiring were independently verified.