### PR TITLE
docs: require focused PR validation evidence

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -35,6 +35,9 @@ List the exact commands run against the submitted Head and their results.
 
 - [ ] `git diff --check`
 - [ ] `git status --short` was inspected after validation.
+- [ ] Formatter evidence (`make fmt-check` or an explained equivalent) is recorded.
+- [ ] Generated-consumer evidence (`make generated-consumers` when generator outputs change, or an explained equivalent) is recorded.
+- [ ] Compatibility evidence (`make api-compat` for public Go changes, relevant contract/downstream checks otherwise) is recorded.
 - [ ] Relevant generated, race, compatibility, process, adapter, documentation, or release checks were run.
 - [ ] Any skipped or unavailable check is identified above and is not represented as passing.
 

--- a/tools/governance-check/main.go
+++ b/tools/governance-check/main.go
@@ -155,7 +155,7 @@ func checkRepository(root string) error {
 		return err
 	}
 	if err := requirePhrases(root, ".github/pull_request_template.md", []string{
-		"## Tracking", "Part of #", "Closes #", "## Behavior and compatibility", "## Validation", "git diff --check", "## AI usage",
+		"## Tracking", "Part of #", "Closes #", "## Behavior and compatibility", "## Validation", "git diff --check", "Formatter evidence", "Generated-consumer evidence", "Compatibility evidence", "## AI usage",
 	}); err != nil {
 		return err
 	}

--- a/tools/governance-check/main_test.go
+++ b/tools/governance-check/main_test.go
@@ -379,7 +379,7 @@ updates:
 }
 
 func validPullRequestTemplate(includeRelationship bool) string {
-	parts := []string{"## Tracking", "Closes #", "## Behavior and compatibility", "## Validation", "git diff --check", "## AI usage"}
+	parts := []string{"## Tracking", "Closes #", "## Behavior and compatibility", "## Validation", "git diff --check", "Formatter evidence", "Generated-consumer evidence", "Compatibility evidence", "## AI usage"}
 	if includeRelationship {
 		parts = append(parts, "Part of #")
 	}


### PR DESCRIPTION
## Tracking

- Tracking issue: #3
- Relationship: `Part of #3` (WP0-C pull request evidence contract)

## Problem and rationale

The PR template required generic relevant validation but did not explicitly prompt authors to record formatter, fresh generated-consumer, and compatibility evidence. Those requirements are easy to omit even when the repository now provides dedicated gates.

## Changes

- Add focused formatter, generated-consumer, and compatibility evidence checkboxes to the PR template.
- Permit an explained equivalent when a specific gate is not applicable, avoiding a blanket expensive-check requirement.
- Extend the governance checker and its valid-template fixture so the contract cannot silently regress.

## Behavior and compatibility

- User-visible behavior: contributor workflow documentation becomes more specific.
- Public API or protocol impact: none.
- Breaking changes or migration requirements: none.
- Explicit non-goals: does not force every PR to run every expensive gate.

## Validation

```text
go test ./tools/governance-check -count=1
PASS

go run ./tools/governance-check
PASS

git diff --check
PASS
```

- [x] `git diff --check`
- [x] `git status --short` was inspected after validation.
- [x] Template and real governance contract validation were run.

## AI usage

AI assistance was used to refine the PR evidence template and governance contract. The real checker and its fixture suite were independently run.