### PR TITLE
ci: verify release security defaults

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -139,14 +139,14 @@ jobs:
         if: inputs.edition != 'full'
         env:
           VERSION: ${{ steps.metadata.outputs.version }}
-        run: go run ./tools/process-smoke -binary bin/powercontext -version "$VERSION"
+        run: go run ./tools/process-smoke -binary bin/powercontext -env-file .env.example -version "$VERSION"
 
       - name: Smoke test the Full process surface
         if: inputs.edition != 'standard'
         env:
           POWERCONTEXT_ONNXRUNTIME_LIBRARY_DIR: ${{ steps.native.outputs.onnxruntime-lib-dir }}
           VERSION: ${{ steps.metadata.outputs.version }}
-        run: go run ./tools/process-smoke -binary bin/powercontext-full -version "$VERSION"
+        run: go run ./tools/process-smoke -binary bin/powercontext-full -env-file .env.example -version "$VERSION"
 
       - name: Build the candidate checksum manifest
         run: |

--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -162,6 +162,7 @@ jobs:
         run: |
           go run ./tools/process-smoke \
             -binary "${{ steps.archives.outputs.standard_root }}/bin/powercontext" \
+            -env-file "${{ steps.archives.outputs.standard_root }}/.env.example" \
             -version "$VERSION"
 
       - name: Exercise the released Full binary
@@ -172,6 +173,7 @@ jobs:
         run: |
           go run ./tools/process-smoke \
             -binary "${{ steps.archives.outputs.full_root }}/bin/powercontext" \
+            -env-file "${{ steps.archives.outputs.full_root }}/.env.example" \
             -version "$VERSION"
 
       - name: Verify immutable GHCR image manifests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,8 +141,8 @@ jobs:
           POWERCONTEXT_ONNXRUNTIME_LIBRARY_DIR: ${{ steps.native.outputs.onnxruntime-lib-dir }}
           VERSION: ${{ needs.prepare.outputs.version }}
         run: |
-          go run ./tools/process-smoke -binary bin/powercontext -version "$VERSION"
-          go run ./tools/process-smoke -binary bin/powercontext-full -version "$VERSION"
+          go run ./tools/process-smoke -binary bin/powercontext -env-file .env.example -version "$VERSION"
+          go run ./tools/process-smoke -binary bin/powercontext-full -env-file .env.example -version "$VERSION"
 
       - name: Build the platform checksum manifest
         run: |

--- a/Makefile
+++ b/Makefile
@@ -310,10 +310,10 @@ build-full: ## Build the Full native-asset server binary.
 		-o bin/powercontext-full ./cmd/powercontext
 
 smoke: build ## Build and smoke-test the standard server binary.
-	$(GO) run ./tools/process-smoke -binary bin/powercontext -version "$(VERSION)"
+	$(GO) run ./tools/process-smoke -binary bin/powercontext -env-file .env.example -version "$(VERSION)"
 
 smoke-full: build-full ## Build and smoke-test the Full server binary.
-	$(GO) run ./tools/process-smoke -binary bin/powercontext-full -version "$(VERSION)"
+	$(GO) run ./tools/process-smoke -binary bin/powercontext-full -env-file .env.example -version "$(VERSION)"
 
 package-standard: build ## Build a standard release archive and SBOM.
 	$(GO) run ./tools/release package \

--- a/docs/release/INSTALL.md
+++ b/docs/release/INSTALL.md
@@ -5,6 +5,14 @@ authoritative OpenAPI document, `.env.example`, all nine host adapters, embedded
 sqlite-vec, dependency licenses, build metadata, an SPDX JSON SBOM, and an
 internal `SHA256SUMS` file.
 
+Release verification checks the packaged `.env.example` before starting the
+binary. Its security-sensitive defaults keep the Server and Client on
+`127.0.0.1`, leave bearer authentication disabled for that loopback-only
+configuration, and keep unauthenticated non-loopback access disabled. Enabling
+remote access requires an explicit host change together with authentication or
+the documented controlled-network opt-in; never ship an active default bearer
+token in the example file.
+
 Verify the downloaded archive and its detached SBOM against the release-level
 `SHA256SUMS`, extract it, then verify the files inside the archive:
 

