### PR TITLE
ci: exercise temporary race exclusions

### DIFF
--- a/.github/workflows/migration-gates.yml
+++ b/.github/workflows/migration-gates.yml
@@ -93,6 +93,20 @@ jobs:
       - name: Run all Go tests with the race detector
         run: make test-race
 
+  race-debt-functional:
+    name: Race debt functional coverage
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - name: Check out
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Set up the Go environment
+        uses: ./.github/actions/setup-go-env
+
+      - name: Exercise temporary exclusions without the race detector
+        run: make race-debt-functional
+
   portable-sdk:
     name: Portable SDK cross-builds
     runs-on: ubuntu-24.04

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ PUBLIC_API_PACKAGES := \
 	$(MODULE_PATH)/trigger
 
 .PHONY: help lint-tools lint lint-fix api-compat-tools api-baseline api-compat govulncheck-tools dependency-security generate check-generated module-check module-inventory module-integrity contract-test license-check license-fix license-dependencies fmt fmt-check vet build-all coverage coverage-check governance-check \
-	test unit-test e2e-test test-sqlite race-debt-check test-race test-full test-oceanbase-live real-provider-test \
+	test unit-test e2e-test test-sqlite race-debt-check race-debt-functional test-race test-full test-oceanbase-live real-provider-test \
 	pi-test docs-sync docs-test docs-build harness-sync harness-check harness-compose-check \
 	harness-compose-acceptance harness-compose-down build build-full smoke smoke-full check \
 	portable-sdk-check check-portable generated-consumers downstream-compat package-standard package-full clean
@@ -226,6 +226,9 @@ test-sqlite: ## Run all standard-tag tests against SQLite.
 
 race-debt-check: ## Validate the exact temporary race-test exclusion ledger.
 	$(GO) run ./tools/race-debt -file .github/race-debt.json $(if $(RACE_DEBT_BASELINE),-baseline "$(RACE_DEBT_BASELINE)")
+
+race-debt-functional: ## Exercise each temporary race exclusion without the race detector.
+	$(GO) run ./tools/race-debt -file .github/race-debt.json -exercise
 
 test-race: ## Run all Go tests with the race detector.
 	CGO_ENABLED=1 $(GO) test -race ./...

--- a/tools/race-debt/main.go
+++ b/tools/race-debt/main.go
@@ -16,12 +16,14 @@
 package main
 
 import (
+	"context"
 	"encoding/json/v2"
 	"flag"
 	"fmt"
 	"go/token"
 	"io"
 	"os"
+	"os/exec"
 	"strconv"
 	"strings"
 	"time"
@@ -57,6 +59,7 @@ func run(arguments []string, output io.Writer) error {
 	flags.SetOutput(io.Discard)
 	path := flags.String("file", defaultLedgerPath, "path to the race-debt ledger")
 	baselinePath := flags.String("baseline", "", "optional approved race-debt ledger that the current ledger may only shrink")
+	exercise := flags.Bool("exercise", false, "run each temporary exclusion without the race detector")
 	if err := flags.Parse(arguments); err != nil {
 		return err
 	}
@@ -83,6 +86,11 @@ func run(arguments []string, output io.Writer) error {
 		}
 		if policyErr := requireNoNewExclusions(value, baseline); policyErr != nil {
 			return policyErr
+		}
+	}
+	if *exercise {
+		if exerciseErr := exerciseWithoutRace(context.Background(), value, output); exerciseErr != nil {
+			return exerciseErr
 		}
 	}
 	_, err = fmt.Fprintf(output, "race debt: %d temporary exclusions verified\n", len(value.Exclusions))
@@ -159,6 +167,18 @@ func requireNoNewExclusions(current, baseline ledger) error {
 		key := exclusionKey(entry)
 		if _, ok := approved[key]; !ok {
 			return fmt.Errorf("new temporary exclusion %q requires a reviewed policy change", key)
+		}
+	}
+	return nil
+}
+
+func exerciseWithoutRace(ctx context.Context, value ledger, output io.Writer) error {
+	for _, entry := range value.Exclusions {
+		command := exec.CommandContext(ctx, "go", "test", entry.Package, "-run", "^"+entry.Test+"$")
+		command.Stdout = output
+		command.Stderr = output
+		if commandErr := command.Run(); commandErr != nil {
+			return fmt.Errorf("exercise temporary exclusion %q without race: %w", exclusionKey(entry), commandErr)
 		}
 	}
 	return nil

--- a/tools/race-debt/main_test.go
+++ b/tools/race-debt/main_test.go
@@ -171,3 +171,33 @@ func TestCommandAppliesTheMonotonicBaselinePolicy(t *testing.T) {
 		})
 	}
 }
