### PR TITLE
build: pin repository-local workflow tools

### DIFF
--- a/.github/workflows/migration-gates.yml
+++ b/.github/workflows/migration-gates.yml
@@ -22,7 +22,7 @@ jobs:
         uses: ./.github/actions/setup-go-env
 
       - name: Lint GitHub Actions workflows
-        run: go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
+        run: make actionlint
 
       - name: Verify generated contracts
         run: make check-generated

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,6 @@ GOCACHE ?=
 GOMODCACHE ?=
 PNPM ?= pnpm
 UV ?= uv
-LICENSE_EYE ?= $(GO) run github.com/apache/skywalking-eyes/cmd/license-eye@v0.8.0
 
 TOOLS_BIN := $(CURDIR)/.tools/bin
 GOLANGCI_LINT_VERSION := v2.13.1
@@ -25,6 +24,12 @@ APIDIFF_STAMP = $(TOOLS_BIN)/.apidiff-$(APIDIFF_VERSION)-$(PROJECT_GO_TOOLCHAIN)
 GOVULNCHECK_VERSION := v1.7.0
 GOVULNCHECK := $(TOOLS_BIN)/govulncheck$(shell $(GO) env GOEXE)
 GOVULNCHECK_STAMP = $(TOOLS_BIN)/.govulncheck-$(GOVULNCHECK_VERSION)-$(PROJECT_GO_TOOLCHAIN)
+LICENSE_EYE_VERSION := v0.8.0
+LICENSE_EYE := $(TOOLS_BIN)/license-eye$(shell $(GO) env GOEXE)
+LICENSE_EYE_STAMP = $(TOOLS_BIN)/.license-eye-$(LICENSE_EYE_VERSION)-$(PROJECT_GO_TOOLCHAIN)
+ACTIONLINT_VERSION := v1.7.12
+ACTIONLINT := $(TOOLS_BIN)/actionlint$(shell $(GO) env GOEXE)
+ACTIONLINT_STAMP = $(TOOLS_BIN)/.actionlint-$(ACTIONLINT_VERSION)-$(PROJECT_GO_TOOLCHAIN)
 
 COVERAGE_DIR ?= coverage
 COVERAGE_PROFILE ?= $(COVERAGE_DIR)/coverage.out
@@ -66,7 +71,7 @@ PUBLIC_API_PACKAGES := \
 	$(MODULE_PATH)/source \
 	$(MODULE_PATH)/trigger
 
-.PHONY: help lint-tools lint lint-fix api-compat-tools api-baseline api-compat govulncheck-tools dependency-security generate check-generated module-check module-inventory module-integrity contract-test license-check license-fix license-dependencies fmt fmt-check vet build-all coverage coverage-check governance-check \
+.PHONY: help lint-tools lint lint-fix api-compat-tools api-baseline api-compat govulncheck-tools license-eye-tools actionlint-tools actionlint dependency-security generate check-generated module-check module-inventory module-integrity contract-test license-check license-fix license-dependencies fmt fmt-check vet build-all coverage coverage-check governance-check \
 	test unit-test e2e-test test-sqlite race-debt-check race-debt-functional test-race test-full test-oceanbase-live real-provider-test \
 	pi-test docs-sync docs-test docs-build harness-sync harness-check harness-compose-check \
 	harness-compose-acceptance harness-compose-down build build-full smoke smoke-full check \
@@ -140,6 +145,31 @@ $(GOVULNCHECK_STAMP): $(GOVULNCHECK)
 
 govulncheck-tools: $(GOVULNCHECK_STAMP) ## Install the pinned Go vulnerability scanner.
 
