### PR TITLE
feat(cli): add integrations doctor status matrix

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -59,6 +59,7 @@ func newDoctorCommand(state *commandState) *cobra.Command {
 		},
 	}
 	command.AddCommand(
+		newDoctorIntegrationsCommand(state),
 		&cobra.Command{
 			Use: "codex", Short: "Check the optional Codex CLI and PowerContext plugin.", Args: cobra.NoArgs,
 			RunE: func(command *cobra.Command, _ []string) error {

--- a/internal/cli/doctor_integrations_test.go
+++ b/internal/cli/doctor_integrations_test.go
@@ -1,0 +1,205 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDoctorIntegrationsJSONIncludesEveryFirstClassHost(t *testing.T) {
+	stdout, _, err := executeSystemCLI(
+		t, nil, &scriptedSystemCommands{t: t}, "doctor", "integrations", "--json",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload := decodeSystemOutput(t, stdout)
+	if payload["ok"] != true || payload["status"] != "ok" {
+		t.Fatalf("doctor integrations summary = %#v", payload)
+	}
+	hosts := payload["hosts"].(map[string]any)
+	if len(hosts) != len(firstClassIntegrationHosts) {
+		t.Fatalf("doctor integrations hosts = %d, want %d", len(hosts), len(firstClassIntegrationHosts))
+	}
+	for _, spec := range firstClassIntegrationHosts {
+		host := hosts[spec.name].(map[string]any)
+		if host["presence"] != "missing" || host[spec.cliKey] == nil {
+			t.Fatalf("host %s = %#v", spec.name, host)
+		}
+		for _, key := range spec.integrationKeys {
+			if host[key] == nil {
+				t.Fatalf("host %s does not include %s: %#v", spec.name, key, host)
+			}
+		}
+	}
+	assertOrderedFragments(t, stdout,
+		`"codex"`, `"claude-code"`, `"dsh"`, `"openclaw"`, `"opencode"`, `"pi"`, `"hermes"`,
+	)
+}
+
+func TestDoctorIntegrationsTreatsMissingCLIsAsSuccess(t *testing.T) {
+	commands := &scriptedSystemCommands{
+		t: t, paths: map[string]string{"codex": "/usr/bin/codex"},
+		results: []systemCommandResult{{
+			output: `{"installed":[{"name":"powercontext","pluginId":"powercontext@powercontext","installed":true,"enabled":true}]}`,
+		}},
+	}
+	stdout, _, err := executeSystemCLI(t, nil, commands, "doctor", "integrations", "--json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload := decodeSystemOutput(t, stdout)
+	hosts := payload["hosts"].(map[string]any)
+	codex := hosts["codex"].(map[string]any)
+	pi := hosts["pi"].(map[string]any)
+	if payload["ok"] != true || payload["status"] != "ok" || codex["presence"] != "present" ||
+		codex["plugin"].(map[string]any)["ok"] != true || pi["presence"] != "missing" ||
+		pi["package"].(map[string]any)["status"] != "skipped" {
+		t.Fatalf("doctor integrations = %#v", payload)
+	}
+}
+
+func TestDoctorIntegrationsPrintsHumanMatrix(t *testing.T) {
+	commands := &scriptedSystemCommands{
+		t: t, paths: map[string]string{"codex": "/usr/bin/codex"},
+		results: []systemCommandResult{{
+			output: `{"installed":[{"name":"powercontext","pluginId":"powercontext@powercontext","installed":true,"enabled":true}]}`,
+		}},
+	}
+	stdout, _, err := executeSystemCLI(t, nil, commands, "doctor", "integrations")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, line := range []string{
+		"codex: present - cli=ok plugin=ok",
+		"claude-code: missing - cli=failed plugin=skipped",
+		"opencode: missing - cli=failed plugin=skipped skill=skipped",
+		"pi: missing - cli=failed package=skipped",
+	} {
+		if !strings.Contains(stdout, line+"\n") {
+			t.Fatalf("doctor integrations output %q does not contain %q", stdout, line)
+		}
+	}
+	assertOrderedFragments(t, stdout, "codex:", "claude-code:", "dsh:", "openclaw:", "opencode:", "pi:", "hermes:")
+}
+
+func TestDoctorIntegrationsFailsWhenPresentPluginIsBroken(t *testing.T) {
+	commands := &scriptedSystemCommands{
+		t: t, paths: map[string]string{"codex": "/usr/bin/codex"},
+		results: []systemCommandResult{{output: `{"installed":[]}`}},
+	}
+	stdout, _, err := executeSystemCLI(t, nil, commands, "doctor", "integrations", "--json")
+	if err == nil || !ErrorAlreadyReported(err) || ExitCode(err) != 1 {
+		t.Fatalf("doctor integrations error = %v, exit = %d", err, ExitCode(err))
+	}
+	payload := decodeSystemOutput(t, stdout)
+	hosts := payload["hosts"].(map[string]any)
+	codex := hosts["codex"].(map[string]any)
+	if payload["ok"] != false || payload["status"] != "failed" || codex["presence"] != "present" ||
+		codex["plugin"].(map[string]any)["status"] != "failed" ||
+		hosts["dsh"].(map[string]any)["presence"] != "missing" {
+		t.Fatalf("doctor integrations = %#v", payload)
+	}
+}
+
+func TestDoctorIntegrationsFailsWhenPresentCLICannotListPlugins(t *testing.T) {
+	commands := &scriptedSystemCommands{
+		t: t, paths: map[string]string{"codex": "/usr/bin/codex"},
+		results: []systemCommandResult{{err: errors.New("codex plugin list failed: timeout")}},
+	}
+	stdout, _, err := executeSystemCLI(t, nil, commands, "doctor", "integrations", "--json")
+	if err == nil || !ErrorAlreadyReported(err) || ExitCode(err) != 1 {
+		t.Fatalf("doctor integrations error = %v, exit = %d", err, ExitCode(err))
+	}
+	codex := decodeSystemOutput(t, stdout)["hosts"].(map[string]any)["codex"].(map[string]any)
+	if codex["presence"] != "present" || codex["codex"].(map[string]any)["status"] != "failed" ||
+		codex["plugin"].(map[string]any)["status"] != "skipped" ||
+		strings.Contains(codex["codex"].(map[string]any)["detail"].(string), "is not installed or is not on PATH") {
+		t.Fatalf("codex diagnostics = %#v", codex)
+	}
+}
+
+func TestDoctorIntegrationsFailsWhenPresentOpenCodeSkillIsBroken(t *testing.T) {
+	config := t.TempDir()
+	plugin := writeOpenCodePlugin(t, t.TempDir())
+	base := &scriptedSystemCommands{
+		t: t, paths: map[string]string{"opencode": "/usr/bin/opencode"},
+		results: []systemCommandResult{
+			{output: "1.18.21\n"},
+			{output: "config " + config + "\n"},
+			{output: fmt.Sprintf(`{"plugin":[%q]}`, plugin)},
+		},
+	}
+	commands := &environmentAwareCommands{scriptedSystemCommands: base}
+	commands.runEnv = func(
+		ctx context.Context,
+		environment map[string]string,
+		executable string,
+		arguments ...string,
+	) ([]byte, error) {
+		output, err := base.Run(ctx, executable, arguments...)
+		if err == nil {
+			if writeErr := os.WriteFile(environment[openCodeProbePath], []byte(environment[openCodeProbeNonce]), 0o600); writeErr != nil {
+				t.Fatal(writeErr)
+			}
+		}
+		return output, err
+	}
+	stdout, _, err := executeSystemCLI(t, nil, commands, "doctor", "integrations", "--json")
+	if err == nil || !ErrorAlreadyReported(err) || ExitCode(err) != 1 {
+		t.Fatalf("doctor integrations error = %v, exit = %d", err, ExitCode(err))
+	}
+	opencode := decodeSystemOutput(t, stdout)["hosts"].(map[string]any)["opencode"].(map[string]any)
+	if opencode["presence"] != "present" || opencode["plugin"].(map[string]any)["status"] != "ok" ||
+		opencode["skill"].(map[string]any)["status"] != "failed" {
+		t.Fatalf("OpenCode diagnostics = %#v", opencode)
+	}
+	if _, statErr := os.Stat(filepath.Join(config, "skills", "project-context", "SKILL.md")); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("doctor integrations mutated OpenCode Skill: %v", statErr)
+	}
+}
+
+func TestDoctorIntegrationsSucceedsWhenEveryHostIsMissing(t *testing.T) {
+	stdout, _, err := executeSystemCLI(t, nil, &scriptedSystemCommands{t: t}, "doctor", "integrations")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, line := range []string{
+		"codex: missing - cli=failed plugin=skipped",
+		"hermes: missing - cli=failed plugin=skipped",
+	} {
+		if !strings.Contains(stdout, line) {
+			t.Fatalf("doctor integrations output %q does not contain %q", stdout, line)
+		}
+	}
+}
+
+func assertOrderedFragments(t *testing.T, value string, fragments ...string) {
+	t.Helper()
+	last := -1
+	for _, fragment := range fragments {
+		index := strings.Index(value, fragment)
+		if index <= last {
+			t.Fatalf("%q is not after the previous fragment in %q", fragment, value)
+		}
+		last = index
+	}
+}

--- a/internal/cli/integration_catalog.go
+++ b/internal/cli/integration_catalog.go
@@ -1,0 +1,217 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+type integrationDiagnosticProbe func(context.Context, systemCommandExecutor) map[string]diagnostic
+
+type integrationHostSpec struct {
+	name            string
+	cliKey          string
+	integrationKeys []string
+	missingDetail   string
+	probe           integrationDiagnosticProbe
+}
+
+var firstClassIntegrationHosts = [...]integrationHostSpec{
+	{
+		name: "codex", cliKey: "codex", integrationKeys: []string{"plugin"},
+		missingDetail: "Codex CLI is not installed or is not on PATH", probe: runCodexDiagnostics,
+	},
+	{
+		name: "claude-code", cliKey: "claude_code", integrationKeys: []string{"plugin"},
+		missingDetail: "Claude Code CLI is not installed or is not on PATH", probe: runClaudeCodeDiagnostics,
+	},
+	{
+		name: "dsh", cliKey: "dsh", integrationKeys: []string{"plugin"},
+		missingDetail: "DeepSeek Harness CLI is not installed or is not on PATH", probe: runDSHDiagnostics,
+	},
+	{
+		name: "openclaw", cliKey: "openclaw", integrationKeys: []string{"plugin"},
+		missingDetail: "OpenClaw CLI is not installed or is not on PATH", probe: runOpenClawDiagnostics,
+	},
+	{
+		name: "opencode", cliKey: "opencode", integrationKeys: []string{"plugin", "skill"},
+		missingDetail: "OpenCode CLI is not installed or is not on PATH", probe: runOpenCodeDiagnostics,
+	},
+	{
+		name: "pi", cliKey: "pi", integrationKeys: []string{"package"},
+		missingDetail: "Pi CLI is not installed or is not on PATH", probe: runPiDiagnostics,
+	},
+	{
+		name: "hermes", cliKey: "hermes", integrationKeys: []string{"plugin"},
+		missingDetail: "Hermes CLI is not installed or is not on PATH", probe: runHermesDiagnostics,
+	},
+}
+
+type integrationCheck struct {
+	name       string
+	diagnostic diagnostic
+}
+
+type integrationHostRow struct {
+	host         string
+	presence     string
+	cliKey       string
+	cli          diagnostic
+	integrations []integrationCheck
+}
+
+func (r integrationHostRow) failed() bool {
+	if r.presence == "missing" {
+		return false
+	}
+	if !r.cli.OK {
+		return true
+	}
+	for _, check := range r.integrations {
+		if !check.diagnostic.OK {
+			return true
+		}
+	}
+	return false
+}
+
+type integrationReport struct {
+	ok     bool
+	status string
+	hosts  []integrationHostRow
+}
+
+func collectIntegrationDiagnostics(
+	ctx context.Context,
+	commands systemCommandExecutor,
+) integrationReport {
+	hosts := make([]integrationHostRow, 0, len(firstClassIntegrationHosts))
+	ok := true
+	for _, spec := range firstClassIntegrationHosts {
+		diagnostics := spec.probe(ctx, commands)
+		row := integrationHostRow{
+			host: spec.name, cliKey: spec.cliKey, cli: diagnostics[spec.cliKey],
+			integrations: make([]integrationCheck, 0, len(spec.integrationKeys)),
+		}
+		missing := row.cli.Detail == spec.missingDetail
+		for _, key := range spec.integrationKeys {
+			check := diagnostics[key]
+			row.integrations = append(row.integrations, integrationCheck{name: key, diagnostic: check})
+			missing = missing && check.Status == "skipped"
+		}
+		if missing {
+			row.presence = "missing"
+		} else {
+			row.presence = "present"
+		}
+		if row.failed() {
+			ok = false
+		}
+		hosts = append(hosts, row)
+	}
+	status := "ok"
+	if !ok {
+		status = "failed"
+	}
+	return integrationReport{ok: ok, status: status, hosts: hosts}
+}
+
+func newDoctorIntegrationsCommand(state *commandState) *cobra.Command {
+	return &cobra.Command{
+		Use: "integrations", Short: "Check all first-class host integrations.", Args: cobra.NoArgs,
+		RunE: func(command *cobra.Command, _ []string) error {
+			report := collectIntegrationDiagnostics(command.Context(), state.system)
+			if err := writeIntegrationReport(state, report); err != nil {
+				return err
+			}
+			if !report.ok {
+				return alreadyReported(errors.New("one or more integration diagnostics did not pass"))
+			}
+			return nil
+		},
+	}
+}
+
+func writeIntegrationReport(state *commandState, report integrationReport) error {
+	if state.json {
+		return writeJSON(state.stdout, report.jsonValue())
+	}
+	for _, row := range report.hosts {
+		statuses := make([]string, 0, len(row.integrations)+1)
+		statuses = append(statuses, "cli="+row.cli.Status)
+		for _, check := range row.integrations {
+			statuses = append(statuses, check.name+"="+check.diagnostic.Status)
+		}
+		if _, err := fmt.Fprintf(
+			state.stdout, "%s: %s - %s\n", row.host, row.presence, strings.Join(statuses, " "),
+		); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type integrationReportJSON struct {
+	OK     bool                 `json:"ok"`
+	Status string               `json:"status"`
+	Hosts  integrationHostsJSON `json:"hosts"`
+}
+
+type integrationHostsJSON struct {
+	Codex      map[string]any `json:"codex"`
+	ClaudeCode map[string]any `json:"claude-code"`
+	DSH        map[string]any `json:"dsh"`
+	OpenClaw   map[string]any `json:"openclaw"`
+	OpenCode   map[string]any `json:"opencode"`
+	Pi         map[string]any `json:"pi"`
+	Hermes     map[string]any `json:"hermes"`
+}
+
+func (r integrationReport) jsonValue() integrationReportJSON {
+	value := integrationReportJSON{OK: r.ok, Status: r.status}
+	for _, row := range r.hosts {
+		host := row.jsonValue()
+		switch row.host {
+		case "codex":
+			value.Hosts.Codex = host
+		case "claude-code":
+			value.Hosts.ClaudeCode = host
+		case "dsh":
+			value.Hosts.DSH = host
+		case "openclaw":
+			value.Hosts.OpenClaw = host
+		case "opencode":
+			value.Hosts.OpenCode = host
+		case "pi":
+			value.Hosts.Pi = host
+		case "hermes":
+			value.Hosts.Hermes = host
+		}
+	}
+	return value
+}
+
+func (r integrationHostRow) jsonValue() map[string]any {
+	value := map[string]any{"presence": r.presence, r.cliKey: r.cli}
+	for _, check := range r.integrations {
+		value[check.name] = check.diagnostic
+	}
+	return value
+}

--- a/internal/cli/integration_hosts_test.go
+++ b/internal/cli/integration_hosts_test.go
@@ -30,8 +30,10 @@ func TestSetupAndDoctorExposeCurrentHostMatrix(t *testing.T) {
 	command := newCommandWithAllDependencies(
 		VersionInfo{Version: "test"}, &strings.Builder{}, &strings.Builder{}, nil, nil, &scriptedSystemCommands{t: t},
 	)
-	want := []string{"claude-code", "codex", "dsh", "hermes", "openclaw", "opencode", "pi"}
-	for _, parentName := range []string{"setup", "doctor"} {
+	for parentName, want := range map[string][]string{
+		"setup":  {"claude-code", "codex", "dsh", "hermes", "openclaw", "opencode", "pi"},
+		"doctor": {"claude-code", "codex", "dsh", "hermes", "integrations", "openclaw", "opencode", "pi"},
+	} {
 		parent, _, err := command.Find([]string{parentName})
 		if err != nil {
 			t.Fatal(err)

--- a/internal/cli/system_contract_test.go
+++ b/internal/cli/system_contract_test.go
@@ -295,8 +295,8 @@ func TestDoctorPreservesDegradedChecks(t *testing.T) {
 
 func TestDoctorCodexReportsMissingCLI(t *testing.T) {
 	stdout, _, err := executeSystemCLI(t, nil, &scriptedSystemCommands{t: t}, "doctor", "codex", "--json")
-	if err == nil {
-		t.Fatal("doctor codex unexpectedly succeeded")
+	if err == nil || ExitCode(err) != 1 {
+		t.Fatalf("doctor codex error = %v, exit = %d", err, ExitCode(err))
 	}
 	checks := decodeSystemOutput(t, stdout)["checks"].(map[string]any)
 	if checks["codex"].(map[string]any)["detail"] != "Codex CLI is not installed or is not on PATH" ||

--- a/test/conformance/parity-inventory-rules.json
+++ b/test/conformance/parity-inventory-rules.json
@@ -152,7 +152,54 @@
     },
     "tests/test_doctor_integrations.py": {
       "mode": "go-port",
-      "reason": "CLI doctor integrations matrix; the CLI is Go (internal/cli)."
+      "reason": "CLI doctor integrations matrix; the CLI is Go (internal/cli).",
+      "cases": {
+        "test_doctor_integrations_json_includes_every_first_class_host": {
+          "evidence": [
+            "go:internal/cli/doctor_integrations_test.go#TestDoctorIntegrationsJSONIncludesEveryFirstClassHost"
+          ]
+        },
+        "test_doctor_integrations_treats_missing_clis_as_success": {
+          "evidence": [
+            "go:internal/cli/doctor_integrations_test.go#TestDoctorIntegrationsTreatsMissingCLIsAsSuccess"
+          ]
+        },
+        "test_doctor_integrations_prints_a_human_matrix": {
+          "evidence": [
+            "go:internal/cli/doctor_integrations_test.go#TestDoctorIntegrationsPrintsHumanMatrix"
+          ]
+        },
+        "test_doctor_integrations_fails_when_a_present_plugin_is_broken": {
+          "evidence": [
+            "go:internal/cli/doctor_integrations_test.go#TestDoctorIntegrationsFailsWhenPresentPluginIsBroken"
+          ]
+        },
+        "test_doctor_integrations_fails_when_a_present_cli_cannot_list_plugins": {
+          "evidence": [
+            "go:internal/cli/doctor_integrations_test.go#TestDoctorIntegrationsFailsWhenPresentCLICannotListPlugins"
+          ]
+        },
+        "test_doctor_integrations_fails_when_a_present_opencode_skill_is_broken": {
+          "evidence": [
+            "go:internal/cli/doctor_integrations_test.go#TestDoctorIntegrationsFailsWhenPresentOpenCodeSkillIsBroken"
+          ]
+        },
+        "test_doctor_integrations_succeeds_when_every_host_is_missing": {
+          "evidence": [
+            "go:internal/cli/doctor_integrations_test.go#TestDoctorIntegrationsSucceedsWhenEveryHostIsMissing"
+          ]
+        },
+        "test_default_doctor_does_not_scan_first_class_hosts": {
+          "evidence": [
+            "go:internal/cli/system_contract_test.go#TestDoctorChecksOnlyServerByDefault"
+          ]
+        },
+        "test_doctor_codex_still_fails_when_the_cli_is_missing": {
+          "evidence": [
+            "go:internal/cli/system_contract_test.go#TestDoctorCodexReportsMissingCLI"
+          ]
+        }
+      }
     },
     "tests/test_hermes_cli.py": {
       "mode": "go-port",

--- a/test/conformance/parity-inventory.json
+++ b/test/conformance/parity-inventory.json
@@ -4,8 +4,8 @@
   "oracle_commit": "3a6cb0151670eaff7dc0293466edd673124e80da",
   "python_test_file_count": 127,
   "python_test_case_count": 759,
-  "mapped_case_count": 651,
-  "pending_case_count": 108,
+  "mapped_case_count": 660,
+  "pending_case_count": 99,
   "entries": [
     {
       "python": {
@@ -8583,8 +8583,15 @@
         "line": 125
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/doctor_integrations_test.go",
+          "test": "TestDoctorIntegrationsJSONIncludesEveryFirstClassHost"
+        }
+      ]
     },
     {
       "python": {
@@ -8593,8 +8600,15 @@
         "line": 140
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/doctor_integrations_test.go",
+          "test": "TestDoctorIntegrationsTreatsMissingCLIsAsSuccess"
+        }
+      ]
     },
     {
       "python": {
@@ -8603,8 +8617,15 @@
         "line": 155
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/doctor_integrations_test.go",
+          "test": "TestDoctorIntegrationsPrintsHumanMatrix"
+        }
+      ]
     },
     {
       "python": {
@@ -8613,8 +8634,15 @@
         "line": 167
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/doctor_integrations_test.go",
+          "test": "TestDoctorIntegrationsFailsWhenPresentPluginIsBroken"
+        }
+      ]
     },
     {
       "python": {
@@ -8623,8 +8651,15 @@
         "line": 181
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/doctor_integrations_test.go",
+          "test": "TestDoctorIntegrationsFailsWhenPresentCLICannotListPlugins"
+        }
+      ]
     },
     {
       "python": {
@@ -8633,8 +8668,15 @@
         "line": 194
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/doctor_integrations_test.go",
+          "test": "TestDoctorIntegrationsFailsWhenPresentOpenCodeSkillIsBroken"
+        }
+      ]
     },
     {
       "python": {
@@ -8643,8 +8685,15 @@
         "line": 206
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/doctor_integrations_test.go",
+          "test": "TestDoctorIntegrationsSucceedsWhenEveryHostIsMissing"
+        }
+      ]
     },
     {
       "python": {
@@ -8653,8 +8702,15 @@
         "line": 216
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/system_contract_test.go",
+          "test": "TestDoctorChecksOnlyServerByDefault"
+        }
+      ]
     },
     {
       "python": {
@@ -8663,8 +8719,15 @@
         "line": 243
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/system_contract_test.go",
+          "test": "TestDoctorCodexReportsMissingCLI"
+        }
+      ]
     },
     {
       "python": {


### PR DESCRIPTION
## Tracking

- Tracking issue: #89
- Relationship: Closes #89
- Parent Epic: Part of #3

## Problem and rationale

The CLI provides individual host diagnostics, but it does not expose one read-only command that reports the complete first-class integration status. This adds the bounded WP3 matrix without changing setup behavior or any existing host-specific command.

## Changes

- Add `powercontext doctor integrations` and `powercontext doctor integrations --json`.
- Reuse the existing diagnostics for Codex, Claude Code, DSH, OpenClaw, OpenCode, Pi, and Hermes.
- Report missing CLIs as non-fatal while failing for broken present CLIs or integrations.
- Continue through the full host matrix after an individual failure.
- Add human-readable and JSON output coverage, failure exit-code checks, and read-only OpenCode coverage.
- Map all nine upstream `tests/test_doctor_integrations.py` cases to Go tests and regenerate the parity inventory.

## Behavior and compatibility

- User-visible behavior: adds a read-only aggregate integration diagnostics command in text and JSON formats.
- Public API or protocol impact: none; this only extends the CLI command tree.
- Breaking changes or migration requirements: none.
- Explicit non-goals: `setup select`, WorkBuddy support, new agent adapters, installation changes, or repair behavior.

## Generated, dependency, and workflow impact

- [x] The parity inventory was regenerated from its source rules against the pinned upstream target.
- [x] No dependency changed; `go.mod` and `go.sum` remain unchanged.
- [x] No CI or release workflow changed.
- [x] No credential, private Source/Memory content, or unredacted production log is included.

The parity inventory changes from 651 mapped / 108 pending cases to 660 mapped / 99 pending cases.

## Validation

Commands run against the rebased submitted Head:

```text
go build ./...
go test -count=1 ./...
make lint
go run ./tools/parity-inventory-generate -upstream <pinned-upstream-checkout> -check
git diff --check
```

Additional validation run before the final rebase:

```text
make check
make unit-test
make e2e-test
```

All commands passed locally. The process smoke check verified the CLI, HTTP, authenticated Dashboard, MCP surfaces, SQLite restart persistence, and graceful shutdown.

- [x] `git diff --check`
- [x] `git status --short` was inspected after validation.
- [x] Formatter evidence is covered by `make lint` and the prior `make check` run.
- [x] No generator implementation changed; parity inventory regeneration and `-check` passed.
- [x] No public Go API changed; relevant CLI, compatibility, unit, E2E, and process checks were run.
- [x] No required check is represented as passing when skipped.

## AI usage

AI assistance was used to inspect the existing diagnostic structure, compare the implementation with the pinned upstream Python tests, and prepare the implementation and test mappings. The final diff was reviewed locally, the parity inventory was regenerated from the pinned upstream checkout, and the submitted Head passed build, full Go tests, lint, and compatibility checks.
