### PR TITLE
ci: add race debt validation gate

### DIFF
--- a/.github/race-debt.json
+++ b/.github/race-debt.json
@@ -1,0 +1,4 @@
+{
+  "version": 1,
+  "exclusions": []
+}

--- a/.github/workflows/migration-gates.yml
+++ b/.github/workflows/migration-gates.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   quality:
-    name: Contract, race, fuzz, and module integrity
+    name: Contract, fuzz, and module integrity
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
@@ -35,9 +35,6 @@ jobs:
 
       - name: Vet
         run: make vet
-
-      - name: Run standard tests with the race detector
-        run: make test-race
 
       - name: Fuzz high-risk parsers and byte boundaries
         run: |
@@ -68,6 +65,23 @@ jobs:
             fi
             exit 1
           fi
+
+  race-debt:
+    name: Race debt
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - name: Check out
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Set up the Go environment
+        uses: ./.github/actions/setup-go-env
+
+      - name: Validate the race-debt ledger
+        run: make race-debt-check
+
+      - name: Run all Go tests with the race detector
+        run: make test-race
 
   portable-sdk:
     name: Portable SDK cross-builds

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -297,3 +297,7 @@ source / artifact / trigger / inference
   parsing at a shell comment before deciding that a command exists. Verify a
   fully commented command cannot satisfy executable-documentation evidence and
   that a valid command still reaches the real CLI boundary.
+- When a workflow contract test injects a step by replacing the next-job
+  boundary, anchor the mutation to the target job's actual adjacent boundary
+  after structural changes. Verify the mutant changes that target job and is
+  rejected by the contract validator.

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ PUBLIC_API_PACKAGES := \
 	$(MODULE_PATH)/trigger
 
 .PHONY: help lint-tools lint lint-fix api-compat-tools api-baseline api-compat govulncheck-tools dependency-security generate check-generated module-check module-inventory module-integrity contract-test license-check license-fix license-dependencies fmt fmt-check vet build-all coverage coverage-check governance-check \
-	test unit-test e2e-test test-sqlite test-race test-full test-oceanbase-live real-provider-test \
+	test unit-test e2e-test test-sqlite race-debt-check test-race test-full test-oceanbase-live real-provider-test \
 	pi-test docs-sync docs-test docs-build harness-sync harness-check harness-compose-check \
 	harness-compose-acceptance harness-compose-down build build-full smoke smoke-full check \
 	check-portable generated-consumers downstream-compat package-standard package-full clean
@@ -222,6 +222,9 @@ e2e-test: ## Run standard-tag process-level end-to-end tests.
 
 test-sqlite: ## Run all standard-tag tests against SQLite.
 	CGO_ENABLED=1 $(GO) test -tags '$(STANDARD_TAGS)' ./...
+
+race-debt-check: ## Validate the exact temporary race-test exclusion ledger.
+	$(GO) run ./tools/race-debt -file .github/race-debt.json
 
 test-race: ## Run all Go tests with the race detector.
 	CGO_ENABLED=1 $(GO) test -race ./...