--- a/tools/process-smoke/main.go
+++ b/tools/process-smoke/main.go
@@ -75,19 +75,21 @@ var baseToolNames = []string{
 
 type options struct {
 	binary  string
+	envFile string
 	version string
 	timeout time.Duration
 }
 
 func main() {
 	binary := flag.String("binary", "bin/powercontext", "built PowerContext executable")
+	envFile := flag.String("env-file", "", "released .env.example with security-sensitive defaults")
 	version := flag.String("version", "devel", "exact version reported by the executable")
 	timeout := flag.Duration("timeout", 60*time.Second, "maximum duration of each server phase")
 	flag.Parse()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 3*(*timeout))
 	defer cancel()
-	if err := run(ctx, options{binary: *binary, version: *version, timeout: *timeout}); err != nil {
+	if err := run(ctx, options{binary: *binary, envFile: *envFile, version: *version, timeout: *timeout}); err != nil {
 		fmt.Fprintln(os.Stderr, "process-smoke:", err)
 		os.Exit(1)
 	}
@@ -100,6 +102,9 @@ func main() {
 func run(ctx context.Context, opts options) error {
 	if opts.timeout <= 0 {
 		return errors.New("timeout must be positive")
+	}
+	if err := verifySecurityDefaults(opts.envFile); err != nil {
+		return err
 	}
 	binary, err := filepath.Abs(opts.binary)
 	if err != nil {
@@ -194,6 +199,67 @@ func run(ctx context.Context, opts options) error {
 		return err
 	}
 	return nil
+}
+
+func verifySecurityDefaults(path string) error {
+	if strings.TrimSpace(path) == "" {
+		return errors.New("released security defaults file is required")
+	}
+	payload, err := os.ReadFile(path)
+	if err != nil {
+		return errors.New("read released security defaults")
+	}
+	values := make(map[string]string)
+	for line := range strings.SplitSeq(string(payload), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		if exported, ok := strings.CutPrefix(line, "export"); ok &&
+			len(exported) > 0 && (exported[0] == ' ' || exported[0] == '\t') {
+			line = strings.TrimSpace(exported)
+		}
+		name, value, ok := strings.Cut(line, "=")
+		name = strings.TrimSpace(name)
+		if !ok || !validEnvironmentName(name) {
+			return errors.New("released security defaults contain an invalid assignment")
+		}
+		if _, exists := values[name]; exists {
+			return fmt.Errorf("released security default %s is declared more than once", name)
+		}
+		values[name] = strings.TrimSpace(value)
+	}
+	for name, expected := range map[string]string{
+		"POWERCONTEXT_SERVER_HTTP_HOST":                          "127.0.0.1",
+		"POWERCONTEXT_SERVER_AUTH_ENABLED":                       "false",
+		"POWERCONTEXT_SERVER_ALLOW_UNAUTHENTICATED_NON_LOOPBACK": "false",
+		"POWERCONTEXT_CLIENT_SERVER_URL":                         "http://127.0.0.1:8000",
+	} {
+		value, exists := values[name]
+		if !exists {
+			return fmt.Errorf("released security default %s is missing", name)
+		}
+		if value != expected {
+			return fmt.Errorf("released security default %s does not match the release policy", name)
+		}
+	}
+	if _, exists := values["POWERCONTEXT_SERVER_AUTH_TOKEN"]; exists {
+		return errors.New("released security default POWERCONTEXT_SERVER_AUTH_TOKEN must remain commented")
+	}
+	return nil
+}
+
+func validEnvironmentName(name string) bool {
+	for index, character := range name {
+		if character == '_' ||
+			character >= 'A' && character <= 'Z' ||
+			character >= 'a' && character <= 'z' ||
+			index > 0 && character >= '0' && character <= '9' {
+			continue
+		}
+		return false
+	}
+	return name != ""
 }
 
 func verifyVersion(ctx context.Context, binary, expected string) error {

--- a/tools/process-smoke/main_test.go
+++ b/tools/process-smoke/main_test.go
@@ -15,10 +15,110 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
 	"slices"
 	"strings"
 	"testing"
 )
+
+const validSecurityDefaults = `
+POWERCONTEXT_SERVER_HTTP_HOST=127.0.0.1
+POWERCONTEXT_SERVER_AUTH_ENABLED=false
+POWERCONTEXT_SERVER_ALLOW_UNAUTHENTICATED_NON_LOOPBACK=false
+POWERCONTEXT_CLIENT_SERVER_URL=http://127.0.0.1:8000
+`
+
+func TestReleaseSecurityDefaultsAcceptRepositoryExample(t *testing.T) {
+	if err := verifySecurityDefaults(filepath.Join("..", "..", ".env.example")); err != nil {
+		t.Fatalf("verify repository security defaults: %v", err)
+	}
+}
+
+func TestReleaseSecurityDefaultsRejectUnsafeOrAmbiguousValues(t *testing.T) {
+	tests := []struct {
+		name       string
+		contents   string
+		wantField  string
+		secretText string
+	}{
+		{
+			name:      "remote Server host",
+			contents:  strings.Replace(validSecurityDefaults, "127.0.0.1", "0.0.0.0", 1),
+			wantField: "POWERCONTEXT_SERVER_HTTP_HOST",
+		},
+		{
+			name:      "authentication enabled by default",
+			contents:  strings.Replace(validSecurityDefaults, "AUTH_ENABLED=false", "AUTH_ENABLED=true", 1),
+			wantField: "POWERCONTEXT_SERVER_AUTH_ENABLED",
+		},
+		{
+			name:      "non-loopback opt-in enabled",
+			contents:  strings.Replace(validSecurityDefaults, "NON_LOOPBACK=false", "NON_LOOPBACK=true", 1),
+			wantField: "POWERCONTEXT_SERVER_ALLOW_UNAUTHENTICATED_NON_LOOPBACK",
+		},
+		{
+			name:      "remote plaintext Client URL",
+			contents:  strings.Replace(validSecurityDefaults, "http://127.0.0.1:8000", "http://memory.example:8000", 1),
+			wantField: "POWERCONTEXT_CLIENT_SERVER_URL",
+		},
+		{
+			name:       "active example bearer token",
+			contents:   validSecurityDefaults + "POWERCONTEXT_SERVER_AUTH_TOKEN=secret-sentinel\n",
+			wantField:  "POWERCONTEXT_SERVER_AUTH_TOKEN",
+			secretText: "secret-sentinel",
+		},
+		{
+			name:       "exported example bearer token",
+			contents:   validSecurityDefaults + "export POWERCONTEXT_SERVER_AUTH_TOKEN=secret-sentinel\n",
+			wantField:  "POWERCONTEXT_SERVER_AUTH_TOKEN",
+			secretText: "secret-sentinel",
+		},
+		{
+			name:       "tab-exported example bearer token",
+			contents:   validSecurityDefaults + "export\tPOWERCONTEXT_SERVER_AUTH_TOKEN=secret-sentinel\n",
+			wantField:  "POWERCONTEXT_SERVER_AUTH_TOKEN",
+			secretText: "secret-sentinel",
+		},
+		{
+			name:       "duplicate Server host",
+			contents:   validSecurityDefaults + "POWERCONTEXT_SERVER_HTTP_HOST=127.0.0.2\n",
+			wantField:  "POWERCONTEXT_SERVER_HTTP_HOST",
+			secretText: "127.0.0.2",
+		},
+		{
+			name:      "missing Client URL",
+			contents:  strings.Replace(validSecurityDefaults, "POWERCONTEXT_CLIENT_SERVER_URL=http://127.0.0.1:8000\n", "", 1),
+			wantField: "POWERCONTEXT_CLIENT_SERVER_URL",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), ".env.example")
+			if err := os.WriteFile(path, []byte(strings.TrimSpace(test.contents)+"\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			err := verifySecurityDefaults(path)
+			if err == nil || !strings.Contains(err.Error(), test.wantField) {
+				t.Fatalf("verifySecurityDefaults() error = %v, want field %s", err, test.wantField)
+			}
+			if test.secretText != "" && strings.Contains(err.Error(), test.secretText) {
+				t.Fatalf("verifySecurityDefaults() exposed configured value in %q", err)
+			}
+		})
+	}
+}
+
+func TestReleaseSecurityDefaultsReadFailureDoesNotExposePath(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "private-config", ".env.example")
+	err := verifySecurityDefaults(path)
+	if err == nil {
+		t.Fatal("verifySecurityDefaults() accepted a missing file")
+	}
+	if strings.Contains(err.Error(), path) {
+		t.Fatalf("verifySecurityDefaults() exposed local path in %q", err)
+	}
+}
 
 func TestIsolatedEnvironmentRemovesPowerContextContamination(t *testing.T) {
 	source := []string{

--- a/tools/release/makefile_test.go
+++ b/tools/release/makefile_test.go
@@ -49,6 +49,35 @@ func TestBareMakeListsSupportedTargets(t *testing.T) {
 	}
 }
 
+func TestSmokeTargetsVerifySecurityDefaultsFile(t *testing.T) {
+	tests := map[string]string{
+		"smoke":      "bin/powercontext",
+		"smoke-full": "bin/powercontext-full",
+	}
+	for target, binary := range tests {
+		t.Run(target, func(t *testing.T) {
+			output, err := runRepositoryMake(
+				t,
+				nil,
+				"",
+				"--dry-run",
+				target,
+				"GO=go",
+				"VERSION=test",
+				"TOKENIZERS_LIB_DIR=/tmp/tokenizers",
+			)
+			if err != nil {
+				t.Fatalf("make %s --dry-run failed: %v\n%s", target, err, output)
+			}
+			operation := `go run ./tools/process-smoke -binary ` + binary +
+				` -env-file .env.example -version "test"`
+			if !strings.Contains(string(output), operation) {
+				t.Fatalf("make %s is missing %q:\n%s", target, operation, output)
+			}
+		})
+	}
+}
+
 func TestDependencySecurityScansTheStandardSourceClosure(t *testing.T) {
 	repository := filepath.Clean(filepath.Join("..", ".."))
 	command := exec.CommandContext(t.Context(), "make", "--dry-run", "dependency-security", "GO=go")

--- a/tools/release/workflow_test.go
+++ b/tools/release/workflow_test.go
@@ -781,6 +781,39 @@ func TestCandidateDeliveryWorkflowsExerciseTheirArtifacts(t *testing.T) {
 	}
 }
 
+func TestReleaseProcessSmokeVerifiesPackagedSecurityDefaults(t *testing.T) {
+	repository := filepath.Clean(filepath.Join("..", ".."))
+	tests := map[string][]string{
+		"build-artifacts.yml": {
+			`go run ./tools/process-smoke -binary bin/powercontext -env-file .env.example -version "$VERSION"`,
+			`go run ./tools/process-smoke -binary bin/powercontext-full -env-file .env.example -version "$VERSION"`,
+		},
+		"release.yml": {
+			`go run ./tools/process-smoke -binary bin/powercontext -env-file .env.example -version "$VERSION"`,
+			`go run ./tools/process-smoke -binary bin/powercontext-full -env-file .env.example -version "$VERSION"`,
+		},
+		"release-verify.yml": {
+			`-env-file "${{ steps.archives.outputs.standard_root }}/.env.example"`,
+			`-env-file "${{ steps.archives.outputs.full_root }}/.env.example"`,
+		},
+	}
+	for name, required := range tests {
+		payload, err := os.ReadFile(filepath.Join(repository, ".github", "workflows", name))
+		if err != nil {
+			t.Fatal(err)
+		}
+		workflow := strings.Join(strings.Fields(string(payload)), " ")
+		if count := strings.Count(workflow, "go run ./tools/process-smoke"); count != 2 {
+			t.Errorf("%s process-smoke calls = %d, want 2", name, count)
+		}
+		for _, operation := range required {
+			if !strings.Contains(workflow, operation) {
+				t.Errorf("%s is missing complete security-default operation %q", name, operation)
+			}
+		}
+	}
+}
+
 func TestReleaseVerificationRechecksPublishedSurfaces(t *testing.T) {
 	repository := filepath.Clean(filepath.Join("..", ".."))
 	payload, err := os.ReadFile(filepath.Join(repository, ".github", "workflows", "release-verify.yml"))


### PR DESCRIPTION
## Tracking

- Tracking issue: #3
- Relationship: `Part of #3` (WP0-B security-sensitive defaults and release verification)

## Problem and rationale

Release archives include `.env.example`, but the published-binary smoke test did not validate its security-sensitive defaults. A release could therefore keep passing CLI, HTTP, MCP, persistence, and shutdown smoke checks while shipping a sample that defaults to a remote bind, enables unauthenticated non-loopback access, points the Client at remote plaintext HTTP, or activates a bearer token.

## Changes

- Require `tools/process-smoke` callers to pass the released `.env.example` through `-env-file`.
- Validate the packaged sample before starting the binary.
- Pin the release defaults to loopback Server and Client endpoints, disabled bearer authentication, and disabled unauthenticated non-loopback opt-in.
- Reject missing or duplicate assignments and any active default bearer token, including shell `export` syntax.
- Keep configured values and local file paths out of validation errors.
- Pass source-tree `.env.example` through both Make smoke targets and candidate/release builds, and pass the extracted archive copy in published release verification.
- Document the machine-verified defaults in the release installation guide.
- Add complete Make and workflow operation contracts for all eight process-smoke invocations.

## Regression proof

Initial RED:

```text
undefined: verifySecurityDefaults
build-artifacts.yml, release.yml, and release-verify.yml were missing all six -env-file operations
```

Additional discriminative RED cases proved that:

- `export<TAB>POWERCONTEXT_SERVER_AUTH_TOKEN=...` could bypass a narrow parser;
- read errors exposed the full temporary path before redaction.

The final parser rejects remote Server/Client defaults, enabled authentication or non-loopback opt-in, active tokens, duplicate fields, missing fields, malformed names, and both space/tab `export` forms without echoing configured values.

The first exact-Head CI exposed two additional callers: `make smoke` and `make smoke-full`. `Standard (linux-arm64)` failed because `make smoke` still omitted `-env-file`. A new dry-run Make contract reproduced both missing operations before the recipes were repaired; the CI-equivalent `make smoke` then passed locally on Linux.
## Behavior and compatibility

- Server and Client runtime defaults: unchanged.
- Public API, OpenAPI, persistence, and generated output: unchanged.
- Release verification now fails before process startup when the packaged sample weakens the reviewed security policy.
- No dependency or lockfile changed.
- Explicit non-goals: no authentication mechanism, container policy, or remote-access behavior changed.

## Validation

```text
go test -count=1 ./tools/process-smoke ./tools/release
PASS on Linux; Windows archive executable-mode test remains a known platform limitation and was not weakened

go build -tags sqlite_fts5 -o /tmp/powercontext-security-defaults ./cmd/powercontext
go run ./tools/process-smoke \
  -binary /tmp/powercontext-security-defaults \
  -env-file .env.example \
  -version devel \
  -timeout 60s
PASS: CLI, HTTP, authenticated Dashboard, MCP, SQLite restart persistence, graceful shutdown

make check-generated
PASS in fresh LF clone

make module-check
all modules verified

make lint TOOLS_BIN=/tmp/powercontext-security-defaults-tools
0 issues

make docs-test
No issues found

go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
PASS

make license-check
807 valid, 0 invalid

git diff --check
PASS
```

## AI usage

AI assistance was used to identify the unverified release boundary, implement the validator and workflow wiring, and run red/green and mutation-oriented checks. The final change was verified with real files, a real Linux release binary, the complete process-smoke, fresh-clone generated/module/lint gates, locked documentation, actionlint, and license validation.