### PR TITLE
feat(workbuddy): add bounded recall integration

### DIFF
--- a/.github/workflows/migration-gates.yml
+++ b/.github/workflows/migration-gates.yml
@@ -424,6 +424,7 @@ jobs:
           uv run --with pytest pytest integrations/claude-code/tests
           uv run --with pytest --with pydantic --with httpx pytest integrations/hermes/tests
           uv run --project integrations/langgraph --locked --with pytest pytest integrations/langgraph/tests
+          uv run --with pytest pytest integrations/workbuddy/tests
 
       - name: Set up pnpm
         uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -294,6 +294,15 @@ source / artifact / trigger / inference
   host-vector fixture. Verify the complete IPv4 `127.0.0.0/8` range, IPv6
   loopback, remote plaintext rejection, and each explicit trusted-transport
   exception in the adapter's native test suite.
+- When setup owns a credential-free authorization environment reference, treat
+  every syntactically valid generated `${NAME:-}` reference as owned rather
+  than only the default name. Verify repeated setup with a custom authorization
+  environment preserves the no-token persistence contract.
+- When an installed host adapter has a persisted credential-free configuration
+  file, treat an invalid existing file as authoritative failure-open input
+  instead of falling back to legacy environment configuration. Verify through
+  the host hook entrypoint that invalid persisted configuration emits no
+  recalled context.
 - When a documentation contract test extracts executable shell commands, stop
   parsing at a shell comment before deciding that a command exists. Verify a
   fully commented command cannot satisfy executable-documentation evidence and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -306,3 +306,7 @@ source / artifact / trigger / inference
   terminal query instead of treating every character device as a TTY. Verify
   null devices and pipes remain non-interactive while a controlled terminal
   input still enables the prompt path.
+- When setup returns a host-home path after resolving symlinks, compare tests
+  against the same resolved path rather than the raw input path. Verify a
+  symlinked temporary-root path and an ordinary path so platform aliases such
+  as macOS `/var` cannot cause a false setup failure.

--- a/integrations/workbuddy/README.md
+++ b/integrations/workbuddy/README.md
@@ -1,0 +1,29 @@
+# WorkBuddy integration
+
+The WorkBuddy adapter recalls bounded project context before a submitted user
+prompt and captures that prompt as a PowerContext Source. It also registers the
+PowerContext Streamable HTTP MCP endpoint. Hook failures always leave the host
+prompt flow intact.
+
+Install the checked-in adapter with:
+
+```sh
+powercontext setup workbuddy
+```
+
+Installation writes a credential-free configuration at
+`$WORKBUDDY_HOME/powercontext.json` (or `~/.workbuddy/powercontext.json`). It
+contains the Server URL, scope mode, request limits, and the name of the
+optional authorization environment variable. The authorization value itself is
+read only when the Hook or MCP client runs and is never written by setup.
+
+Run `powercontext doctor workbuddy` to check the installed Python Hook,
+configuration, MCP registration, Skill ownership, and the configured Server
+health endpoints. It reports fixed diagnostic categories and does not print
+configuration credentials, prompt content, retrieved context, or scope IDs.
+
+Adapter-only tests run without a WorkBuddy installation:
+
+```sh
+uv run --with pytest pytest integrations/workbuddy/tests
+```

