### PR TITLE
test: consume fresh DSH operations output

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,6 +160,10 @@ source / artifact / trigger / inference
 - When a test invokes a freshly built external binary, disable result caching
   or key it to the binary content. Verify the gate reruns after the binary
   changes without changing the test package.
+- When a test synchronously invokes real CLI or compiler subprocesses, measure
+  cold supported-host durations and set a bounded timeout on that test only;
+  do not raise the suite-wide default. Verify the real exit status and output,
+  then prove the focused test completes on the measured slow host.
 - When a release or end-to-end CLI adds a required flag, inventory every direct
   invocation instead of updating only wrapper targets. Verify each script and
   Make entrypoint with executable fakes that assert the complete argument list.
@@ -275,6 +279,10 @@ source / artifact / trigger / inference
   the underlying error matchable and name concrete operator remediation without
   exposing configured values. Verify exit code 2 and that execution never
   reaches the operation runner.
+- When a CLI option consumes the following token as a value, reject a missing
+  value or another option before any read or write. Verify the real CLI exits
+  nonzero with an actionable diagnostic even when an option-named file would
+  otherwise make the malformed command succeed.
 - When isolated host adapters vendor the same transport policy, drive every
   configuration and directly constructible client boundary from one shared
   host-vector fixture. Verify the complete IPv4 `127.0.0.0/8` range, IPv6

