### PR TITLE
ci: review pull request dependency changes

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -102,6 +102,23 @@ jobs:
       - name: Scan the standard Server dependency surface for known vulnerabilities
         run: make dependency-security
 
+  dependency-review:
+    name: dependency-review
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Check out
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Review pull request dependency changes
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+        with:
+          fail-on-severity: low
+          fail-on-scopes: runtime,development,unknown
+          license-check: true
+          vulnerability-check: true
+
   coverage:
     name: coverage
     runs-on: ubuntu-24.04

--- a/tools/release/workflow_test.go
+++ b/tools/release/workflow_test.go
@@ -164,6 +164,58 @@ func TestMigrationQualityRunsModuleIntegrity(t *testing.T) {
 	t.Fatal("migration-gates.yml quality job does not execute make module-integrity")
 }
 
+func TestDependencyReviewRejectsUnsafePullRequestDependencyChanges(t *testing.T) {
+	repository := filepath.Clean(filepath.Join("..", ".."))
+	payload, err := os.ReadFile(filepath.Join(repository, ".github", "workflows", "master.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var workflow struct {
+		Jobs map[string]struct {
+			If      string `yaml:"if"`
+			RunsOn  string `yaml:"runs-on"`
+			Timeout int    `yaml:"timeout-minutes"`
+			Steps   []struct {
+				Name string `yaml:"name"`
+				Uses string `yaml:"uses"`
+				With struct {
+					FailOnSeverity     string `yaml:"fail-on-severity"`
+					FailOnScopes       string `yaml:"fail-on-scopes"`
+					LicenseCheck       string `yaml:"license-check"`
+					VulnerabilityCheck string `yaml:"vulnerability-check"`
+				} `yaml:"with"`
+			} `yaml:"steps"`
+		} `yaml:"jobs"`
+	}
+	if err := yaml.Unmarshal(payload, &workflow); err != nil {
+		t.Fatal(err)
+	}
+	job, ok := workflow.Jobs["dependency-review"]
+	if !ok {
+		t.Fatal("master.yml has no dependency-review job")
+	}
+	if job.If != "github.event_name == 'pull_request'" || job.RunsOn != "ubuntu-24.04" || job.Timeout != 10 {
+		t.Fatalf("dependency-review job contract = if %q, runs-on %q, timeout %d", job.If, job.RunsOn, job.Timeout)
+	}
+	if len(job.Steps) != 2 {
+		t.Fatalf("dependency-review step count = %d, want 2", len(job.Steps))
+	}
+	if job.Steps[0].Name != "Check out" || job.Steps[0].Uses != "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" {
+		t.Fatalf("dependency-review checkout step = %#v", job.Steps[0])
+	}
+	step := job.Steps[1]
+	if step.Name != "Review pull request dependency changes" || step.Uses != "actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294" {
+		t.Fatalf("dependency-review step = %#v", step)
+	}
+	if step.With.FailOnSeverity != "low" || step.With.FailOnScopes != "runtime,development,unknown" ||
+		step.With.LicenseCheck != "true" || step.With.VulnerabilityCheck != "true" {
+		t.Fatalf(
+			"dependency-review policy = severity %q, scopes %q, license %q, vulnerability %q",
+			step.With.FailOnSeverity, step.With.FailOnScopes, step.With.LicenseCheck, step.With.VulnerabilityCheck,
+		)
+	}
+}
+
 type migrationWorkflowStep struct {
 	Name  string `yaml:"name"`
 	If    string `yaml:"if"`


### PR DESCRIPTION
## Tracking

- Tracking issue: #3
- Relationship: `Part of #3`

## Problem and rationale

The repository's `dependency-security` job scans the built standard Server dependency closure, but it does not review whether a pull request newly introduces a vulnerable or license-incompatible dependency. WP0 requires both an accepted vulnerability policy and module verification. This adds GitHub's dependency-diff gate without replacing the existing binary scan.

The pinned v5.0.0 Dependency Review action is available to public repositories, needs only `contents: read` for this no-comment configuration, and supports all changed dependency scopes. The job uses its immutable v5.0.0 commit rather than a mutable tag.

## Changes

- Add a PR-only `dependency-review` job to `.github/workflows/master.yml`.
- Pin `actions/dependency-review-action` at `a1d282b36b6f3519aa1f3fc636f609c47dddb294` (`v5.0.0`).
- Review runtime, development, and unknown scopes; explicitly enable vulnerability and license checks and fail on introduced low-or-higher severity vulnerabilities.
- Add a workflow contract test for the event scope, timeout, checkout/action pins, and policy inputs.

## Behavior and compatibility

- User-visible behavior: pull requests introducing vulnerable or license-incompatible dependencies now receive a blocking `dependency-review` check.
- Public API or protocol impact: none.
- Breaking changes or migration requirements: no application dependency changes. Future PRs that introduce unsafe dependencies will be blocked until the dependency is fixed or deliberately governed.
- Explicit non-goals: this does not disable or replace the existing `govulncheck` binary scan, alter dependency versions, or add PR comments/extra permissions.

## Generated, dependency, and workflow impact

- [x] No generated contract changed.
- [x] No application dependency changed.
- [x] CI contract changed with an explicit 10-minute timeout, `contents: read` global permission, PR-only condition, and SHA-pinned third-party actions.
- [x] No credential, private Source/Memory content, or unredacted production log is included.

## Validation

```text
go test ./tools/release -run '^TestDependencyReviewRejectsUnsafePullRequestDependencyChanges$' -count=1 -v
PASS.

go vet ./tools/release
PASS.

gofmt -d tools/release/workflow_test.go; git diff --check
PASS (no output).
```

- [x] `git diff --check` was run.
- [x] `git status --short` was inspected after validation.
- [x] Formatter evidence is the clean `gofmt -d` result for the changed Go test.
- [x] Generated-consumer evidence is not applicable: no generator input or output changed.
- [x] Compatibility evidence is the workflow contract test; no public Go API changed.
- [x] Relevant workflow and security-contract checks were run.
- [x] Any skipped or unavailable check is identified above and is not represented as passing.

## AI usage

AI assistance was used to inspect the current official action contract, resolve the v5.0.0 commit, implement the narrow workflow change, and independently run the targeted regression test, vet, and diff check.