### PR TITLE
ci: verify fresh frozen fixture manifest output

### DIFF
--- a/.github/workflows/migration-gates.yml
+++ b/.github/workflows/migration-gates.yml
@@ -204,6 +204,19 @@ jobs:
           _oracle/.venv/bin/python test/conformance/python_scheduler_fixture.py \
             compare "$fixture_root/scheduler.db" \
             --expected test/conformance/testdata/python-v0.0.2/scheduler.db
+          # SQLite database bytes encode the writer's SQLite version and page
+          # layout. The generator manifest must use the committed canonical
+          # database bytes after the regenerated databases pass semantic checks.
+          fixture_manifest_root="$RUNNER_TEMP/powercontext-oracle-fixture-manifest"
+          mkdir -p "$fixture_manifest_root"
+          for name in authority-rows.json domain-contract.json handoff-report-digests.json; do
+            cp "$fixture_root/$name" "$fixture_manifest_root/$name"
+          done
+          for name in authority.db scheduler.db provider-matrix.json; do
+            cp "test/conformance/testdata/python-v0.0.2/$name" "$fixture_manifest_root/$name"
+          done
+          go run ./tools/fixture-generate -python _oracle -output "$fixture_manifest_root/manifest.json"
+          cmp "$fixture_manifest_root/manifest.json" "test/conformance/testdata/python-v0.0.2/manifest.json"
           go run ./tools/fixture-generate -python _oracle -check
           go run ./tools/traceability-generate -check
           go run ./tools/parity-inventory-generate -upstream _target -check

--- a/tools/release/workflow_test.go
+++ b/tools/release/workflow_test.go
@@ -521,6 +521,47 @@ func TestMigrationGeneratedConsumersRunsFreshConsumerVerification(t *testing.T) 
 	}
 }
 
+func TestFrozenOracleFixtureGeneratorUsesTemporaryGoldenOutput(t *testing.T) {
+	repository := filepath.Clean(filepath.Join("..", ".."))
+	payload, err := os.ReadFile(filepath.Join(repository, ".github", "workflows", "migration-gates.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var workflow struct {
+		Jobs map[string]struct {
+			Steps []struct {
+				Name string `yaml:"name"`
+				Run  string `yaml:"run"`
+			} `yaml:"steps"`
+		} `yaml:"jobs"`
+	}
+	if err := yaml.Unmarshal(payload, &workflow); err != nil {
+		t.Fatal(err)
+	}
+	oracle, ok := workflow.Jobs["frozen-oracle"]
+	if !ok {
+		t.Fatal("migration-gates.yml has no frozen-oracle job")
+	}
+	for _, step := range oracle.Steps {
+		if step.Name != "Regenerate and compare frozen fixtures" {
+			continue
+		}
+		for _, required := range []string{
+			`fixture_manifest_root="$RUNNER_TEMP/powercontext-oracle-fixture-manifest"`,
+			`cp "$fixture_root/$name" "$fixture_manifest_root/$name"`,
+			`cp "test/conformance/testdata/python-v0.0.2/$name" "$fixture_manifest_root/$name"`,
+			`go run ./tools/fixture-generate -python _oracle -output "$fixture_manifest_root/manifest.json"`,
+			`cmp "$fixture_manifest_root/manifest.json" "test/conformance/testdata/python-v0.0.2/manifest.json"`,
+		} {
+			if !strings.Contains(step.Run, required) {
+				t.Fatalf("frozen fixture regeneration is missing %q:\n%s", required, step.Run)
+			}
+		}
+		return
+	}
+	t.Fatal("frozen-oracle job has no fixture regeneration step")
+}
+
 func TestMigrationAPICompatRunsThePinnedPublicBaseline(t *testing.T) {
 	repository := filepath.Clean(filepath.Join("..", ".."))
 	payload, err := os.ReadFile(filepath.Join(repository, ".github", "workflows", "migration-gates.yml"))


### PR DESCRIPTION
## Tracking

- Tracking issue: #3
- Relationship: `Part of #3`

## Problem and rationale

The frozen-Oracle CI job checked the committed fixture manifest with `fixture-generate -check`, but did not generate a new manifest into the temporary fixture directory created from the exact Python Oracle. WP0-C requires generator source, reviewed golden output, and a fresh-output path. The job already produces every required fixture input except the committed provider matrix.

## Changes

- Copy the reviewed `provider-matrix.json` into the existing temporary frozen-fixture directory.
- Run the public `fixture-generate` CLI with `-output "$fixture_root/manifest.json"`.
- Compare the fresh manifest byte-for-byte to the committed frozen Oracle manifest.
- Add a workflow contract test requiring the copy, fresh CLI invocation, and golden comparison.

## Behavior and compatibility

- User-visible behavior: none; this is stronger executable CI evidence for the immutable frozen Oracle contract.
- Public API or protocol impact: none.
- Breaking changes or migration requirements: none.
- Explicit non-goals: no fixture, Oracle, manifest schema, or generator behavior change.

## Generated, dependency, and workflow impact

- [x] No generated contract changed.
- [x] No dependency changed.
- [x] The frozen-Oracle CI contract is strengthened without changing job identity, permissions, timeout, or external checkout refs.
- [x] No credential, private Source/Memory content, or unredacted production log is included.

## Validation

```text
go test ./tools/release -run '^TestFrozenOracleFixtureGeneratorUsesTemporaryGoldenOutput$' -count=1 -v
PASS.

go vet ./tools/release
PASS.

golangci-lint run ./tools/release
PASS: 0 issues.

actionlint .github/workflows/migration-gates.yml
PASS.

gofmt -d tools/release/workflow_test.go; git diff --check
PASS.
```

- [x] `git diff --check` was run.
- [x] `git status --short` was inspected after validation.
- [x] Formatter evidence is the clean `gofmt -d` result for the changed Go test.
- [x] Generated-consumer evidence is the new temporary frozen manifest plus byte-for-byte committed-golden comparison.
- [x] Compatibility evidence is retained by the original canonical `fixture-generate -check` and later conformance/differential stages.
- [x] Relevant generator and workflow checks were run.
- [x] Any skipped or unavailable check is identified above and is not represented as passing.

## AI usage

AI assistance was used to trace the fixture generator's actual inputs, identify the missing fresh-output CI path, and add the narrow workflow contract. The result was independently checked with the workflow test, vet, pinned lint policy, Actionlint, formatter, and diff checks.