### PR TITLE
feat(cli): add multi-host setup selection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -274,12 +274,13 @@ source / artifact / trigger / inference
   caller supplies the client and explicitly vouches for transport security.
   Return a typed refusal that preserves configuration-error matching, names the
   non-loopback policy, and never includes the rejected URL in its representations.
-- When a cross-field security policy depends on environment values plus CLI
-  overrides, preserve whether each override was explicitly present, reject
-  explicit blank values as operator input, and merge valid overrides before the
-  final validation. Verify both directions: a safe override repairs an unsafe
-  environment value, and an unsafe override cannot replace a safe environment
-  value without failing.
+- When a cross-field security policy or parent command depends on optional CLI
+  overrides, preserve explicit presence separately from the value, reject an
+  explicit blank instead of treating it as omission, and merge or forward valid
+  overrides before final validation. For environment merges, verify both safe
+  and unsafe override directions; for parent forwarding, verify omission keeps
+  the child default while an explicit blank reaches child validation before any
+  write.
 - When a CLI converts a typed configuration failure into a usage error, keep
   the underlying error matchable and name concrete operator remediation without
   exposing configured values. Verify exit code 2 and that execution never

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -301,3 +301,7 @@ source / artifact / trigger / inference
   boundary, anchor the mutation to the target job's actual adjacent boundary
   after structural changes. Verify the mutant changes that target job and is
   rejected by the contract validator.
+- When CLI behavior depends on whether stdin is interactive, use an actual
+  terminal query instead of treating every character device as a TTY. Verify
+  null devices and pipes remain non-interactive while a controlled terminal
+  input still enables the prompt path.

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.44.0
 	go.opentelemetry.io/otel/trace v1.44.0
 	golang.org/x/mod v0.40.0
+	golang.org/x/term v0.45.0
 	golang.org/x/text v0.41.0
 	golang.org/x/tools v0.49.0
 	google.golang.org/genai v1.65.0
