### PR TITLE
ci: require shrinking race debt ledger

### DIFF
--- a/.github/workflows/migration-gates.yml
+++ b/.github/workflows/migration-gates.yml
@@ -77,6 +77,16 @@ jobs:
       - name: Set up the Go environment
         uses: ./.github/actions/setup-go-env
 
+      - name: Reject new temporary race exclusions
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          git fetch --no-tags --depth=1 origin "$BASE_SHA"
+          baseline="$RUNNER_TEMP/race-debt-base.json"
+          git show "$BASE_SHA:.github/race-debt.json" > "$baseline"
+          make race-debt-check RACE_DEBT_BASELINE="$baseline"
+
       - name: Validate the race-debt ledger
         run: make race-debt-check
 

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ COVERAGE_PROFILE ?= $(COVERAGE_DIR)/coverage.out
 COVERAGE_SUMMARY ?= $(COVERAGE_DIR)/summary.txt
 COVERAGE_MINIMUM ?= 16.0
 LICENSE_DEPENDENCY_OUTPUT ?= $(COVERAGE_DIR)/dependencies.json
+RACE_DEBT_BASELINE ?=
 
 STANDARD_TAGS := sqlite_fts5
 FULL_TAGS := sqlite_fts5,local_embeddings,ORT
@@ -224,7 +225,7 @@ test-sqlite: ## Run all standard-tag tests against SQLite.
 	CGO_ENABLED=1 $(GO) test -tags '$(STANDARD_TAGS)' ./...
 
 race-debt-check: ## Validate the exact temporary race-test exclusion ledger.
-	$(GO) run ./tools/race-debt -file .github/race-debt.json
+	$(GO) run ./tools/race-debt -file .github/race-debt.json $(if $(RACE_DEBT_BASELINE),-baseline "$(RACE_DEBT_BASELINE)")
 
 test-race: ## Run all Go tests with the race detector.
 	CGO_ENABLED=1 $(GO) test -race ./...

--- a/tools/race-debt/main.go
+++ b/tools/race-debt/main.go
@@ -56,6 +56,7 @@ func run(arguments []string, output io.Writer) error {
 	flags := flag.NewFlagSet("race-debt", flag.ContinueOnError)
 	flags.SetOutput(io.Discard)
 	path := flags.String("file", defaultLedgerPath, "path to the race-debt ledger")
+	baselinePath := flags.String("baseline", "", "optional approved race-debt ledger that the current ledger may only shrink")
 	if err := flags.Parse(arguments); err != nil {
 		return err
 	}
@@ -63,21 +64,42 @@ func run(arguments []string, output io.Writer) error {
 		return fmt.Errorf("unexpected argument %q", flags.Arg(0))
 	}
 
-	contents, err := os.ReadFile(*path)
+	value, err := readLedger(*path)
 	if err != nil {
-		return fmt.Errorf("read ledger: %w", err)
-	}
-	var value ledger
-	decodeErr := json.Unmarshal(contents, &value, json.RejectUnknownMembers(true))
-	if decodeErr != nil {
-		return fmt.Errorf("parse ledger: %w", decodeErr)
+		return err
 	}
 	validationErr := validate(value, time.Now().UTC())
 	if validationErr != nil {
 		return validationErr
 	}
+	if *baselinePath != "" {
+		baseline, baselineErr := readLedger(*baselinePath)
+		if baselineErr != nil {
+			return fmt.Errorf("read baseline: %w", baselineErr)
+		}
+		baselineValidationErr := validate(baseline, time.Now().UTC())
+		if baselineValidationErr != nil {
+			return fmt.Errorf("validate baseline: %w", baselineValidationErr)
+		}
+		if policyErr := requireNoNewExclusions(value, baseline); policyErr != nil {
+			return policyErr
+		}
+	}
 	_, err = fmt.Fprintf(output, "race debt: %d temporary exclusions verified\n", len(value.Exclusions))
 	return err
+}
+
+func readLedger(path string) (ledger, error) {
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		return ledger{}, fmt.Errorf("read ledger: %w", err)
+	}
+	var value ledger
+	decodeErr := json.Unmarshal(contents, &value, json.RejectUnknownMembers(true))
+	if decodeErr != nil {
+		return ledger{}, fmt.Errorf("parse ledger: %w", decodeErr)
+	}
+	return value, nil
 }
 
 func validate(value ledger, now time.Time) error {
@@ -119,13 +141,31 @@ func validate(value ledger, now time.Time) error {
 		if now.After(expires.AddDate(0, 0, 1)) {
 			return fmt.Errorf("%s.expires has passed; remove or renew the exclusion through its Issue", prefix)
 		}
-		key := entry.Package + "#" + entry.Test
+		key := exclusionKey(entry)
 		if _, ok := seen[key]; ok {
 			return fmt.Errorf("%s duplicates %q", prefix, key)
 		}
 		seen[key] = struct{}{}
 	}
 	return nil
+}
+
+func requireNoNewExclusions(current, baseline ledger) error {
+	approved := make(map[string]struct{}, len(baseline.Exclusions))
+	for _, entry := range baseline.Exclusions {
+		approved[exclusionKey(entry)] = struct{}{}
+	}
+	for _, entry := range current.Exclusions {
+		key := exclusionKey(entry)
+		if _, ok := approved[key]; !ok {
+			return fmt.Errorf("new temporary exclusion %q requires a reviewed policy change", key)
+		}
+	}
+	return nil
+}
+
+func exclusionKey(entry exclusion) string {
+	return entry.Package + "#" + entry.Test
 }
 
 func validateIssue(value string) error {

--- a/tools/race-debt/main_test.go
+++ b/tools/race-debt/main_test.go
@@ -109,3 +109,65 @@ func TestCommandChecksRaceDebtEntries(t *testing.T) {
 		})
 	}
 }
