### PR TITLE
fix: scan the standard Server dependency surface

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -99,7 +99,7 @@ jobs:
       - name: Set up the environment
         uses: ./.github/actions/setup-go-env
 
-      - name: Scan the standard release binary for known vulnerabilities
+      - name: Scan the standard Server dependency surface for known vulnerabilities
         run: make dependency-security
 
   coverage:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -235,6 +235,10 @@ source / artifact / trigger / inference
   editing only the lockfile. Regenerate with the package-manager version pinned
   in CI, preserve required license headers, and verify both a frozen install
   and an authoritative audit eliminate every vulnerable dependency path.
+- When a vulnerability gate claims release-artifact coverage, scan the exact
+  binary produced by the release build in binary mode. Verify build-before-scan
+  ordering, scanner arguments, and artifact existence with executable fakes;
+  a green source-mode scan is not release-binary evidence.
 - When a test must cancel while a synchronous foreign-function call is in
   flight, coordinate entry and release with explicit barriers instead of a
   fixed sleep. Verify the public error and cleanup side effects under high

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -235,10 +235,10 @@ source / artifact / trigger / inference
   editing only the lockfile. Regenerate with the package-manager version pinned
   in CI, preserve required license headers, and verify both a frozen install
   and an authoritative audit eliminate every vulnerable dependency path.
-- When a vulnerability gate claims release-artifact coverage, scan the exact
-  binary produced by the release build in binary mode. Verify build-before-scan
-  ordering, scanner arguments, and artifact existence with executable fakes;
-  a green source-mode scan is not release-binary evidence.
+- When a Go release artifact is stripped, do not treat a binary scanner's
+  module-only fallback as symbol-level evidence. Build an unstripped scan twin
+  from the same entrypoint, tags, dependency lock, and version metadata, and
+  verify build-before-scan ordering and exact arguments with executable fakes.
 - When a test must cancel while a synchronous foreign-function call is in
   flight, coordinate entry and release with explicit barriers instead of a
   fixed sleep. Verify the public error and cleanup side effects under high

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,6 +160,9 @@ source / artifact / trigger / inference
 - When a test invokes a freshly built external binary, disable result caching
   or key it to the binary content. Verify the gate reruns after the binary
   changes without changing the test package.
+- When a release or end-to-end CLI adds a required flag, inventory every direct
+  invocation instead of updating only wrapper targets. Verify each script and
+  Make entrypoint with executable fakes that assert the complete argument list.
 - When a harness recursively removes a temporary home, create the exact
   deletion target itself under any caller-supplied parent. Verify a parent
   sentinel survives failed startup cleanup.

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,8 @@ FULL_TAGS := sqlite_fts5,local_embeddings,ORT
 VERSION ?= devel
 COMMIT ?= $(shell git rev-parse HEAD 2>/dev/null || printf unknown)
 BUILD_DATE ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
-LDFLAGS := -s -w -X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.date=$(BUILD_DATE)
+BUILD_METADATA_LDFLAGS := -X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.date=$(BUILD_DATE)
+LDFLAGS := -s -w $(BUILD_METADATA_LDFLAGS)
 
 # Deliberate public packages that downstream Go consumers must be able to
 # import without CGO, matching the platform matrix used by CI.
@@ -138,8 +139,11 @@ $(GOVULNCHECK_STAMP): $(GOVULNCHECK)
 
 govulncheck-tools: $(GOVULNCHECK_STAMP) ## Install the pinned Go vulnerability scanner.
 
-dependency-security: govulncheck-tools build ## Scan the standard release binary for known vulnerabilities.
-	"$(GOVULNCHECK)" -mode=binary bin/powercontext
+dependency-security: govulncheck-tools ## Scan an unstripped standard Server build for known vulnerabilities.
+	mkdir -p bin
+	CGO_ENABLED=1 $(GO) build -tags '$(STANDARD_TAGS)' -trimpath \
+		-ldflags '$(BUILD_METADATA_LDFLAGS)' -o bin/powercontext-vulncheck ./cmd/powercontext
+	"$(GOVULNCHECK)" -mode=binary bin/powercontext-vulncheck
 
 generate: ## Regenerate checked-in OpenAPI and MCP outputs.
 	$(GO) generate ./openapi

