### PR TITLE
test: synchronize local embedding shutdown

### DIFF
--- a/internal/modelprovider/sentence_transformers_ort_test.go
+++ b/internal/modelprovider/sentence_transformers_ort_test.go
@@ -21,10 +21,10 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
-	"runtime"
 	"slices"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 
 	"github.com/ob-labs/powercontext-go/inference"
 )
@@ -73,64 +73,79 @@ func TestSentenceTransformersFactoryIsLazy(t *testing.T) {
 }
 
 func TestLocalEmbeddingTransportCancellationAndCloseDrainNativeCall(t *testing.T) {
-	started := make(chan struct{})
-	release := make(chan struct{})
-	var destroyed atomic.Int32
-	transport := newLocalEmbeddingTransport(func([]string) ([][]float32, error) {
-		close(started)
-		<-release
-		return [][]float32{{1}}, nil
-	}, func() error {
-		destroyed.Add(1)
-		return nil
-	})
+	synctest.Test(t, func(t *testing.T) {
+		started := make(chan struct{})
+		release := make(chan struct{})
+		var destroyed atomic.Int32
+		transport := newLocalEmbeddingTransport(func([]string) ([][]float32, error) {
+			close(started)
+			<-release
+			return [][]float32{{1}}, nil
+		}, func() error {
+			destroyed.Add(1)
+			return nil
+		})
 
-	callContext, cancelCall := context.WithCancel(context.Background())
-	callDone := make(chan error, 1)
-	go func() {
-		_, err := transport.Embed(callContext, []string{"alpha"}, inference.EmbeddingDocument)
-		callDone <- err
-	}()
-	<-started
-	cancelCall()
-	if err := <-callDone; !errors.Is(err, context.Canceled) {
-		t.Fatalf("embed error = %v", err)
-	}
-
-	closeDone := make(chan error, 1)
-	go func() { closeDone <- transport.Close(context.Background()) }()
-	for {
-		transport.stateMu.Lock()
-		closing := transport.closing
-		transport.stateMu.Unlock()
-		if closing {
-			break
+		callContext, cancelCall := context.WithCancel(t.Context())
+		callDone := make(chan error, 1)
+		go func() {
+			_, err := transport.Embed(callContext, []string{"alpha"}, inference.EmbeddingDocument)
+			callDone <- err
+		}()
+		<-started
+		cancelCall()
+		if err := <-callDone; !errors.Is(err, context.Canceled) {
+			t.Fatalf("embed error = %v", err)
 		}
-		runtime.Gosched()
-	}
-	_, err := transport.Embed(t.Context(), []string{"late"}, inference.EmbeddingDocument)
-	var unavailable *inference.UnavailableError
-	if !errors.As(err, &unavailable) {
-		t.Fatalf("late embed error = %v", err)
-	}
-	select {
-	case err := <-closeDone:
-		t.Fatalf("close returned before native call drained: %v", err)
-	default:
-	}
-	close(release)
-	if err := <-closeDone; err != nil {
-		t.Fatal(err)
-	}
-	if destroyed.Load() != 1 {
-		t.Fatalf("destroy calls = %d", destroyed.Load())
-	}
-	if err := transport.Close(t.Context()); err != nil {
-		t.Fatal(err)
-	}
-	if destroyed.Load() != 1 {
-		t.Fatalf("idempotent destroy calls = %d", destroyed.Load())
-	}
+
+		closeDone := make(chan error, 1)
+		go func() { closeDone <- transport.Close(t.Context()) }()
+		synctest.Wait()
+
+		lateContext, cancelLate := context.WithCancel(t.Context())
+		defer cancelLate()
+		lateDone := make(chan error, 1)
+		go func() {
+			_, err := transport.Embed(lateContext, []string{"late"}, inference.EmbeddingDocument)
+			lateDone <- err
+		}()
+		synctest.Wait()
+		select {
+		case err := <-lateDone:
+			var unavailable *inference.UnavailableError
+			if !errors.As(err, &unavailable) {
+				t.Fatalf("late embed error = %v", err)
+			}
+		default:
+			cancelLate()
+			close(release)
+			if err := <-lateDone; !errors.Is(err, context.Canceled) {
+				t.Fatalf("late admitted embed error = %v", err)
+			}
+			if err := <-closeDone; err != nil {
+				t.Fatal(err)
+			}
+			t.Fatal("late embed was admitted while Close was draining")
+		}
+		select {
+		case err := <-closeDone:
+			t.Fatalf("close returned before native call drained: %v", err)
+		default:
+		}
+		close(release)
+		if err := <-closeDone; err != nil {
+			t.Fatal(err)
+		}
+		if destroyed.Load() != 1 {
+			t.Fatalf("destroy calls = %d", destroyed.Load())
+		}
+		if err := transport.Close(t.Context()); err != nil {
+			t.Fatal(err)
+		}
+		if destroyed.Load() != 1 {
+			t.Fatalf("idempotent destroy calls = %d", destroyed.Load())
+		}
+	})
 }
 
 func TestLocalEmbeddingTransportSerializesPipeline(t *testing.T) {


### PR DESCRIPTION
## Summary
- replace the local ONNX embedding shutdown test's `runtime.Gosched` state polling with deterministic `testing/synctest` barriers
- verify Close rejects a late Embed while an already-started native call is still draining
- bound the unexpected-admission failure path by cancelling the late request and releasing the original native call before reporting the assertion

## Verification
- `go test ./internal/modelprovider -count=1`
- `gofmt -w internal/modelprovider/sentence_transformers_ort_test.go`
- `git diff --check`

The changed test has `local_embeddings && cgo && (ORT || ALL)` build constraints. On this Windows host, the tagged build stops in `github.com/knights-analytics/ortgenai` because `dlfcn.h` is unavailable. This PR therefore requires the existing Linux full-build-tags CI jobs as the authoritative compile and execution evidence; CGo/tags were not disabled locally.

Part of #3; does not close the tracking issue.