+$(LICENSE_EYE): Makefile go.mod go.sum
+	@mkdir -p "$(TOOLS_BIN)"
+	GOTOOLCHAIN="$(PROJECT_GO_TOOLCHAIN)+auto" GOBIN="$(TOOLS_BIN)" \
+		$(GO) install github.com/apache/skywalking-eyes/cmd/license-eye@$(LICENSE_EYE_VERSION)
+
+$(LICENSE_EYE_STAMP): $(LICENSE_EYE)
+	@$(GO) version -m "$(LICENSE_EYE)" | awk '$$1 == "mod" && $$2 == "github.com/apache/skywalking-eyes" && $$3 == "$(LICENSE_EYE_VERSION)" { found = 1 } END { exit !found }'
+	@touch "$@"
+
+license-eye-tools: $(LICENSE_EYE_STAMP) ## Install the pinned license checker under .tools/bin.
+
+$(ACTIONLINT): Makefile go.mod go.sum
+	@mkdir -p "$(TOOLS_BIN)"
+	GOTOOLCHAIN="$(PROJECT_GO_TOOLCHAIN)+auto" GOBIN="$(TOOLS_BIN)" \
+		$(GO) install github.com/rhysd/actionlint/cmd/actionlint@$(ACTIONLINT_VERSION)
+
+$(ACTIONLINT_STAMP): $(ACTIONLINT)
+	@$(GO) version -m "$(ACTIONLINT)" | awk '$$1 == "mod" && $$2 == "github.com/rhysd/actionlint" && $$3 == "$(ACTIONLINT_VERSION)" { found = 1 } END { exit !found }'
+	@touch "$@"
+
+actionlint-tools: $(ACTIONLINT_STAMP) ## Install the pinned GitHub Actions workflow linter under .tools/bin.
+
+actionlint: actionlint-tools ## Lint GitHub Actions workflows with the pinned repository-local tool.
+	"$(ACTIONLINT)"
+
 dependency-security: govulncheck-tools ## Scan an unstripped standard Server build for known vulnerabilities.
 	mkdir -p bin
 	CGO_ENABLED=1 $(GO) build -tags '$(STANDARD_TAGS)' -trimpath \
@@ -186,10 +216,10 @@ contract-test: check-generated ## Test the generated OpenAPI transport contract.
 	CGO_ENABLED=1 $(GO) test -tags '$(STANDARD_TAGS)' \
 		./openapi ./api/v1 ./client ./internal/httpapi ./internal/mcpapi ./server
 
-license-check: ## Verify required Apache-2.0 source headers.
+license-check: license-eye-tools ## Verify required Apache-2.0 source headers.
 	$(LICENSE_EYE) -c .licenserc.yaml header check
 
-license-fix: ## Repair eligible source headers and recheck them.
+license-fix: license-eye-tools ## Repair eligible source headers and recheck them.
 	$(LICENSE_EYE) -c .licenserc.yaml header fix
 	$(LICENSE_EYE) -c .licenserc.yaml header check
 

--- a/tools/release/workflow_test.go
+++ b/tools/release/workflow_test.go
@@ -1017,54 +1017,42 @@ func TestWorkflowsReuseTheGoSetup(t *testing.T) {
 	}
 }
 