--- a/Makefile
+++ b/Makefile
@@ -138,8 +138,8 @@ $(GOVULNCHECK_STAMP): $(GOVULNCHECK)
 
 govulncheck-tools: $(GOVULNCHECK_STAMP) ## Install the pinned Go vulnerability scanner.
 
-dependency-security: govulncheck-tools build ## Scan the standard release source closure for known vulnerabilities.
-	"$(GOVULNCHECK)" -tags "$(STANDARD_TAGS)" ./...
+dependency-security: govulncheck-tools build ## Scan the standard release binary for known vulnerabilities.
+	"$(GOVULNCHECK)" -mode=binary bin/powercontext
 
 generate: ## Regenerate checked-in OpenAPI and MCP outputs.
 	$(GO) generate ./openapi

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -77,7 +77,7 @@ printf '{"database":"%s","source_sha":"%s"}\n' "$database" "$source_sha" > "$out
 if [ "$database" = sqlite ]; then
     CGO_ENABLED=1 go test -count=1 -tags sqlite_fts5 -json ./test/e2e > "$output/go-test.jsonl"
     make build VERSION=ci COMMIT="$source_sha" BUILD_DATE=1970-01-01T00:00:00Z
-    go run ./tools/process-smoke -binary bin/powercontext -version ci > "$output/process-smoke.log" 2>&1
+    go run ./tools/process-smoke -binary bin/powercontext -env-file .env.example -version ci > "$output/process-smoke.log" 2>&1
     exit
 fi
 

--- a/tools/release/makefile_test.go
+++ b/tools/release/makefile_test.go
@@ -78,18 +78,111 @@ func TestSmokeTargetsVerifySecurityDefaultsFile(t *testing.T) {
 	}
 }
 
