### PR TITLE
fix: preserve absolute parity inventory output paths

### DIFF
--- a/tools/parity-inventory-generate/main.go
+++ b/tools/parity-inventory-generate/main.go
@@ -277,7 +277,7 @@ func run(root, contractPath, traceabilityPath, rulesPath, outputPath, upstream s
 		return err
 	}
 	payload = append(payload, '\n')
-	fullOutput := filepath.Join(root, outputPath)
+	fullOutput := resolveOutputPath(root, outputPath)
 	current, err := os.ReadFile(fullOutput)
 	if err == nil && bytes.Equal(current, payload) {
 		return nil
@@ -289,6 +289,13 @@ func run(root, contractPath, traceabilityPath, rulesPath, outputPath, upstream s
 		return fmt.Errorf("%s is stale; regenerate with tools/parity-inventory-generate", outputPath)
 	}
 	return os.WriteFile(fullOutput, payload, 0o644)
+}
+
+func resolveOutputPath(root, output string) string {
+	if filepath.IsAbs(output) {
+		return output
+	}
+	return filepath.Join(root, output)
 }
 
 func validMode(mode string) bool {

--- a/tools/parity-inventory-generate/main_test.go
+++ b/tools/parity-inventory-generate/main_test.go
@@ -64,3 +64,22 @@ func TestDeclaresTestRequiresTypeScriptCall(t *testing.T) {
 		})
 	}
 }
+
+func TestResolveOutputPathKeepsAbsoluteAndRootsRelative(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "repository")
+	absolute := filepath.Join(t.TempDir(), "parity-inventory.json")
+	for _, test := range []struct {
+		name   string
+		output string
+		want   string
+	}{
+		{name: "absolute", output: absolute, want: absolute},
+		{name: "relative", output: filepath.Join("test", "parity-inventory.json"), want: filepath.Join(root, "test", "parity-inventory.json")},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := resolveOutputPath(root, test.output); got != test.want {
+				t.Fatalf("resolveOutputPath(%q, %q) = %q, want %q", root, test.output, got, test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Tracking

- Tracking issue: #3
- Relationship: `Part of #3`

## Problem and rationale

`parity-inventory-generate` exposes `-output`, but unconditionally joined it with `-root`. On Windows, an absolute path such as `C:\temp\parity-inventory.json` became `<root>\C:\temp\...` and failed before any output was written. That blocked the WP0-C requirement to generate the active 759-case inventory into a temporary empty directory for fresh-consumer proof.

## Changes

- Preserve absolute `-output` paths.
- Keep relative output paths rooted under `-root`, preserving existing default behavior.
- Add table-driven regression coverage for both output forms.

## Behavior and compatibility

- User-visible behavior: generator callers may now direct output to an absolute temporary path on Windows and other supported platforms.
- Public API or protocol impact: none.
- Breaking changes or migration requirements: none; relative output behavior is unchanged.
- Explicit non-goals: no change to the active parity target, generated inventory contents, mapping rules, or frozen Oracle assets.

## Generated, dependency, and workflow impact

- [x] No generated contract changed.
- [x] No dependency changed.
- [x] No CI/release workflow definition changed; the existing frozen-Oracle job retains the canonical `-check` path.
- [x] No credential, private Source/Memory content, or unredacted production log is included.

## Validation

```text
go test ./tools/parity-inventory-generate -count=1
PASS.

go vet ./tools/parity-inventory-generate
PASS.

golangci-lint run ./tools/parity-inventory-generate
PASS: 0 issues.

Real CLI proof with an exact active-target worktree:
go run ./tools/parity-inventory-generate -root <LF-main-clone> -upstream <f2ec1f75 checkout> -output <absolute-temp-path>
PASS: output SHA-256 equals the committed parity-inventory.json golden.

gofmt -d changed Go files; git diff --check
PASS.
```

- [x] `git diff --check` was run.
- [x] `git status --short` was inspected after validation.
- [x] Formatter evidence is the clean `gofmt -d` result for changed Go files.
- [x] Generated-consumer evidence is the real temporary absolute output plus byte-for-byte golden comparison.
- [x] Compatibility evidence is the unchanged relative-output branch in the regression test.
- [x] Relevant generator and static checks were run.
- [x] Any skipped or unavailable check is identified below and is not represented as passing.

Local environment limit:

- The subsequent `test/conformance` consumer cannot compile on this Windows host because the repository's SQLite native package cannot find `sqlite3.h`. The Linux frozen-Oracle/differential CI job installs SQLite development headers and runs the consumer contract.

## AI usage

AI assistance was used to discover the Windows absolute-path failure through a real target checkout, isolate it to output-path composition, add the minimal regression test, and verify real temporary output against the reviewed golden.