### PR TITLE
ci: check test worktree cleanliness

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -217,6 +217,20 @@ jobs:
       - name: Run end-to-end tests
         run: make e2e-test
 
+      - name: Verify repository cleanliness after test execution
+        if: always()
+        shell: bash
+        run: |
+          status="$(git status --porcelain)"
+          if test -n "$status"; then
+            count="$(printf '%s\n' "$status" | wc -l | tr -d '[:space:]')"
+            printf '%s\n' "$status" | sed -n '1,100p'
+            if test "$count" -gt 100; then
+              printf '... %s additional paths omitted\n' "$((count - 100))"
+            fi
+            exit 1
+          fi
+
   pi-package:
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/tools/release/workflow_test.go
+++ b/tools/release/workflow_test.go
@@ -662,6 +662,40 @@ func TestMigrationGeneratedConsumersRunsFreshConsumerVerification(t *testing.T) 
 	}
 }
 
+func TestMainTestsJobChecksRepositoryCleanlinessAfterTestExecution(t *testing.T) {
+	repository := filepath.Clean(filepath.Join("..", ".."))
+	payload, err := os.ReadFile(filepath.Join(repository, ".github", "workflows", "master.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var workflow struct {
+		Jobs map[string]struct {
+			Steps []migrationWorkflowStep `yaml:"steps"`
+		} `yaml:"jobs"`
+	}
+	if err := yaml.Unmarshal(payload, &workflow); err != nil {
+		t.Fatal(err)
+	}
+	job, ok := workflow.Jobs["tests"]
+	if !ok {
+		t.Fatal("master.yml has no tests job")
+	}
+	if len(job.Steps) == 0 {
+		t.Fatal("master.yml tests job has no steps")
+	}
+	want := migrationWorkflowStep{
+		Name:  "Verify repository cleanliness after test execution",
+		If:    "always()",
+		Shell: "bash",
+		Run:   boundedGitStatusCleanlinessScript(),
+	}
+	got := job.Steps[len(job.Steps)-1]
+	got.Run = strings.TrimSpace(got.Run)
+	if got != want {
+		t.Fatalf("master.yml final tests step = %#v, want %#v", got, want)
+	}
+}
+
 func TestFrozenOracleGeneratorsUseTemporaryGoldenOutput(t *testing.T) {
 	repository := filepath.Clean(filepath.Join("..", ".."))
 	payload, err := os.ReadFile(filepath.Join(repository, ".github", "workflows", "migration-gates.yml"))


### PR DESCRIPTION
## Summary

- add an always-run, bounded `git status --porcelain` check after the Main unit and end-to-end test job
- preserve the existing 100-path diagnostic cap and make the check the final tests-job step
- lock the workflow contract with a parsed YAML regression test

Part of #3; this does not close WP0.

## Verification

- `go test -count=1 -run '^TestMainTestsJobChecksRepositoryCleanlinessAfterTestExecution$' ./tools/release`
- `go vet ./tools/release`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12`