### PR TITLE
fix(mcp): annotate destructive candidate-review writes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -180,6 +180,9 @@ source / artifact / trigger / inference
   raw database bytes that contain the producing SQLite version and physical
   page-layout metadata. Keep committed fixture hashes pinned separately, and
   verify both semantic regeneration and cross-runtime read/write compatibility.
+- When a newly exposed MCP tool mutates review state, declare its complete
+  `ToolAnnotations` tuple and verify it through `tools/list`; annotations must
+  remain host hints and never replace authorization or state-transition checks.
 - When defining or changing LF checkout rules, enumerate every tracked
   byte-sensitive executable, module manifest or checksum, prompt, schema,
   dataset, fixture, and generated-contract format, including extensionless

--- a/internal/mcpapi/server.go
+++ b/internal/mcpapi/server.go
@@ -514,6 +514,12 @@ func annotations(name string) *mcp.ToolAnnotations {
 		value.DestructiveHint = &nondestructive
 		value.IdempotentHint = true
 		return value
+	case "approve_artifact_candidate", "reject_artifact_candidate", "revise_artifact_candidate":
+		value := &mcp.ToolAnnotations{OpenWorldHint: &closedWorld}
+		destructive := true
+		value.DestructiveHint = &destructive
+		value.IdempotentHint = true
+		return value
 	default:
 		return nil
 	}

--- a/internal/mcpapi/server_test.go
+++ b/internal/mcpapi/server_test.go
@@ -100,6 +100,35 @@ func TestHandoffToolAnnotationsMatchFrozenHostApprovalSemantics(t *testing.T) {
 	}
 }
 
+func TestReviewWriteToolAnnotationsMatchFrozenHostApprovalSemantics(t *testing.T) {
+	t.Parallel()
+	server, err := NewServer(endpoint.NewHandler(endpoint.HandlerOptions{}), Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := connectInMemory(t, server).ListTools(context.Background(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tools := make(map[string]*mcp.Tool, len(result.Tools))
+	for _, tool := range result.Tools {
+		tools[tool.Name] = tool
+	}
+
+	for _, name := range []string{
+		"approve_artifact_candidate",
+		"reject_artifact_candidate",
+		"revise_artifact_candidate",
+	} {
+		annotation := tools[name].Annotations
+		if annotation == nil || annotation.ReadOnlyHint || annotation.DestructiveHint == nil ||
+			!*annotation.DestructiveHint || !annotation.IdempotentHint || annotation.OpenWorldHint == nil ||
+			*annotation.OpenWorldHint {
+			t.Fatalf("%s annotations = %#v", name, annotation)
+		}
+	}
+}
+
 func TestServerExposesFrozenToolSet(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Progresses #117 and contributes the narrowly scoped MCP annotation item in #3 (WP1).

The Go MCP server previously registered pprove_artifact_candidate, eject_artifact_candidate, and evise_artifact_candidate without ToolAnnotations. MCP hosts therefore could not see that these review writes should be confirmation-worthy. The accepted upstream v0.1.0 release at 7b736206a53a6de6f43d4b517893ee1a80e7183d specifies the following tuple for all three tools:

- eadOnlyHint: false
- destructiveHint: true
- idempotentHint: true
- openWorldHint: false

This PR adds exactly that closed-world tuple at MCP tool registration and a 	ools/list-based regression test over the registered server.

## Scope and non-goals

Changed files:

- internal/mcpapi/server.go: declarative annotation mapping only.
- internal/mcpapi/server_test.go: in-memory MCP discovery regression proof.
- AGENTS.md: reusable guardrail requiring a complete tuple for newly exposed review-write tools.

No OpenAPI or generated files change: the annotations are server-registration metadata, not HTTP contract/schema input. This PR does not alter authorization, input validation, optimistic concurrency, review state transitions, persistence, CLI behavior, or host integrations. MCP annotations remain hints for hosts; they are not authorization.

## Validation

- gofmt -w internal/mcpapi/server.go completed.
- git diff --check completed with no output.
- The focused test was added before the mapping change. Local execution is currently blocked before compilation by a corrupt Go toolchain/module cache: the configured checksum setting first prevents toolchain verification, and restoring the official checksum service then reports invalid cached zip data. A clean-cache retry also fails while downloading the configured Go toolchain with the same invalid-zip condition.

GitHub Actions will provide the required clean-cache regression result for go test ./internal/mcpapi; expected generated validation is make check-generated with no generated-file diff.

## Follow-up plan

1. Confirm the focused MCP test and generated-contract check in the PR workflow.
2. Rebase only if main changes the same nnotations mapping, then rerun validation on the exact head.
3. Mark ready for review after the clean-run evidence is available.