-func TestGoSetupRestoresRepositoryLocalToolCache(t *testing.T) {
+func TestMakefilePinsWorkflowGoToolsInTheRepositoryToolDirectory(t *testing.T) {
 	repository := filepath.Clean(filepath.Join("..", ".."))
-	type actionStep struct {
-		Name string            `yaml:"name"`
-		Uses string            `yaml:"uses"`
-		With map[string]string `yaml:"with"`
+	payload, err := os.ReadFile(filepath.Join(repository, "Makefile"))
+	if err != nil {
+		t.Fatal(err)
 	}
-	type compositeAction struct {
-		Name string `yaml:"name"`
-		Runs struct {
-			Steps []actionStep `yaml:"steps"`
-		} `yaml:"runs"`
-	}
-
-	var setupGo compositeAction
-	readCompositeAction(t, filepath.Join(repository, ".github", "actions", "setup-go-env", "action.yml"), &setupGo)
-	if len(setupGo.Runs.Steps) != 3 || setupGo.Runs.Steps[2].Uses != "./.github/actions/setup-tools" {
-		t.Fatalf("setup-go-env steps = %#v, want setup-tools after locked module verification", setupGo.Runs.Steps)
-	}
-
-	var setupTools compositeAction
-	readCompositeAction(t, filepath.Join(repository, ".github", "actions", "setup-tools", "action.yml"), &setupTools)
-	if setupTools.Name != "Setup repository tools" || len(setupTools.Runs.Steps) != 1 {
-		t.Fatalf("setup-tools action = %#v", setupTools)
-	}
-	cache := setupTools.Runs.Steps[0]
-	if cache.Name != "Restore repository-local tool cache" ||
-		cache.Uses != "actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9" {
-		t.Fatalf("setup-tools cache action = %#v", cache)
-	}
-	if cache.With["path"] != ".tools/bin" {
-		t.Fatalf("setup-tools cache path = %q", cache.With["path"])
-	}
-	for _, required := range []string{"runner.os", "Makefile", "go.mod", "go.sum", ".golangci.yml", "tools/**"} {
-		if !strings.Contains(cache.With["key"], required) {
-			t.Errorf("setup-tools cache key is missing %q: %q", required, cache.With["key"])
+	contents := string(payload)
+	for _, required := range []string{
+		"LICENSE_EYE_VERSION := v0.8.0",
+		"github.com/apache/skywalking-eyes/cmd/license-eye@$(LICENSE_EYE_VERSION)",
+		"ACTIONLINT_VERSION := v1.7.12",
+		"github.com/rhysd/actionlint/cmd/actionlint@$(ACTIONLINT_VERSION)",
+		"license-eye-tools:",
+		"actionlint-tools:",
+		"license-check: license-eye-tools",
+		"license-fix: license-eye-tools",
+		"actionlint: actionlint-tools",
+	} {
+		if !strings.Contains(contents, required) {
+			t.Errorf("Makefile is missing pinned repository-local tool contract %q", required)
 		}
 	}
 }
 
-func readCompositeAction(t *testing.T, path string, destination any) {
-	t.Helper()
-	payload, err := os.ReadFile(path)
+func TestMigrationWorkflowRunsThePinnedActionlintTarget(t *testing.T) {
+	repository := filepath.Clean(filepath.Join("..", ".."))
+	payload, err := os.ReadFile(filepath.Join(repository, ".github", "workflows", "migration-gates.yml"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := yaml.Unmarshal(payload, destination); err != nil {
-		t.Fatal(err)
+	contents := string(payload)
+	if !strings.Contains(contents, "run: make actionlint") {
+		t.Fatal("migration-gates.yml does not run the repository-local actionlint target")
+	}
+	if strings.Contains(contents, "go run github.com/rhysd/actionlint") {
+		t.Fatal("migration-gates.yml bypasses the pinned repository-local actionlint target")
 	}
 }
 

--- a/tools/release/workflow_test.go
+++ b/tools/release/workflow_test.go
@@ -1171,7 +1171,8 @@ func TestLicenseHeadersHaveOneLocalRepairAndCIContract(t *testing.T) {
 	repository := filepath.Clean(filepath.Join("..", ".."))
 	tests := map[string][]string{
 		"Makefile": {
-			"github.com/apache/skywalking-eyes/cmd/license-eye@v0.8.0",
+			"github.com/apache/skywalking-eyes/cmd/license-eye@$(LICENSE_EYE_VERSION)",
+			"LICENSE_EYE_VERSION := v0.8.0",
 			"license-check:",
 			"header check",
 			"license-fix:",


### PR DESCRIPTION
## Summary

- move License Eye and Actionlint from direct `go run module@version` invocations into pinned `.tools/bin` targets
- verify each cached binary's embedded module path and exact version before recording its toolchain-scoped stamp
- make both `license-check` and `license-fix` depend on the same pinned License Eye target
- route migration workflow linting through `make actionlint`, so it uses the shared repository-local cache

Part of #3; this does not close WP0.

## Verification

- `go test -timeout 30s -count=1 -run '^(TestMakefilePinsWorkflowGoToolsInTheRepositoryToolDirectory|TestMigrationWorkflowRunsThePinnedActionlintTarget)$' ./tools/release`
- `go vet ./tools/release`
- `make --dry-run actionlint license-check license-fix`
- Local `make actionlint` reached the fixed v1.7.12 install command but could not contact `proxy.golang.org`; exact PR CI must execute the real linter.