### PR TITLE
build: invalidate local tools on lockfile changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ PUBLIC_API_PACKAGES := \
 help: ## Show supported development, verification, and release commands.
 	@awk 'BEGIN { FS = ":.*##"; print "Supported targets:" } /^[[:alnum:]_-]+:.*##/ { printf "  %-28s %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
 
-$(GOLANGCI_LINT): Makefile go.mod
+$(GOLANGCI_LINT): Makefile go.mod go.sum
 	@mkdir -p "$(TOOLS_BIN)"
 	GOTOOLCHAIN="$(PROJECT_GO_TOOLCHAIN)+auto" GOBIN="$(TOOLS_BIN)" \
 		$(GO) install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
@@ -92,7 +92,7 @@ lint-fix: lint-tools ## Format and apply supported automatic lint fixes.
 	"$(GOLANGCI_LINT)" fmt
 	"$(GOLANGCI_LINT)" run --fix
 
-$(APIDIFF): Makefile go.mod
+$(APIDIFF): Makefile go.mod go.sum
 	@mkdir -p "$(TOOLS_BIN)"
 	GOTOOLCHAIN="$(PROJECT_GO_TOOLCHAIN)+auto" GOBIN="$(TOOLS_BIN)" \
 		$(GO) install golang.org/x/exp/cmd/apidiff@$(APIDIFF_VERSION)

--- a/tools/release/makefile_test.go
+++ b/tools/release/makefile_test.go
@@ -1129,6 +1129,9 @@ func TestFmtFailsWhenGoSyntaxIsInvalid(t *testing.T) {
 	if writeModuleErr := os.WriteFile(filepath.Join(temporary, "go.mod"), []byte("module example.com/malformed\n\ngo 1.27.0\n"), 0o644); writeModuleErr != nil {
 		t.Fatal(writeModuleErr)
 	}
+	if writeSumErr := os.WriteFile(filepath.Join(temporary, "go.sum"), nil, 0o644); writeSumErr != nil {
+		t.Fatal(writeSumErr)
+	}
 	if writeSourceErr := os.WriteFile(filepath.Join(temporary, "malformed.go"), []byte("package invalid\n\nfunc broken( {\n"), 0o644); writeSourceErr != nil {
 		t.Fatal(writeSourceErr)
 	}

--- a/tools/release/makefile_test.go
+++ b/tools/release/makefile_test.go
@@ -1035,6 +1035,7 @@ chmod +x "$GOBIN/golangci-lint"
 	for _, arguments := range [][]string{
 		{"lint-tools", "GO=" + fakeGo, "TOOLS_BIN=" + toolsBin},
 		{"lint-tools", "-W", "go.mod", "GO=" + fakeGo, "TOOLS_BIN=" + toolsBin},
+		{"lint-tools", "-W", "go.sum", "GO=" + fakeGo, "TOOLS_BIN=" + toolsBin},
 	} {
 		command := exec.CommandContext(t.Context(), "make", arguments...)
 		command.Dir = repository
@@ -1052,8 +1053,8 @@ chmod +x "$GOBIN/golangci-lint"
 	if err != nil {
 		t.Fatal(err)
 	}
-	if count != 2 {
-		t.Fatalf("lint tool install count = %d, want 2 after go.mod changes", count)
+	if count != 3 {
+		t.Fatalf("lint tool install count = %d, want 3 after go.mod and go.sum changes", count)
 	}
 }
 


### PR DESCRIPTION
## Tracking

- Tracking issue: #3
- Relationship: `Part of #3` (WP0-C reproducible local tools)

## Problem and rationale

Repository-local lint and API compatibility tools were invalidated by Makefile or go.mod changes, but a go.sum lockfile change could leave a stale installed tool in place. The WP0 contract requires tool cache inputs to include the lockfile.

## Changes

- Add go.sum as an explicit prerequisite for repository-local golangci-lint and apidiff installation targets.
- Extend the POSIX fake-installer regression test so initial installation, go.mod change, and go.sum change each require a clean reinstall.

## Behavior and compatibility

- User-visible behavior: only local tool cache invalidation becomes stricter.
- Public API or protocol impact: none.
- Breaking changes or migration requirements: none.
- Explicit non-goals: tool versions and tool selection do not change.

## Validation

```text
go test ./tools/release -run TestLintToolReinstallsWhenGoModSelectsNewGoVersion -count=1
PASS on this host; the POSIX fake-installer body is skipped on Windows by existing test policy and runs in Linux CI.

git diff --check
PASS
```

- [x] `git diff --check`
- [x] `git status --short` was inspected after validation.
- [x] The lockfile invalidation contract was extended for Linux CI execution.

## AI usage

AI assistance was used to add the lockfile cache-input dependency and regression assertion. The Make prerequisites and existing POSIX test execution boundary were independently reviewed.