### PR TITLE
ci: classify owned Go modules

### DIFF
--- a/test/module-inventory.json
+++ b/test/module-inventory.json
@@ -1,7 +1,11 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "modules": [
-    {"path": "."},
-    {"path": "test/downstream"}
-  ]
+    {"path": ".", "kind": "production"},
+    {"path": "test/downstream", "kind": "external-consumer"}
+  ],
+  "generated_consumers": {
+    "mode": "temporary",
+    "package": "tools/generated-consumers"
+  }
 }

--- a/tools/module-integrity/main.go
+++ b/tools/module-integrity/main.go
@@ -28,15 +28,22 @@ import (
 	"strings"
 )
 
-const inventorySchemaVersion = 1
+const inventorySchemaVersion = 2
 
 type inventory struct {
-	SchemaVersion int           `json:"schema_version"`
-	Modules       []moduleEntry `json:"modules"`
+	SchemaVersion      int                `json:"schema_version"`
+	Modules            []moduleEntry      `json:"modules"`
+	GeneratedConsumers generatedConsumers `json:"generated_consumers"`
 }
 
 type moduleEntry struct {
 	Path string `json:"path"`
+	Kind string `json:"kind"`
+}
+
+type generatedConsumers struct {
+	Mode    string `json:"mode"`
+	Package string `json:"package"`
 }
 
 func main() {
@@ -106,6 +113,9 @@ func readInventory(ctx context.Context, path string) ([]string, error) {
 	if len(value.Modules) == 0 {
 		return nil, errors.New("module inventory must declare at least one module")
 	}
+	if value.GeneratedConsumers.Mode != "temporary" || value.GeneratedConsumers.Package != "tools/generated-consumers" {
+		return nil, errors.New("module inventory must declare temporary generated consumers from tools/generated-consumers")
+	}
 	paths := make([]string, 0, len(value.Modules))
 	seen := make(map[string]struct{}, len(value.Modules))
 	for _, entry := range value.Modules {
@@ -116,11 +126,30 @@ func readInventory(ctx context.Context, path string) ([]string, error) {
 		if _, exists := seen[path]; exists {
 			return nil, fmt.Errorf("module inventory declares %s more than once", path)
 		}
+		if err := validateModuleKind(path, entry.Kind); err != nil {
+			return nil, err
+		}
 		seen[path] = struct{}{}
 		paths = append(paths, path)
 	}
 	slices.Sort(paths)
 	return paths, nil
+}
+
+func validateModuleKind(path, kind string) error {
+	switch kind {
+	case "production":
+		if strings.HasPrefix(path, "test/") {
+			return fmt.Errorf("production module %s must not be under test/", path)
+		}
+	case "external-consumer":
+		if !strings.HasPrefix(path, "test/") {
+			return fmt.Errorf("external-consumer module %s must be under test/", path)
+		}
+	default:
+		return fmt.Errorf("module %s has unsupported kind %q", path, kind)
+	}
+	return nil
 }
 
 func cleanModulePath(path string) (string, error) {

--- a/tools/module-integrity/main_test.go
+++ b/tools/module-integrity/main_test.go
@@ -21,20 +21,49 @@ import (
 	"testing"
 )
 
-func TestValidateInventoryAcceptsEveryOwnedModule(t *testing.T) {
+func TestValidateInventoryAcceptsClassifiedOwnedModules(t *testing.T) {
 	root := t.TempDir()
 	writeModule(t, root, ".")
 	writeModule(t, root, "test/downstream")
 	inventory := writeInventory(t, root, `{
-  "schema_version": 1,
+  "schema_version": 2,
   "modules": [
-    {"path": "."},
-    {"path": "test/downstream"}
-  ]
+    {"path": ".", "kind": "production"},
+    {"path": "test/downstream", "kind": "external-consumer"}
+  ],
+  "generated_consumers": {"mode": "temporary", "package": "tools/generated-consumers"}
 }`)
 
 	if err := validateInventory(t.Context(), root, inventory); err != nil {
 		t.Fatalf("validate complete module inventory: %v", err)
+	}
+}
+
+func TestReadInventoryRejectsMixedModuleClassifications(t *testing.T) {
+	tests := map[string]string{
+		"production test module": `{
+  "schema_version": 2,
+  "modules": [{"path": "test/downstream", "kind": "production"}],
+  "generated_consumers": {"mode": "temporary", "package": "tools/generated-consumers"}
+}`,
+		"consumer outside test": `{
+  "schema_version": 2,
+  "modules": [{"path": ".", "kind": "external-consumer"}],
+  "generated_consumers": {"mode": "temporary", "package": "tools/generated-consumers"}
+}`,
+		"persistent generated consumer": `{
+  "schema_version": 2,
+  "modules": [{"path": ".", "kind": "production"}],
+  "generated_consumers": {"mode": "checked-in", "package": "tools/generated-consumers"}
+}`,
+	}
+	for name, contents := range tests {
+		t.Run(name, func(t *testing.T) {
+			inventory := writeInventory(t, t.TempDir(), contents)
+			if _, err := readInventory(t.Context(), inventory); err == nil {
+				t.Fatal("readInventory accepted an invalid module classification")
+			}
+		})
 	}
 }
 
@@ -43,10 +72,11 @@ func TestValidateInventoryRejectsUninventoriedNestedModule(t *testing.T) {
 	writeModule(t, root, ".")
 	writeModule(t, root, "test/downstream")
 	inventory := writeInventory(t, root, `{
-  "schema_version": 1,
+  "schema_version": 2,
   "modules": [
-    {"path": "."}
-  ]
+    {"path": ".", "kind": "production"}
+  ],
+  "generated_consumers": {"mode": "temporary", "package": "tools/generated-consumers"}
 }`)
 
 	err := validateInventory(t.Context(), root, inventory)
@@ -60,10 +90,11 @@ func TestValidateInventoryRejectsOwnedModuleBelowGeneratedLikeDirectory(t *testi
 	writeModule(t, root, ".")
 	writeModule(t, root, "tools/bin/owned")
 	inventory := writeInventory(t, root, `{
-  "schema_version": 1,
+  "schema_version": 2,
   "modules": [
-    {"path": "."}
-  ]
+    {"path": ".", "kind": "production"}
+  ],
+  "generated_consumers": {"mode": "temporary", "package": "tools/generated-consumers"}
 }`)
 
 	err := validateInventory(t.Context(), root, inventory)
@@ -103,10 +134,11 @@ func TestValidateInventoryRejectsRepositoryParentPath(t *testing.T) {
 	root := t.TempDir()
 	writeModule(t, root, ".")
 	inventory := writeInventory(t, root, `{
-  "schema_version": 1,
+  "schema_version": 2,
   "modules": [
-    {"path": ".."}
-  ]
+    {"path": "..", "kind": "production"}
+  ],
+  "generated_consumers": {"mode": "temporary", "package": "tools/generated-consumers"}
 }`)
 
 	err := validateInventory(t.Context(), root, inventory)
@@ -135,11 +167,12 @@ func TestValidateInventoryRejectsInvalidChecksum(t *testing.T) {
 			writeModule(t, root, "test/downstream")
 			invalidate(t, filepath.Join(root, "test", "downstream", "go.sum"))
 			inventory := writeInventory(t, root, `{
-  "schema_version": 1,
+  "schema_version": 2,
   "modules": [
-    {"path": "."},
-    {"path": "test/downstream"}
-  ]
+    {"path": ".", "kind": "production"},
+    {"path": "test/downstream", "kind": "external-consumer"}
+  ],
+  "generated_consumers": {"mode": "temporary", "package": "tools/generated-consumers"}
 }`)
 
 			err := validateInventory(t.Context(), root, inventory)

--- a/tools/release/makefile_test.go
+++ b/tools/release/makefile_test.go
@@ -373,16 +373,30 @@ func expectedModuleIntegrityCalls(t *testing.T, repository string) []string {
 	}
 	type moduleEntry struct {
 		Path string `json:"path"`
+		Kind string `json:"kind"`
 	}
 	var inventory struct {
-		SchemaVersion int           `json:"schema_version"`
-		Modules       []moduleEntry `json:"modules"`
+		SchemaVersion      int           `json:"schema_version"`
+		Modules            []moduleEntry `json:"modules"`
+		GeneratedConsumers struct {
+			Mode    string `json:"mode"`
+			Package string `json:"package"`
+		} `json:"generated_consumers"`
 	}
 	if decodeErr := json.Unmarshal(payload, &inventory, json.RejectUnknownMembers(true)); decodeErr != nil {
 		t.Fatal(decodeErr)
 	}
-	if inventory.SchemaVersion != 1 {
-		t.Fatalf("module inventory schema_version = %d, want 1", inventory.SchemaVersion)
+	if inventory.SchemaVersion != 2 {
+		t.Fatalf("module inventory schema_version = %d, want 2", inventory.SchemaVersion)
+	}
+	if inventory.GeneratedConsumers.Mode != "temporary" || inventory.GeneratedConsumers.Package != "tools/generated-consumers" {
+		t.Fatalf("generated consumer inventory = %#v", inventory.GeneratedConsumers)
+	}
+	for _, module := range inventory.Modules {
+		if module.Path == "." && module.Kind != "production" ||
+			module.Path == "test/downstream" && module.Kind != "external-consumer" {
+			t.Fatalf("module inventory entry = %#v", module)
+		}
 	}
 	slices.SortFunc(inventory.Modules, func(left, right moduleEntry) int {
 		return cmp.Compare(left.Path, right.Path)


### PR DESCRIPTION
## Summary

- upgrade the owned Go module inventory to schema v2 with explicit module kinds
- identify the root as `production` and `test/downstream` as an `external-consumer`
- declare generated consumer modules as temporary outputs owned by `tools/generated-consumers`
- reject production modules under `test/`, external consumers outside `test/`, and non-temporary generated consumers

Part of #3; this does not close WP0.

## Verification

- `go test -timeout 45s -count=1 ./tools/module-integrity`
- `go vet ./tools/module-integrity`
- `git diff --check`