+
+func TestCommandAppliesTheMonotonicBaselinePolicy(t *testing.T) {
+	const emptyLedger = `{
+  "version": 1,
+  "exclusions": []
+}`
+	const exclusionLedger = `{
+  "version": 1,
+  "exclusions": [{
+    "package": "./internal/runtime",
+    "test": "TestShutdown",
+    "issue": "https://github.com/ob-labs/powercontext-go/issues/3",
+    "owner": "@powercontext-maintainers",
+    "reason": "bounded reproduction",
+    "added": "2026-08-31",
+    "removal_condition": "replace the synchronization with a deterministic barrier",
+    "expires": "2999-12-31"
+  }]
+	}`
+	tests := []struct {
+		name       string
+		baseline   string
+		ledger     string
+		wantErr    bool
+		wantOutput string
+	}{
+		{
+			name:       "rejects a new exclusion",
+			baseline:   emptyLedger,
+			ledger:     exclusionLedger,
+			wantErr:    true,
+			wantOutput: "new temporary exclusion",
+		},
+		{
+			name:     "allows removing a baseline exclusion",
+			baseline: exclusionLedger,
+			ledger:   emptyLedger,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := t.TempDir()
+			baseline := filepath.Join(root, "baseline.json")
+			if err := os.WriteFile(baseline, []byte(test.baseline), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			ledger := filepath.Join(root, "race-debt.json")
+			if err := os.WriteFile(ledger, []byte(test.ledger), 0o600); err != nil {
+				t.Fatal(err)
+			}
+
+			command := exec.CommandContext(t.Context(), "go", "run", ".", "-file", ledger, "-baseline", baseline)
+			output, err := command.CombinedOutput()
+			if (err != nil) != test.wantErr {
+				t.Fatalf("race-debt check error = %v, want error %t\n%s", err, test.wantErr, output)
+			}
+			if test.wantOutput != "" && !strings.Contains(string(output), test.wantOutput) {
+				t.Fatalf("race-debt check output = %q, want substring %q", output, test.wantOutput)
+			}
+		})
+	}
+}

--- a/tools/release/makefile_test.go
+++ b/tools/release/makefile_test.go
@@ -62,6 +62,21 @@ func TestRaceDebtCheckUsesTheCheckedInLedger(t *testing.T) {
 	}
 }
 
