### PR TITLE
test: verify repeated Server stop

### DIFF
--- a/tools/process-smoke/main.go
+++ b/tools/process-smoke/main.go
@@ -305,7 +305,10 @@ func runPhase(
 	stopCtx, stopCancel := context.WithTimeout(context.Background(), 20*time.Second)
 	defer stopCancel()
 	stopErr := process.stop(stopCtx)
-	return errors.Join(exerciseErr, stopErr)
+	if stopErr != nil {
+		return errors.Join(exerciseErr, stopErr)
+	}
+	return errors.Join(exerciseErr, process.stop(stopCtx))
 }
 
 func availablePort() (int, error) {

--- a/tools/process-smoke/main_test.go
+++ b/tools/process-smoke/main_test.go
@@ -160,3 +160,21 @@ func TestFrozenBaseToolNamesAreUnique(t *testing.T) {
 		t.Fatalf("base MCP tools = %d, want 20", len(seen))
 	}
 }
+
+func TestStoppedServerProcessCanBeStoppedAgain(t *testing.T) {
+	log, err := os.CreateTemp(t.TempDir(), "server.log")
+	if err != nil {
+		t.Fatal(err)
+	}
+	process := &serverProcess{log: log, done: make(chan struct{})}
+	close(process.done)
+
+	for range 2 {
+		if err := process.stop(t.Context()); err != nil {
+			t.Fatalf("stop completed Server: %v", err)
+		}
+	}
+	if _, err := log.Write([]byte("closed")); err == nil {
+		t.Fatal("stop did not close the completed Server log")
+	}
+}


### PR DESCRIPTION
## Summary

- require each real release-smoke Server phase to stop successfully twice after a graceful SIGTERM
- preserve first-stop diagnostics and only perform the repeat assertion after the first stop succeeds
- add a focused regression test for repeated stop on an already completed process and one-time log closure

Part of #3; this does not close WP0.

## Verification

- `go test -timeout 45s -count=1 ./tools/process-smoke`
- `go vet ./tools/process-smoke`
- `git diff --check`