--- a/tools/race-debt/main.go
+++ b/tools/race-debt/main.go
@@ -1,0 +1,141 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Command race-debt validates the bounded ledger for temporary race-test exclusions.
+package main
+
+import (
+	"encoding/json/v2"
+	"flag"
+	"fmt"
+	"go/token"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const defaultLedgerPath = ".github/race-debt.json"
+
+type ledger struct {
+	Version    int         `json:"version"`
+	Exclusions []exclusion `json:"exclusions"`
+}
+
+type exclusion struct {
+	Package          string `json:"package"`
+	Test             string `json:"test"`
+	Issue            string `json:"issue"`
+	Owner            string `json:"owner"`
+	Reason           string `json:"reason"`
+	Added            string `json:"added"`
+	RemovalCondition string `json:"removal_condition"`
+	Expires          string `json:"expires"`
+}
+
+func main() {
+	if err := run(os.Args[1:], os.Stdout); err != nil {
+		fmt.Fprintln(os.Stderr, "race debt:", err)
+		os.Exit(1)
+	}
+}
+
+func run(arguments []string, output io.Writer) error {
+	flags := flag.NewFlagSet("race-debt", flag.ContinueOnError)
+	flags.SetOutput(io.Discard)
+	path := flags.String("file", defaultLedgerPath, "path to the race-debt ledger")
+	if err := flags.Parse(arguments); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return fmt.Errorf("unexpected argument %q", flags.Arg(0))
+	}
+
+	contents, err := os.ReadFile(*path)
+	if err != nil {
+		return fmt.Errorf("read ledger: %w", err)
+	}
+	var value ledger
+	decodeErr := json.Unmarshal(contents, &value, json.RejectUnknownMembers(true))
+	if decodeErr != nil {
+		return fmt.Errorf("parse ledger: %w", decodeErr)
+	}
+	validationErr := validate(value, time.Now().UTC())
+	if validationErr != nil {
+		return validationErr
+	}
+	_, err = fmt.Fprintf(output, "race debt: %d temporary exclusions verified\n", len(value.Exclusions))
+	return err
+}
+
+func validate(value ledger, now time.Time) error {
+	if value.Version != 1 {
+		return fmt.Errorf("version = %d, want 1", value.Version)
+	}
+	seen := make(map[string]struct{}, len(value.Exclusions))
+	for index, entry := range value.Exclusions {
+		prefix := fmt.Sprintf("exclusions[%d]", index)
+		if !strings.HasPrefix(entry.Package, "./") || strings.TrimSpace(entry.Package) == "./" {
+			return fmt.Errorf("%s.package must be a repository-relative package path", prefix)
+		}
+		if !strings.HasPrefix(entry.Test, "Test") || !token.IsIdentifier(entry.Test) || entry.Test == "Test" {
+			return fmt.Errorf("%s.test must name one Test function", prefix)
+		}
+		if err := validateIssue(entry.Issue); err != nil {
+			return fmt.Errorf("%s.issue: %w", prefix, err)
+		}
+		if !strings.HasPrefix(entry.Owner, "@") || len(strings.TrimSpace(entry.Owner)) == 1 {
+			return fmt.Errorf("%s.owner must name an accountable GitHub user or team", prefix)
+		}
+		if strings.TrimSpace(entry.Reason) == "" {
+			return fmt.Errorf("%s.reason must explain the temporary exclusion", prefix)
+		}
+		added, addedErr := time.Parse(time.DateOnly, entry.Added)
+		if addedErr != nil {
+			return fmt.Errorf("%s.added must use YYYY-MM-DD: %w", prefix, addedErr)
+		}
+		if strings.TrimSpace(entry.RemovalCondition) == "" {
+			return fmt.Errorf("%s.removal_condition must state how the exclusion will be removed", prefix)
+		}
+		expires, expiresErr := time.Parse(time.DateOnly, entry.Expires)
+		if expiresErr != nil {
+			return fmt.Errorf("%s.expires must use YYYY-MM-DD: %w", prefix, expiresErr)
+		}
+		if expires.Before(added) {
+			return fmt.Errorf("%s.expires must not precede added", prefix)
+		}
+		if now.After(expires.AddDate(0, 0, 1)) {
+			return fmt.Errorf("%s.expires has passed; remove or renew the exclusion through its Issue", prefix)
+		}
+		key := entry.Package + "#" + entry.Test
+		if _, ok := seen[key]; ok {
+			return fmt.Errorf("%s duplicates %q", prefix, key)
+		}
+		seen[key] = struct{}{}
+	}
+	return nil
+}
+
+func validateIssue(value string) error {
+	const prefix = "https://github.com/ob-labs/powercontext-go/issues/"
+	identifier, ok := strings.CutPrefix(value, prefix)
+	if !ok || identifier == "" {
+		return fmt.Errorf("must be an ob-labs/powercontext-go Issue URL")
+	}
+	if _, err := strconv.ParseUint(identifier, 10, 64); err != nil {
+		return fmt.Errorf("must end with a numeric Issue number")
+	}
+	return nil
+}

