### PR TITLE
docs: describe current Go assurance jobs

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -6,7 +6,7 @@ counterpart or enforces a Go release constraint that does not exist in Python.
 
 | Python workflow | Go workflow | Deliberate adaptation |
 | --- | --- | --- |
-| `master.yml` | `master.yml` | Pinned lint and formatting, an independent Go 1.27 readonly package build with explicit SQLite development headers, race-enabled atomic coverage, built-binary dependency-license evidence, machine-checked contribution contracts, Go module verification, vet, generated transport contracts, Go tests, and the same Pi package replace Python lock, prek, and interpreter tests. |
+| `master.yml` | `master.yml` | Pinned lint and formatting, an independent Go 1.27 readonly package build with explicit SQLite development headers, race-enabled atomic coverage, built-binary dependency-license evidence, a pinned standard-release vulnerability scan, machine-checked contribution contracts, Go module verification, vet, generated transport contracts, Go tests, and the same Pi package replace Python lock, prek, and interpreter tests. |
 | `e2e-harness.yml` | `e2e-harness.yml` | The same validate/SQLite/OceanBase/evidence lifecycle drives the Go process and live OceanBase acceptance tests. |
 | `license-check.yml` | `license-check.yml` | Both call SkyWalking Eyes 0.8.0 directly. `make license-check` and `make license-fix` remain local entry points. |
 | `deploy-docs.yml` | `deploy-docs.yml` | Both build locked Zensical documentation and deploy GitHub Pages. |
@@ -19,7 +19,7 @@ Four Go-specific workflows extend, rather than replace, that Python topology:
 
 | Go workflow | Purpose |
 | --- | --- |
-| `migration-gates.yml` | Reusable PR assurance called by `master.yml`: owned Go-module inventory, frozen Python Oracle regeneration, Python↔Go interoperability, HTTP differential, race/fuzz, live OceanBase, host adapters, evaluation, four-platform standard/Full builds, CGO-disabled portable SDK cross-builds, and the isolated downstream public-consumer workflow. |
+| `migration-gates.yml` | Reusable PR assurance called by `master.yml`: explicit owned-module integrity, fresh generated-consumer builds, public API compatibility, frozen Python Oracle regeneration, Python↔Go interoperability, HTTP differential, race/fuzz, live OceanBase, host adapters, evaluation, four-platform standard/Full builds, CGO-disabled portable SDK cross-builds, and the isolated downstream public-consumer workflow. |
 | `codeql.yml` | Go CodeQL analysis on pull requests, pushes to `main`, a weekly schedule, and manual dispatch. Pull request runs check out the exact submitted head commit before the explicit Go build. |
 | `provider-smoke.yml` | Explicitly dispatched, credentialed, bounded real-provider verification; never required on an ordinary pull request. |
 | `windows-contract.yml` | Windows checkout-only contract guard: verifies LF attributes, frozen fixture SHA-256 values, and generated-contract cleanliness without claiming Windows binary support. |


### PR DESCRIPTION
## Tracking

- Tracking issue: #3
- Relationship: `Part of #3` (WP0 workflow documentation)

## Problem and rationale

The workflow README described an older Go assurance topology. It omitted the merged dependency-security job and the explicit module-integrity, fresh generated-consumer, and public API compatibility checks, making supported CI evidence harder to discover.

## Changes

- Document the pinned standard-release vulnerability scan in master workflow assurance.
- Document explicit module integrity, fresh generated consumers, and public API compatibility in migration assurance.

## Behavior and compatibility

- User-visible behavior: CI documentation matches implemented assurance.
- Public API or protocol impact: none.
- Breaking changes or migration requirements: none.
- Explicit non-goals: no workflow behavior, job name, or dependency changes.

## Validation

```text
git diff --check
PASS
```

- [x] `git diff --check`
- [x] `git status --short` was inspected after validation.
- [x] Documentation change was checked against current workflow definitions.

## AI usage

AI assistance was used to synchronize workflow documentation with the current CI topology. The referenced job names and scopes were independently checked in workflow source.