### PR TITLE
ci: verify fresh parity inventory output

### DIFF
--- a/.github/workflows/migration-gates.yml
+++ b/.github/workflows/migration-gates.yml
@@ -217,6 +217,9 @@ jobs:
           done
           go run ./tools/fixture-generate -python _oracle -output "$fixture_manifest_root/manifest.json"
           cmp "$fixture_manifest_root/manifest.json" "test/conformance/testdata/python-v0.0.2/manifest.json"
+          parity_inventory="$RUNNER_TEMP/powercontext-parity-inventory.json"
+          go run ./tools/parity-inventory-generate -upstream _target -output "$parity_inventory"
+          cmp "$parity_inventory" "test/conformance/parity-inventory.json"
           go run ./tools/fixture-generate -python _oracle -check
           go run ./tools/traceability-generate -check
           go run ./tools/parity-inventory-generate -upstream _target -check

--- a/tools/release/workflow_test.go
+++ b/tools/release/workflow_test.go
@@ -521,7 +521,7 @@ func TestMigrationGeneratedConsumersRunsFreshConsumerVerification(t *testing.T) 
 	}
 }
 
-func TestFrozenOracleFixtureGeneratorUsesTemporaryGoldenOutput(t *testing.T) {
+func TestFrozenOracleGeneratorsUseTemporaryGoldenOutput(t *testing.T) {
 	repository := filepath.Clean(filepath.Join("..", ".."))
 	payload, err := os.ReadFile(filepath.Join(repository, ".github", "workflows", "migration-gates.yml"))
 	if err != nil {
@@ -552,6 +552,9 @@ func TestFrozenOracleFixtureGeneratorUsesTemporaryGoldenOutput(t *testing.T) {
 			`cp "test/conformance/testdata/python-v0.0.2/$name" "$fixture_manifest_root/$name"`,
 			`go run ./tools/fixture-generate -python _oracle -output "$fixture_manifest_root/manifest.json"`,
 			`cmp "$fixture_manifest_root/manifest.json" "test/conformance/testdata/python-v0.0.2/manifest.json"`,
+			`parity_inventory="$RUNNER_TEMP/powercontext-parity-inventory.json"`,
+			`go run ./tools/parity-inventory-generate -upstream _target -output "$parity_inventory"`,
+			`cmp "$parity_inventory" "test/conformance/parity-inventory.json"`,
 		} {
 			if !strings.Contains(step.Run, required) {
 				t.Fatalf("frozen fixture regeneration is missing %q:\n%s", required, step.Run)


### PR DESCRIPTION
## Tracking

- Tracking issue: #3
- Relationship: `Part of #3`

## Problem and rationale

Parity inventory already had a canonical `-check` in frozen-Oracle CI, and PR #94 made absolute temporary output valid on Windows. But CI did not exercise that new public output path against the exact active 759-case target. WP0-C requires fresh temporary output and golden comparison, not only in-place drift checking.

## Changes

- Generate `parity-inventory.json` into `$RUNNER_TEMP` from the exact `_target` checkout.
- Compare the fresh output byte-for-byte with committed `test/conformance/parity-inventory.json`.
- Retain the existing canonical `-check` after the fresh-output comparison.
- Extend the frozen Oracle workflow contract test to require both fixture and parity fresh-output paths.

## Behavior and compatibility

- User-visible behavior: none; this strengthens executable CI evidence for the active parity inventory.
- Public API or protocol impact: none.
- Breaking changes or migration requirements: none.
- Explicit non-goals: no target SHA, mapping rule, fixture, or inventory content change.

## Generated, dependency, and workflow impact

- [x] No generated contract changed.
- [x] No dependency changed.
- [x] The existing frozen-Oracle CI job is strengthened without changing its identity, permissions, timeout, or exact upstream refs.
- [x] No credential, private Source/Memory content, or unredacted production log is included.

## Validation

```text
go test ./tools/release -run '^TestFrozenOracleGeneratorsUseTemporaryGoldenOutput$' -count=1 -v
PASS.

go vet ./tools/release
PASS.

golangci-lint run ./tools/release
PASS: 0 issues.

actionlint .github/workflows/migration-gates.yml
PASS.

gofmt -d tools/release/workflow_test.go; git diff --check
PASS.
```

- [x] `git diff --check` was run.
- [x] `git status --short` was inspected after validation.
- [x] Formatter evidence is the clean `gofmt -d` result for the changed Go test.
- [x] Generated-consumer evidence is the new temporary inventory output plus byte-for-byte golden comparison.
- [x] Compatibility evidence is retained by the canonical parity `-check` and later conformance consumer stage.
- [x] Relevant generator and workflow checks were run.
- [x] Any skipped or unavailable check is identified above and is not represented as passing.

## AI usage

AI assistance was used to identify the difference between canonical drift checking and fresh-output execution, then add the narrow CI and workflow-contract coverage. The result was independently checked with the focused workflow test, vet, pinned lint policy, Actionlint, formatter, and diff checks.