### PR TITLE
feat(mcp): annotate review write tools

### DIFF
--- a/internal/mcpapi/server.go
+++ b/internal/mcpapi/server.go
@@ -514,6 +514,15 @@ func annotations(name string) *mcp.ToolAnnotations {
 		value.DestructiveHint = &nondestructive
 		value.IdempotentHint = true
 		return value
+	case "approve_artifact_candidate", "reject_artifact_candidate", "revise_artifact_candidate":
+		// These hints let MCP hosts apply their own confirmation policy; they
+		// do not grant authorization. Exact replays are rejected by the
+		// pending-head CAS before another write can occur.
+		return &mcp.ToolAnnotations{
+			DestructiveHint: new(true),
+			IdempotentHint:  true,
+			OpenWorldHint:   &closedWorld,
+		}
 	default:
 		return nil
 	}

--- a/internal/mcpapi/server_test.go
+++ b/internal/mcpapi/server_test.go
@@ -100,6 +100,38 @@ func TestHandoffToolAnnotationsMatchFrozenHostApprovalSemantics(t *testing.T) {
 	}
 }
 
+func TestReviewWriteToolAnnotationsMatchUpstreamHostApprovalSemantics(t *testing.T) {
+	t.Parallel()
+	server, err := NewServer(endpoint.NewHandler(endpoint.HandlerOptions{}), Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := connectInMemory(t, server).ListTools(t.Context(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tools := make(map[string]*mcp.Tool, len(result.Tools))
+	for _, tool := range result.Tools {
+		tools[tool.Name] = tool
+	}
+	for _, name := range []string{
+		"approve_artifact_candidate",
+		"reject_artifact_candidate",
+		"revise_artifact_candidate",
+	} {
+		tool := tools[name]
+		if tool == nil {
+			t.Fatalf("MCP tool %q is missing", name)
+		}
+		decision := tool.Annotations
+		if decision == nil || decision.ReadOnlyHint || decision.DestructiveHint == nil ||
+			!*decision.DestructiveHint || !decision.IdempotentHint ||
+			decision.OpenWorldHint == nil || *decision.OpenWorldHint {
+			t.Fatalf("%s annotations = %#v", name, decision)
+		}
+	}
+}
+
 func TestServerExposesFrozenToolSet(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Tracking

- Tracking issue: #120
- Relationship: Closes #120
- Parent Epic: Part of #3

## Problem and rationale

The Go MCP server exposes candidate approval, rejection, and revision tools without the ToolAnnotations present in the accepted PowerContext v0.1.0 behavior.

Without these annotations, MCP hosts cannot reliably identify Review operations that should be considered for user confirmation.

## Changes

- Mark `approve_artifact_candidate`, `reject_artifact_candidate`, and `revise_artifact_candidate` as destructive, idempotent, closed-world write operations.
- Add focused MCP tool-list coverage for the three Review operations.
- Clarify that the annotations guide host confirmation policy and do not grant authorization.

## Behavior and compatibility

- User-visible behavior: MCP hosts can identify the three Review writes as destructive and may request confirmation.
- Public API or protocol impact: the existing MCP tools now include additional ToolAnnotations.
- Breaking changes or migration requirements: none.
- Explicit non-goals: no Review business logic, authorization, OpenAPI, persistence, or generated-code changes.

## Generated, dependency, and workflow impact

- [x] No generated contract changed.
- [x] No dependency changed; `go.mod` and `go.sum` remain unchanged.
- [x] No CI or release workflow changed.
- [x] No credential, private Source/Memory content, or unredacted production log is included.

## Validation

```text
go test ./internal/mcpapi -run '^TestReviewWriteToolAnnotationsMatchUpstreamHostApprovalSemantics$' -count=1
ok

go test ./internal/mcpapi -count=1
ok

make lint
0 issues.

git diff --check
passed
```

- [x] `git diff --check`
- [x] `git status --short` was inspected after validation.
- [x] The changed Go files were formatted with `gofmt`.
- [x] No generator output changed.
- [x] No public Go API changed.
- [x] Relevant MCP package tests and repository lint passed.
- [x] No skipped check is represented as passing.

## AI usage

AI assistance was used to compare the Go MCP behavior with the accepted upstream PowerContext v0.1.0 implementation and prepare the focused change. The resulting diff was reviewed locally and verified with targeted tests, the complete MCP package tests, and the repository lint gate.