--- a/tools/race-debt/main_test.go
+++ b/tools/race-debt/main_test.go
@@ -1,0 +1,111 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCommandChecksRaceDebtEntries(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		contents   string
+		wantErr    bool
+		wantOutput string
+	}{
+		{
+			name: "empty allowlist succeeds",
+			contents: `{
+  "version": 1,
+  "exclusions": []
+}`,
+		},
+		{
+			name: "missing issue is rejected",
+			contents: `{
+  "version": 1,
+  "exclusions": [{
+    "package": "./internal/runtime",
+    "test": "TestShutdown",
+    "owner": "@powercontext-maintainers",
+    "reason": "bounded reproduction",
+    "added": "2026-08-31",
+    "removal_condition": "replace the synchronization with a deterministic barrier",
+    "expires": "2999-12-31"
+  }]
+}`,
+			wantErr:    true,
+			wantOutput: "issue",
+		},
+		{
+			name: "test selector is rejected",
+			contents: `{
+  "version": 1,
+  "exclusions": [{
+    "package": "./internal/runtime",
+    "test": "Test.*",
+    "issue": "https://github.com/ob-labs/powercontext-go/issues/3",
+    "owner": "@powercontext-maintainers",
+    "reason": "bounded reproduction",
+    "added": "2026-08-31",
+    "removal_condition": "replace the synchronization with a deterministic barrier",
+    "expires": "2999-12-31"
+  }]
+}`,
+			wantErr:    true,
+			wantOutput: "test function",
+		},
+		{
+			name: "complete temporary exclusion succeeds",
+			contents: `{
+  "version": 1,
+  "exclusions": [{
+    "package": "./internal/runtime",
+    "test": "TestShutdown",
+    "issue": "https://github.com/ob-labs/powercontext-go/issues/3",
+    "owner": "@powercontext-maintainers",
+    "reason": "bounded reproduction",
+    "added": "2026-08-31",
+    "removal_condition": "replace the synchronization with a deterministic barrier",
+    "expires": "2999-12-31"
+  }]
+}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "race-debt.json")
+			if err := os.WriteFile(path, []byte(test.contents), 0o600); err != nil {
+				t.Fatal(err)
+			}
+
+			command := exec.CommandContext(t.Context(), "go", "run", ".", "-file", path)
+			output, err := command.CombinedOutput()
+			if (err != nil) != test.wantErr {
+				t.Fatalf("go run error = %v, want error %t\n%s", err, test.wantErr, output)
+			}
+			if test.wantOutput != "" && !strings.Contains(strings.ToLower(string(output)), test.wantOutput) {
+				t.Fatalf("go run output = %q, want substring %q", output, test.wantOutput)
+			}
+		})
+	}
+}

--- a/tools/release/makefile_test.go
+++ b/tools/release/makefile_test.go
@@ -42,10 +42,23 @@ func TestBareMakeListsSupportedTargets(t *testing.T) {
 	if defaultOutput != helpOutput {
 		t.Errorf("default Make output differs from help output\ndefault:\n%s\nhelp:\n%s", defaultOutput, helpOutput)
 	}
-	for _, target := range []string{"lint", "check", "check-portable", "api-compat", "dependency-security", "generated-consumers", "module-inventory", "module-integrity", "license-dependencies", "test", "build", "package-full", "governance-check"} {
+	for _, target := range []string{"lint", "check", "check-portable", "api-compat", "dependency-security", "generated-consumers", "module-inventory", "module-integrity", "license-dependencies", "race-debt-check", "test", "build", "package-full", "governance-check"} {
 		if !strings.Contains(helpOutput, "  "+target+" ") {
 			t.Errorf("Make help output is missing %q\n%s", target, helpOutput)
 		}
+	}
+}
+
+func TestRaceDebtCheckUsesTheCheckedInLedger(t *testing.T) {
+	repository := filepath.Clean(filepath.Join("..", ".."))
+	command := exec.CommandContext(t.Context(), "make", "--dry-run", "race-debt-check", "GO=go")
+	command.Dir = repository
+	output, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("make race-debt-check dry-run failed: %v\n%s", err, output)
+	}
+	if !strings.Contains(string(output), "go run ./tools/race-debt -file .github/race-debt.json") {
+		t.Fatalf("make race-debt-check does not validate the checked-in ledger:\n%s", output)
 	}
 }
 

--- a/tools/release/workflow_test.go
+++ b/tools/release/workflow_test.go
@@ -216,6 +216,62 @@ func TestDependencyReviewRejectsUnsafePullRequestDependencyChanges(t *testing.T)
 	}
 }
 
+func TestMigrationRaceDebtValidatesTheLedgerBeforeTheFullRaceSuite(t *testing.T) {
+	repository := filepath.Clean(filepath.Join("..", ".."))
+	payload, err := os.ReadFile(filepath.Join(repository, ".github", "workflows", "migration-gates.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var workflow struct {
+		Jobs map[string]struct {
+			Name           string `yaml:"name"`
+			RunsOn         string `yaml:"runs-on"`
+			TimeoutMinutes int    `yaml:"timeout-minutes"`
+			Steps          []struct {
+				Name string `yaml:"name"`
+				Uses string `yaml:"uses"`
+				Run  string `yaml:"run"`
+			} `yaml:"steps"`
+		} `yaml:"jobs"`
+	}
+	if err := yaml.Unmarshal(payload, &workflow); err != nil {
+		t.Fatal(err)
+	}
+	job, ok := workflow.Jobs["race-debt"]
+	if !ok {
+		t.Fatal("migration-gates.yml has no race-debt job")
+	}
+	if job.Name != "Race debt" || job.RunsOn != "ubuntu-24.04" || job.TimeoutMinutes != 30 {
+		t.Fatalf(
+			"race-debt job identity = (%q, %q, %d), want (%q, %q, %d)",
+			job.Name, job.RunsOn, job.TimeoutMinutes,
+			"Race debt", "ubuntu-24.04", 30,
+		)
+	}
+	wantSteps := []struct {
+		name string
+		uses string
+		run  string
+	}{
+		{name: "Check out", uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"},
+		{name: "Set up the Go environment", uses: "./.github/actions/setup-go-env"},
+		{name: "Validate the race-debt ledger", run: "make race-debt-check"},
+		{name: "Run all Go tests with the race detector", run: "make test-race"},
+	}
+	if len(job.Steps) != len(wantSteps) {
+		t.Fatalf("race-debt step count = %d, want %d", len(job.Steps), len(wantSteps))
+	}
+	for index, want := range wantSteps {
+		got := job.Steps[index]
+		if got.Name != want.name || got.Uses != want.uses || strings.TrimSpace(got.Run) != want.run {
+			t.Fatalf(
+				"race-debt step %d = (%q, %q, %q), want (%q, %q, %q)",
+				index, got.Name, got.Uses, strings.TrimSpace(got.Run), want.name, want.uses, want.run,
+			)
+		}
+	}
+}
+
 type migrationWorkflowStep struct {
 	Name  string `yaml:"name"`
 	If    string `yaml:"if"`
@@ -248,10 +304,10 @@ func TestMigrationQualityRejectsWorktreeSideEffects(t *testing.T) {
 		},
 		{
 			name: "not final",
-			old:  "\n  portable-sdk:\n",
+			old:  "\n  race-debt:\n",
 			new: "\n      - name: Later quality step\n" +
 				"        run: true\n\n" +
-				"  portable-sdk:\n",
+				"  race-debt:\n",
 		},
 	}
 	for _, mutation := range mutations {


### PR DESCRIPTION
## Summary

- add a versioned empty race-debt ledger and a strict Go validator for any future temporary race-test exclusion
- expose `make race-debt-check` and run it before the unfiltered full race suite in a stable `Race debt` migration-assurance job
- protect the Make and workflow contracts with executable regression tests; retain the quality-job cleanliness mutation after the new job boundary

## Scope

Part of #3. This does not add a race exclusion or change the test selection. Any future entry must use one exact Go test name and record its PowerContext Go Issue URL, owner, reason, added date, removal condition, and expiry.

## Validation

- `go test -race ./tools/race-debt -count=1`
- `go test -race ./tools/release -run '^(TestMigrationRaceDebtValidatesTheLedgerBeforeTheFullRaceSuite|TestMigrationQualityRejectsWorktreeSideEffects|TestRaceDebtCheckUsesTheCheckedInLedger)$' -count=1`
- `go vet ./tools/race-debt ./tools/release`
- `make race-debt-check`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12`
- `git diff --check`

## Local limitation

`go test ./tools/race-debt ./tools/release -count=1` reaches the pre-existing Windows-only `TestReleaseArchiveKeepsStableExecutablePathAndMode` failure (`packaged binary mode = 0644`). The touched packages and workflow contract tests pass; Linux CI remains the required evidence for the complete race suite.