+
+func TestCommandExercisesTemporaryExclusionsWithoutTheRaceDetector(t *testing.T) {
+	ledger := filepath.Join(t.TempDir(), "race-debt.json")
+	if err := os.WriteFile(ledger, []byte(`{
+  "version": 1,
+  "exclusions": [{
+    "package": "./tools/race-debt",
+    "test": "TestCommandChecksRaceDebtEntries",
+    "issue": "https://github.com/ob-labs/powercontext-go/issues/3",
+    "owner": "@powercontext-maintainers",
+    "reason": "exercise the non-race coverage path",
+    "added": "2026-08-31",
+    "removal_condition": "replace the synchronization with a deterministic barrier",
+    "expires": "2999-12-31"
+  }]
+}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	repository := filepath.Clean(filepath.Join("..", ".."))
+	command := exec.CommandContext(t.Context(), "go", "run", "./tools/race-debt", "-file", ledger, "-exercise")
+	command.Dir = repository
+	output, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("race-debt non-race exercise failed: %v\n%s", err, output)
+	}
+	if !strings.Contains(string(output), "github.com/ob-labs/powercontext-go/tools/race-debt") {
+		t.Fatalf("race-debt non-race exercise output = %q", output)
+	}
+}

--- a/tools/release/makefile_test.go
+++ b/tools/release/makefile_test.go
@@ -42,7 +42,7 @@ func TestBareMakeListsSupportedTargets(t *testing.T) {
 	if defaultOutput != helpOutput {
 		t.Errorf("default Make output differs from help output\ndefault:\n%s\nhelp:\n%s", defaultOutput, helpOutput)
 	}
-	for _, target := range []string{"lint", "check", "portable-sdk-check", "check-portable", "api-compat", "dependency-security", "generated-consumers", "module-inventory", "module-integrity", "license-dependencies", "race-debt-check", "test", "build", "package-full", "governance-check"} {
+	for _, target := range []string{"lint", "check", "portable-sdk-check", "check-portable", "api-compat", "dependency-security", "generated-consumers", "module-inventory", "module-integrity", "license-dependencies", "race-debt-check", "race-debt-functional", "test", "build", "package-full", "governance-check"} {
 		if !strings.Contains(helpOutput, "  "+target+" ") {
 			t.Errorf("Make help output is missing %q\n%s", target, helpOutput)
 		}
@@ -74,6 +74,19 @@ func TestRaceDebtCheckPassesTheOptionalBaseline(t *testing.T) {
 	}
 	if !strings.Contains(string(output), `go run ./tools/race-debt -file .github/race-debt.json -baseline "test/base-race-debt.json"`) {
 		t.Fatalf("make race-debt-check does not pass the optional baseline:\n%s", output)
+	}
+}
+
+func TestRaceDebtFunctionalCoverageUsesTheCheckedInLedger(t *testing.T) {
+	repository := filepath.Clean(filepath.Join("..", ".."))
+	command := exec.CommandContext(t.Context(), "make", "--dry-run", "race-debt-functional", "GO=go")
+	command.Dir = repository
+	output, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("make race-debt-functional dry-run failed: %v\n%s", err, output)
+	}
+	if !strings.Contains(string(output), "go run ./tools/race-debt -file .github/race-debt.json -exercise") {
+		t.Fatalf("make race-debt-functional does not exercise the checked-in ledger:\n%s", output)
 	}
 }
 

--- a/tools/release/workflow_test.go
+++ b/tools/release/workflow_test.go
@@ -288,6 +288,61 @@ make race-debt-check RACE_DEBT_BASELINE="$baseline"
 	}
 }
 
+func TestMigrationRaceDebtFunctionalCoverageRunsSeparately(t *testing.T) {
+	repository := filepath.Clean(filepath.Join("..", ".."))
+	payload, err := os.ReadFile(filepath.Join(repository, ".github", "workflows", "migration-gates.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var workflow struct {
+		Jobs map[string]struct {
+			Name           string `yaml:"name"`
+			RunsOn         string `yaml:"runs-on"`
+			TimeoutMinutes int    `yaml:"timeout-minutes"`
+			Steps          []struct {
+				Name string `yaml:"name"`
+				Uses string `yaml:"uses"`
+				Run  string `yaml:"run"`
+			} `yaml:"steps"`
+		} `yaml:"jobs"`
+	}
+	if err := yaml.Unmarshal(payload, &workflow); err != nil {
+		t.Fatal(err)
+	}
+	job, ok := workflow.Jobs["race-debt-functional"]
+	if !ok {
+		t.Fatal("migration-gates.yml has no race-debt-functional job")
+	}
+	if job.Name != "Race debt functional coverage" || job.RunsOn != "ubuntu-24.04" || job.TimeoutMinutes != 20 {
+		t.Fatalf(
+			"race-debt-functional job identity = (%q, %q, %d), want (%q, %q, %d)",
+			job.Name, job.RunsOn, job.TimeoutMinutes,
+			"Race debt functional coverage", "ubuntu-24.04", 20,
+		)
+	}
+	wantSteps := []struct {
+		name string
+		uses string
+		run  string
+	}{
+		{name: "Check out", uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"},
+		{name: "Set up the Go environment", uses: "./.github/actions/setup-go-env"},
+		{name: "Exercise temporary exclusions without the race detector", run: "make race-debt-functional"},
+	}
+	if len(job.Steps) != len(wantSteps) {
+		t.Fatalf("race-debt-functional step count = %d, want %d", len(job.Steps), len(wantSteps))
+	}
+	for index, want := range wantSteps {
+		got := job.Steps[index]
+		if got.Name != want.name || got.Uses != want.uses || strings.TrimSpace(got.Run) != want.run {
+			t.Fatalf(
+				"race-debt-functional step %d = (%q, %q, %q), want (%q, %q, %q)",
+				index, got.Name, got.Uses, strings.TrimSpace(got.Run), want.name, want.uses, want.run,
+			)
+		}
+	}
+}
+
 type migrationWorkflowStep struct {
 	Name  string `yaml:"name"`
 	If    string `yaml:"if"`


### PR DESCRIPTION
## Summary

- add a stable `Race debt functional coverage` CI job alongside the required full-race job
- add `make race-debt-functional`, which executes each exact temporary exclusion without `-race`
- keep empty-ledger execution explicit and fast; no test is skipped or removed

## Scope

Part of #3. If a future reviewed policy change admits a temporary race exclusion, its exact non-race functional test now executes in a separate CI job. The existing `Race debt` job still validates the ledger and runs `make test-race` in full.

## Validation

- red/green real CLI regression exercising an exact temporary exclusion without the race detector
- `go test -race ./tools/race-debt -count=1`
- focused race workflow/Makefile contract tests
- pinned `golangci-lint run ./tools/race-debt ./tools/release` (0 issues)
- `go vet ./tools/race-debt ./tools/release`
- `make race-debt-functional`
- `make license-check`, `actionlint`, and `git diff --check`