--- a/integrations/workbuddy/plugins/powercontext/hooks/hooks.workbuddy.json
+++ b/integrations/workbuddy/plugins/powercontext/hooks/hooks.workbuddy.json
@@ -1,0 +1,17 @@
+{
+  "description": "Recall bounded PowerContext context and capture a WorkBuddy prompt.",
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${POWERCONTEXT_PYTHON}\" \"${WORKBUDDY_HOOKS_DIR}/workbuddy_powercontext_hook.py\"",
+            "timeout": 10,
+            "statusMessage": "Syncing PowerContext"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrations/workbuddy/plugins/powercontext/hooks/workbuddy_powercontext_hook.py
+++ b/integrations/workbuddy/plugins/powercontext/hooks/workbuddy_powercontext_hook.py
@@ -46,18 +46,16 @@ sys.path.insert(0, str(_PLUGIN_ROOT))
 sys.path.insert(0, str(_HOOKS_ROOT))
 
 import prepared_context as _prepared_context  # noqa: E402
-from workbuddy_settings import WorkBuddyPluginSettings  # noqa: E402
+from workbuddy_settings import WorkBuddyConfigurationError, WorkBuddyPluginSettings, load_settings  # noqa: E402
 
 if (_HOOKS_ROOT / "powercontext_project_scope.py").is_file():
     from powercontext_project_scope import resolve_scope_id
 else:
     from scripts.project_scope import resolve_scope_id
 
-_MAX_CONTEXT_BYTES = _prepared_context.MAX_CONTEXT_BYTES
 _InvalidResponseError = _prepared_context.InvalidPreparedContextResponse
 _validate_prepared_context = _prepared_context.validate_prepared_context
 _MAX_RESPONSE_BYTES = 1_048_576
-_MAX_SOURCE_LENGTH = 200_000
 _READ_CHUNK_BYTES = 65_536
 _REQUEST_HEADERS = {
     "Accept": "application/json",
@@ -110,7 +108,7 @@ def main(settings: WorkBuddyPluginSettings | None = None) -> int:
     """Process one WorkBuddy hook payload and fail open."""
 
     try:
-        settings = WorkBuddyPluginSettings.from_environment() if settings is None else settings
+        settings = _settings_from_default_path() if settings is None else settings
         payload = _read_payload()
         if not _is_user_prompt_submit(payload.get("hook_event_name")):
             return 0
@@ -119,7 +117,7 @@ def main(settings: WorkBuddyPluginSettings | None = None) -> int:
         context = None
         if prompt is not None and prompt.strip() and isinstance(cwd, str):
             try:
-                scope_id = resolve_scope_id(cwd, configured_scope_id=settings.scope_id)
+                scope_id = resolve_scope_id(cwd, configured_scope_id=settings.scope_id, scope_mode=settings.scope_mode)
             except Exception:
                 scope_id = None
             if scope_id:
@@ -132,7 +130,7 @@ def main(settings: WorkBuddyPluginSettings | None = None) -> int:
                         deadline=http_deadline,
                     )
 
-                if settings.capture_prompts and len(prompt) <= _MAX_SOURCE_LENGTH:
+                if settings.capture_prompts and len(prompt.encode("utf-8")) <= settings.source_max_bytes:
                     with suppress(Exception):
                         captured = _capture_prompt(
                             payload,
@@ -166,6 +164,14 @@ def main(settings: WorkBuddyPluginSettings | None = None) -> int:
     return 0
 
 
+def _settings_from_default_path() -> WorkBuddyPluginSettings:
+    configured = _PLUGIN_ROOT / "powercontext.json"
+    try:
+        return load_settings(configured)
+    except WorkBuddyConfigurationError:
+        return WorkBuddyPluginSettings.from_environment()
+
+
 def _read_payload() -> dict[str, Any]:
     stdin = sys.stdin
     if hasattr(stdin, "buffer"):
@@ -193,7 +199,7 @@ def _prepare_context(
         {
             "scope_id": scope_id,
             "query": query,
-            "max_bytes": _MAX_CONTEXT_BYTES,
+            "max_bytes": settings.prepare_max_bytes,
         },
         settings=settings,
         deadline=deadline,

--- a/integrations/workbuddy/plugins/powercontext/hooks/workbuddy_powercontext_hook.py
+++ b/integrations/workbuddy/plugins/powercontext/hooks/workbuddy_powercontext_hook.py
@@ -166,10 +166,9 @@ def main(settings: WorkBuddyPluginSettings | None = None) -> int:
 
 def _settings_from_default_path() -> WorkBuddyPluginSettings:
     configured = _PLUGIN_ROOT / "powercontext.json"
-    try:
-        return load_settings(configured)
-    except WorkBuddyConfigurationError:
+    if not configured.is_file():
         return WorkBuddyPluginSettings.from_environment()
+    return load_settings(configured)
 
 
 def _read_payload() -> dict[str, Any]:

--- a/integrations/workbuddy/plugins/powercontext/hooks/workbuddy_settings.py
+++ b/integrations/workbuddy/plugins/powercontext/hooks/workbuddy_settings.py
@@ -21,42 +21,89 @@
 from __future__ import annotations
 
 import os
+import json
+import math
+import re
+from collections.abc import Mapping
 from dataclasses import dataclass
+from pathlib import Path
 from urllib.parse import urlsplit, urlunsplit
 
+_CONFIG_SCHEMA = 1
+_DEFAULT_SERVER_URL = "http://127.0.0.1:8000"
+_DEFAULT_AUTHORIZATION_ENVIRONMENT = "POWERCONTEXT_WORKBUDDY_AUTHORIZATION"
+_DEFAULT_REQUEST_TIMEOUT_SECONDS = 1.5
+_DEFAULT_REQUEST_BUDGET_SECONDS = 3.0
+_DEFAULT_PREPARE_MAX_BYTES = 8_000
+_DEFAULT_SOURCE_MAX_BYTES = 16_384
+_MAX_REQUEST_BUDGET_SECONDS = 10.0
+_MAX_PREPARE_BYTES = 32 * 1024
+_MAX_SOURCE_BYTES = 64 * 1024
 _LOOPBACK_HOSTS = frozenset({"127.0.0.1", "::1", "localhost"})
 _TRUE_VALUES = frozenset({"1", "true", "yes", "on"})
 _FALSE_VALUES = frozenset({"0", "false", "no", "off"})
+_AUTHORIZATION_ENVIRONMENT = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_FIELDS = frozenset(
+    {
+        "schema",
+        "server_url",
+        "scope_mode",
+        "authorization_environment",
+        "request_timeout_seconds",
+        "request_budget_seconds",
+        "prepare_max_bytes",
+        "source_max_bytes",
+    }
+)
+
+
+class WorkBuddyConfigurationError(ValueError):
+    """Raised when the persisted WorkBuddy configuration is unsafe or invalid."""
 
 
 @dataclass(frozen=True, slots=True)
 class WorkBuddyPluginSettings:
     """Configuration loaded once by a WorkBuddy hooks entry point."""
 
-    server_url: str = "http://127.0.0.1:8000"
+    server_url: str = _DEFAULT_SERVER_URL
     authorization: str | None = None
+    authorization_environment: str = _DEFAULT_AUTHORIZATION_ENVIRONMENT
     scope_id: str | None = None
+    scope_mode: str = "project"
     capture_prompts: bool = True
     flush_on_capture: bool = False
-    request_timeout_seconds: float = 1.0
-    http_budget_seconds: float = 4.0
+    request_timeout_seconds: float = _DEFAULT_REQUEST_TIMEOUT_SECONDS
+    request_budget_seconds: float = _DEFAULT_REQUEST_BUDGET_SECONDS
+    prepare_max_bytes: int = _DEFAULT_PREPARE_MAX_BYTES
+    source_max_bytes: int = _DEFAULT_SOURCE_MAX_BYTES
     flush_max_calls: int = 4
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "server_url", _http_base_url(self.server_url))
         object.__setattr__(self, "authorization", _authorization_header(self.authorization))
+        object.__setattr__(self, "authorization_environment", _authorization_environment_name(self.authorization_environment))
         object.__setattr__(self, "scope_id", _optional_text(self.scope_id))
-        if self.request_timeout_seconds <= 0 or self.http_budget_seconds <= 0:
-            raise ValueError("PowerContext HTTP timeouts must be positive")  # noqa: TRY003
-        if not 1 <= self.flush_max_calls <= 16:
-            raise ValueError("PowerContext flush_max_calls must be between 1 and 16")  # noqa: TRY003
+        _validate_scope_mode(self.scope_mode)
+        _validate_limits(
+            self.request_timeout_seconds,
+            self.request_budget_seconds,
+            self.prepare_max_bytes,
+            self.source_max_bytes,
+            self.flush_max_calls,
+        )
+
+    @property
+    def http_budget_seconds(self) -> float:
+        """Compatibility alias for the existing hook implementation."""
+
+        return self.request_budget_seconds
 
     @classmethod
     def from_environment(cls) -> WorkBuddyPluginSettings:
         """Load WorkBuddy user options and integration-specific environment values."""
 
         return cls(
-            server_url=_first_environment("POWERCONTEXT_WORKBUDDY_SERVER_URL") or "http://127.0.0.1:8000",
+            server_url=_first_environment("POWERCONTEXT_WORKBUDDY_SERVER_URL") or _DEFAULT_SERVER_URL,
             authorization=_first_environment("POWERCONTEXT_WORKBUDDY_AUTHORIZATION"),
             scope_id=_first_environment("POWERCONTEXT_WORKBUDDY_SCOPE_ID"),
             capture_prompts=_environment_bool(
@@ -69,11 +116,20 @@ class WorkBuddyPluginSettings:
             ),
             request_timeout_seconds=_environment_float(
                 "POWERCONTEXT_WORKBUDDY_REQUEST_TIMEOUT_SECONDS",
-                default=1.0,
+                default=_DEFAULT_REQUEST_TIMEOUT_SECONDS,
             ),
-            http_budget_seconds=_environment_float(
+            request_budget_seconds=_environment_float(
                 "POWERCONTEXT_WORKBUDDY_HTTP_BUDGET_SECONDS",
-                default=4.0,
+                "POWERCONTEXT_WORKBUDDY_REQUEST_BUDGET_SECONDS",
+                default=_DEFAULT_REQUEST_BUDGET_SECONDS,
+            ),
+            prepare_max_bytes=_environment_int(
+                "POWERCONTEXT_WORKBUDDY_PREPARE_MAX_BYTES",
+                default=_DEFAULT_PREPARE_MAX_BYTES,
+            ),
+            source_max_bytes=_environment_int(
+                "POWERCONTEXT_WORKBUDDY_SOURCE_MAX_BYTES",
+                default=_DEFAULT_SOURCE_MAX_BYTES,
             ),
             flush_max_calls=_environment_int(
                 "POWERCONTEXT_WORKBUDDY_FLUSH_MAX_CALLS",
@@ -82,12 +138,63 @@ class WorkBuddyPluginSettings:
         )
 
 
+def load_settings(
+    path: str | os.PathLike[str],
+    *,
+    environment: Mapping[str, str] | None = None,
+) -> WorkBuddyPluginSettings:
+    """Load the credential-free setup configuration and runtime credentials."""
+
+    configuration_path = Path(path)
+    try:
+        payload = json.loads(configuration_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise WorkBuddyConfigurationError("invalid WorkBuddy configuration") from error
+    if not isinstance(payload, dict) or set(payload) != _FIELDS:
+        raise WorkBuddyConfigurationError("invalid WorkBuddy configuration")
+    if payload["schema"] != _CONFIG_SCHEMA:
+        raise WorkBuddyConfigurationError("invalid WorkBuddy configuration schema")
+    authorization_environment = _text_field(payload, "authorization_environment")
+    runtime_environment = os.environ if environment is None else environment
+    return WorkBuddyPluginSettings(
+        server_url=_text_field(payload, "server_url"),
+        authorization=runtime_environment.get(authorization_environment),
+        authorization_environment=authorization_environment,
+        scope_mode=_text_field(payload, "scope_mode"),
+        request_timeout_seconds=_float_field(payload, "request_timeout_seconds"),
+        request_budget_seconds=_float_field(payload, "request_budget_seconds"),
+        prepare_max_bytes=_int_field(payload, "prepare_max_bytes"),
+        source_max_bytes=_int_field(payload, "source_max_bytes"),
+    )
+
+
 def _first_environment(*names: str) -> str | None:
     for name in names:
         value = os.environ.get(name)
         if value is not None:
             return value
     return None
+
+
+def _text_field(payload: Mapping[str, object], name: str) -> str:
+    value = payload[name]
+    if not isinstance(value, str):
+        raise WorkBuddyConfigurationError(f"invalid WorkBuddy {name.replace('_', ' ')}")
+    return value
+
+
+def _float_field(payload: Mapping[str, object], name: str) -> float:
+    value = payload[name]
+    if not isinstance(value, int | float) or isinstance(value, bool):
+        raise WorkBuddyConfigurationError(f"invalid WorkBuddy {name.replace('_', ' ')}")
+    return float(value)
+
+
+def _int_field(payload: Mapping[str, object], name: str) -> int:
+    value = payload[name]
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise WorkBuddyConfigurationError(f"invalid WorkBuddy {name.replace('_', ' ')}")
+    return value
 
 
 def _environment_bool(*names: str, default: bool) -> bool:
@@ -99,11 +206,11 @@ def _environment_bool(*names: str, default: bool) -> bool:
         return True
     if normalized in _FALSE_VALUES:
         return False
-    raise ValueError("invalid boolean PowerContext configuration")  # noqa: TRY003
+    raise WorkBuddyConfigurationError("invalid boolean PowerContext configuration")
 
 
-def _environment_float(name: str, *, default: float) -> float:
-    value = os.environ.get(name)
+def _environment_float(*names: str, default: float) -> float:
+    value = _first_environment(*names)
     return default if value is None else float(value)
 
 
@@ -131,25 +238,67 @@ def _authorization_header(value: str | None) -> str | None:
         or not credential.isprintable()
         or any(character.isspace() for character in credential)
     ):
-        raise ValueError("WorkBuddy authorization must be a valid Bearer header")  # noqa: TRY003
+        raise WorkBuddyConfigurationError("WorkBuddy authorization must be a valid Bearer header")
     return normalized
+
+
+def _authorization_environment_name(value: str) -> str:
+    normalized = value.strip()
+    if not _AUTHORIZATION_ENVIRONMENT.fullmatch(normalized):
+        raise WorkBuddyConfigurationError("invalid WorkBuddy authorization environment name")
+    return normalized
+
+
+def _validate_scope_mode(value: str) -> None:
+    if value not in {"agent", "project"}:
+        raise WorkBuddyConfigurationError("WorkBuddy scope must be agent or project")
+
+
+def _validate_limits(
+    request_timeout_seconds: float,
+    request_budget_seconds: float,
+    prepare_max_bytes: int,
+    source_max_bytes: int,
+    flush_max_calls: int,
+) -> None:
+    if (
+        math.isnan(request_timeout_seconds)
+        or math.isinf(request_timeout_seconds)
+        or request_timeout_seconds <= 0
+    ):
+        raise WorkBuddyConfigurationError("WorkBuddy request timeout must be positive")
+    if (
+        math.isnan(request_budget_seconds)
+        or math.isinf(request_budget_seconds)
+        or request_budget_seconds <= 0
+        or request_budget_seconds > _MAX_REQUEST_BUDGET_SECONDS
+    ):
+        raise WorkBuddyConfigurationError("WorkBuddy request budget is invalid")
+    if request_timeout_seconds > request_budget_seconds:
+        raise WorkBuddyConfigurationError("WorkBuddy request timeout must not exceed the budget")
+    if prepare_max_bytes < 1 or prepare_max_bytes > _MAX_PREPARE_BYTES:
+        raise WorkBuddyConfigurationError("WorkBuddy prepare byte limit is invalid")
+    if source_max_bytes < 1 or source_max_bytes > _MAX_SOURCE_BYTES:
+        raise WorkBuddyConfigurationError("WorkBuddy source byte limit is invalid")
+    if not 1 <= flush_max_calls <= 16:
+        raise WorkBuddyConfigurationError("PowerContext flush_max_calls must be between 1 and 16")
 
 
 def _http_base_url(value: str) -> str:
     normalized = value.strip().rstrip("/")
     parsed = urlsplit(normalized)
     if parsed.username is not None or parsed.password is not None:
-        raise ValueError("PowerContext Server URL must not contain credentials")  # noqa: TRY003
+        raise WorkBuddyConfigurationError("PowerContext Server URL must not contain credentials")
     if parsed.hostname is None or parsed.scheme not in {"http", "https"}:
-        raise ValueError("PowerContext Server URL must use HTTP or HTTPS")  # noqa: TRY003
+        raise WorkBuddyConfigurationError("PowerContext Server URL must use HTTP or HTTPS")
     if parsed.query or parsed.fragment:
-        raise ValueError("PowerContext Server URL must not contain a query or fragment")  # noqa: TRY003
+        raise WorkBuddyConfigurationError("PowerContext Server URL must not contain a query or fragment")
     if parsed.scheme == "http" and parsed.hostname.lower() not in _LOOPBACK_HOSTS:
-        raise ValueError("unencrypted PowerContext URLs must be loopback addresses")  # noqa: TRY003
+        raise WorkBuddyConfigurationError("unencrypted PowerContext URLs must be loopback addresses")
     path = parsed.path.rstrip("/")
     if path.endswith("/mcp"):
         path = path.removesuffix("/mcp")
     return urlunsplit((parsed.scheme, parsed.netloc, path, "", "")).rstrip("/")
 
 
-__all__ = ["WorkBuddyPluginSettings"]
+__all__ = ["WorkBuddyConfigurationError", "WorkBuddyPluginSettings", "load_settings"]

--- a/integrations/workbuddy/plugins/powercontext/hooks/workbuddy_settings.py
+++ b/integrations/workbuddy/plugins/powercontext/hooks/workbuddy_settings.py
@@ -20,12 +20,13 @@
 
 from __future__ import annotations
 
-import os
 import json
 import math
+import os
 import re
 from collections.abc import Mapping
 from dataclasses import dataclass
+from ipaddress import ip_address
 from pathlib import Path
 from urllib.parse import urlsplit, urlunsplit
 
@@ -293,12 +294,22 @@ def _http_base_url(value: str) -> str:
         raise WorkBuddyConfigurationError("PowerContext Server URL must use HTTP or HTTPS")
     if parsed.query or parsed.fragment:
         raise WorkBuddyConfigurationError("PowerContext Server URL must not contain a query or fragment")
-    if parsed.scheme == "http" and parsed.hostname.lower() not in _LOOPBACK_HOSTS:
+    if parsed.scheme == "http" and not _is_loopback_host(parsed.hostname):
         raise WorkBuddyConfigurationError("unencrypted PowerContext URLs must be loopback addresses")
     path = parsed.path.rstrip("/")
     if path.endswith("/mcp"):
         path = path.removesuffix("/mcp")
     return urlunsplit((parsed.scheme, parsed.netloc, path, "", "")).rstrip("/")
+
+
+def _is_loopback_host(value: str) -> bool:
+    host = value.lower()
+    if host in _LOOPBACK_HOSTS:
+        return True
+    try:
+        return ip_address(host).is_loopback
+    except ValueError:
+        return False
 
 
 __all__ = ["WorkBuddyConfigurationError", "WorkBuddyPluginSettings", "load_settings"]

--- a/integrations/workbuddy/plugins/powercontext/powercontext.json.example
+++ b/integrations/workbuddy/plugins/powercontext/powercontext.json.example
@@ -1,0 +1,10 @@
+{
+  "schema": 1,
+  "server_url": "http://127.0.0.1:8000",
+  "scope_mode": "project",
+  "authorization_environment": "POWERCONTEXT_WORKBUDDY_AUTHORIZATION",
+  "request_timeout_seconds": 1.5,
+  "request_budget_seconds": 3.0,
+  "prepare_max_bytes": 8000,
+  "source_max_bytes": 16384
+}

--- a/integrations/workbuddy/plugins/powercontext/scripts/project_scope.py
+++ b/integrations/workbuddy/plugins/powercontext/scripts/project_scope.py
@@ -49,11 +49,15 @@ _WORKSPACE_STATE_DIRECTORY = "powercontext"
 _WORKSPACE_STATE_FILE = "codex-workspace.json"
 
 
-def resolve_scope_id(cwd: str, *, configured_scope_id: str | None = None) -> str:
+def resolve_scope_id(cwd: str, *, configured_scope_id: str | None = None, scope_mode: str = "project") -> str:
     """Return the configured, workspace-bound, or derived scope for one checkout."""
 
     if configured_scope_id:
         return _bounded_explicit(configured_scope_id)
+    if scope_mode == "agent":
+        return "workbuddy:agent"
+    if scope_mode != "project":
+        raise ValueError("WorkBuddy scope mode must be agent or project")  # noqa: TRY003
     bound_scope_id = read_bound_scope_id(cwd)
     if bound_scope_id is not None:
         return bound_scope_id
@@ -223,7 +227,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     if arguments.clear_workstream:
         clear_workstream_scope(arguments.cwd)
     settings = WorkBuddyPluginSettings.from_environment()
-    print(resolve_scope_id(arguments.cwd, configured_scope_id=settings.scope_id))
+    print(resolve_scope_id(arguments.cwd, configured_scope_id=settings.scope_id, scope_mode=settings.scope_mode))
     return 0
 
 

--- a/integrations/workbuddy/tests/test_artifacts.py
+++ b/integrations/workbuddy/tests/test_artifacts.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2026 OceanBase.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+PLUGIN_ROOT = Path(__file__).resolve().parents[1] / "plugins" / "powercontext"
+
+
+def test_mcp_and_skill_keep_authorization_credential_free() -> None:
+    mcp = json.loads((PLUGIN_ROOT / ".mcp.json").read_text(encoding="utf-8"))
+    server = mcp["mcpServers"]["powercontext"]
+
+    assert server["type"] == "http"
+    assert server["url"] == "${POWERCONTEXT_WORKBUDDY_SERVER_URL:-http://127.0.0.1:8000}/mcp"
+    assert server["headers"] == {"Authorization": "${POWERCONTEXT_WORKBUDDY_AUTHORIZATION:-}"}
+    assert "Bearer " not in (PLUGIN_ROOT / ".mcp.json").read_text(encoding="utf-8")
+
+    skill = (PLUGIN_ROOT / "skills" / "project-context" / "SKILL.md").read_text(encoding="utf-8")
+    assert "${POWERCONTEXT_PYTHON}" in skill
+    assert "${POWERCONTEXT_PROJECT_SCOPE_SCRIPT}" in skill
+    assert "POWERCONTEXT_WORKBUDDY_AUTHORIZATION" not in skill
+    assert (PLUGIN_ROOT / "scripts" / "__init__.py").is_file()
+    assert (PLUGIN_ROOT.parents[1] / "README.md").is_file()

--- a/integrations/workbuddy/tests/test_config.py
+++ b/integrations/workbuddy/tests/test_config.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2026 OceanBase.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+PLUGIN_ROOT = Path(__file__).resolve().parents[1] / "plugins" / "powercontext"
+
+
+def load_config_module() -> ModuleType:
+    path = PLUGIN_ROOT / "hooks" / "workbuddy_settings.py"
+    spec = importlib.util.spec_from_file_location("powercontext_workbuddy_settings", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_config_uses_credential_free_file_and_runtime_authorization_environment(tmp_path: Path) -> None:
+    settings_module = load_config_module()
+    configuration_path = tmp_path / "powercontext.json"
+    configuration_path.write_text(
+        json.dumps(
+            {
+                "schema": 1,
+                "server_url": "http://127.0.0.1:8000",
+                "scope_mode": "project",
+                "authorization_environment": "WORKBUDDY_TOKEN",
+                "request_timeout_seconds": 1.5,
+                "request_budget_seconds": 3.0,
+                "prepare_max_bytes": 8192,
+                "source_max_bytes": 16384,
+            }
+        ),
+        encoding="utf-8",
+    )
+    configuration = settings_module.load_settings(
+        configuration_path,
+        environment={"WORKBUDDY_TOKEN": "Bearer test-token"},
+    )
+
+    assert configuration.server_url == "http://127.0.0.1:8000"
+    assert configuration.authorization == "Bearer test-token"
+    assert configuration.authorization_environment == "WORKBUDDY_TOKEN"
+    assert "test-token" not in configuration_path.read_text(encoding="utf-8")

--- a/integrations/workbuddy/tests/test_configuration_contract.py
+++ b/integrations/workbuddy/tests/test_configuration_contract.py
@@ -62,6 +62,18 @@ def test_config_declares_bounded_request_limits(tmp_path: Path) -> None:
     assert settings.source_max_bytes == 16384
 
 
+def test_config_accepts_the_ipv4_loopback_range(tmp_path: Path) -> None:
+    settings_module = load_settings_module()
+    payload = configuration()
+    payload["server_url"] = "http://127.2.3.4:8000/"
+    configuration_path = tmp_path / "powercontext.json"
+    configuration_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    settings = settings_module.load_settings(configuration_path)
+
+    assert settings.server_url == "http://127.2.3.4:8000"
+
+
 @pytest.mark.parametrize(
     ("changes", "expected_message"),
     [

--- a/integrations/workbuddy/tests/test_configuration_contract.py
+++ b/integrations/workbuddy/tests/test_configuration_contract.py
@@ -1,0 +1,102 @@
+# Copyright (c) 2026 OceanBase.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+
+PLUGIN_ROOT = Path(__file__).resolve().parents[1] / "plugins" / "powercontext"
+
+
+def load_settings_module() -> ModuleType:
+    path = PLUGIN_ROOT / "hooks" / "workbuddy_settings.py"
+    spec = importlib.util.spec_from_file_location("powercontext_workbuddy_settings_contract", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def configuration() -> dict[str, object]:
+    return {
+        "schema": 1,
+        "server_url": "http://127.0.0.1:8000",
+        "scope_mode": "project",
+        "authorization_environment": "WORKBUDDY_TOKEN",
+        "request_timeout_seconds": 1.5,
+        "request_budget_seconds": 3.0,
+        "prepare_max_bytes": 4096,
+        "source_max_bytes": 16384,
+    }
+
+
+def test_config_declares_bounded_request_limits(tmp_path: Path) -> None:
+    settings_module = load_settings_module()
+    configuration_path = tmp_path / "powercontext.json"
+    configuration_path.write_text(json.dumps(configuration()), encoding="utf-8")
+
+    settings = settings_module.load_settings(configuration_path)
+
+    assert settings.request_timeout_seconds == 1.5
+    assert settings.request_budget_seconds == 3.0
+    assert settings.prepare_max_bytes == 4096
+    assert settings.source_max_bytes == 16384
+
+
+@pytest.mark.parametrize(
+    ("changes", "expected_message"),
+    [
+        ({"server_url": "http://198.51.100.4:8000"}, "loopback"),
+        ({"request_timeout_seconds": 0}, "timeout"),
+        ({"request_timeout_seconds": 4.0}, "budget"),
+        ({"prepare_max_bytes": 0}, "prepare"),
+        ({"source_max_bytes": 65537}, "source"),
+        ({"authorization_environment": "授权"}, "authorization environment"),
+    ],
+)
+def test_config_rejects_unsafe_or_unbounded_runtime_limits(
+    tmp_path: Path,
+    changes: dict[str, object],
+    expected_message: str,
+) -> None:
+    settings_module = load_settings_module()
+    payload = configuration()
+    payload.update(changes)
+    configuration_path = tmp_path / "powercontext.json"
+    configuration_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(settings_module.WorkBuddyConfigurationError, match=expected_message):
+        settings_module.load_settings(configuration_path)
+
+
+def test_config_rejects_persisted_authorization_without_echoing_it(tmp_path: Path) -> None:
+    settings_module = load_settings_module()
+    persisted_secret = "Bearer persisted-workbuddy-secret"
+    payload = configuration()
+    payload["authorization"] = persisted_secret
+    configuration_path = tmp_path / "powercontext.json"
+    configuration_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(settings_module.WorkBuddyConfigurationError) as raised:
+        settings_module.load_settings(configuration_path)
+
+    assert persisted_secret not in str(raised.value)

--- a/integrations/workbuddy/tests/test_configuration_template.py
+++ b/integrations/workbuddy/tests/test_configuration_template.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2026 OceanBase.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+PLUGIN_ROOT = Path(__file__).resolve().parents[1] / "plugins" / "powercontext"
+
+
+def test_setup_configuration_template_is_credential_free_and_complete() -> None:
+    configuration_path = PLUGIN_ROOT / "powercontext.json.example"
+    payload = json.loads(configuration_path.read_text(encoding="utf-8"))
+
+    assert payload == {
+        "schema": 1,
+        "server_url": "http://127.0.0.1:8000",
+        "scope_mode": "project",
+        "authorization_environment": "POWERCONTEXT_WORKBUDDY_AUTHORIZATION",
+        "request_timeout_seconds": 1.5,
+        "request_budget_seconds": 3.0,
+        "prepare_max_bytes": 8000,
+        "source_max_bytes": 16384,
+    }
+    assert not {"authorization", "token", "password", "secret"}.intersection(payload)

--- a/integrations/workbuddy/tests/test_scope.py
+++ b/integrations/workbuddy/tests/test_scope.py
@@ -1,0 +1,55 @@
+# Copyright (c) 2026 OceanBase.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+PLUGIN_ROOT = Path(__file__).resolve().parents[1] / "plugins" / "powercontext"
+
+
+def load_scope_module() -> ModuleType:
+    path = PLUGIN_ROOT / "scripts" / "project_scope.py"
+    spec = importlib.util.spec_from_file_location("powercontext_workbuddy_scope", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_project_scope_uses_normalized_git_remote_for_cross_host_recall(monkeypatch) -> None:
+    scope = load_scope_module()
+
+    def git_value(_cwd: str, *arguments: str) -> str | None:
+        if arguments == ("rev-parse", "--show-toplevel"):
+            return r"C:\work\powercontext-go"
+        if arguments == ("config", "--get", "remote.origin.url"):
+            return "git@github.com:ob-labs/powercontext-go.git"
+        return None
+
+    monkeypatch.setattr(scope, "_git_value", git_value)
+
+    assert scope.resolve_scope_id(r"C:\work\powercontext-go") == "git:github.com/ob-labs/powercontext-go"
+
+
+def test_agent_scope_does_not_depend_on_the_checkout_path() -> None:
+    scope = load_scope_module()
+
+    assert scope.resolve_scope_id(r"C:\one", scope_mode="agent") == "workbuddy:agent"
+    assert scope.resolve_scope_id(r"D:\two", scope_mode="agent") == "workbuddy:agent"

--- a/integrations/workbuddy/tests/test_service_chain.py
+++ b/integrations/workbuddy/tests/test_service_chain.py
@@ -1,0 +1,161 @@
+# Copyright (c) 2026 OceanBase.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import os
+import sys
+import threading
+from collections.abc import Iterator
+from contextlib import contextmanager
+from hashlib import sha256
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from types import ModuleType
+
+
+PLUGIN_ROOT = Path(__file__).resolve().parents[1] / "plugins" / "powercontext"
+
+
+def load_hook_module() -> ModuleType:
+    hooks = PLUGIN_ROOT / "hooks"
+    scripts = PLUGIN_ROOT / "scripts"
+    sys.path[:0] = [str(hooks), str(scripts)]
+    path = hooks / "workbuddy_powercontext_hook.py"
+    spec = importlib.util.spec_from_file_location("powercontext_workbuddy_service_chain", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@contextmanager
+def serve(handler: type[BaseHTTPRequestHandler]) -> Iterator[str]:
+    server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}"
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+        server.server_close()
+
+
+def test_hook_uses_the_live_service_chain_with_bounded_requests(monkeypatch, tmp_path: Path) -> None:
+    received: list[tuple[str, dict[str, str], dict[str, object]]] = []
+
+    class Service(BaseHTTPRequestHandler):
+        def do_POST(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler API.
+            content_length = int(self.headers["Content-Length"])
+            request = json.loads(self.rfile.read(content_length))
+            received.append((self.path, dict(self.headers), request))
+            if self.path == "/v1/context/prepare":
+                self._respond(200, {"schema": "powercontext.prepared-context.v1", "status": "ready", "content": "Use approved policy.", "content_bytes": 20})
+                return
+            if self.path == "/v1/sources/content":
+                self._respond(201, {"position": 3})
+                return
+            self._respond(404, {})
+
+        def log_message(self, _format: str, *_arguments: object) -> None:
+            return
+
+        def _respond(self, status: int, payload: dict[str, object]) -> None:
+            encoded = json.dumps(payload).encode("utf-8")
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(encoded)))
+            self.end_headers()
+            self.wfile.write(encoded)
+
+    hook = load_hook_module()
+    authorization = "Bearer workbuddy-runtime-token"
+    with serve(Service) as server_url:
+        settings = hook.WorkBuddyPluginSettings(
+            server_url=server_url,
+            scope_mode="project",
+            authorization_environment="WORKBUDDY_TOKEN",
+            authorization=authorization,
+            request_timeout_seconds=1.0,
+            request_budget_seconds=2.0,
+            prepare_max_bytes=64,
+            source_max_bytes=128,
+        )
+        prompt = "Which policy applies?"
+        cwd = str(tmp_path)
+        scope_id = "local:" + sha256(os.fsencode(tmp_path.resolve())).hexdigest()
+        payload = {"hook_event_name": "UserPromptSubmit", "cwd": cwd, "prompt": prompt, "session_id": "session-1"}
+        monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(payload)))
+        stdout = io.StringIO()
+        monkeypatch.setattr(sys, "stdout", stdout)
+
+        assert hook.main(settings) == 0
+
+    assert json.loads(stdout.getvalue()) == {
+        "hookSpecificOutput": {"hookEventName": "UserPromptSubmit", "additionalContext": "Use approved policy."}
+    }
+    assert authorization not in stdout.getvalue()
+    assert received[0][0] == "/v1/context/prepare"
+    assert received[0][1]["Authorization"] == authorization
+    assert received[0][2] == {"scope_id": scope_id, "query": prompt, "max_bytes": 64}
+    assert received[1][0] == "/v1/sources/content"
+    assert received[1][2]["source_id"] == "workbuddy-user-prompt:" + sha256(
+        f"{scope_id}\0session-1\0\0{prompt}".encode("utf-8")
+    ).hexdigest()
+
+
+def test_hook_preserves_the_host_prompt_when_the_live_service_is_unavailable(monkeypatch, tmp_path: Path) -> None:
+    class UnavailableService(BaseHTTPRequestHandler):
+        def do_POST(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler API.
+            self.send_response(503)
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+
+        def log_message(self, _format: str, *_arguments: object) -> None:
+            return
+
+    hook = load_hook_module()
+    prompt_secret = "workbuddy-prompt-secret"
+    authorization_secret = "workbuddy-runtime-secret"
+    with serve(UnavailableService) as server_url:
+        settings = hook.WorkBuddyPluginSettings(
+            server_url=server_url,
+            scope_mode="project",
+            authorization_environment="WORKBUDDY_TOKEN",
+            authorization=f"Bearer {authorization_secret}",
+            request_timeout_seconds=1.0,
+            request_budget_seconds=2.0,
+            prepare_max_bytes=64,
+            source_max_bytes=128,
+        )
+        monkeypatch.setattr(
+            sys,
+            "stdin",
+            io.StringIO(json.dumps({"hook_event_name": "UserPromptSubmit", "cwd": str(tmp_path), "prompt": prompt_secret})),
+        )
+        stdout = io.StringIO()
+        monkeypatch.setattr(sys, "stdout", stdout)
+
+        assert hook.main(settings) == 0
+
+    assert json.loads(stdout.getvalue()) == {
+        "hookSpecificOutput": {"hookEventName": "UserPromptSubmit", "additionalContext": ""}
+    }
+    assert prompt_secret not in stdout.getvalue()
+    assert authorization_secret not in stdout.getvalue()

--- a/integrations/workbuddy/tests/test_service_chain.py
+++ b/integrations/workbuddy/tests/test_service_chain.py
@@ -159,3 +159,32 @@ def test_hook_preserves_the_host_prompt_when_the_live_service_is_unavailable(mon
     }
     assert prompt_secret not in stdout.getvalue()
     assert authorization_secret not in stdout.getvalue()
+
+
+def test_hook_rejects_invalid_persisted_configuration_instead_of_falling_back_to_environment(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    hook = load_hook_module()
+    (tmp_path / "powercontext.json").write_text(
+        json.dumps(
+            {
+                "schema": 1,
+                "server_url": "http://127.0.0.1:8000",
+                "authorization": "Bearer persisted-secret",
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(hook, "_PLUGIN_ROOT", tmp_path)
+    monkeypatch.setenv("POWERCONTEXT_WORKBUDDY_SERVER_URL", "http://127.0.0.1:8000")
+    monkeypatch.setattr(
+        sys,
+        "stdin",
+        io.StringIO(json.dumps({"hook_event_name": "UserPromptSubmit", "cwd": str(tmp_path), "prompt": "hello"})),
+    )
+    stdout = io.StringIO()
+    monkeypatch.setattr(sys, "stdout", stdout)
+
+    assert hook.main() == 0
+    assert stdout.getvalue() == ""

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -92,6 +92,7 @@ func newDoctorCommand(state *commandState) *cobra.Command {
 		newDoctorOpenCodeCommand(state),
 		newDoctorHermesCommand(state),
 		newDoctorOpenClawCommand(state),
+		newDoctorWorkBuddyCommand(state),
 	)
 	return command
 }
@@ -216,7 +217,7 @@ func writeDiagnostics(state *commandState, values map[string]diagnostic) error {
 	}
 	order := []string{
 		"package", "server_liveness", "server_readiness", "codex", "claude_code", "dsh", "pi", "opencode",
-		"hermes", "openclaw", "plugin", "skill", "activation", "version",
+		"hermes", "openclaw", "workbuddy", "python", "config", "hooks", "settings", "mcp", "plugin", "skill", "activation", "version",
 	}
 	for _, name := range order {
 		value, ok := values[name]

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -92,7 +92,6 @@ func newDoctorCommand(state *commandState) *cobra.Command {
 		newDoctorOpenCodeCommand(state),
 		newDoctorHermesCommand(state),
 		newDoctorOpenClawCommand(state),
-		newDoctorWorkBuddyCommand(state),
 	)
 	return command
 }

--- a/internal/cli/integration_workbuddy.go
+++ b/internal/cli/integration_workbuddy.go
@@ -618,10 +618,10 @@ func workBuddyMCPDiagnostic(path string, configuration workBuddyConfiguration) d
 	if !ok {
 		return diagnostic{Status: "failed", Detail: "PowerContext WorkBuddy MCP server is not registered in mcp.json"}
 	}
-	if _, ok := servers[workBuddyPluginName].(map[string]any); !ok {
+	entry, entryOK := servers[workBuddyPluginName].(map[string]any)
+	if !entryOK {
 		return diagnostic{Status: "failed", Detail: "PowerContext WorkBuddy MCP server is not registered in mcp.json"}
 	}
-	entry := servers[workBuddyPluginName].(map[string]any)
 	if entry["description"] != workBuddyMCPDescription || entry["url"] != configuration.ServerURL+"/mcp" {
 		return diagnostic{Status: "failed", Detail: "PowerContext WorkBuddy MCP server does not match its configuration"}
 	}
@@ -801,8 +801,17 @@ func isOwnedWorkBuddyMCP(entry map[string]any) bool {
 	authorization, _ := headers["Authorization"].(string)
 	description, _ := entry["description"].(string)
 	kind, _ := entry["type"].(string)
-	return kind == "http" && headersOK && authorization == workBuddyAuthorizationTemplate &&
+	return kind == "http" && headersOK && isWorkBuddyAuthorizationTemplate(authorization) &&
 		description == workBuddyMCPDescription
+}
+
+func isWorkBuddyAuthorizationTemplate(value string) bool {
+	name, ok := strings.CutPrefix(value, "${")
+	if !ok {
+		return false
+	}
+	name, ok = strings.CutSuffix(name, ":-}")
+	return ok && workBuddyAuthorizationEnvironmentPattern.MatchString(name)
 }
 
 func workBuddyHookCommand(hooksDir string) string {

--- a/internal/cli/integration_workbuddy.go
+++ b/internal/cli/integration_workbuddy.go
@@ -15,18 +15,27 @@
 package cli
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"maps"
+	"math"
+	"net/url"
 	"os"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/spf13/cobra"
+
+	"github.com/ob-labs/powercontext-go/internal/transportpolicy"
 )
 
 const (
@@ -37,19 +46,33 @@ const (
 	workBuddyScopeResolver         = "powercontext_project_scope.py"
 	workBuddySkillName             = "project-context"
 	workBuddySkillOwner            = ".powercontext.json"
+	workBuddyConfigFilename        = "powercontext.json"
+	workBuddyConfigSchema          = 1
 	workBuddyPythonPlaceholder     = "${POWERCONTEXT_PYTHON}"
 	workBuddyScopePlaceholder      = "${POWERCONTEXT_PROJECT_SCOPE_SCRIPT}"
 	workBuddyServerURLTemplate     = "${POWERCONTEXT_WORKBUDDY_SERVER_URL:-http://127.0.0.1:8000}/mcp"
 	workBuddyAuthorizationTemplate = "${POWERCONTEXT_WORKBUDDY_AUTHORIZATION:-}"
 	workBuddyLegacyMCPURL          = "http://127.0.0.1:8000/mcp"
 	workBuddyMCPDescription        = "PowerContext agent memory & handoff MCP server (local service on port 8000)"
+
+	workBuddyDefaultAuthorizationEnvironment = "POWERCONTEXT_WORKBUDDY_AUTHORIZATION"
+	workBuddyDefaultRequestTimeoutSeconds    = 1.5
+	workBuddyDefaultRequestBudgetSeconds     = 3.0
+	workBuddyDefaultPrepareMaxBytes          = 8_000
+	workBuddyDefaultSourceMaxBytes           = 16_384
+	workBuddyMaximumRequestBudgetSeconds     = 10.0
+	workBuddyMaximumPrepareBytes             = 32 * 1024
+	workBuddyMaximumSourceBytes              = 64 * 1024
 )
 
-var workBuddyHookModules = [...]string{
-	workBuddyHookDriver,
-	"workbuddy_settings.py",
-	"prepared_context.py",
-}
+var (
+	workBuddyAuthorizationEnvironmentPattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+	workBuddyHookModules                     = [...]string{
+		workBuddyHookDriver,
+		"workbuddy_settings.py",
+		"prepared_context.py",
+	}
+)
 
 type workBuddySetupResult struct {
 	Plugin        string `json:"plugin"`
@@ -57,14 +80,31 @@ type workBuddySetupResult struct {
 	WorkBuddyHome string `json:"workbuddy_home"`
 	HooksDir      string `json:"hooks_dir"`
 	DataDir       string `json:"data_dir"`
+	ServerURL     string `json:"server_url"`
+	ScopeMode     string `json:"scope_mode"`
+}
+
+type workBuddyConfiguration struct {
+	Schema                   int     `json:"schema"`
+	ServerURL                string  `json:"server_url"`
+	ScopeMode                string  `json:"scope_mode"`
+	AuthorizationEnvironment string  `json:"authorization_environment"`
+	RequestTimeoutSeconds    float64 `json:"request_timeout_seconds"`
+	RequestBudgetSeconds     float64 `json:"request_budget_seconds"`
+	PrepareMaxBytes          int     `json:"prepare_max_bytes"`
+	SourceMaxBytes           int     `json:"source_max_bytes"`
 }
 
 func newSetupWorkBuddyCommand(state *commandState) *cobra.Command {
-	var source, ref string
+	var source, ref, serverURL, scopeMode, authorizationEnvironment string
 	command := &cobra.Command{
 		Use: "workbuddy", Short: "Install the PowerContext WorkBuddy hooks, MCP server, and Skill.", Args: cobra.NoArgs,
 		RunE: func(command *cobra.Command, _ []string) error {
-			result, err := installWorkBuddyPlugin(command.Context(), state.system, source, ref)
+			configuration, err := newWorkBuddyConfiguration(serverURL, scopeMode, authorizationEnvironment)
+			if err != nil {
+				return err
+			}
+			result, err := installWorkBuddyPlugin(command.Context(), state.system, source, ref, configuration)
 			if err != nil {
 				return err
 			}
@@ -87,14 +127,20 @@ func newSetupWorkBuddyCommand(state *commandState) *cobra.Command {
 	}
 	command.Flags().StringVar(&source, "source", defaultMarketplaceSource, "PowerContext Git source or local checkout path.")
 	command.Flags().StringVar(&ref, "ref", defaultMarketplaceRef, "Git ref used for a remote source.")
+	command.Flags().StringVar(&serverURL, "server-url", defaultServerURL, "PowerContext Server base URL configured for WorkBuddy.")
+	command.Flags().StringVar(&scopeMode, "scope-mode", "project", "Memory scope mode: agent or project.")
+	command.Flags().StringVar(&authorizationEnvironment, "authorization-environment", workBuddyDefaultAuthorizationEnvironment, "Runtime environment variable containing an optional Bearer authorization header.")
 	return command
 }
 
 func newDoctorWorkBuddyCommand(state *commandState) *cobra.Command {
 	return &cobra.Command{
 		Use: "workbuddy", Short: "Check the PowerContext WorkBuddy hooks, MCP server, and Skill.", Args: cobra.NoArgs,
-		RunE: func(_ *cobra.Command, _ []string) error {
+		RunE: func(command *cobra.Command, _ []string) error {
 			checks := runWorkBuddyDiagnostics()
+			if configuration, ok := workBuddyConfiguredServerURL(); ok {
+				maps.Copy(checks, runServerDiagnostics(command.Context(), state.version.Version, configuration, state.httpClient))
+			}
 			if writeErr := writeDiagnostics(state, checks); writeErr != nil {
 				return writeErr
 			}
@@ -106,10 +152,79 @@ func newDoctorWorkBuddyCommand(state *commandState) *cobra.Command {
 	}
 }
 
+func newWorkBuddyConfiguration(serverURL, scopeMode, authorizationEnvironment string) (workBuddyConfiguration, error) {
+	normalizedURL, err := normalizeWorkBuddyServerURL(serverURL)
+	if err != nil {
+		return workBuddyConfiguration{}, err
+	}
+	configuration := workBuddyConfiguration{
+		Schema:                   workBuddyConfigSchema,
+		ServerURL:                normalizedURL,
+		ScopeMode:                scopeMode,
+		AuthorizationEnvironment: authorizationEnvironment,
+		RequestTimeoutSeconds:    workBuddyDefaultRequestTimeoutSeconds,
+		RequestBudgetSeconds:     workBuddyDefaultRequestBudgetSeconds,
+		PrepareMaxBytes:          workBuddyDefaultPrepareMaxBytes,
+		SourceMaxBytes:           workBuddyDefaultSourceMaxBytes,
+	}
+	if err := validateWorkBuddyConfiguration(configuration); err != nil {
+		return workBuddyConfiguration{}, err
+	}
+	return configuration, nil
+}
+
+func normalizeWorkBuddyServerURL(value string) (string, error) {
+	parsed, err := url.Parse(strings.TrimRight(strings.TrimSpace(value), "/"))
+	if err != nil || parsed.Host == "" || (parsed.Scheme != "http" && parsed.Scheme != "https") {
+		return "", errors.New("WorkBuddy PowerContext Server URL must use HTTP or HTTPS")
+	}
+	if parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" {
+		return "", errors.New("WorkBuddy PowerContext Server URL must not contain credentials, a query, or a fragment")
+	}
+	if transportpolicy.IsPlaintextNonLoopback(parsed) {
+		return "", errors.New("unencrypted WorkBuddy PowerContext Server URLs must be loopback addresses")
+	}
+	parsed.Path, parsed.RawPath = strings.TrimRight(parsed.Path, "/"), ""
+	return strings.TrimRight(parsed.String(), "/"), nil
+}
+
+func validateWorkBuddyConfiguration(configuration workBuddyConfiguration) error {
+	if configuration.Schema != workBuddyConfigSchema {
+		return errors.New("invalid WorkBuddy configuration schema")
+	}
+	if _, err := normalizeWorkBuddyServerURL(configuration.ServerURL); err != nil {
+		return err
+	}
+	if configuration.ScopeMode != "agent" && configuration.ScopeMode != "project" {
+		return errors.New("WorkBuddy scope must be agent or project")
+	}
+	if !workBuddyAuthorizationEnvironmentPattern.MatchString(configuration.AuthorizationEnvironment) {
+		return errors.New("invalid WorkBuddy authorization environment name")
+	}
+	if math.IsNaN(configuration.RequestTimeoutSeconds) || math.IsInf(configuration.RequestTimeoutSeconds, 0) || configuration.RequestTimeoutSeconds <= 0 {
+		return errors.New("WorkBuddy request timeout must be positive")
+	}
+	if math.IsNaN(configuration.RequestBudgetSeconds) || math.IsInf(configuration.RequestBudgetSeconds, 0) || configuration.RequestBudgetSeconds <= 0 ||
+		configuration.RequestBudgetSeconds > workBuddyMaximumRequestBudgetSeconds {
+		return errors.New("WorkBuddy request budget is invalid")
+	}
+	if configuration.RequestTimeoutSeconds > configuration.RequestBudgetSeconds {
+		return errors.New("WorkBuddy request timeout must not exceed the budget")
+	}
+	if configuration.PrepareMaxBytes < 1 || configuration.PrepareMaxBytes > workBuddyMaximumPrepareBytes {
+		return errors.New("WorkBuddy prepare byte limit is invalid")
+	}
+	if configuration.SourceMaxBytes < 1 || configuration.SourceMaxBytes > workBuddyMaximumSourceBytes {
+		return errors.New("WorkBuddy source byte limit is invalid")
+	}
+	return nil
+}
+
 func installWorkBuddyPlugin(
 	ctx context.Context,
 	commands systemCommandExecutor,
 	source, ref string,
+	configuration workBuddyConfiguration,
 ) (workBuddySetupResult, error) {
 	dataDir, err := prepareDataDirectory()
 	if err != nil {
@@ -127,11 +242,15 @@ func installWorkBuddyPlugin(
 	skillDir := filepath.Join(home, "skills", workBuddySkillName)
 	settingsFile := filepath.Join(home, "settings.json")
 	mcpFile := filepath.Join(home, "mcp.json")
+	configFile := filepath.Join(home, workBuddyConfigFilename)
 	if mkdirErr := os.MkdirAll(home, 0o755); mkdirErr != nil {
 		return workBuddySetupResult{}, errors.New("cannot create WorkBuddy home")
 	}
 	if replaceableErr := requireReplaceableWorkBuddySkill(skillDir); replaceableErr != nil {
 		return workBuddySetupResult{}, replaceableErr
+	}
+	if _, _, configErr := readWorkBuddyConfiguration(configFile); configErr != nil {
+		return workBuddySetupResult{}, errors.New("existing WorkBuddy configuration is not owned by PowerContext")
 	}
 	settingsSnapshot, err := snapshotWorkBuddyFile(settingsFile)
 	if err != nil {
@@ -140,6 +259,10 @@ func installWorkBuddyPlugin(
 	mcpSnapshot, err := snapshotWorkBuddyFile(mcpFile)
 	if err != nil {
 		return workBuddySetupResult{}, errors.New("Cannot update WorkBuddy MCP configuration")
+	}
+	configSnapshot, err := snapshotWorkBuddyFile(configFile)
+	if err != nil {
+		return workBuddySetupResult{}, errors.New("cannot snapshot WorkBuddy configuration")
 	}
 	hooksBackup, err := snapshotWorkBuddyDirectory(hooksDir)
 	if err != nil {
@@ -159,6 +282,7 @@ func installWorkBuddyPlugin(
 		}
 		_ = restoreWorkBuddyFile(settingsFile, settingsSnapshot)
 		_ = restoreWorkBuddyFile(mcpFile, mcpSnapshot)
+		_ = restoreWorkBuddyFile(configFile, configSnapshot)
 		_ = restoreWorkBuddyDirectory(hooksDir, hooksBackup)
 		_ = restoreWorkBuddyDirectory(skillDir, skillBackup)
 	}()
@@ -168,8 +292,20 @@ func installWorkBuddyPlugin(
 	if settingsErr := mergeWorkBuddySettings(settingsFile, hooksDir); settingsErr != nil {
 		return workBuddySetupResult{}, settingsErr
 	}
-	if mcpErr := mergeWorkBuddyMCP(mcpFile); mcpErr != nil {
+	if mcpErr := mergeWorkBuddyMCP(mcpFile, configuration); mcpErr != nil {
 		return workBuddySetupResult{}, mcpErr
+	}
+	if configErr := writeWorkBuddyJSON(configFile, map[string]any{
+		"schema":                    configuration.Schema,
+		"server_url":                configuration.ServerURL,
+		"scope_mode":                configuration.ScopeMode,
+		"authorization_environment": configuration.AuthorizationEnvironment,
+		"request_timeout_seconds":   configuration.RequestTimeoutSeconds,
+		"request_budget_seconds":    configuration.RequestBudgetSeconds,
+		"prepare_max_bytes":         configuration.PrepareMaxBytes,
+		"source_max_bytes":          configuration.SourceMaxBytes,
+	}); configErr != nil {
+		return workBuddySetupResult{}, errors.New("cannot write WorkBuddy configuration")
 	}
 	if skillErr := installWorkBuddySkill(plugin, skillDir, hooksDir); skillErr != nil {
 		return workBuddySetupResult{}, skillErr
@@ -177,6 +313,7 @@ func installWorkBuddyPlugin(
 	succeeded = true
 	return workBuddySetupResult{
 		Plugin: workBuddyPluginName, PluginPath: plugin, WorkBuddyHome: home, HooksDir: hooksDir, DataDir: dataDir,
+		ServerURL: configuration.ServerURL, ScopeMode: configuration.ScopeMode,
 	}, nil
 }
 
@@ -335,7 +472,7 @@ func mergeWorkBuddySettings(settingsFile, hooksDir string) error {
 	return writeWorkBuddyJSON(settingsFile, settings)
 }
 
-func mergeWorkBuddyMCP(mcpFile string) error {
+func mergeWorkBuddyMCP(mcpFile string, configuration workBuddyConfiguration) error {
 	config, err := loadWorkBuddyJSON(mcpFile)
 	if err != nil {
 		return errors.New("cannot update WorkBuddy MCP configuration")
@@ -349,22 +486,14 @@ func mergeWorkBuddyMCP(mcpFile string) error {
 		config["mcpServers"] = servers
 	}
 	entry := map[string]any{
-		"type": "http", "url": workBuddyServerURLTemplate,
-		"headers":     map[string]any{"Authorization": workBuddyAuthorizationTemplate},
+		"type": "http", "url": configuration.ServerURL + "/mcp",
+		"headers":     map[string]any{"Authorization": "${" + configuration.AuthorizationEnvironment + ":-}"},
 		"description": workBuddyMCPDescription, "disabled": false,
 	}
-	if existing, ok := servers[workBuddyPluginName].(map[string]any); ok && !isLegacyWorkBuddyMCP(existing) {
-		if url, ok := existing["url"].(string); ok && strings.TrimSpace(url) != "" {
-			entry["url"] = url
-		}
-		if headers, ok := existing["headers"].(map[string]any); ok && len(headers) != 0 {
-			entry["headers"] = headers
-		}
-		for name, value := range existing {
-			if _, known := entry[name]; !known {
-				entry[name] = value
-			}
-		}
+	if existing, ok := servers[workBuddyPluginName].(map[string]any); ok &&
+		!isLegacyWorkBuddyMCP(existing) &&
+		!isOwnedWorkBuddyMCP(existing) {
+		return errors.New("existing WorkBuddy PowerContext MCP entry is not owned by PowerContext")
 	}
 	servers[workBuddyPluginName] = entry
 	return writeWorkBuddyJSON(mcpFile, config)
@@ -431,6 +560,7 @@ func runWorkBuddyDiagnostics() map[string]diagnostic {
 	home, err := workBuddyHome()
 	if err != nil {
 		return map[string]diagnostic{
+			"config":   {Status: "failed", Detail: "cannot resolve WorkBuddy home"},
 			"hooks":    {Status: "failed", Detail: "cannot resolve WorkBuddy home"},
 			"settings": {Status: "failed", Detail: "cannot resolve WorkBuddy home"},
 			"mcp":      {Status: "failed", Detail: "cannot resolve WorkBuddy home"},
@@ -438,6 +568,11 @@ func runWorkBuddyDiagnostics() map[string]diagnostic {
 		}
 	}
 	hooksDir := filepath.Join(home, "hooks")
+	configuration, present, configErr := readWorkBuddyConfiguration(filepath.Join(home, workBuddyConfigFilename))
+	config := diagnostic{OK: true, Status: "ok", Detail: "credential-free WorkBuddy configuration is valid"}
+	if configErr != nil || !present {
+		config = diagnostic{Status: "failed", Detail: "PowerContext WorkBuddy configuration is missing or invalid"}
+	}
 	hooks := diagnostic{OK: true, Status: "ok", Detail: "hooks installed in " + hooksDir}
 	for _, name := range workBuddyHookModules {
 		if !isRegularWorkBuddyFile(filepath.Join(hooksDir, name)) {
@@ -449,9 +584,12 @@ func runWorkBuddyDiagnostics() map[string]diagnostic {
 		hooks = diagnostic{Status: "failed", Detail: "PowerContext WorkBuddy hooks are not installed"}
 	}
 	settings := workBuddySettingsDiagnostic(filepath.Join(home, "settings.json"))
-	mcp := workBuddyMCPDiagnostic(filepath.Join(home, "mcp.json"))
+	mcp := diagnostic{Status: "failed", Detail: "PowerContext WorkBuddy MCP server is not registered in mcp.json"}
+	if config.OK {
+		mcp = workBuddyMCPDiagnostic(filepath.Join(home, "mcp.json"), configuration)
+	}
 	skill := workBuddySkillDiagnostic(filepath.Join(home, "skills", workBuddySkillName))
-	return map[string]diagnostic{"hooks": hooks, "settings": settings, "mcp": mcp, "skill": skill}
+	return map[string]diagnostic{"config": config, "hooks": hooks, "settings": settings, "mcp": mcp, "skill": skill}
 }
 
 func workBuddySettingsDiagnostic(path string) diagnostic {
@@ -462,7 +600,16 @@ func workBuddySettingsDiagnostic(path string) diagnostic {
 	return diagnostic{OK: true, Status: "ok", Detail: path}
 }
 
-func workBuddyMCPDiagnostic(path string) diagnostic {
+func workBuddyConfiguredServerURL() (string, bool) {
+	home, err := workBuddyHome()
+	if err != nil {
+		return "", false
+	}
+	configuration, present, err := readWorkBuddyConfiguration(filepath.Join(home, workBuddyConfigFilename))
+	return configuration.ServerURL, present && err == nil
+}
+
+func workBuddyMCPDiagnostic(path string, configuration workBuddyConfiguration) diagnostic {
 	config, err := loadWorkBuddyJSON(path)
 	if err != nil {
 		return diagnostic{Status: "failed", Detail: "PowerContext WorkBuddy MCP server is not registered in mcp.json"}
@@ -473,6 +620,14 @@ func workBuddyMCPDiagnostic(path string) diagnostic {
 	}
 	if _, ok := servers[workBuddyPluginName].(map[string]any); !ok {
 		return diagnostic{Status: "failed", Detail: "PowerContext WorkBuddy MCP server is not registered in mcp.json"}
+	}
+	entry := servers[workBuddyPluginName].(map[string]any)
+	if entry["description"] != workBuddyMCPDescription || entry["url"] != configuration.ServerURL+"/mcp" {
+		return diagnostic{Status: "failed", Detail: "PowerContext WorkBuddy MCP server does not match its configuration"}
+	}
+	headers, ok := entry["headers"].(map[string]any)
+	if !ok || headers["Authorization"] != "${"+configuration.AuthorizationEnvironment+":-}" {
+		return diagnostic{Status: "failed", Detail: "PowerContext WorkBuddy MCP authorization reference does not match its configuration"}
 	}
 	return diagnostic{OK: true, Status: "ok", Detail: path}
 }
@@ -527,6 +682,69 @@ func loadWorkBuddyJSON(path string) (map[string]any, error) {
 	return value, nil
 }
 
+func readWorkBuddyConfiguration(path string) (workBuddyConfiguration, bool, error) {
+	payload, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return workBuddyConfiguration{}, false, nil
+	}
+	if err != nil {
+		return workBuddyConfiguration{}, false, err
+	}
+	configuration, err := decodeWorkBuddyConfiguration(payload)
+	return configuration, true, err
+}
+
+func decodeWorkBuddyConfiguration(payload []byte) (workBuddyConfiguration, error) {
+	if !utf8.Valid(payload) {
+		return workBuddyConfiguration{}, errors.New("invalid WorkBuddy configuration")
+	}
+	decoder := json.NewDecoder(bytes.NewReader(payload))
+	token, err := decoder.Token()
+	if err != nil || token != json.Delim('{') {
+		return workBuddyConfiguration{}, errors.New("invalid WorkBuddy configuration")
+	}
+	fields := make(map[string]json.RawMessage, 8)
+	for decoder.More() {
+		name, err := decoder.Token()
+		if err != nil {
+			return workBuddyConfiguration{}, errors.New("invalid WorkBuddy configuration")
+		}
+		key, ok := name.(string)
+		if !ok || fields[key] != nil {
+			return workBuddyConfiguration{}, errors.New("invalid WorkBuddy configuration")
+		}
+		var value json.RawMessage
+		if err := decoder.Decode(&value); err != nil {
+			return workBuddyConfiguration{}, errors.New("invalid WorkBuddy configuration")
+		}
+		fields[key] = value
+	}
+	if token, err := decoder.Token(); err != nil || token != json.Delim('}') {
+		return workBuddyConfiguration{}, errors.New("invalid WorkBuddy configuration")
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		return workBuddyConfiguration{}, errors.New("invalid WorkBuddy configuration")
+	}
+	expected := map[string]bool{
+		"schema": true, "server_url": true, "scope_mode": true, "authorization_environment": true,
+		"request_timeout_seconds": true, "request_budget_seconds": true, "prepare_max_bytes": true, "source_max_bytes": true,
+	}
+	if len(fields) != len(expected) {
+		return workBuddyConfiguration{}, errors.New("invalid WorkBuddy configuration")
+	}
+	for name := range expected {
+		if fields[name] == nil {
+			return workBuddyConfiguration{}, errors.New("invalid WorkBuddy configuration")
+		}
+	}
+	var configuration workBuddyConfiguration
+	if err := json.Unmarshal(payload, &configuration); err != nil || validateWorkBuddyConfiguration(configuration) != nil {
+		return workBuddyConfiguration{}, errors.New("invalid WorkBuddy configuration")
+	}
+	return configuration, nil
+}
+
 func writeWorkBuddyJSON(path string, value map[string]any) error {
 	payload, err := json.MarshalIndent(value, "", "  ")
 	if err != nil {
@@ -576,6 +794,15 @@ func isLegacyWorkBuddyMCP(entry map[string]any) bool {
 	kind, _ := entry["type"].(string)
 	return kind == "http" && url == workBuddyLegacyMCPURL && headersOK && len(headers) == 0 &&
 		description == workBuddyMCPDescription && disabledOK && !disabled
+}
+
+func isOwnedWorkBuddyMCP(entry map[string]any) bool {
+	headers, headersOK := entry["headers"].(map[string]any)
+	authorization, _ := headers["Authorization"].(string)
+	description, _ := entry["description"].(string)
+	kind, _ := entry["type"].(string)
+	return kind == "http" && headersOK && authorization == workBuddyAuthorizationTemplate &&
+		description == workBuddyMCPDescription
 }
 
 func workBuddyHookCommand(hooksDir string) string {

--- a/internal/cli/integration_workbuddy.go
+++ b/internal/cli/integration_workbuddy.go
@@ -532,7 +532,7 @@ func installWorkBuddySkill(plugin, target, hooksDir string) error {
 		return errors.New("cannot write WorkBuddy Skill ownership manifest")
 	}
 	backup := ""
-	if _, err := os.Lstat(target); err == nil {
+	if _, targetStatErr := os.Lstat(target); targetStatErr == nil {
 		backup, err = os.MkdirTemp(parent, ".project-context-backup-")
 		if err != nil {
 			return errors.New("cannot stage WorkBuddy Skill replacement")

--- a/internal/cli/integration_workbuddy_test.go
+++ b/internal/cli/integration_workbuddy_test.go
@@ -15,13 +15,34 @@
 package cli
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 )
+
+type workBuddyDiagnosticTransport struct {
+	paths []string
+}
+
+func (t *workBuddyDiagnosticTransport) RoundTrip(request *http.Request) (*http.Response, error) {
+	t.paths = append(t.paths, request.URL.Path)
+	payload := `{"status":"ok"}`
+	if request.URL.Path == "/health/ready" {
+		payload = `{"status":"ready","checks":{}}`
+	}
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(payload)),
+		Request:    request,
+	}, nil
+}
 
 func TestSetupWorkBuddyInstallsLocalPluginAndDoctorReportsOK(t *testing.T) {
 	checkout := filepath.Join(t.TempDir(), "powercontext")
@@ -62,13 +83,17 @@ func TestSetupWorkBuddyInstallsLocalPluginAndDoctorReportsOK(t *testing.T) {
 		t.Fatalf("installed Skill error = %v", statErr)
 	}
 
-	doctorOutput, _, doctorErr := executeSystemCLI(
-		t, nil, &scriptedSystemCommands{t: t}, "doctor", "workbuddy", "--json",
+	var doctorOutput, doctorStderr bytes.Buffer
+	transport := &workBuddyDiagnosticTransport{}
+	doctorCommand := newCommandWithAllDependencies(
+		VersionInfo{Version: "0.0.1"}, &doctorOutput, &doctorStderr, &http.Client{Transport: transport}, nil, &scriptedSystemCommands{t: t},
 	)
+	doctorCommand.SetArgs([]string{"doctor", "workbuddy", "--json"})
+	doctorErr := doctorCommand.ExecuteContext(t.Context())
 	if doctorErr != nil {
 		t.Fatal(doctorErr)
 	}
-	payload := decodeSystemOutput(t, doctorOutput)
+	payload := decodeSystemOutput(t, doctorOutput.String())
 	if payload["ok"] != true || payload["status"] != "ok" {
 		t.Fatalf("doctor result = %#v", payload)
 	}
@@ -108,53 +133,106 @@ func TestSetupWorkBuddyPreservesExistingSettingsAndMCP(t *testing.T) {
 	mcp := readWorkBuddyJSON(t, filepath.Join(home, "mcp.json"))
 	servers := mcp["mcpServers"].(map[string]any)
 	if servers["other-server"].(map[string]any)["command"] != "other" ||
-		servers[workBuddyPluginName].(map[string]any)["url"] != workBuddyServerURLTemplate {
+		servers[workBuddyPluginName].(map[string]any)["url"] != "http://127.0.0.1:8000/mcp" {
 		t.Fatalf("MCP = %#v", mcp)
 	}
 }
 
-func TestSetupWorkBuddyPreservesRemoteMCPAndMigratesLegacyEntry(t *testing.T) {
-	for _, test := range []struct {
-		name     string
-		existing map[string]any
-		wantURL  string
-		wantAuth string
-	}{
-		{
-			name: "remote authenticated",
-			existing: map[string]any{
-				"type": "http", "url": "https://memory.example.test/mcp",
-				"headers": map[string]any{"Authorization": "Bearer existing-token"}, "disabled": true,
-			},
-			wantURL: "https://memory.example.test/mcp", wantAuth: "Bearer existing-token",
-		},
-		{
-			name: "legacy generated",
-			existing: map[string]any{
-				"type": "http", "url": workBuddyLegacyMCPURL, "headers": map[string]any{},
-				"description": workBuddyMCPDescription, "disabled": false,
-			},
-			wantURL: workBuddyServerURLTemplate, wantAuth: workBuddyAuthorizationTemplate,
-		},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			checkout := filepath.Join(t.TempDir(), "powercontext")
-			writeWorkBuddyPlugin(t, checkout)
-			home := filepath.Join(t.TempDir(), "workbuddy")
-			t.Setenv("WORKBUDDY_HOME", home)
-			t.Setenv("POWERCONTEXT_HOME", filepath.Join(t.TempDir(), "data"))
-			writeWorkBuddyTestJSON(t, filepath.Join(home, "mcp.json"), map[string]any{
-				"mcpServers": map[string]any{workBuddyPluginName: test.existing},
-			})
+func TestSetupWorkBuddyWritesCredentialFreeConfiguration(t *testing.T) {
+	checkout := filepath.Join(t.TempDir(), "powercontext")
+	writeWorkBuddyPlugin(t, checkout)
+	home := filepath.Join(t.TempDir(), "workbuddy")
+	t.Setenv("WORKBUDDY_HOME", home)
+	t.Setenv("POWERCONTEXT_HOME", filepath.Join(t.TempDir(), "data"))
 
-			if _, _, err := executeSystemCLI(t, nil, &scriptedSystemCommands{t: t}, "setup", "workbuddy", "--source", checkout); err != nil {
-				t.Fatal(err)
-			}
-			entry := readWorkBuddyJSON(t, filepath.Join(home, "mcp.json"))["mcpServers"].(map[string]any)[workBuddyPluginName].(map[string]any)
-			if entry["url"] != test.wantURL || entry["headers"].(map[string]any)["Authorization"] != test.wantAuth || entry["disabled"] != false {
-				t.Fatalf("MCP entry = %#v", entry)
-			}
-		})
+	stdout, _, err := executeSystemCLI(t, nil, &scriptedSystemCommands{t: t},
+		"setup", "workbuddy", "--source", checkout, "--server-url", "http://127.0.0.1:8765/", "--json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := decodeSystemOutput(t, stdout)
+	if result["server_url"] != "http://127.0.0.1:8765" || result["scope_mode"] != "project" {
+		t.Fatalf("setup output = %#v", result)
+	}
+
+	configuration := readWorkBuddyJSON(t, filepath.Join(home, "powercontext.json"))
+	if fmt.Sprint(configuration["schema"]) != "1" ||
+		configuration["server_url"] != "http://127.0.0.1:8765" ||
+		configuration["authorization_environment"] != "POWERCONTEXT_WORKBUDDY_AUTHORIZATION" ||
+		configuration["request_timeout_seconds"] != float64(1.5) ||
+		configuration["request_budget_seconds"] != float64(3) ||
+		configuration["prepare_max_bytes"] != float64(8000) ||
+		configuration["source_max_bytes"] != float64(16384) {
+		t.Fatalf("configuration = %#v", configuration)
+	}
+	payload, err := os.ReadFile(filepath.Join(home, "powercontext.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(payload), "Bearer") || strings.Contains(string(payload), "token") {
+		t.Fatalf("configuration persisted a credential: %s", payload)
+	}
+	mcp := readWorkBuddyJSON(t, filepath.Join(home, "mcp.json"))
+	entry := mcp["mcpServers"].(map[string]any)[workBuddyPluginName].(map[string]any)
+	if entry["url"] != "http://127.0.0.1:8765/mcp" ||
+		entry["headers"].(map[string]any)["Authorization"] != "${POWERCONTEXT_WORKBUDDY_AUTHORIZATION:-}" {
+		t.Fatalf("MCP entry = %#v", entry)
+	}
+}
+
+func TestSetupWorkBuddyRejectsRemotePlaintextBeforePythonLookup(t *testing.T) {
+	commands := &scriptedSystemCommands{t: t}
+
+	_, _, err := executeSystemCLI(t, nil, commands, "setup", "workbuddy", "--server-url", "http://198.51.100.8:8000")
+	if err == nil || !strings.Contains(err.Error(), "loopback") || len(commands.lookups) != 0 {
+		t.Fatalf("setup error = %v, lookups = %v", err, commands.lookups)
+	}
+}
+
+func TestSetupWorkBuddyRefusesCredentialBearingMCPEntryBeforeMutation(t *testing.T) {
+	checkout := filepath.Join(t.TempDir(), "powercontext")
+	writeWorkBuddyPlugin(t, checkout)
+	home := filepath.Join(t.TempDir(), "workbuddy")
+	t.Setenv("WORKBUDDY_HOME", home)
+	t.Setenv("POWERCONTEXT_HOME", filepath.Join(t.TempDir(), "data"))
+	original := map[string]any{
+		"mcpServers": map[string]any{workBuddyPluginName: map[string]any{
+			"type": "http", "url": "https://memory.example.test/mcp",
+			"headers": map[string]any{"Authorization": "Bearer existing-token"}, "disabled": true,
+		}},
+	}
+	writeWorkBuddyTestJSON(t, filepath.Join(home, "mcp.json"), original)
+
+	_, _, err := executeSystemCLI(t, nil, &scriptedSystemCommands{t: t}, "setup", "workbuddy", "--source", checkout)
+	if err == nil || !strings.Contains(err.Error(), "not owned by PowerContext") {
+		t.Fatalf("setup error = %v", err)
+	}
+	if got := readWorkBuddyJSON(t, filepath.Join(home, "mcp.json")); fmt.Sprint(got) != fmt.Sprint(original) {
+		t.Fatalf("MCP after refusal = %#v", got)
+	}
+}
+
+func TestSetupWorkBuddyMigratesLegacyMCPEntry(t *testing.T) {
+	checkout := filepath.Join(t.TempDir(), "powercontext")
+	writeWorkBuddyPlugin(t, checkout)
+	home := filepath.Join(t.TempDir(), "workbuddy")
+	t.Setenv("WORKBUDDY_HOME", home)
+	t.Setenv("POWERCONTEXT_HOME", filepath.Join(t.TempDir(), "data"))
+	writeWorkBuddyTestJSON(t, filepath.Join(home, "mcp.json"), map[string]any{
+		"mcpServers": map[string]any{workBuddyPluginName: map[string]any{
+			"type": "http", "url": workBuddyLegacyMCPURL, "headers": map[string]any{},
+			"description": workBuddyMCPDescription, "disabled": false,
+		}},
+	})
+
+	if _, _, err := executeSystemCLI(t, nil, &scriptedSystemCommands{t: t}, "setup", "workbuddy", "--source", checkout); err != nil {
+		t.Fatal(err)
+	}
+	entry := readWorkBuddyJSON(t, filepath.Join(home, "mcp.json"))["mcpServers"].(map[string]any)[workBuddyPluginName].(map[string]any)
+	if entry["url"] != "http://127.0.0.1:8000/mcp" ||
+		entry["headers"].(map[string]any)["Authorization"] != workBuddyAuthorizationTemplate ||
+		entry["disabled"] != false {
+		t.Fatalf("MCP entry = %#v", entry)
 	}
 }
 
@@ -373,12 +451,59 @@ func TestBundledWorkBuddyPluginCarriesInstallableHooksSkillAndMCP(t *testing.T) 
 	}
 }
 
+func TestDoctorWorkBuddyChecksTheConfiguredServerReadiness(t *testing.T) {
+	checkout := filepath.Join(t.TempDir(), "powercontext")
+	writeWorkBuddyPlugin(t, checkout)
+	home := filepath.Join(t.TempDir(), "workbuddy")
+	t.Setenv("WORKBUDDY_HOME", home)
+	t.Setenv("POWERCONTEXT_HOME", filepath.Join(t.TempDir(), "data"))
+	commands := &scriptedSystemCommands{t: t}
+	serverURL := "http://127.0.0.1:8000"
+	if _, _, err := executeSystemCLI(t, nil, commands, "setup", "workbuddy", "--source", checkout, "--server-url", serverURL); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	transport := &workBuddyDiagnosticTransport{}
+	command := newCommandWithAllDependencies(
+		VersionInfo{Version: "0.0.1"}, &stdout, &stderr, &http.Client{Transport: transport}, nil, commands,
+	)
+	command.SetArgs([]string{"doctor", "workbuddy", "--json"})
+	err := command.ExecuteContext(t.Context())
+	if err != nil {
+		t.Fatalf("doctor error = %v, output = %s", err, stdout.String())
+	}
+	checks := decodeSystemOutput(t, stdout.String())["checks"].(map[string]any)
+	if checks["server_liveness"].(map[string]any)["status"] != "ok" || checks["server_readiness"].(map[string]any)["status"] != "ok" {
+		t.Fatalf("doctor checks = %#v", checks)
+	}
+	if strings.Join(transport.paths, ",") != "/health/live,/health/ready" {
+		t.Fatalf("health requests = %v", transport.paths)
+	}
+}
+
+func TestDoctorWorkBuddyRedactsInvalidCredentialConfiguration(t *testing.T) {
+	home := filepath.Join(t.TempDir(), "workbuddy")
+	secret := "workbuddy-should-not-appear"
+	writeTestFile(t, filepath.Join(home, "powercontext.json"), `{"authorization":"Bearer `+secret+`"}`)
+	t.Setenv("WORKBUDDY_HOME", home)
+
+	stdout, stderr, err := executeSystemCLI(t, nil, &scriptedSystemCommands{t: t}, "doctor", "workbuddy", "--json")
+	if err == nil {
+		t.Fatal("doctor unexpectedly accepted an invalid WorkBuddy configuration")
+	}
+	if strings.Contains(stdout+stderr+err.Error(), secret) {
+		t.Fatalf("doctor exposed configuration secret: stdout=%q stderr=%q error=%v", stdout, stderr, err)
+	}
+}
+
 func writeWorkBuddyPlugin(t *testing.T, root string) string {
 	t.Helper()
 	plugin := filepath.Join(root, "integrations", "workbuddy", "plugins", "powercontext")
 	for _, name := range []string{"workbuddy_powercontext_hook.py", "workbuddy_settings.py", "prepared_context.py"} {
 		writeTestFile(t, filepath.Join(plugin, "hooks", name), "# "+name+"\n")
 	}
+	writeTestFile(t, filepath.Join(plugin, "powercontext.json.example"), "{}\n")
 	writeTestFile(t, filepath.Join(plugin, "scripts", "project_scope.py"), "def resolve_scope_id(*_args): return 'scope'\n")
 	writeTestFile(t, filepath.Join(plugin, "skills", "project-context", "SKILL.md"), "${POWERCONTEXT_PYTHON} ${POWERCONTEXT_PROJECT_SCOPE_SCRIPT}\n")
 	resolved, err := resolvePath(plugin)

--- a/internal/cli/integration_workbuddy_test.go
+++ b/internal/cli/integration_workbuddy_test.go
@@ -180,6 +180,25 @@ func TestSetupWorkBuddyWritesCredentialFreeConfiguration(t *testing.T) {
 	}
 }
 
+func TestSetupWorkBuddyRefreshesOwnedCustomAuthorizationEnvironment(t *testing.T) {
+	checkout := filepath.Join(t.TempDir(), "powercontext")
+	writeWorkBuddyPlugin(t, checkout)
+	home := filepath.Join(t.TempDir(), "workbuddy")
+	t.Setenv("WORKBUDDY_HOME", home)
+	t.Setenv("POWERCONTEXT_HOME", filepath.Join(t.TempDir(), "data"))
+
+	for range 2 {
+		if _, _, err := executeSystemCLI(t, nil, &scriptedSystemCommands{t: t},
+			"setup", "workbuddy", "--source", checkout, "--authorization-environment", "WORKBUDDY_TOKEN"); err != nil {
+			t.Fatal(err)
+		}
+	}
+	entry := readWorkBuddyJSON(t, filepath.Join(home, "mcp.json"))["mcpServers"].(map[string]any)[workBuddyPluginName].(map[string]any)
+	if entry["headers"].(map[string]any)["Authorization"] != "${WORKBUDDY_TOKEN:-}" {
+		t.Fatalf("MCP entry = %#v", entry)
+	}
+}
+
 func TestSetupWorkBuddyRejectsRemotePlaintextBeforePythonLookup(t *testing.T) {
 	commands := &scriptedSystemCommands{t: t}
 

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -50,6 +50,7 @@ func newSetupCommand(state *commandState) *cobra.Command {
 		newSetupOpenCodeCommand(state),
 		newSetupHermesCommand(state),
 		newSetupOpenClawCommand(state),
+		newSetupWorkBuddyCommand(state),
 	)
 	return command
 }

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -50,7 +50,6 @@ func newSetupCommand(state *commandState) *cobra.Command {
 		newSetupOpenCodeCommand(state),
 		newSetupHermesCommand(state),
 		newSetupOpenClawCommand(state),
-		newSetupWorkBuddyCommand(state),
 	)
 	return command
 }

--- a/test/conformance/parity-inventory-rules.json
+++ b/test/conformance/parity-inventory-rules.json
@@ -130,12 +130,12 @@
         },
         "test_setup_workbuddy_preserves_remote_authenticated_mcp_configuration": {
           "evidence": [
-            "go:internal/cli/integration_workbuddy_test.go#TestSetupWorkBuddyPreservesRemoteMCPAndMigratesLegacyEntry"
+            "go:internal/cli/integration_workbuddy_test.go#TestSetupWorkBuddyRefusesCredentialBearingMCPEntryBeforeMutation"
           ]
         },
         "test_setup_workbuddy_migrates_the_legacy_generated_mcp_entry": {
           "evidence": [
-            "go:internal/cli/integration_workbuddy_test.go#TestSetupWorkBuddyPreservesRemoteMCPAndMigratesLegacyEntry"
+            "go:internal/cli/integration_workbuddy_test.go#TestSetupWorkBuddyMigratesLegacyMCPEntry"
           ]
         },
         "test_setup_workbuddy_preserves_other_hooks_shared_scripts": {

--- a/test/conformance/parity-inventory.json
+++ b/test/conformance/parity-inventory.json
@@ -8074,7 +8074,7 @@
         {
           "kind": "go",
           "file": "internal/cli/integration_workbuddy_test.go",
-          "test": "TestSetupWorkBuddyPreservesRemoteMCPAndMigratesLegacyEntry"
+          "test": "TestSetupWorkBuddyRefusesCredentialBearingMCPEntryBeforeMutation"
         }
       ]
     },
@@ -8091,7 +8091,7 @@
         {
           "kind": "go",
           "file": "internal/cli/integration_workbuddy_test.go",
-          "test": "TestSetupWorkBuddyPreservesRemoteMCPAndMigratesLegacyEntry"
+          "test": "TestSetupWorkBuddyMigratesLegacyMCPEntry"
         }
       ]
     },


### PR DESCRIPTION
## Summary
- add a credential-free WorkBuddy Hook, MCP declaration, project-context Skill, and adapter tests
- add setup workbuddy and doctor workbuddy with ownership-safe merge, redacted diagnostics, and configured Server health checks
- run the WorkBuddy adapter tests in the host-adapters CI job

## Validation
- uv run --with pytest pytest integrations/workbuddy/tests -q
- go test ./internal/cli -run ^(TestSetupAndDoctorExposeCurrentHostMatrix|TestSetupWorkBuddy|TestDoctorWorkBuddy) -count=1 with the local CGO SQLite header workaround
- go vet ./internal/cli

## Remaining Evidence Gap
- Native WorkBuddy was not installed on this Windows host, so this PR does not claim native-host E2E evidence. The adapter service chain, installed-artifact path, setup, doctor, collision, redaction, and readiness contracts are covered locally.

Progresses #107.