+func TestRaceDebtCheckPassesTheOptionalBaseline(t *testing.T) {
+	repository := filepath.Clean(filepath.Join("..", ".."))
+	command := exec.CommandContext(
+		t.Context(), "make", "--dry-run", "race-debt-check", "GO=go", "RACE_DEBT_BASELINE=test/base-race-debt.json",
+	)
+	command.Dir = repository
+	output, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("make race-debt-check dry-run failed: %v\n%s", err, output)
+	}
+	if !strings.Contains(string(output), `go run ./tools/race-debt -file .github/race-debt.json -baseline "test/base-race-debt.json"`) {
+		t.Fatalf("make race-debt-check does not pass the optional baseline:\n%s", output)
+	}
+}
+
 func TestSmokeTargetsVerifySecurityDefaultsFile(t *testing.T) {
 	tests := map[string]string{
 		"smoke":      "bin/powercontext",

--- a/tools/release/workflow_test.go
+++ b/tools/release/workflow_test.go
@@ -17,6 +17,7 @@ package main
 import (
 	"fmt"
 	"io/fs"
+	"maps"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -228,9 +229,11 @@ func TestMigrationRaceDebtValidatesTheLedgerBeforeTheFullRaceSuite(t *testing.T)
 			RunsOn         string `yaml:"runs-on"`
 			TimeoutMinutes int    `yaml:"timeout-minutes"`
 			Steps          []struct {
-				Name string `yaml:"name"`
-				Uses string `yaml:"uses"`
-				Run  string `yaml:"run"`
+				Name string            `yaml:"name"`
+				If   string            `yaml:"if"`
+				Env  map[string]string `yaml:"env"`
+				Uses string            `yaml:"uses"`
+				Run  string            `yaml:"run"`
 			} `yaml:"steps"`
 		} `yaml:"jobs"`
 	}
@@ -250,11 +253,24 @@ func TestMigrationRaceDebtValidatesTheLedgerBeforeTheFullRaceSuite(t *testing.T)
 	}
 	wantSteps := []struct {
 		name string
+		if_  string
+		env  map[string]string
 		uses string
 		run  string
 	}{
 		{name: "Check out", uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"},
 		{name: "Set up the Go environment", uses: "./.github/actions/setup-go-env"},
+		{
+			name: "Reject new temporary race exclusions",
+			if_:  "github.event_name == 'pull_request'",
+			env:  map[string]string{"BASE_SHA": "${{ github.event.pull_request.base.sha }}"},
+			run: strings.TrimSpace(`
+git fetch --no-tags --depth=1 origin "$BASE_SHA"
+baseline="$RUNNER_TEMP/race-debt-base.json"
+git show "$BASE_SHA:.github/race-debt.json" > "$baseline"
+make race-debt-check RACE_DEBT_BASELINE="$baseline"
+`),
+		},
 		{name: "Validate the race-debt ledger", run: "make race-debt-check"},
 		{name: "Run all Go tests with the race detector", run: "make test-race"},
 	}
@@ -263,10 +279,10 @@ func TestMigrationRaceDebtValidatesTheLedgerBeforeTheFullRaceSuite(t *testing.T)
 	}
 	for index, want := range wantSteps {
 		got := job.Steps[index]
-		if got.Name != want.name || got.Uses != want.uses || strings.TrimSpace(got.Run) != want.run {
+		if got.Name != want.name || got.If != want.if_ || !maps.Equal(got.Env, want.env) || got.Uses != want.uses || strings.TrimSpace(got.Run) != want.run {
 			t.Fatalf(
-				"race-debt step %d = (%q, %q, %q), want (%q, %q, %q)",
-				index, got.Name, got.Uses, strings.TrimSpace(got.Run), want.name, want.uses, want.run,
+				"race-debt step %d = (%q, %q, %#v, %q, %q), want (%q, %q, %#v, %q, %q)",
+				index, got.Name, got.If, got.Env, got.Uses, strings.TrimSpace(got.Run), want.name, want.if_, want.env, want.uses, want.run,
 			)
 		}
 	}


### PR DESCRIPTION
## Summary

- add an optional approved baseline to the race-debt validator
- reject any PR that adds a temporary race exclusion relative to its immutable base SHA; removal remains allowed
- fetch and read the exact pull-request base ledger in the reusable `Race debt` job before the full race suite runs

## Scope

Part of #3. This enforces a monotonic shrinking policy: a new temporary race waiver now requires a separately reviewed policy change instead of silently widening CI exclusions. It does not introduce a skip or reduce the `make test-race` surface.

## Validation

- red/green CLI regression for new-exclusion rejection
- real CLI regression proving removal of an approved baseline entry succeeds
- `go test -race ./tools/race-debt -count=1`
- `go test -race ./tools/release -run '^(TestRaceDebtCheckUsesTheCheckedInLedger|TestRaceDebtCheckPassesTheOptionalBaseline|TestMigrationRaceDebtValidatesTheLedgerBeforeTheFullRaceSuite|TestMigrationQualityRejectsWorktreeSideEffects)$' -count=1`
- pinned `golangci-lint run ./tools/race-debt ./tools/release` (0 issues)
- `go vet ./tools/race-debt ./tools/release`
- `make race-debt-check RACE_DEBT_BASELINE=.github/race-debt.json`
- `make license-check`, `actionlint`, and `git diff --check`