### PR TITLE
ci: guard portable SDK dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ PUBLIC_API_PACKAGES := \
 	test unit-test e2e-test test-sqlite race-debt-check test-race test-full test-oceanbase-live real-provider-test \
 	pi-test docs-sync docs-test docs-build harness-sync harness-check harness-compose-check \
 	harness-compose-acceptance harness-compose-down build build-full smoke smoke-full check \
-	check-portable generated-consumers downstream-compat package-standard package-full clean
+	portable-sdk-check check-portable generated-consumers downstream-compat package-standard package-full clean
 
 help: ## Show supported development, verification, and release commands.
 	@awk 'BEGIN { FS = ":.*##"; print "Supported targets:" } /^[[:alnum:]_-]+:.*##/ { printf "  %-28s %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
@@ -338,10 +338,15 @@ package-full: build-full ## Build a Full release archive and SBOM.
 
 check: module-check fmt-check vet ## Run the core module, formatting, and vet checks.
 
+# Prove the deliberate public SDK surface stays free of accidental native,
+# filesystem, environment, process-lifecycle, and SQL dependencies.
+portable-sdk-check: ## Validate direct imports in the pure public SDK boundary.
+	$(GO) run ./tools/portable-sdk-check -root .
+
 # Prove the deliberate public SDK surface stays CGO-free and cross-compilable
 # for every supported platform. A failure here means a public package gained a
 # CGO dependency or platform-specific code that breaks pure-Go consumers.
-check-portable: ## Cross-build the deliberate public SDK packages without CGO.
+check-portable: portable-sdk-check ## Cross-build the deliberate public SDK packages without CGO.
 	@for target in $(PORTABLE_TARGETS); do \
 		os=$${target%/*}; arch=$${target#*/}; \
 		printf 'building portable SDK for %s/%s: ' "$$os" "$$arch"; \

--- a/tools/portable-sdk-check/main.go
+++ b/tools/portable-sdk-check/main.go
@@ -1,0 +1,124 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Command portable-sdk-check rejects direct native, filesystem, environment,
+// process-lifecycle, and SQL imports from the deliberate pure public SDK.
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+)
+
+var pureSDKRoots = []string{
+	"api/v1",
+	"artifact",
+	"client",
+	"inference",
+	"source",
+	"trigger",
+}
+
+var forbiddenImports = map[string]struct{}{
+	"C":             {},
+	"database/sql":  {},
+	"io/fs":         {},
+	"os":            {},
+	"os/exec":       {},
+	"path/filepath": {},
+	"plugin":        {},
+	"runtime":       {},
+	"syscall":       {},
+}
+
+func main() {
+	root := flag.String("root", ".", "repository root containing the public SDK")
+	flag.Parse()
+	if flag.NArg() != 0 {
+		fmt.Fprintln(os.Stderr, "portable-sdk-check: unexpected positional arguments")
+		os.Exit(2)
+	}
+	if err := check(*root); err != nil {
+		fmt.Fprintln(os.Stderr, "portable-sdk-check:", err)
+		os.Exit(1)
+	}
+}
+
+func check(root string) error {
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return fmt.Errorf("resolve repository root: %w", err)
+	}
+	violations := make([]string, 0)
+	for _, packageRoot := range pureSDKRoots {
+		rootPath := filepath.Join(absRoot, filepath.FromSlash(packageRoot))
+		if _, statErr := os.Stat(rootPath); errors.Is(statErr, os.ErrNotExist) {
+			continue
+		} else if statErr != nil {
+			return fmt.Errorf("inspect %s: %w", packageRoot, statErr)
+		}
+		walkErr := filepath.WalkDir(rootPath, func(path string, entry os.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				return walkErr
+			}
+			relative, relativeErr := filepath.Rel(absRoot, path)
+			if relativeErr != nil {
+				return relativeErr
+			}
+			relative = filepath.ToSlash(relative)
+			if entry.IsDir() {
+				// artifact/skill deliberately owns host-facing Skill discovery and
+				// projection, so filesystem imports there are part of its public
+				// contract rather than accidental pure-SDK dependencies.
+				if relative == "artifact/skill" {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+			if !strings.HasSuffix(entry.Name(), ".go") || strings.HasSuffix(entry.Name(), "_test.go") {
+				return nil
+			}
+			file, parseErr := parser.ParseFile(token.NewFileSet(), path, nil, parser.ImportsOnly)
+			if parseErr != nil {
+				return fmt.Errorf("parse %s: %w", relative, parseErr)
+			}
+			for _, importSpec := range file.Imports {
+				importPath, unquoteErr := strconv.Unquote(importSpec.Path.Value)
+				if unquoteErr != nil {
+					return fmt.Errorf("parse import in %s: %w", relative, unquoteErr)
+				}
+				if _, forbidden := forbiddenImports[importPath]; forbidden {
+					violations = append(violations, fmt.Sprintf("%s imports forbidden package %q", relative, importPath))
+				}
+			}
+			return nil
+		})
+		if walkErr != nil {
+			return fmt.Errorf("scan %s: %w", packageRoot, walkErr)
+		}
+	}
+	if len(violations) == 0 {
+		return nil
+	}
+	slices.Sort(violations)
+	return errors.New(strings.Join(violations, "\n"))
+}

