### PR TITLE
test: exercise downstream Memory restart lifecycle

### DIFF
--- a/test/downstream/consumer_test.go
+++ b/test/downstream/consumer_test.go
@@ -115,6 +115,57 @@ func TestCurrentWorkHandoffRequestUsesPublicContract(t *testing.T) {
 	}
 }
 
+func TestPublicClientMemoryPersistsAcrossGracefulServerRestart(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 20*time.Second)
+	defer cancel()
+
+	home := t.TempDir()
+	first, firstURL := startServerWithHome(t, ctx, home)
+	firstClient, err := client.New(firstURL, client.Options{Timeout: 5 * time.Second})
+	if err != nil {
+		t.Fatalf("create first public client: %v", err)
+	}
+	if _, rememberErr := firstClient.RememberMemory(ctx, &v1.RememberMemoryRequest{}); rememberErr == nil {
+		t.Fatal("empty Memory request was accepted")
+	} else {
+		var validationErr *client.RequestValidationError
+		if !errors.As(rememberErr, &validationErr) || validationErr.Path != "/v1/memory/remember" {
+			t.Fatalf("empty Memory request error = %#v", rememberErr)
+		}
+	}
+
+	rememberedResult, err := firstClient.RememberMemory(ctx, &v1.RememberMemoryRequest{
+		ScopeID: downstreamScope,
+		Kind:    "fact",
+		Text:    "A public client persisted this Memory entry.",
+	})
+	if err != nil {
+		t.Fatalf("remember Memory through public client: %v", err)
+	}
+	if _, ok := rememberedResult.(*v1.MemoryMutationResponseHeaders); !ok {
+		t.Fatalf("remember Memory response = %T", rememberedResult)
+	}
+	stopServer(t, first)
+
+	second, secondURL := startServerWithHome(t, ctx, home)
+	t.Cleanup(func() { stopServer(t, second) })
+	secondClient, err := client.New(secondURL, client.Options{Timeout: 5 * time.Second})
+	if err != nil {
+		t.Fatalf("create restarted public client: %v", err)
+	}
+	listedResult, err := secondClient.ListMemoryEntries(ctx, &v1.ListMemoryEntriesRequest{ScopeID: downstreamScope})
+	if err != nil {
+		t.Fatalf("list Memory through restarted public client: %v", err)
+	}
+	listed, ok := listedResult.(*v1.ListMemoryEntriesResponseHeaders)
+	if !ok {
+		t.Fatalf("list Memory response = %T", listedResult)
+	}
+	if len(listed.Response.Entries) != 1 || listed.Response.Entries[0].Text != "A public client persisted this Memory entry." {
+		t.Fatalf("Memory entries after restart = %#v", listed.Response.Entries)
+	}
+}
+
 func TestServerStartupReportsEarlyChildExit(t *testing.T) {
 	goBinary, err := exec.LookPath("go")
 	if err != nil {
@@ -176,6 +227,13 @@ func currentWorkHandoffRequest() *v1.HandoffCurrentWorkRequest {
 
 func startServer(t *testing.T, ctx context.Context) string {
 	t.Helper()
+	process, serverURL := startServerWithHome(t, ctx, t.TempDir())
+	t.Cleanup(func() { stopServer(t, process) })
+	return serverURL
+}
+
+func startServerWithHome(t *testing.T, ctx context.Context, home string) (*serverProcess, string) {
+	t.Helper()
 	binary := os.Getenv("POWERCONTEXT_DOWNSTREAM_BINARY")
 	if binary == "" {
 		t.Fatal("POWERCONTEXT_DOWNSTREAM_BINARY must name the prebuilt PowerContext Server")
@@ -189,18 +247,16 @@ func startServer(t *testing.T, ctx context.Context) string {
 		t.Fatalf("release loopback port: %v", closeErr)
 	}
 
-	home := t.TempDir()
 	process, err := startServerProcess(ctx, binary, home, port)
 	if err != nil {
 		t.Fatalf("start prebuilt Server: %v", err)
 	}
-	t.Cleanup(func() { stopServer(t, process) })
 
 	serverURL := "http://127.0.0.1:" + strconv.Itoa(port)
 	if err := waitForServer(ctx, process, serverURL); err != nil {
 		t.Fatal(err)
 	}
-	return serverURL
+	return process, serverURL
 }
 
 type serverLogBuffer struct {


### PR DESCRIPTION
## Tracking

- Tracking issue: #3
- Relationship: `Part of #3`

## Problem and rationale

The isolated downstream consumer proved the public Handoff path, but did not prove the wider consumer contract required by WP0-C: public request validation, representative Memory persistence, graceful Server shutdown, and restart behavior. Unit tests inside the root module do not establish that an external module can make those calls against the built Server.

## Changes

- Add an external consumer scenario that creates the public client, verifies an invalid Memory request is classified as `RequestValidationError`, writes Memory through the public client, gracefully stops the Server, restarts against the same data home, and reads the persisted entry through `ListMemoryEntries`.
- Refactor only the downstream test helper so tests can start a Server against a caller-supplied data home.

## Behavior and compatibility

- User-visible behavior: none; this is executable evidence for existing public behavior.
- Public API or protocol impact: none.
- Breaking changes or migration requirements: none.
- Explicit non-goals: no internal imports, database inspection, server implementation change, or test-only bypass of the public HTTP client.

## Generated, dependency, and workflow impact

- [x] No generated contract changed.
- [x] No dependency changed.
- [x] No CI/release workflow definition changed; the existing `downstream-compat` job executes this consumer through the built standard Server.
- [x] No credential, private Source/Memory content, or unredacted production log is included.

## Validation

```text
GOWORK=off go -C test/downstream test -count=1 -mod=readonly -run '^$'
PASS: independent consumer module compiles with readonly resolution.

GOWORK=off go -C test/downstream vet ./...
PASS.

(cd test/downstream && GOWORK=off ../../.tools/bin/golangci-lint run --config ../../.golangci.yml)
PASS: 0 issues.

gofmt -d test/downstream/consumer_test.go; git diff --check
PASS (no output).
```

- [x] `git diff --check` was run.
- [x] `git status --short` was inspected after validation.
- [x] Formatter evidence is the clean `gofmt -d` result for the changed Go test.
- [x] Generated-consumer evidence is not applicable: no generator input or output changed.
- [x] Compatibility evidence is the independent-module compile and the existing Linux `downstream-compat` process gate.
- [x] Relevant downstream lifecycle and static checks were run.
- [x] Any skipped or unavailable check is identified below and is not represented as passing.

Local environment limit:

- This Windows host cannot build the `sqlite_fts5` Server required to run the process scenario because `internal/sqlstore/sqlitevec` cannot locate `sqlite3.h`. The PR's Linux `downstream-compat` job installs `libsqlite3-dev`, builds the Server, and runs the new real lifecycle flow.

## AI usage

AI assistance was used to map the existing public client contract and add this narrow external-consumer evidence. The result was independently checked through the actual separate module compilation, vet, pinned lint policy, formatter, and diff checks.