@@ -117,7 +118,6 @@ require (
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
-	golang.org/x/term v0.45.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	google.golang.org/grpc v1.82.1 // indirect

--- a/internal/cli/integration_catalog.go
+++ b/internal/cli/integration_catalog.go
@@ -27,6 +27,7 @@ type integrationDiagnosticProbe func(context.Context, systemCommandExecutor) map
 
 type integrationHostSpec struct {
 	name            string
+	label           string
 	cliKey          string
 	integrationKeys []string
 	missingDetail   string
@@ -35,31 +36,31 @@ type integrationHostSpec struct {
 
 var firstClassIntegrationHosts = [...]integrationHostSpec{
 	{
-		name: "codex", cliKey: "codex", integrationKeys: []string{"plugin"},
+		name: "codex", label: "Codex", cliKey: "codex", integrationKeys: []string{"plugin"},
 		missingDetail: "Codex CLI is not installed or is not on PATH", probe: runCodexDiagnostics,
 	},
 	{
-		name: "claude-code", cliKey: "claude_code", integrationKeys: []string{"plugin"},
+		name: "claude-code", label: "Claude Code", cliKey: "claude_code", integrationKeys: []string{"plugin"},
 		missingDetail: "Claude Code CLI is not installed or is not on PATH", probe: runClaudeCodeDiagnostics,
 	},
 	{
-		name: "dsh", cliKey: "dsh", integrationKeys: []string{"plugin"},
+		name: "dsh", label: "DeepSeek Harness", cliKey: "dsh", integrationKeys: []string{"plugin"},
 		missingDetail: "DeepSeek Harness CLI is not installed or is not on PATH", probe: runDSHDiagnostics,
 	},
 	{
-		name: "openclaw", cliKey: "openclaw", integrationKeys: []string{"plugin"},
+		name: "openclaw", label: "OpenClaw", cliKey: "openclaw", integrationKeys: []string{"plugin"},
 		missingDetail: "OpenClaw CLI is not installed or is not on PATH", probe: runOpenClawDiagnostics,
 	},
 	{
-		name: "opencode", cliKey: "opencode", integrationKeys: []string{"plugin", "skill"},
+		name: "opencode", label: "OpenCode", cliKey: "opencode", integrationKeys: []string{"plugin", "skill"},
 		missingDetail: "OpenCode CLI is not installed or is not on PATH", probe: runOpenCodeDiagnostics,
 	},
 	{
-		name: "pi", cliKey: "pi", integrationKeys: []string{"package"},
+		name: "pi", label: "Pi", cliKey: "pi", integrationKeys: []string{"package"},
 		missingDetail: "Pi CLI is not installed or is not on PATH", probe: runPiDiagnostics,
 	},
 	{
-		name: "hermes", cliKey: "hermes", integrationKeys: []string{"plugin"},
+		name: "hermes", label: "Hermes", cliKey: "hermes", integrationKeys: []string{"plugin"},
 		missingDetail: "Hermes CLI is not installed or is not on PATH", probe: runHermesDiagnostics,
 	},
 }

--- a/internal/cli/integration_codex.go
+++ b/internal/cli/integration_codex.go
@@ -72,7 +72,7 @@ func newSetupCodexCommand(state *commandState) *cobra.Command {
 				if writeErr := writeDiagnostics(state, checks); writeErr != nil {
 					return writeErr
 				}
-				return alreadyReported(errors.New("Codex diagnostics did not pass"))
+				return alreadyReported(setupVerificationError(checks))
 			}
 			result := map[string]string{
 				"marketplace": marketplaceName, "plugin": name, "plugin_version": version, "data_dir": dataDirectory,

--- a/internal/cli/integration_dsh.go
+++ b/internal/cli/integration_dsh.go
@@ -56,7 +56,7 @@ func newSetupDSHCommand(state *commandState) *cobra.Command {
 				if writeErr := writeDiagnostics(state, checks); writeErr != nil {
 					return writeErr
 				}
-				return alreadyReported(errors.New("DeepSeek Harness diagnostics did not pass"))
+				return alreadyReported(setupVerificationError(checks))
 			}
 			result := map[string]string{"plugin": dshPluginName, "plugin_path": pluginPath, "data_dir": dataDirectory}
 			if state.json {

--- a/internal/cli/integration_hermes.go
+++ b/internal/cli/integration_hermes.go
@@ -69,7 +69,7 @@ func newSetupHermesCommand(state *commandState) *cobra.Command {
 				if writeErr := writeDiagnostics(state, checks); writeErr != nil {
 					return writeErr
 				}
-				return alreadyReported(errors.New("Hermes diagnostics did not pass"))
+				return alreadyReported(setupVerificationError(checks))
 			}
 			result := map[string]string{
 				"plugin": hermesPluginName, "plugin_path": target, "hermes_home": home, "data_dir": dataDirectory,

--- a/internal/cli/integration_hosts_test.go
+++ b/internal/cli/integration_hosts_test.go
@@ -31,7 +31,7 @@ func TestSetupAndDoctorExposeCurrentHostMatrix(t *testing.T) {
 		VersionInfo{Version: "test"}, &strings.Builder{}, &strings.Builder{}, nil, nil, &scriptedSystemCommands{t: t},
 	)
 	for parentName, want := range map[string][]string{
-		"setup":  {"claude-code", "codex", "dsh", "hermes", "openclaw", "opencode", "pi"},
+		"setup":  {"claude-code", "codex", "dsh", "hermes", "openclaw", "opencode", "pi", "select"},
 		"doctor": {"claude-code", "codex", "dsh", "hermes", "integrations", "openclaw", "opencode", "pi"},
 	} {
 		parent, _, err := command.Find([]string{parentName})

--- a/internal/cli/integration_openclaw.go
+++ b/internal/cli/integration_openclaw.go
@@ -55,16 +55,16 @@ func newSetupOpenClawCommand(state *commandState) *cobra.Command {
 	command := &cobra.Command{
 		Use: "openclaw", Short: "Build, install, and configure the PowerContext OpenClaw memory plugin.", Args: cobra.NoArgs,
 		RunE: func(command *cobra.Command, _ []string) error {
+			normalizedURL, err := normalizeOpenClawServerURL(serverURL)
+			if err != nil {
+				return err
+			}
 			executable, err := openClawExecutable(state.system, runtime.GOOS)
 			if err != nil {
 				return errors.New("OpenClaw CLI is not installed or is not on PATH")
 			}
 			if _, versionErr := supportedOpenClawVersion(command.Context(), state.system, executable); versionErr != nil {
 				return versionErr
-			}
-			normalizedURL, err := normalizeOpenClawServerURL(serverURL)
-			if err != nil {
-				return err
 			}
 			if scopeMode != "agent" && scopeMode != "project" {
 				return errors.New("OpenClaw scope must be agent or project")

--- a/internal/cli/integration_pi.go
+++ b/internal/cli/integration_pi.go
@@ -69,7 +69,7 @@ func newSetupPiCommand(state *commandState) *cobra.Command {
 				if writeErr := writeDiagnostics(state, checks); writeErr != nil {
 					return writeErr
 				}
-				return alreadyReported(errors.New("Pi diagnostics did not pass"))
+				return alreadyReported(setupVerificationError(checks))
 			}
 			result := map[string]string{"package": piPackageName, "package_path": packagePath, "data_dir": dataDirectory}
 			if state.json {

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -31,8 +31,17 @@ const (
 )
 
 func newSetupCommand(state *commandState) *cobra.Command {
-	command := &cobra.Command{Use: "setup", Short: "Install and configure PowerContext integrations."}
+	command := &cobra.Command{
+		Use: "setup", Short: "Install and configure PowerContext integrations.", Args: cobra.NoArgs,
+		RunE: func(command *cobra.Command, _ []string) error {
+			if err := command.Help(); err != nil {
+				return err
+			}
+			return usageError(errors.New("setup requires a subcommand"))
+		},
+	}
 	command.AddCommand(
+		newSetupSelectCommand(state),
 		newSetupCodexCommand(state),
 		newSetupClaudeCodeCommand(state),
 		newSetupDSHCommand(state),

--- a/internal/cli/setup_select.go
+++ b/internal/cli/setup_select.go
@@ -1,0 +1,307 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/term"
+)
+
+type setupSelectOptions struct {
+	hosts            []string
+	source           string
+	ref              string
+	serverURL        string
+	scopeMode        string
+	capturePrompts   bool
+	noCapturePrompts bool
+}
+
+type setupHostRow struct {
+	Host   string `json:"host"`
+	Status string `json:"status"`
+	Error  string `json:"error,omitempty"`
+}
+
+type setupSelectReport struct {
+	Hosts []setupHostRow `json:"hosts"`
+}
+
+func (r setupSelectReport) failed() bool {
+	for _, row := range r.Hosts {
+		if row.Status == "failed" {
+			return true
+		}
+	}
+	return false
+}
+
+func newSetupSelectCommand(state *commandState) *cobra.Command {
+	options := setupSelectOptions{capturePrompts: true}
+	command := &cobra.Command{
+		Use: "select", Short: "Install selected first-class host integrations.", Args: cobra.NoArgs,
+		RunE: func(command *cobra.Command, _ []string) error {
+			selected, err := resolveSetupSelection(command, state.json, options.hosts)
+			if err != nil || selected == nil {
+				return err
+			}
+			if options.noCapturePrompts {
+				options.capturePrompts = false
+			}
+			report := runSetupSelection(command.Context(), state, selected, options)
+			if err := writeSetupSelectReport(state, report); err != nil {
+				return err
+			}
+			if report.failed() {
+				return alreadyReported(errors.New("one or more selected integrations failed"))
+			}
+			return nil
+		},
+	}
+	command.Flags().StringArrayVar(&options.hosts, "host", nil, "First-class host to install. Repeatable. Required with --json or a non-TTY.")
+	command.Flags().StringVar(&options.source, "source", defaultMarketplaceSource, "Git source or local path passed to each selected installer.")
+	command.Flags().StringVar(&options.ref, "ref", defaultMarketplaceRef, "Git ref used for a remote source.")
+	command.Flags().StringVar(&options.serverURL, "server-url", "", "PowerContext Server base URL override for Claude Code and OpenClaw.")
+	command.Flags().StringVar(&options.scopeMode, "scope-mode", "agent", "OpenClaw memory scope mode: agent or project.")
+	command.Flags().BoolVar(&options.capturePrompts, "capture-prompts", true, "Capture Claude Code user prompts as ordinary Source evidence.")
+	command.Flags().BoolVar(&options.noCapturePrompts, "no-capture-prompts", false, "Do not capture Claude Code user prompts.")
+	command.MarkFlagsMutuallyExclusive("capture-prompts", "no-capture-prompts")
+	return command
+}
+
+func runSetupSelection(
+	ctx context.Context,
+	state *commandState,
+	selected []string,
+	options setupSelectOptions,
+) setupSelectReport {
+	selectedHosts := make(map[string]bool, len(selected))
+	for _, host := range selected {
+		selectedHosts[host] = true
+	}
+	report := setupSelectReport{Hosts: make([]setupHostRow, 0, len(firstClassIntegrationHosts))}
+	for _, host := range firstClassIntegrationHosts {
+		row := setupHostRow{Host: host.name, Status: "skipped"}
+		if selectedHosts[host.name] {
+			row.Status = "installed"
+			if err := runSelectedSetupHost(ctx, state, host.name, options); err != nil {
+				row.Status = "failed"
+				row.Error = err.Error()
+			}
+		}
+		report.Hosts = append(report.Hosts, row)
+	}
+	return report
+}
+
+func runSelectedSetupHost(
+	ctx context.Context,
+	state *commandState,
+	host string,
+	options setupSelectOptions,
+) error {
+	isolated := *state
+	isolated.stdout = io.Discard
+	isolated.stderr = io.Discard
+	isolated.json = true
+
+	var command *cobra.Command
+	switch host {
+	case "codex":
+		command = newSetupCodexCommand(&isolated)
+	case "claude-code":
+		command = newSetupClaudeCodeCommand(&isolated)
+	case "dsh":
+		command = newSetupDSHCommand(&isolated)
+	case "openclaw":
+		command = newSetupOpenClawCommand(&isolated)
+	case "opencode":
+		command = newSetupOpenCodeCommand(&isolated)
+	case "pi":
+		command = newSetupPiCommand(&isolated)
+	case "hermes":
+		command = newSetupHermesCommand(&isolated)
+	default:
+		return fmt.Errorf("unknown host: %s", host)
+	}
+	arguments := []string{"--source", options.source, "--ref", options.ref}
+	if host == "claude-code" {
+		if options.serverURL != "" {
+			arguments = append(arguments, "--server-url", options.serverURL)
+		}
+		if !options.capturePrompts {
+			arguments = append(arguments, "--no-capture-prompts")
+		}
+	}
+	if host == "openclaw" {
+		if options.serverURL != "" {
+			arguments = append(arguments, "--server-url", options.serverURL)
+		}
+		arguments = append(arguments, "--scope-mode", options.scopeMode)
+	}
+	command.SetOut(io.Discard)
+	command.SetErr(io.Discard)
+	command.SetArgs(arguments)
+	if err := command.ExecuteContext(ctx); err != nil {
+		return err
+	}
+	if host == "opencode" {
+		checks := runOpenCodeDiagnostics(ctx, state.system)
+		if diagnosticsStatus(checks) != "ok" {
+			return setupVerificationError(checks)
+		}
+	}
+	return nil
+}
+
+func setupVerificationError(checks map[string]diagnostic) error {
+	failures := make([]string, 0, len(checks))
+	for _, name := range []string{"codex", "claude_code", "dsh", "openclaw", "opencode", "pi", "hermes", "plugin", "package", "skill"} {
+		check, ok := checks[name]
+		if ok && !check.OK {
+			failures = append(failures, name+": "+check.Detail)
+		}
+	}
+	if len(failures) == 0 {
+		return errors.New("post-install verification failed")
+	}
+	return errors.New("post-install verification failed: " + strings.Join(failures, "; "))
+}
+
+func writeSetupSelectReport(state *commandState, report setupSelectReport) error {
+	if state.json {
+		return writeJSON(state.stdout, report)
+	}
+	installed := false
+	hermesInstalled := false
+	for _, row := range report.Hosts {
+		if row.Status == "failed" {
+			if _, err := fmt.Fprintf(state.stdout, "%s: failed - %s\n", row.Host, row.Error); err != nil {
+				return err
+			}
+			continue
+		}
+		if _, err := fmt.Fprintf(state.stdout, "%s: %s\n", row.Host, row.Status); err != nil {
+			return err
+		}
+		installed = installed || row.Status == "installed"
+		hermesInstalled = hermesInstalled || row.Host == "hermes" && row.Status == "installed"
+	}
+	if installed {
+		if _, err := fmt.Fprintln(state.stdout, "Next: run `powercontext server run`, then start a new host session."); err != nil {
+			return err
+		}
+	}
+	if hermesInstalled {
+		_, err := fmt.Fprintln(state.stdout, "Hermes: run `hermes memory setup` and select PowerContext before starting Hermes.")
+		return err
+	}
+	return nil
+}
+
+func resolveSetupSelection(command *cobra.Command, jsonOutput bool, requested []string) ([]string, error) {
+	if len(requested) != 0 {
+		return normalizeSetupHosts(requested)
+	}
+	if jsonOutput {
+		return nil, errors.New("setup select --json requires --host")
+	}
+	if !setupInputIsTerminal(command.InOrStdin()) {
+		return nil, errors.New("setup select requires --host when stdin is not a TTY")
+	}
+	if err := writeSetupHostCatalog(command.OutOrStdout()); err != nil {
+		return nil, err
+	}
+	line, err := bufio.NewReader(command.InOrStdin()).ReadString('\n')
+	if err != nil && !errors.Is(err, io.EOF) {
+		return nil, err
+	}
+	return parseSetupHostSelection(line)
+}
+
+func normalizeSetupHosts(requested []string) ([]string, error) {
+	selected := make(map[string]bool, len(requested))
+	for _, token := range requested {
+		name, err := resolveSetupHostToken(strings.TrimSpace(token))
+		if err != nil {
+			return nil, err
+		}
+		selected[name] = true
+	}
+	result := make([]string, 0, len(selected))
+	for _, host := range firstClassIntegrationHosts {
+		if selected[host.name] {
+			result = append(result, host.name)
+		}
+	}
+	return result, nil
+}
+
+func parseSetupHostSelection(value string) ([]string, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil, nil
+	}
+	return normalizeSetupHosts(strings.Split(value, ","))
+}
+
+func resolveSetupHostToken(token string) (string, error) {
+	for index, host := range firstClassIntegrationHosts {
+		if token == host.name || token == fmt.Sprint(index+1) {
+			return host.name, nil
+		}
+	}
+	names := make([]string, 0, len(firstClassIntegrationHosts))
+	for _, host := range firstClassIntegrationHosts {
+		names = append(names, host.name)
+	}
+	return "", fmt.Errorf("unknown host: %s. Choose from: %s", token, strings.Join(names, ", "))
+}
+
+func writeSetupHostCatalog(output io.Writer) error {
+	if _, err := fmt.Fprintln(output, "Official first-class integrations:"); err != nil {
+		return err
+	}
+	for index, host := range firstClassIntegrationHosts {
+		if _, err := fmt.Fprintf(output, "  %d) %s (%s)\n", index+1, host.label, host.name); err != nil {
+			return err
+		}
+	}
+	_, err := fmt.Fprintln(output, "Select hosts by number or name (comma-separated), or press Enter to cancel:")
+	return err
+}
+
+type setupTerminalInput interface {
+	SetupInputIsTerminal() bool
+}
+
+func setupInputIsTerminal(input io.Reader) bool {
+	if terminal, ok := input.(setupTerminalInput); ok {
+		return terminal.SetupInputIsTerminal()
+	}
+	file, ok := input.(*os.File)
+	if !ok {
+		return false
+	}
+	return term.IsTerminal(int(file.Fd()))
+}

--- a/internal/cli/setup_select.go
+++ b/internal/cli/setup_select.go
@@ -32,6 +32,7 @@ type setupSelectOptions struct {
 	source           string
 	ref              string
 	serverURL        string
+	serverURLSet     bool
 	scopeMode        string
 	capturePrompts   bool
 	noCapturePrompts bool
@@ -61,6 +62,7 @@ func newSetupSelectCommand(state *commandState) *cobra.Command {
 	command := &cobra.Command{
 		Use: "select", Short: "Install selected first-class host integrations.", Args: cobra.NoArgs,
 		RunE: func(command *cobra.Command, _ []string) error {
+			options.serverURLSet = command.Flags().Changed("server-url")
 			selected, err := resolveSetupSelection(command, state.json, options.hosts)
 			if err != nil || selected == nil {
 				return err
@@ -146,7 +148,7 @@ func runSelectedSetupHost(
 	}
 	arguments := []string{"--source", options.source, "--ref", options.ref}
 	if host == "claude-code" {
-		if options.serverURL != "" {
+		if options.serverURLSet {
 			arguments = append(arguments, "--server-url", options.serverURL)
 		}
 		if !options.capturePrompts {
@@ -154,7 +156,7 @@ func runSelectedSetupHost(
 		}
 	}
 	if host == "openclaw" {
-		if options.serverURL != "" {
+		if options.serverURLSet {
 			arguments = append(arguments, "--server-url", options.serverURL)
 		}
 		arguments = append(arguments, "--scope-mode", options.scopeMode)

--- a/internal/cli/setup_select_test.go
+++ b/internal/cli/setup_select_test.go
@@ -57,18 +57,46 @@ func TestSetupSelectNonTTYRequiresHostBeforeInstalling(t *testing.T) {
 	assertNoSetupCommands(t, commands)
 }
 
-func TestSetupSelectTreatsNullDeviceAsNonTTY(t *testing.T) {
-	input, err := os.Open(os.DevNull)
-	if err != nil {
-		t.Fatal(err)
+func TestSetupSelectTreatsNonTerminalFilesAsNonTTY(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		open func(*testing.T) *os.File
+	}{
+		{
+			name: "null device",
+			open: func(t *testing.T) *os.File {
+				input, err := os.Open(os.DevNull)
+				if err != nil {
+					t.Fatal(err)
+				}
+				t.Cleanup(func() { _ = input.Close() })
+				return input
+			},
+		},
+		{
+			name: "pipe",
+			open: func(t *testing.T) *os.File {
+				input, output, err := os.Pipe()
+				if err != nil {
+					t.Fatal(err)
+				}
+				if err := output.Close(); err != nil {
+					t.Fatal(err)
+				}
+				t.Cleanup(func() { _ = input.Close() })
+				return input
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			commands := &scriptedSystemCommands{t: t}
+			_, _, err := executeSystemCLIWithInput(t, commands, test.open(t), "setup", "select")
+			if err == nil || ExitCode(err) != 1 || !strings.Contains(err.Error(), "--host") {
+				t.Fatalf("setup select error = %v, exit = %d", err, ExitCode(err))
+			}
+			assertNoSetupCommands(t, commands)
+		})
 	}
-	t.Cleanup(func() { _ = input.Close() })
-	commands := &scriptedSystemCommands{t: t}
-	_, _, err = executeSystemCLIWithInput(t, commands, input, "setup", "select")
-	if err == nil || ExitCode(err) != 1 || !strings.Contains(err.Error(), "--host") {
-		t.Fatalf("setup select error = %v, exit = %d", err, ExitCode(err))
-	}
-	assertNoSetupCommands(t, commands)
 }
 
 func TestSetupSelectRejectsUnknownHostBeforeInstalling(t *testing.T) {
@@ -357,6 +385,45 @@ func TestSetupSelectPassesSourceRefAndClaudeOptions(t *testing.T) {
 	options := settings["pluginConfigs"].(map[string]any)[claudePluginID].(map[string]any)["options"].(map[string]any)
 	if options["server_url"] != "https://memory.example" || options["capture_prompts"] != false {
 		t.Fatalf("Claude options = %#v", options)
+	}
+}
+
+func TestSetupSelectPreservesExplicitBlankServerURL(t *testing.T) {
+	for _, test := range []struct {
+		host     string
+		want     string
+		commands func(*testing.T) *scriptedSystemCommands
+	}{
+		{
+			host: "claude-code", want: "PowerContext Server URL must use HTTP or HTTPS",
+			commands: successfulClaudeCommands,
+		},
+		{
+			host: "openclaw", want: "OpenClaw PowerContext Server URL must use HTTP or HTTPS",
+			commands: func(t *testing.T) *scriptedSystemCommands {
+				return &scriptedSystemCommands{
+					t: t, paths: map[string]string{"openclaw": "/usr/bin/openclaw"},
+					results: []systemCommandResult{{output: "OpenClaw 2026.8.1-beta.2\n"}},
+				}
+			},
+		},
+	} {
+		t.Run(test.host, func(t *testing.T) {
+			t.Setenv("CLAUDE_CONFIG_DIR", filepath.Join(t.TempDir(), "claude"))
+			t.Setenv("POWERCONTEXT_HOME", filepath.Join(t.TempDir(), "data"))
+			commands := test.commands(t)
+			stdout, _, err := executeSystemCLIWithInput(
+				t, commands, strings.NewReader(""),
+				"setup", "select", "--host", test.host, "--server-url", "", "--json",
+			)
+			if err == nil || !ErrorAlreadyReported(err) || ExitCode(err) != 1 {
+				t.Fatalf("setup select error = %v, exit = %d", err, ExitCode(err))
+			}
+			assertSetupRow(t, setupRowsByHost(t, stdout), test.host, "failed", test.want)
+			if len(commands.calls) != 0 {
+				t.Fatalf("explicit blank server URL ran external commands: %v", commands.calls)
+			}
+		})
 	}
 }
 

--- a/internal/cli/setup_select_test.go
+++ b/internal/cli/setup_select_test.go
@@ -1,0 +1,562 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSetupWithoutSubcommandPrintsHelpAndInstallsNothing(t *testing.T) {
+	commands := &scriptedSystemCommands{t: t}
+	stdout, _, err := executeSystemCLIWithInput(t, commands, strings.NewReader(""), "setup")
+	if err == nil || ExitCode(err) != 2 {
+		t.Fatalf("setup error = %v, exit = %d", err, ExitCode(err))
+	}
+	if !strings.Contains(stdout, "Usage:") || !strings.Contains(stdout, "Install and configure PowerContext integrations.") {
+		t.Fatalf("setup output = %q", stdout)
+	}
+	assertNoSetupCommands(t, commands)
+}
+
+func TestSetupSelectJSONRequiresHostBeforeInstalling(t *testing.T) {
+	commands := &scriptedSystemCommands{t: t}
+	_, _, err := executeSystemCLIWithInput(t, commands, strings.NewReader(""), "setup", "select", "--json")
+	if err == nil || ExitCode(err) != 1 || !strings.Contains(err.Error(), "--host") {
+		t.Fatalf("setup select error = %v, exit = %d", err, ExitCode(err))
+	}
+	assertNoSetupCommands(t, commands)
+}
+
+func TestSetupSelectNonTTYRequiresHostBeforeInstalling(t *testing.T) {
+	commands := &scriptedSystemCommands{t: t}
+	_, _, err := executeSystemCLIWithInput(t, commands, strings.NewReader(""), "setup", "select")
+	if err == nil || ExitCode(err) != 1 || !strings.Contains(err.Error(), "--host") {
+		t.Fatalf("setup select error = %v, exit = %d", err, ExitCode(err))
+	}
+	assertNoSetupCommands(t, commands)
+}
+
+func TestSetupSelectTreatsNullDeviceAsNonTTY(t *testing.T) {
+	input, err := os.Open(os.DevNull)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = input.Close() })
+	commands := &scriptedSystemCommands{t: t}
+	_, _, err = executeSystemCLIWithInput(t, commands, input, "setup", "select")
+	if err == nil || ExitCode(err) != 1 || !strings.Contains(err.Error(), "--host") {
+		t.Fatalf("setup select error = %v, exit = %d", err, ExitCode(err))
+	}
+	assertNoSetupCommands(t, commands)
+}
+
+func TestSetupSelectRejectsUnknownHostBeforeInstalling(t *testing.T) {
+	commands := &scriptedSystemCommands{t: t}
+	_, _, err := executeSystemCLIWithInput(
+		t, commands, strings.NewReader(""), "setup", "select", "--host", "unknown",
+	)
+	if err == nil || ExitCode(err) != 1 || !strings.Contains(err.Error(), "unknown host: unknown") ||
+		!strings.Contains(err.Error(), "codex") {
+		t.Fatalf("setup select error = %v, exit = %d", err, ExitCode(err))
+	}
+	assertNoSetupCommands(t, commands)
+}
+
+func TestSetupSelectInstallsOnlyRequestedHostsAndDeduplicatesFlags(t *testing.T) {
+	t.Setenv("POWERCONTEXT_HOME", filepath.Join(t.TempDir(), "data"))
+	commands := successfulCodexCommands(t, 1)
+	stdout, _, err := executeSystemCLIWithInput(
+		t, commands, strings.NewReader(""),
+		"setup", "select", "--host", "codex", "--host", "codex", "--json",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(stdout, "Select hosts") || strings.Contains(stdout, "Next:") {
+		t.Fatalf("JSON output contains interactive or human text: %q", stdout)
+	}
+	rows := setupRowsByHost(t, stdout)
+	assertSetupRow(t, rows, "codex", "installed", "")
+	for _, host := range []string{"claude-code", "dsh", "openclaw", "opencode", "pi", "hermes"} {
+		assertSetupRow(t, rows, host, "skipped", "")
+	}
+	if got := fmt.Sprint(commands.lookups); got != "[codex codex]" {
+		t.Fatalf("PATH lookups = %s", got)
+	}
+	if len(commands.calls) != 3 {
+		t.Fatalf("external commands = %v", commands.calls)
+	}
+}
+
+func TestSetupSelectContinuesAfterSelectedHostFails(t *testing.T) {
+	t.Setenv("POWERCONTEXT_HOME", filepath.Join(t.TempDir(), "data"))
+	t.Setenv("CLAUDE_CONFIG_DIR", filepath.Join(t.TempDir(), "claude"))
+	commands := successfulClaudeCommands(t)
+	stdout, _, err := executeSystemCLIWithInput(
+		t, commands, strings.NewReader(""),
+		"setup", "select", "--host", "codex", "--host", "claude-code", "--json",
+	)
+	if err == nil || !ErrorAlreadyReported(err) || ExitCode(err) != 1 {
+		t.Fatalf("setup select error = %v, exit = %d", err, ExitCode(err))
+	}
+	rows := setupRowsByHost(t, stdout)
+	assertSetupRow(t, rows, "codex", "failed", "Codex CLI is not installed or is not on PATH")
+	assertSetupRow(t, rows, "claude-code", "installed", "")
+	for _, host := range []string{"dsh", "openclaw", "opencode", "pi", "hermes"} {
+		assertSetupRow(t, rows, host, "skipped", "")
+	}
+	if got := fmt.Sprint(commands.lookups); got != "[codex claude]" {
+		t.Fatalf("PATH lookups = %s", got)
+	}
+}
+
+func TestSetupSelectHumanReportIncludesFailureAndContinues(t *testing.T) {
+	t.Setenv("POWERCONTEXT_HOME", filepath.Join(t.TempDir(), "data"))
+	t.Setenv("CLAUDE_CONFIG_DIR", filepath.Join(t.TempDir(), "claude"))
+	commands := successfulClaudeCommands(t)
+	stdout, _, err := executeSystemCLIWithInput(
+		t, commands, strings.NewReader(""), "setup", "select", "--host", "codex", "--host", "claude-code",
+	)
+	if err == nil || !ErrorAlreadyReported(err) || ExitCode(err) != 1 {
+		t.Fatalf("setup select error = %v, exit = %d", err, ExitCode(err))
+	}
+	for _, fragment := range []string{
+		"codex: failed - Codex CLI is not installed or is not on PATH",
+		"claude-code: installed",
+		"dsh: skipped",
+		"Next:",
+	} {
+		if !strings.Contains(stdout, fragment) {
+			t.Fatalf("setup select output %q does not contain %q", stdout, fragment)
+		}
+	}
+}
+
+func TestSetupSelectReportsSuccessfulRerunAsInstalled(t *testing.T) {
+	t.Setenv("POWERCONTEXT_HOME", filepath.Join(t.TempDir(), "data"))
+	commands := successfulCodexCommands(t, 2)
+	for attempt := range 2 {
+		stdout, _, err := executeSystemCLIWithInput(
+			t, commands, strings.NewReader(""), "setup", "select", "--host", "codex", "--json",
+		)
+		if err != nil {
+			t.Fatalf("attempt %d: %v", attempt+1, err)
+		}
+		assertSetupRow(t, setupRowsByHost(t, stdout), "codex", "installed", "")
+	}
+}
+
+func TestSetupSelectContinuesAfterPostInstallVerificationFails(t *testing.T) {
+	t.Setenv("POWERCONTEXT_HOME", filepath.Join(t.TempDir(), "data"))
+	t.Setenv("CLAUDE_CONFIG_DIR", filepath.Join(t.TempDir(), "claude"))
+	commands := successfulClaudeCommands(t)
+	commands.paths["codex"] = "/usr/bin/codex"
+	commands.results = append([]systemCommandResult{
+		{output: `{"marketplaceName":"powercontext","alreadyAdded":false}`},
+		{output: `{"name":"powercontext","version":"0.1.0"}`},
+		{output: `{"installed":[]}`},
+	}, commands.results...)
+	stdout, _, err := executeSystemCLIWithInput(
+		t, commands, strings.NewReader(""),
+		"setup", "select", "--host", "codex", "--host", "claude-code", "--json",
+	)
+	if err == nil || !ErrorAlreadyReported(err) || ExitCode(err) != 1 {
+		t.Fatalf("setup select error = %v, exit = %d", err, ExitCode(err))
+	}
+	rows := setupRowsByHost(t, stdout)
+	assertSetupRow(
+		t, rows, "codex", "failed",
+		"post-install verification failed: plugin: PowerContext plugin is not installed",
+	)
+	assertSetupRow(t, rows, "claude-code", "installed", "")
+}
+
+func TestSetupSelectFailsOpenCodeRowWhenActivationVerificationFails(t *testing.T) {
+	checkout := filepath.Join(t.TempDir(), "checkout")
+	plugin := writeOpenCodePlugin(t, checkout)
+	config := filepath.Join(t.TempDir(), "config")
+	t.Setenv("POWERCONTEXT_HOME", filepath.Join(t.TempDir(), "data"))
+	base := &scriptedSystemCommands{
+		t: t, paths: map[string]string{"opencode": "/usr/bin/opencode"},
+		results: []systemCommandResult{
+			{output: "1.18.21\n"},
+			{output: "config " + config + "\n"},
+			{},
+			{output: "1.18.21\n"},
+			{output: "config " + config + "\n"},
+			{output: fmt.Sprintf(`{"plugin":[%q]}`, plugin)},
+		},
+	}
+	commands := &environmentAwareCommands{scriptedSystemCommands: base}
+	commands.runEnv = func(ctx context.Context, _ map[string]string, executable string, arguments ...string) ([]byte, error) {
+		return base.Run(ctx, executable, arguments...)
+	}
+	stdout, _, err := executeSystemCLIWithInput(
+		t, commands, strings.NewReader(""),
+		"setup", "select", "--host", "opencode", "--source", checkout, "--json",
+	)
+	if err == nil || !ErrorAlreadyReported(err) || ExitCode(err) != 1 {
+		t.Fatalf("setup select error = %v, exit = %d", err, ExitCode(err))
+	}
+	assertSetupRow(
+		t, setupRowsByHost(t, stdout), "opencode", "failed",
+		"post-install verification failed: plugin: PowerContext OpenCode plugin is configured but did not activate",
+	)
+}
+
+func TestSetupSelectFailsRowsWhenPostInstallVerificationFails(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		host    string
+		prepare func(*testing.T) (systemCommandExecutor, []string)
+		want    string
+	}{
+		{
+			name: "dsh", host: "dsh", want: "post-install verification failed: plugin: PowerContext DSH plugin is not installed",
+			prepare: func(t *testing.T) (systemCommandExecutor, []string) {
+				checkout := filepath.Join(t.TempDir(), "checkout")
+				plugin := filepath.Join(checkout, "integrations", "dsh", "plugins", "powercontext")
+				writeTestFile(t, filepath.Join(plugin, "package.json"), `{"name":"powercontext-dsh"}`)
+				writeTestFile(t, filepath.Join(plugin, "lib", "index.js"), "export default {}\n")
+				t.Setenv("POWERCONTEXT_HOME", filepath.Join(t.TempDir(), "data"))
+				commands := &scriptedSystemCommands{
+					t: t, paths: map[string]string{"dsh": "/usr/bin/dsh"},
+					results: []systemCommandResult{{}, {output: "plugins:\n"}},
+				}
+				return commands, []string{"--source", checkout}
+			},
+		},
+		{
+			name: "pi", host: "pi", want: "post-install verification failed: package: PowerContext Pi package is not installed",
+			prepare: func(t *testing.T) (systemCommandExecutor, []string) {
+				checkout := filepath.Join(t.TempDir(), "checkout")
+				writePiPackage(t, checkout)
+				t.Setenv("POWERCONTEXT_HOME", filepath.Join(t.TempDir(), "data"))
+				commands := &scriptedSystemCommands{
+					t: t, paths: map[string]string{"pi": "/usr/bin/pi"},
+					results: []systemCommandResult{{}, {output: "User packages:\n"}, {output: "User packages:\n"}},
+				}
+				return commands, []string{"--source", checkout}
+			},
+		},
+		{
+			name: "hermes", host: "hermes", want: "post-install verification failed: plugin: provider doctor failed",
+			prepare: func(t *testing.T) (systemCommandExecutor, []string) {
+				checkout := filepath.Join(t.TempDir(), "checkout")
+				writeHermesPlugin(t, checkout)
+				t.Setenv("HERMES_HOME", filepath.Join(t.TempDir(), "hermes"))
+				t.Setenv("POWERCONTEXT_HOME", filepath.Join(t.TempDir(), "data"))
+				commands := &scriptedSystemCommands{
+					t: t, paths: map[string]string{"hermes": "/usr/bin/hermes"},
+					results: []systemCommandResult{
+						{output: "Hermes Agent v0.20.4\n"},
+						{},
+						{output: "Hermes Agent v0.20.4\n"},
+						{err: errors.New("provider doctor failed")},
+					},
+				}
+				return commands, []string{"--source", checkout}
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			commands, extra := test.prepare(t)
+			arguments := []string{"setup", "select", "--host", test.host, "--json"}
+			arguments = append(arguments, extra...)
+			stdout, _, err := executeSystemCLIWithInput(t, commands, strings.NewReader(""), arguments...)
+			if err == nil || !ErrorAlreadyReported(err) || ExitCode(err) != 1 {
+				t.Fatalf("setup select error = %v, exit = %d", err, ExitCode(err))
+			}
+			assertSetupRow(t, setupRowsByHost(t, stdout), test.host, "failed", test.want)
+		})
+	}
+}
+
+func TestSetupSelectPrintsHermesNextStepOnlyWhenInstalled(t *testing.T) {
+	checkout := filepath.Join(t.TempDir(), "checkout")
+	writeHermesPlugin(t, checkout)
+	t.Setenv("HERMES_HOME", filepath.Join(t.TempDir(), "hermes"))
+	t.Setenv("POWERCONTEXT_HOME", filepath.Join(t.TempDir(), "data"))
+	hermesCommands := &scriptedSystemCommands{
+		t: t, paths: map[string]string{"hermes": "/usr/bin/hermes"},
+		results: []systemCommandResult{
+			{output: "Hermes Agent v0.20.4\n"}, {}, {output: "Hermes Agent v0.20.4\n"}, {},
+		},
+	}
+	installed, _, err := executeSystemCLIWithInput(
+		t, hermesCommands, strings.NewReader(""),
+		"setup", "select", "--host", "hermes", "--source", checkout,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(installed, "`hermes memory setup`") {
+		t.Fatalf("Hermes setup output = %q", installed)
+	}
+
+	codexCommands := successfulCodexCommands(t, 1)
+	other, _, err := executeSystemCLIWithInput(
+		t, codexCommands, strings.NewReader(""), "setup", "select", "--host", "codex",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(other, "`hermes memory setup`") {
+		t.Fatalf("non-Hermes setup output = %q", other)
+	}
+}
+
+func TestSetupSelectPassesSourceRefAndClaudeOptions(t *testing.T) {
+	config := filepath.Join(t.TempDir(), "claude")
+	t.Setenv("CLAUDE_CONFIG_DIR", config)
+	t.Setenv("POWERCONTEXT_HOME", filepath.Join(t.TempDir(), "data"))
+	commands := successfulClaudeCommands(t)
+	stdout, _, err := executeSystemCLIWithInput(
+		t, commands, strings.NewReader(""),
+		"setup", "select", "--host", "claude-code",
+		"--source", "ob-labs/custom-powercontext", "--ref", "tested-ref",
+		"--server-url", "https://memory.example", "--no-capture-prompts", "--json",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertSetupRow(t, setupRowsByHost(t, stdout), "claude-code", "installed", "")
+	calls := strings.Join(commandCallStrings(commands.calls), "\n")
+	if !strings.Contains(calls, "plugin marketplace add ob-labs/custom-powercontext@tested-ref --scope user") {
+		t.Fatalf("Claude commands = %s", calls)
+	}
+	content, err := os.ReadFile(filepath.Join(config, "settings.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var settings map[string]any
+	if err := json.Unmarshal(content, &settings); err != nil {
+		t.Fatal(err)
+	}
+	options := settings["pluginConfigs"].(map[string]any)[claudePluginID].(map[string]any)["options"].(map[string]any)
+	if options["server_url"] != "https://memory.example" || options["capture_prompts"] != false {
+		t.Fatalf("Claude options = %#v", options)
+	}
+}
+
+func TestSetupSelectPassesServerAndScopeOverridesToOpenClaw(t *testing.T) {
+	checkout := filepath.Join(t.TempDir(), "checkout")
+	plugin := writeOpenClawPlugin(t, checkout)
+	t.Setenv("POWERCONTEXT_HOME", filepath.Join(t.TempDir(), "data"))
+	commands := &scriptedSystemCommands{
+		t: t, paths: map[string]string{"openclaw": "/usr/bin/openclaw", "pnpm": "/usr/bin/pnpm"},
+		results: []systemCommandResult{
+			{output: "OpenClaw 2026.8.1-beta.2\n"},
+			{},
+			{after: func(systemCommandCall) {
+				bundle := filepath.Join(plugin, "dist", "index.js")
+				if err := os.MkdirAll(filepath.Dir(bundle), 0o755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(bundle, []byte("export default {}\n"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}},
+			{},
+			{err: errors.New("missing gateway mode")},
+			{},
+			{output: `[]`},
+			{},
+			{},
+		},
+	}
+	stdout, _, err := executeSystemCLIWithInput(
+		t, commands, strings.NewReader(""),
+		"setup", "select", "--host", "openclaw", "--source", checkout, "--ref", "tested-ref",
+		"--server-url", "https://memory.example", "--scope-mode", "project", "--json",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertSetupRow(t, setupRowsByHost(t, stdout), "openclaw", "installed", "")
+	var settings []map[string]any
+	if call := commands.calls[5]; len(call.arguments) != 4 ||
+		json.Unmarshal([]byte(call.arguments[3]), &settings) != nil {
+		t.Fatalf("OpenClaw batch settings command = %v", call)
+	}
+	values := make(map[string]any, len(settings))
+	for _, setting := range settings {
+		values[setting["path"].(string)] = setting["value"]
+	}
+	if values["plugins.entries.memory-powercontext.config.endpoint"] != "https://memory.example" ||
+		values["plugins.entries.memory-powercontext.config.scopeMode"] != "project" {
+		t.Fatalf("OpenClaw settings = %#v", values)
+	}
+}
+
+func TestSetupSelectReadsTTYSelectionByNumber(t *testing.T) {
+	t.Setenv("POWERCONTEXT_HOME", filepath.Join(t.TempDir(), "data"))
+	commands := successfulCodexCommands(t, 1)
+	stdout, _, err := executeSystemCLIWithInput(
+		t, commands, setupTTYInput{Reader: strings.NewReader("1\n")}, "setup", "select",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, fragment := range []string{
+		"Official first-class integrations:", "1) Codex (codex)", "3) DeepSeek Harness (dsh)",
+		"Select hosts", "codex: installed", "claude-code: skipped", "Next:",
+	} {
+		if !strings.Contains(stdout, fragment) {
+			t.Fatalf("setup select output %q does not contain %q", stdout, fragment)
+		}
+	}
+}
+
+func TestSetupSelectCancelsEmptyTTYSelection(t *testing.T) {
+	commands := &scriptedSystemCommands{t: t}
+	stdout, _, err := executeSystemCLIWithInput(
+		t, commands, setupTTYInput{Reader: strings.NewReader("\n")}, "setup", "select",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stdout, "Select hosts") || strings.Contains(stdout, "codex: skipped") {
+		t.Fatalf("setup select cancel output = %q", stdout)
+	}
+	assertNoSetupCommands(t, commands)
+}
+
+func TestSetupSelectRejectsInvalidTTYTokenBeforeInstalling(t *testing.T) {
+	commands := &scriptedSystemCommands{t: t}
+	_, _, err := executeSystemCLIWithInput(
+		t, commands, setupTTYInput{Reader: strings.NewReader("nope\n")}, "setup", "select",
+	)
+	if err == nil || !strings.Contains(err.Error(), "unknown host: nope") {
+		t.Fatalf("setup select error = %v", err)
+	}
+	assertNoSetupCommands(t, commands)
+}
+
+func TestParseSetupHostSelectionAcceptsNamesAndCatalogNumbers(t *testing.T) {
+	for _, test := range []struct {
+		input string
+		want  string
+	}{
+		{input: "dsh,codex", want: "[codex dsh]"},
+		{input: "4", want: "[openclaw]"},
+		{input: "5", want: "[opencode]"},
+		{input: "7", want: "[hermes]"},
+		{input: "", want: "[]"},
+		{input: "  ", want: "[]"},
+	} {
+		got, err := parseSetupHostSelection(test.input)
+		if err != nil || fmt.Sprint(got) != test.want {
+			t.Errorf("parseSetupHostSelection(%q) = %v, %v; want %s", test.input, got, err, test.want)
+		}
+	}
+}
+
+func executeSystemCLIWithInput(
+	t *testing.T,
+	commands systemCommandExecutor,
+	input io.Reader,
+	arguments ...string,
+) (string, string, error) {
+	t.Helper()
+	var stdout, stderr bytes.Buffer
+	command := newCommandWithAllDependencies(
+		VersionInfo{Version: "0.0.1"}, &stdout, &stderr, nil, nil, commands,
+	)
+	command.SetIn(input)
+	command.SetArgs(arguments)
+	err := command.ExecuteContext(t.Context())
+	return stdout.String(), stderr.String(), err
+}
+
+func assertNoSetupCommands(t *testing.T, commands *scriptedSystemCommands) {
+	t.Helper()
+	if len(commands.lookups) != 0 || len(commands.calls) != 0 {
+		t.Fatalf("setup inspected PATH or ran commands: lookups=%v calls=%v", commands.lookups, commands.calls)
+	}
+}
+
+func setupRowsByHost(t *testing.T, output string) map[string]map[string]any {
+	t.Helper()
+	payload := decodeSystemOutput(t, output)
+	values, ok := payload["hosts"].([]any)
+	if !ok || len(values) != len(firstClassIntegrationHosts) {
+		t.Fatalf("setup select payload = %#v", payload)
+	}
+	rows := make(map[string]map[string]any, len(values))
+	for _, value := range values {
+		row, ok := value.(map[string]any)
+		if !ok {
+			t.Fatalf("setup select row = %#v", value)
+		}
+		host, _ := row["host"].(string)
+		rows[host] = row
+	}
+	return rows
+}
+
+func assertSetupRow(t *testing.T, rows map[string]map[string]any, host, status, detail string) {
+	t.Helper()
+	row := rows[host]
+	if row["host"] != host || row["status"] != status {
+		t.Fatalf("setup row %s = %#v", host, row)
+	}
+	got, _ := row["error"].(string)
+	if got != detail {
+		t.Fatalf("setup row %s error = %q, want %q", host, got, detail)
+	}
+}
+
+type setupTTYInput struct {
+	*strings.Reader
+}
+
+func (setupTTYInput) SetupInputIsTerminal() bool { return true }
+
+func successfulCodexCommands(t *testing.T, repetitions int) *scriptedSystemCommands {
+	t.Helper()
+	results := make([]systemCommandResult, 0, repetitions*3)
+	for range repetitions {
+		results = append(results,
+			systemCommandResult{output: `{"marketplaceName":"powercontext","alreadyAdded":false}`},
+			systemCommandResult{output: `{"name":"powercontext","version":"0.1.0"}`},
+			systemCommandResult{output: `{"installed":[{"name":"powercontext","pluginId":"powercontext@powercontext","installed":true,"enabled":true}]}`},
+		)
+	}
+	return &scriptedSystemCommands{t: t, paths: map[string]string{"codex": "/usr/bin/codex"}, results: results}
+}
+
+func successfulClaudeCommands(t *testing.T) *scriptedSystemCommands {
+	t.Helper()
+	return &scriptedSystemCommands{
+		t: t, paths: map[string]string{"claude": "/usr/bin/claude"},
+		results: []systemCommandResult{
+			{output: `[]`},
+			{output: `[]`},
+			{},
+			{},
+			{output: `[{"id":"powercontext@powercontext","version":"0.1.0","enabled":true}]`},
+		},
+	}
+}

--- a/test/conformance/parity-inventory-rules.json
+++ b/test/conformance/parity-inventory-rules.json
@@ -211,7 +211,112 @@
     },
     "tests/test_setup_select.py": {
       "mode": "go-port",
-      "reason": "Interactive/non-interactive host selection CLI; the CLI is Go (internal/cli)."
+      "reason": "Interactive/non-interactive host selection CLI; the CLI is Go (internal/cli).",
+      "cases": {
+        "test_setup_without_subcommand_prints_help_and_installs_nothing": {
+          "evidence": [
+            "go:internal/cli/setup_select_test.go#TestSetupWithoutSubcommandPrintsHelpAndInstallsNothing"
+          ]
+        },
+        "test_setup_select_json_without_host_does_not_install": {
+          "evidence": [
+            "go:internal/cli/setup_select_test.go#TestSetupSelectJSONRequiresHostBeforeInstalling"
+          ]
+        },
+        "test_setup_select_without_host_requires_host_on_a_non_tty": {
+          "evidence": [
+            "go:internal/cli/setup_select_test.go#TestSetupSelectNonTTYRequiresHostBeforeInstalling"
+          ]
+        },
+        "test_setup_select_rejects_an_unknown_host_before_installing": {
+          "evidence": [
+            "go:internal/cli/setup_select_test.go#TestSetupSelectRejectsUnknownHostBeforeInstalling"
+          ]
+        },
+        "test_setup_select_installs_only_the_requested_hosts": {
+          "evidence": [
+            "go:internal/cli/setup_select_test.go#TestSetupSelectInstallsOnlyRequestedHostsAndDeduplicatesFlags"
+          ]
+        },
+        "test_setup_select_continues_after_a_selected_host_fails": {
+          "evidence": [
+            "go:internal/cli/setup_select_test.go#TestSetupSelectContinuesAfterSelectedHostFails"
+          ]
+        },
+        "test_setup_select_reports_an_unavailable_selected_host_and_continues": {
+          "evidence": [
+            "go:internal/cli/setup_select_test.go#TestSetupSelectHumanReportIncludesFailureAndContinues"
+          ]
+        },
+        "test_setup_select_reports_a_successful_rerun_as_installed": {
+          "evidence": [
+            "go:internal/cli/setup_select_test.go#TestSetupSelectReportsSuccessfulRerunAsInstalled"
+          ]
+        },
+        "test_setup_select_reads_a_tty_selection_by_number": {
+          "evidence": [
+            "go:internal/cli/setup_select_test.go#TestSetupSelectReadsTTYSelectionByNumber"
+          ]
+        },
+        "test_setup_select_cancels_an_empty_tty_selection": {
+          "evidence": [
+            "go:internal/cli/setup_select_test.go#TestSetupSelectCancelsEmptyTTYSelection"
+          ]
+        },
+        "test_setup_select_rejects_an_invalid_tty_token_without_installing": {
+          "evidence": [
+            "go:internal/cli/setup_select_test.go#TestSetupSelectRejectsInvalidTTYTokenBeforeInstalling"
+          ]
+        },
+        "test_setup_select_deduplicates_repeated_host_flags": {
+          "evidence": [
+            "go:internal/cli/setup_select_test.go#TestSetupSelectInstallsOnlyRequestedHostsAndDeduplicatesFlags"
+          ]
+        },
+        "test_setup_select_json_writes_the_matrix_without_a_prompt": {
+          "evidence": [
+            "go:internal/cli/setup_select_test.go#TestSetupSelectInstallsOnlyRequestedHostsAndDeduplicatesFlags"
+          ]
+        },
+        "test_setup_select_passes_source_ref_and_host_specific_defaults": {
+          "evidence": [
+            "go:internal/cli/setup_select_test.go#TestSetupSelectPassesSourceRefAndClaudeOptions",
+            "go:internal/cli/integration_hosts_test.go#TestOpenClawSetupFlagsPreservePythonDefaults"
+          ]
+        },
+        "test_setup_select_passes_server_and_scope_overrides_to_openclaw": {
+          "evidence": [
+            "go:internal/cli/setup_select_test.go#TestSetupSelectPassesServerAndScopeOverridesToOpenClaw"
+          ]
+        },
+        "test_setup_select_fails_a_row_when_post_install_verification_fails": {
+          "evidence": [
+            "go:internal/cli/setup_select_test.go#TestSetupSelectContinuesAfterPostInstallVerificationFails",
+            "go:internal/cli/setup_select_test.go#TestSetupSelectFailsRowsWhenPostInstallVerificationFails",
+            "go:internal/cli/setup_select_test.go#TestSetupSelectFailsOpenCodeRowWhenActivationVerificationFails"
+          ]
+        },
+        "test_setup_select_continues_after_post_install_verification_fails": {
+          "evidence": [
+            "go:internal/cli/setup_select_test.go#TestSetupSelectContinuesAfterPostInstallVerificationFails"
+          ]
+        },
+        "test_setup_select_prints_hermes_specific_next_step_only_when_installed": {
+          "evidence": [
+            "go:internal/cli/setup_select_test.go#TestSetupSelectPrintsHermesNextStepOnlyWhenInstalled"
+          ]
+        },
+        "test_setup_dsh_still_fails_closed_when_the_cli_is_missing": {
+          "evidence": [
+            "go:internal/cli/system_contract_test.go#TestSetupDSHReportsMissingCLI"
+          ]
+        },
+        "test_parse_host_selection_accepts_names_and_reorders_to_the_catalog": {
+          "evidence": [
+            "go:internal/cli/setup_select_test.go#TestParseSetupHostSelectionAcceptsNamesAndCatalogNumbers"
+          ]
+        }
+      }
     },
     "tests/test_transport.py": {
       "mode": "go-port",

--- a/test/conformance/parity-inventory.json
+++ b/test/conformance/parity-inventory.json
@@ -4,8 +4,8 @@
   "oracle_commit": "3a6cb0151670eaff7dc0293466edd673124e80da",
   "python_test_file_count": 127,
   "python_test_case_count": 759,
-  "mapped_case_count": 660,
-  "pending_case_count": 99,
+  "mapped_case_count": 680,
+  "pending_case_count": 79,
   "entries": [
     {
       "python": {
@@ -11671,8 +11671,15 @@
         "line": 89
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/setup_select_test.go",
+          "test": "TestSetupWithoutSubcommandPrintsHelpAndInstallsNothing"
+        }
+      ]
     },
     {
       "python": {
@@ -11681,8 +11688,15 @@
         "line": 100
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/setup_select_test.go",
+          "test": "TestSetupSelectJSONRequiresHostBeforeInstalling"
+        }
+      ]
     },
     {
       "python": {
@@ -11691,8 +11705,15 @@
         "line": 110
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/setup_select_test.go",
+          "test": "TestSetupSelectNonTTYRequiresHostBeforeInstalling"
+        }
+      ]
     },
     {
       "python": {
@@ -11701,8 +11722,15 @@
         "line": 121
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/setup_select_test.go",
+          "test": "TestSetupSelectRejectsUnknownHostBeforeInstalling"
+        }
+      ]
     },
     {
       "python": {
@@ -11711,8 +11739,15 @@
         "line": 132
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/setup_select_test.go",
+          "test": "TestSetupSelectInstallsOnlyRequestedHostsAndDeduplicatesFlags"
+        }
+      ]
     },
     {
       "python": {
@@ -11721,8 +11756,15 @@
         "line": 160
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/setup_select_test.go",
+          "test": "TestSetupSelectContinuesAfterSelectedHostFails"
+        }
+      ]
     },
     {
       "python": {
@@ -11731,8 +11773,15 @@
         "line": 188
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/setup_select_test.go",
+          "test": "TestSetupSelectHumanReportIncludesFailureAndContinues"
+        }
+      ]
     },
     {
       "python": {
@@ -11741,8 +11790,15 @@
         "line": 203
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/setup_select_test.go",
+          "test": "TestSetupSelectReportsSuccessfulRerunAsInstalled"
+        }
+      ]
     },
     {
       "python": {
@@ -11751,8 +11807,15 @@
         "line": 215
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/setup_select_test.go",
+          "test": "TestSetupSelectReadsTTYSelectionByNumber"
+        }
+      ]
     },
     {
       "python": {
@@ -11761,8 +11824,15 @@
         "line": 236
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/setup_select_test.go",
+          "test": "TestSetupSelectCancelsEmptyTTYSelection"
+        }
+      ]
     },
     {
       "python": {
@@ -11771,8 +11841,15 @@
         "line": 246
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/setup_select_test.go",
+          "test": "TestSetupSelectRejectsInvalidTTYTokenBeforeInstalling"
+        }
+      ]
     },
     {
       "python": {
@@ -11781,8 +11858,15 @@
         "line": 257
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/setup_select_test.go",
+          "test": "TestSetupSelectInstallsOnlyRequestedHostsAndDeduplicatesFlags"
+        }
+      ]
     },
     {
       "python": {
@@ -11791,8 +11875,15 @@
         "line": 266
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/setup_select_test.go",
+          "test": "TestSetupSelectInstallsOnlyRequestedHostsAndDeduplicatesFlags"
+        }
+      ]
     },
     {
       "python": {
@@ -11801,8 +11892,20 @@
         "line": 280
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/setup_select_test.go",
+          "test": "TestSetupSelectPassesSourceRefAndClaudeOptions"
+        },
+        {
+          "kind": "go",
+          "file": "internal/cli/integration_hosts_test.go",
+          "test": "TestOpenClawSetupFlagsPreservePythonDefaults"
+        }
+      ]
     },
     {
       "python": {
@@ -11811,8 +11914,15 @@
         "line": 317
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/setup_select_test.go",
+          "test": "TestSetupSelectPassesServerAndScopeOverridesToOpenClaw"
+        }
+      ]
     },
     {
       "python": {
@@ -11821,8 +11931,25 @@
         "line": 350
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/setup_select_test.go",
+          "test": "TestSetupSelectContinuesAfterPostInstallVerificationFails"
+        },
+        {
+          "kind": "go",
+          "file": "internal/cli/setup_select_test.go",
+          "test": "TestSetupSelectFailsRowsWhenPostInstallVerificationFails"
+        },
+        {
+          "kind": "go",
+          "file": "internal/cli/setup_select_test.go",
+          "test": "TestSetupSelectFailsOpenCodeRowWhenActivationVerificationFails"
+        }
+      ]
     },
     {
       "python": {
@@ -11831,8 +11958,15 @@
         "line": 375
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/setup_select_test.go",
+          "test": "TestSetupSelectContinuesAfterPostInstallVerificationFails"
+        }
+      ]
     },
     {
       "python": {
@@ -11841,8 +11975,15 @@
         "line": 392
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/setup_select_test.go",
+          "test": "TestSetupSelectPrintsHermesNextStepOnlyWhenInstalled"
+        }
+      ]
     },
     {
       "python": {
@@ -11851,8 +11992,15 @@
         "line": 403
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/system_contract_test.go",
+          "test": "TestSetupDSHReportsMissingCLI"
+        }
+      ]
     },
     {
       "python": {
@@ -11861,8 +12009,15 @@
         "line": 412
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/setup_select_test.go",
+          "test": "TestParseSetupHostSelectionAcceptsNamesAndCatalogNumbers"
+        }
+      ]
     },
     {
       "python": {


### PR DESCRIPTION
## Summary

- add `powercontext setup select` for ordered multi-host setup with repeatable `--host` selection
- isolate per-host installation and post-install verification failures while preserving existing single-host setup behavior
- support TTY selection, non-interactive validation, JSON/human matrices, host-specific overrides, and Hermes guidance
- map all 20 upstream `tests/test_setup_select.py` cases and regenerate the parity inventory from 660/99 to 680/79
- use a real terminal query so null devices and pipes cannot enter the interactive prompt path

## Verification

- `go test ./internal/cli -count=1`
- `go test ./test/conformance -run TestParityInventory -count=1`
- `go run ./tools/parity-inventory-generate -upstream <f2ec1f75... checkout> -check`
- `go mod tidy` with no subsequent module diff

## Dependency

PR #90 is merged; this branch was rebuilt on current `main` after #98 and #99 landed.