--- a/tools/portable-sdk-check/main_test.go
+++ b/tools/portable-sdk-check/main_test.go
@@ -1,0 +1,60 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCommandRejectsForbiddenPublicSDKImport(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "client", "client.go")
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("package client\n\nimport \"os\"\n\nvar _ = os.Getenv\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	command := exec.CommandContext(t.Context(), "go", "run", ".", "-root", root)
+	output, err := command.CombinedOutput()
+	if err == nil {
+		t.Fatalf("portable SDK check accepted a forbidden import:\n%s", output)
+	}
+	if !strings.Contains(string(output), `client/client.go imports forbidden package "os"`) {
+		t.Fatalf("portable SDK check output = %q", output)
+	}
+}
+
+func TestCommandAllowsTheIntentionalExternalSkillFilesystemBoundary(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "artifact", "skill", "projection.go")
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("package skill\n\nimport \"os\"\n\nvar _ = os.ReadFile\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	command := exec.CommandContext(t.Context(), "go", "run", ".", "-root", root)
+	output, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("portable SDK check rejected the external Skill filesystem boundary: %v\n%s", err, output)
+	}
+}

--- a/tools/release/makefile_test.go
+++ b/tools/release/makefile_test.go
@@ -42,7 +42,7 @@ func TestBareMakeListsSupportedTargets(t *testing.T) {
 	if defaultOutput != helpOutput {
 		t.Errorf("default Make output differs from help output\ndefault:\n%s\nhelp:\n%s", defaultOutput, helpOutput)
 	}
-	for _, target := range []string{"lint", "check", "check-portable", "api-compat", "dependency-security", "generated-consumers", "module-inventory", "module-integrity", "license-dependencies", "race-debt-check", "test", "build", "package-full", "governance-check"} {
+	for _, target := range []string{"lint", "check", "portable-sdk-check", "check-portable", "api-compat", "dependency-security", "generated-consumers", "module-inventory", "module-integrity", "license-dependencies", "race-debt-check", "test", "build", "package-full", "governance-check"} {
 		if !strings.Contains(helpOutput, "  "+target+" ") {
 			t.Errorf("Make help output is missing %q\n%s", target, helpOutput)
 		}
@@ -615,6 +615,24 @@ func TestDownstreamCompatDisablesGoTestCaching(t *testing.T) {
 	}
 }
 
+func TestCheckPortableValidatesThePublicSDKDependencyBoundary(t *testing.T) {
+	repository := filepath.Clean(filepath.Join("..", ".."))
+	command := exec.CommandContext(t.Context(), "make", "--dry-run", "check-portable", "GO=go")
+	command.Dir = repository
+	output, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("make check-portable dry-run failed: %v\n%s", err, output)
+	}
+	contents := string(output)
+	check := "go run ./tools/portable-sdk-check -root ."
+	build := "CGO_ENABLED=0 GOOS=$os GOARCH=$arch go build"
+	checkIndex := strings.Index(contents, check)
+	buildIndex := strings.Index(contents, build)
+	if checkIndex < 0 || buildIndex < 0 || checkIndex > buildIndex {
+		t.Fatalf("make check-portable does not validate the dependency boundary before cross-builds:\n%s", output)
+	}
+}
+
 func TestGeneratedConsumersTargetRunsFreshConsumerVerification(t *testing.T) {
 	repository := filepath.Clean(filepath.Join("..", ".."))
 	command := exec.CommandContext(t.Context(), "make", "--dry-run", "generated-consumers", "GO=go")
@@ -990,6 +1008,9 @@ case "${1:-} ${2:-}" in
     printf 'go1.27.0\n'
     exit 0
     ;;
+  "run ./tools/portable-sdk-check")
+    exit 0
+    ;;
 esac
 
 printf '%s|%s|%s|%s\n' "$GOOS" "$GOARCH" "$CGO_ENABLED" "$*" >> "$PORTABLE_CALL_LOG"
@@ -1063,6 +1084,9 @@ case "${1:-} ${2:-}" in
     ;;
   "env GOVERSION")
     printf 'go1.27.0\n'
+    exit 0
+    ;;
+  "run ./tools/portable-sdk-check")
     exit 0
     ;;
 esac


### PR DESCRIPTION
## Summary

- add a static public-SDK import guard before the existing CGO-disabled portable cross-build matrix
- reject direct CGO, SQL, filesystem, environment, process-lifecycle, plugin, runtime, and syscall imports from the pure public SDK roots
- retain `artifact/skill` as an explicit exception because its public contract intentionally discovers and projects host Skill files

## Scope

Part of #3. The check protects generated API, Client, Source, Trigger, Inference, and pure Artifact domains against accidental host/runtime dependencies; it does not change their APIs or the four existing cross-build targets.

## Validation

- red/green CLI regression: a temporary public `client` package importing `os` is rejected
- `go test -race ./tools/portable-sdk-check -count=1`
- `go test -race ./tools/release -run '^(TestCheckPortableValidatesThePublicSDKDependencyBoundary|TestBareMakeListsSupportedTargets)$' -count=1`
- `make check-portable` (linux amd64/arm64 and darwin amd64/arm64)
- pinned `golangci-lint run ./tools/portable-sdk-check ./tools/release` (0 issues)
- `go vet ./tools/portable-sdk-check ./tools/release`
- `make license-check`
- `git diff --check`