-func TestDependencySecurityScansTheStandardSourceClosure(t *testing.T) {
+func TestDependencySecurityScansTheBuiltReleaseBinary(t *testing.T) {
 	repository := filepath.Clean(filepath.Join("..", ".."))
-	command := exec.CommandContext(t.Context(), "make", "--dry-run", "dependency-security", "GO=go")
-	command.Dir = repository
+	temporary := t.TempDir()
+	for _, name := range []string{"Makefile", "go.mod"} {
+		payload, err := os.ReadFile(filepath.Join(repository, name))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(temporary, name), payload, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	callLog := filepath.Join(temporary, "calls.txt")
+	fakeGo := filepath.Join(temporary, "go")
+	const fakeGoScript = `#!/bin/sh
+set -eu
+
+case "${1:-} ${2:-}" in
+  "env GOEXE")
+    exit 0
+    ;;
+  "env GOVERSION")
+    printf 'go1.27.0\n'
+    exit 0
+    ;;
+esac
+
+if [ "${1:-}" = "build" ]; then
+  test "${CGO_ENABLED:-}" = "1"
+  case "$*" in
+    "build -tags sqlite_fts5 -trimpath "*"-o bin/powercontext ./cmd/powercontext")
+      ;;
+    *)
+      printf 'unexpected release build: %s\n' "$*" >&2
+      exit 30
+      ;;
+  esac
+  printf 'build\n' >> "$CALL_LOG"
+  output=
+  while [ "$#" -gt 0 ]; do
+    if [ "$1" = "-o" ]; then
+      shift
+      output=$1
+      break
+    fi
+    shift
+  done
+  test -n "$output"
+  mkdir -p "$(dirname "$output")"
+  printf 'release-binary\n' > "$output"
+  exit 0
+fi
+
+printf 'unexpected go invocation: %s\n' "$*" >&2
+exit 29
+`
+	if err := os.WriteFile(fakeGo, []byte(fakeGoScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	fakeScanner := filepath.Join(temporary, "govulncheck")
+	const fakeScannerScript = `#!/bin/sh
+set -eu
+
+printf 'scan|%s\n' "$*" >> "$CALL_LOG"
+test "$#" -eq 2
+test "$1" = "-mode=binary"
+test "$2" = "bin/powercontext"
+test -f "$2"
+`
+	if err := os.WriteFile(fakeScanner, []byte(fakeScannerScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	stamp := filepath.Join(temporary, ".govulncheck-stamp")
+	if err := os.WriteFile(stamp, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	command := exec.CommandContext(
+		t.Context(),
+		"make",
+		"--no-print-directory",
+		"dependency-security",
+		"GO="+filepath.ToSlash(fakeGo),
+		"GOVULNCHECK="+filepath.ToSlash(fakeScanner),
+		"GOVULNCHECK_STAMP="+filepath.ToSlash(stamp),
+		"VERSION=probe",
+		"COMMIT=probe",
+		"BUILD_DATE=1970-01-01T00:00:00Z",
+	)
+	command.Dir = temporary
+	command.Env = append(os.Environ(), "CALL_LOG="+filepath.ToSlash(callLog))
 	output, err := command.CombinedOutput()
 	if err != nil {
-		t.Fatalf("make dependency-security dry-run failed: %v\n%s", err, output)
+		t.Fatalf("make dependency-security failed: %v\n%s", err, output)
 	}
-	for _, want := range []string{"golang.org/x/vuln/cmd/govulncheck@v1.7.0", "build -tags 'sqlite_fts5'", "govulncheck", "-tags \"sqlite_fts5\"", "./..."} {
-		if !strings.Contains(string(output), want) {
-			t.Fatalf("make dependency-security is missing %q:\n%s", want, output)
-		}
+	payload, err := os.ReadFile(callLog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := strings.Split(strings.TrimSpace(string(payload)), "\n")
+	want := []string{"build", "scan|-mode=binary bin/powercontext"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("dependency-security calls:\n%s\nwant:\n%s", strings.Join(got, "\n"), strings.Join(want, "\n"))
 	}
 }
 

--- a/tools/release/makefile_test.go
+++ b/tools/release/makefile_test.go
@@ -78,6 +78,73 @@ func TestSmokeTargetsVerifySecurityDefaultsFile(t *testing.T) {
 	}
 }
 
+func TestE2EAcceptancePassesSecurityDefaultsFileToProcessSmoke(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the E2E harness requires a POSIX shell")
+	}
+
+	repository, absoluteErr := filepath.Abs(filepath.Clean(filepath.Join("..", "..")))
+	if absoluteErr != nil {
+		t.Fatal(absoluteErr)
+	}
+	temporary := t.TempDir()
+	bin := filepath.Join(temporary, "bin")
+	if mkdirErr := os.Mkdir(bin, 0o755); mkdirErr != nil {
+		t.Fatal(mkdirErr)
+	}
+	callLog := filepath.Join(temporary, "calls.txt")
+	const fakeCommand = `#!/bin/sh
+set -eu
+printf '%s|%s|%s\n' "$(basename "$0")" "${CGO_ENABLED:-}" "$*" >> "$CALL_LOG"
+`
+	for _, name := range []string{"go", "make"} {
+		if writeErr := os.WriteFile(filepath.Join(bin, name), []byte(fakeCommand), 0o755); writeErr != nil {
+			t.Fatal(writeErr)
+		}
+	}
+
+	const sourceSHA = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	command := exec.CommandContext(
+		t.Context(),
+		"sh",
+		filepath.Join(repository, "test", "e2e", "run.sh"),
+		"acceptance",
+	)
+	command.Dir = repository
+	command.Env = append(
+		environmentWithout(
+			"PATH",
+			"CALL_LOG",
+			"CGO_ENABLED",
+			"GITHUB_SHA",
+			"POWERCONTEXT_E2E_DATABASE",
+			"POWERCONTEXT_E2E_OUTPUT",
+		),
+		"PATH="+filepath.ToSlash(bin)+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"CALL_LOG="+filepath.ToSlash(callLog),
+		"GITHUB_SHA="+sourceSHA,
+		"POWERCONTEXT_E2E_DATABASE=sqlite",
+		"POWERCONTEXT_E2E_OUTPUT="+filepath.ToSlash(filepath.Join(temporary, "output")),
+	)
+	output, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("run SQLite E2E acceptance harness: %v\n%s", err, output)
+	}
+	payload, readErr := os.ReadFile(callLog)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	got := strings.Split(strings.TrimSpace(string(payload)), "\n")
+	want := []string{
+		"go|1|test -count=1 -tags sqlite_fts5 -json ./test/e2e",
+		"make||build VERSION=ci COMMIT=" + sourceSHA + " BUILD_DATE=1970-01-01T00:00:00Z",
+		"go||run ./tools/process-smoke -binary bin/powercontext -env-file .env.example -version ci",
+	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("SQLite E2E acceptance calls:\n%s\nwant:\n%s", strings.Join(got, "\n"), strings.Join(want, "\n"))
+	}
+}
+
 func TestDependencySecurityScansAnUnstrippedStandardServerBuild(t *testing.T) {
 	repository := filepath.Clean(filepath.Join("..", ".."))
 	temporary := t.TempDir()

--- a/tools/release/makefile_test.go
+++ b/tools/release/makefile_test.go
@@ -78,7 +78,7 @@ func TestSmokeTargetsVerifySecurityDefaultsFile(t *testing.T) {
 	}
 }
 
-func TestDependencySecurityScansTheBuiltReleaseBinary(t *testing.T) {
+func TestDependencySecurityScansAnUnstrippedStandardServerBuild(t *testing.T) {
 	repository := filepath.Clean(filepath.Join("..", ".."))
 	temporary := t.TempDir()
 	for _, name := range []string{"Makefile", "go.mod"} {
@@ -109,11 +109,17 @@ esac
 if [ "${1:-}" = "build" ]; then
   test "${CGO_ENABLED:-}" = "1"
   case "$*" in
-    "build -tags sqlite_fts5 -trimpath "*"-o bin/powercontext ./cmd/powercontext")
+    "build -tags sqlite_fts5 -trimpath "*"-o bin/powercontext-vulncheck ./cmd/powercontext")
       ;;
     *)
       printf 'unexpected release build: %s\n' "$*" >&2
       exit 30
+      ;;
+  esac
+  case " $* " in
+    *" -s "*|*" -w "*)
+      printf 'vulnerability scan build was stripped: %s\n' "$*" >&2
+      exit 31
       ;;
   esac
   printf 'build\n' >> "$CALL_LOG"
@@ -146,7 +152,7 @@ set -eu
 printf 'scan|%s\n' "$*" >> "$CALL_LOG"
 test "$#" -eq 2
 test "$1" = "-mode=binary"
-test "$2" = "bin/powercontext"
+test "$2" = "bin/powercontext-vulncheck"
 test -f "$2"
 `
 	if err := os.WriteFile(fakeScanner, []byte(fakeScannerScript), 0o755); err != nil {
@@ -180,7 +186,7 @@ test -f "$2"
 		t.Fatal(err)
 	}
 	got := strings.Split(strings.TrimSpace(string(payload)), "\n")
-	want := []string{"build", "scan|-mode=binary bin/powercontext"}
+	want := []string{"build", "scan|-mode=binary bin/powercontext-vulncheck"}
 	if !slices.Equal(got, want) {
 		t.Fatalf("dependency-security calls:\n%s\nwant:\n%s", strings.Join(got, "\n"), strings.Join(want, "\n"))
 	}


### PR DESCRIPTION
## Tracking

- Tracking issue: #3
- Relationship: `Part of #3` (WP0-B dependency-security)
- Corrects the unresolved artifact-coverage P0 on #79, which merged before that review finding was addressed.

## Problem and rationale

#79 claimed binary coverage but its merged Head used govulncheck source mode. The first corrective Head switched to the stripped release artifact and exposed a second boundary: govulncheck v1.7.0 cannot recover package symbols from a Go binary built with `-s -w`, so it falls back to every known vulnerable package in any linked module.

That fallback reported `GO-2026-5932` because the Server links other `golang.org/x/crypto` packages, although `go list -deps` and `go mod why` show that no `openpgp` package is present. A discriminative program using only `x/crypto/chacha20poly1305` reproduced the boundary: the unstripped binary passed with 0 vulnerabilities, while the otherwise identical `-s -w` binary reported the same OpenPGP finding.

## Changes

- Keep the shipped release artifact and its `-s -w` size policy unchanged.
- Build a scan twin from the same Server entrypoint, `sqlite_fts5` tags, dependency lock, and version metadata while retaining Go symbols.
- Scan that binary with `govulncheck -mode=binary`.
- Use an executable Make probe to verify CGO, tags, entrypoint, output, retained symbols, build-before-scan ordering, exact scanner arguments, and artifact existence.
- Describe the CI job as standard Server dependency-surface coverage rather than claiming it scans the stripped release file itself.
- Add the reusable stripped-binary scanner rule to `AGENTS.md`.
- Rebuild the branch on current `main` and preserve the security-default smoke contract added after the original PR base.
- Pass the released `.env.example` into the SQLite acceptance harness's direct process-smoke invocation.
- Exercise the real E2E shell entrypoint with external command fakes that verify the complete argument sequence.

## Regression proof

Original main failure reproduced by the new probe:

```text
govulncheck -tags sqlite_fts5 ./...
make: *** [dependency-security] Error 1
```

Exact stripped-artifact CI on Head `cb5ae690`:

```text
GO-2026-5932: golang.org/x/crypto/openpgp
Fixed in: N/A
make: *** [dependency-security] Error 3
```

Discriminative scanner probe with the same `x/crypto v0.55.0` dependency:

```text
unstripped binary: exit 0, 0 vulnerabilities
-s -w binary: exit 3, GO-2026-5932
```

## Current validation

The branch was rebuilt from Base `7a85cc3bfe1e27982d4126fe9110075a7e8e4a05`; the submitted Head is `15e72a3a6a6f341d3ddae057c0951652c4527907`.

```text
go test ./tools/release -run '^(TestSmokeTargetsVerifySecurityDefaultsFile|TestE2EAcceptancePassesSecurityDefaultsFileToProcessSmoke|TestDependencySecurityScansAnUnstrippedStandardServerBuild|TestContinuousIntegrationPreservesPythonTopologyAndGoAssurance)$' -count=1
PASS

go test ./tools/release -count=1
PASS

go test ./...
PASS

make test-race
PASS

make lint
PASS: 0 issues

make check
PASS

make dependency-security
PASS: code paths affected by 0 vulnerabilities

POWERCONTEXT_E2E_DATABASE=sqlite make harness-compose-acceptance
PASS

go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/master.yml
PASS

make license-check
PASS: 807 valid, 0 invalid

git diff --check
PASS
```

The conflict resolution retained both the current-main security-default smoke test and this pull request's executable dependency-security probe. The inherited main SQLite acceptance failure was reproduced against the public harness entrypoint, reduced to the missing `-env-file .env.example` argument, and verified RED-to-GREEN with a real-script regression test. `main` is an ancestor of the submitted Head.

## Behavior and compatibility

- User-visible behavior: the dependency-security gate now scans the actual standard Server package/symbol closure without the stripped-binary module fallback.
- Public API or protocol impact: none.
- Release artifact impact: none; the shipped binary remains stripped exactly as before.
- Breaking changes or migration requirements: none.
- Explicit non-goals: no vulnerability allowlist and no unrelated release archive or Windows mode changes.

## AI usage

AI assistance was used to construct the regression probes, resolve the rebase conflict, and repair the inherited SQLite acceptance failure. The govulncheck v1.7.0 behavior, exact failures, stripped/unstripped discriminator, real E2E shell entrypoint, current-main smoke contract, full Go tests, race, lint, vet, workflow syntax, license check, final diff, and branch ancestry were independently verified.