--- a/integrations/dsh/plugins/powercontext/scripts/gen-operations.mjs
+++ b/integrations/dsh/plugins/powercontext/scripts/gen-operations.mjs
@@ -54,8 +54,11 @@ export function generateOperations(outputPath = generatedPath) {
 
 function main() {
   const outputIndex = process.argv.indexOf('--output')
-  const outputPath = outputIndex === -1 ? generatedPath : process.argv[outputIndex + 1]
-  if (!outputPath) throw new Error('gen-operations: --output requires a path')
+  const outputArgument = outputIndex === -1 ? undefined : process.argv[outputIndex + 1]
+  if (outputIndex !== -1 && (!outputArgument || outputArgument.startsWith('--'))) {
+    throw new Error('gen-operations: --output requires a path')
+  }
+  const outputPath = outputArgument ?? generatedPath
   if (process.argv.includes('--check')) {
     checkGenerated(outputPath)
     console.log('generated operations are current')

--- a/integrations/dsh/plugins/powercontext/scripts/gen-operations.mjs
+++ b/integrations/dsh/plugins/powercontext/scripts/gen-operations.mjs
@@ -44,21 +44,24 @@ export function checkGenerated(path = generatedPath) {
   if (normalizeNewlines(actual) !== normalizeNewlines(expected)) throw new Error(DRIFT_MESSAGE)
 }
 
-export function generateOperations() {
+export function generateOperations(outputPath = generatedPath) {
   const yamlPath = syncOpenApi()
   const source = renderGeneratedSource(yamlPath)
-  mkdirSync(dirname(generatedPath), { recursive: true })
-  writeFileSync(generatedPath, source)
-  return generatedPath
+  mkdirSync(dirname(outputPath), { recursive: true })
+  writeFileSync(outputPath, source)
+  return outputPath
 }
 
 function main() {
+  const outputIndex = process.argv.indexOf('--output')
+  const outputPath = outputIndex === -1 ? generatedPath : process.argv[outputIndex + 1]
+  if (!outputPath) throw new Error('gen-operations: --output requires a path')
   if (process.argv.includes('--check')) {
-    checkGenerated()
+    checkGenerated(outputPath)
     console.log('generated operations are current')
     return
   }
-  const path = generateOperations()
+  const path = generateOperations(outputPath)
   console.log(`wrote operations to ${path}`)
 }
 

--- a/integrations/dsh/plugins/powercontext/tests/gen-check.spec.ts
+++ b/integrations/dsh/plugins/powercontext/tests/gen-check.spec.ts
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
-import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
+import { execFileSync } from 'node:child_process'
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
-import { checkGenerated, renderGeneratedSource } from '../scripts/gen-operations.mjs'
+import { checkGenerated, generateOperations, renderGeneratedSource } from '../scripts/gen-operations.mjs'
 
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..')
 
@@ -38,5 +39,33 @@ describe('generated operations check', () => {
   it('renders the same source the repository currently commits', () => {
     const committed = readFileSync(join(repoRoot, 'src', 'operations.generated.ts'), 'utf8').replace(/\r\n/g, '\n')
     expect(renderGeneratedSource()).toBe(committed)
+  })
+
+  it('writes a fresh generated table to an explicit output path', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'pc-gen-output-'))
+    const output = join(dir, 'operations.generated.ts')
+    expect(generateOperations(output)).toBe(output)
+    expect(existsSync(output)).toBe(true)
+    expect(readFileSync(output, 'utf8')).toBe(renderGeneratedSource())
+
+    writeFileSync(join(dir, 'consumer.ts'), `
+import { OPERATION_IDS, OPERATIONS } from './operations.generated.ts'
+
+const first = OPERATION_IDS[0]
+const operation = OPERATIONS[first]
+void operation
+`)
+    writeFileSync(join(dir, 'tsconfig.json'), JSON.stringify({
+      compilerOptions: {
+        allowImportingTsExtensions: true,
+        module: 'ESNext',
+        moduleResolution: 'bundler',
+        noEmit: true,
+        strict: true,
+        target: 'ES2022',
+      },
+      include: ['consumer.ts', 'operations.generated.ts'],
+    }))
+    execFileSync(process.execPath, [join(repoRoot, 'node_modules', 'typescript', 'bin', 'tsc'), '-p', join(dir, 'tsconfig.json')])
   })
 })

--- a/integrations/dsh/plugins/powercontext/tests/gen-check.spec.ts
+++ b/integrations/dsh/plugins/powercontext/tests/gen-check.spec.ts
@@ -14,39 +14,67 @@
  * limitations under the License.
  */
 
-import { execFileSync } from 'node:child_process'
-import { existsSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
+import { execFileSync, spawnSync } from 'node:child_process'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { fileURLToPath } from 'node:url'
-import { describe, expect, it } from 'vitest'
-import { checkGenerated, generateOperations, renderGeneratedSource } from '../scripts/gen-operations.mjs'
+import { afterEach, describe, expect, it } from 'vitest'
+import { checkGenerated, renderGeneratedSource } from '../scripts/gen-operations.mjs'
 
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..')
+const generatorScript = join(repoRoot, 'scripts', 'gen-operations.mjs')
+const tempDirs: string[] = []
+const processTestTimeoutMs = 60_000
+
+function makeTempDir(prefix: string) {
+  const dir = mkdtempSync(join(tmpdir(), prefix))
+  tempDirs.push(dir)
+  return dir
+}
+
+function normalizeNewlines(text: string) {
+  return text.replace(/\r\n/g, '\n')
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
 
 describe('generated operations check', () => {
   it('passes when the committed table matches OpenAPI', () => {
     expect(() => checkGenerated()).not.toThrow()
   })
 
-  it('fails when the committed table has drifted', () => {
-    const dir = mkdtempSync(join(tmpdir(), 'pc-gen-'))
+  it('fails when an explicit CLI output has drifted', () => {
+    const dir = makeTempDir('pc-gen-')
     const drifted = join(dir, 'operations.generated.ts')
     writeFileSync(drifted, 'export const OPERATIONS = {}\n')
-    expect(() => checkGenerated(drifted)).toThrow(/drifted/)
-  })
+    const result = spawnSync(process.execPath, [generatorScript, '--check', '--output', drifted], {
+      encoding: 'utf8',
+    })
+
+    expect(result.status).not.toBe(0)
+    expect(result.stderr).toContain('Generated API code drifted')
+  }, processTestTimeoutMs)
 
   it('renders the same source the repository currently commits', () => {
-    const committed = readFileSync(join(repoRoot, 'src', 'operations.generated.ts'), 'utf8').replace(/\r\n/g, '\n')
+    const committed = normalizeNewlines(readFileSync(join(repoRoot, 'src', 'operations.generated.ts'), 'utf8'))
     expect(renderGeneratedSource()).toBe(committed)
   })
 
-  it('writes a fresh generated table to an explicit output path', () => {
-    const dir = mkdtempSync(join(tmpdir(), 'pc-gen-output-'))
+  it('writes and checks a fresh generated table through the public CLI', () => {
+    const dir = makeTempDir('pc-gen-output-')
     const output = join(dir, 'operations.generated.ts')
-    expect(generateOperations(output)).toBe(output)
-    expect(existsSync(output)).toBe(true)
-    expect(readFileSync(output, 'utf8')).toBe(renderGeneratedSource())
+    execFileSync(process.execPath, [generatorScript, '--output', output])
+    const committed = normalizeNewlines(readFileSync(join(repoRoot, 'src', 'operations.generated.ts'), 'utf8'))
+    expect(normalizeNewlines(readFileSync(output, 'utf8'))).toBe(committed)
+    execFileSync(
+      process.execPath,
+      [generatorScript, '--check', '--output', output],
+    )
 
     writeFileSync(join(dir, 'consumer.ts'), `
 import { OPERATION_IDS, OPERATIONS } from './operations.generated.ts'
@@ -67,5 +95,19 @@ void operation
       include: ['consumer.ts', 'operations.generated.ts'],
     }))
     execFileSync(process.execPath, [join(repoRoot, 'node_modules', 'typescript', 'bin', 'tsc'), '-p', join(dir, 'tsconfig.json')])
-  })
+  }, processTestTimeoutMs)
+
+  it('rejects another option where --output requires a path', () => {
+    const dir = makeTempDir('pc-gen-missing-output-')
+    execFileSync(process.execPath, [generatorScript, '--output', join(dir, '--check')])
+
+    const result = spawnSync(process.execPath, [generatorScript, '--output', '--check'], {
+      cwd: dir,
+      encoding: 'utf8',
+    })
+
+    expect(result.status).not.toBe(0)
+    expect(result.stderr).toContain('gen-operations: --output requires a path')
+    expect(result.stdout).not.toContain('generated operations are current')
+  }, processTestTimeoutMs)
 })


### PR DESCRIPTION
## Tracking

- Tracking issue: #3
- Relationship: `Part of #3` (WP0-C retained generator consumer integrity)

## Problem and rationale

The DSH operation generator could only write into the repository source tree. Existing drift, test, and build checks could not prove that a fresh generated operation table can be emitted to an isolated location and consumed by an independent TypeScript compilation.

The initial output-option parser also accepted another option as the `--output` value. With an option-named file present, `--output --check` could incorrectly exit successfully without receiving an output path.

## Changes

- Let `generateOperations` accept an explicit output path while preserving the existing default.
- Add `--output <path>` support to the public generator CLI; `--check --output <path>` validates the same target.
- Reject a missing output path or another option before the generator reads or writes any target file.
- Exercise generation, drift checking, and malformed arguments through the real CLI.
- Generate into a temporary directory and type-check an independent TypeScript consumer using the pinned package compiler.
- Clean up every temporary directory created by the regression tests.
- Give only the real CLI/compiler tests an evidence-based 60-second budget; the suite-wide Vitest timeout remains unchanged.

## Behavior and compatibility

- Existing `pnpm gen`, `pnpm gen:check`, and build defaults are unchanged.
- A malformed `--output` invocation now fails before file access instead of interpreting another option as a path.
- Public API or protocol impact: none.
- Breaking changes or migration requirements: none.
- Explicit non-goals: this does not change the operation table contract or the DSH runtime bundle.

## Validation

Submitted Head: `948a1bd3fa4563321ed6389038bae6c93dd930d0`

```text
pnpm install --frozen-lockfile
PASS: lockfile unchanged

pnpm exec vitest run tests/gen-check.spec.ts
PASS: 1 file, 5 tests

pnpm run gen:check
PASS

pnpm build
PASS

git diff --exit-code -- src/operations.generated.ts lib
PASS

git diff --check
PASS
```

Local Windows limitation:

```text
pnpm test
RESULT: 11/14 files and 73/78 tests passed
```

The remaining local failures occurred while the host was severely resource-constrained: even an empty Node child took 0.8-2.4 seconds, generator/check children took about 5.6 seconds each, and the pinned `tsc` invocation took about 30 seconds. Unchanged YAML coverage tests exceeded Vitest's five-second default, and unchanged short-lived E2E fixtures were terminated by their 250 ms harness deadline before Node could report exit code 7. No unrelated timeout or harness behavior was changed in this pull request.

Exact-Head GitHub evidence:

```text
34 successful, 0 failing, 0 cancelled, 0 pending
```

The exact-Head Linux Host adapters job ran the DSH frozen install, generated check, full non-E2E test suite, real E2E suite, build, and generated/lib cleanliness check successfully. The exact-Head tests, dependency-security, coverage, lint, race/fuzz/module-integrity, generated-consumer, public-API, platform, CodeQL, license, and Acceptance checks also succeeded.

Regression proof:

- Before the parser fix, the real CLI regression failed because `--output --check` returned status 0.
- After the fix, the same real-CLI regression passes and rejects the malformed invocation before file access.

- [x] `git diff --check`
- [x] `git status --short` was inspected after validation.
- [x] Public generator output, custom-target drift checking, malformed CLI handling, isolated TypeScript consumer compilation, generated diff, and build were run.
- [x] Exact submitted-Head CI completed without failed, cancelled, skipped, or pending checks.

## AI usage

AI assistance was used for the exact-Head review, bounded CLI repair, Base rebuild, and evidence reconciliation. The malformed public invocation was reproduced before the change, the regression was observed failing for the expected reason, the fix was rebuilt onto the current main, and the exact submitted Head was verified through local focused checks and the complete GitHub check matrix.