### PR TITLE
fix(workbuddy): preserve remote authenticated MCP configuration

### DIFF
--- a/internal/cli/integration_workbuddy.go
+++ b/internal/cli/integration_workbuddy.go
@@ -490,10 +490,15 @@ func mergeWorkBuddyMCP(mcpFile string, configuration workBuddyConfiguration) err
 		"headers":     map[string]any{"Authorization": "${" + configuration.AuthorizationEnvironment + ":-}"},
 		"description": workBuddyMCPDescription, "disabled": false,
 	}
-	if existing, ok := servers[workBuddyPluginName].(map[string]any); ok &&
-		!isLegacyWorkBuddyMCP(existing) &&
-		!isOwnedWorkBuddyMCP(existing) {
-		return errors.New("existing WorkBuddy PowerContext MCP entry is not owned by PowerContext")
+	if existing, ok := servers[workBuddyPluginName].(map[string]any); ok {
+		if isRemoteAuthenticatedWorkBuddyMCP(existing) {
+			existing["disabled"] = false
+			servers[workBuddyPluginName] = existing
+			return writeWorkBuddyJSON(mcpFile, config)
+		}
+		if !isLegacyWorkBuddyMCP(existing) && !isOwnedWorkBuddyMCP(existing) {
+			return errors.New("existing WorkBuddy PowerContext MCP entry is not owned by PowerContext")
+		}
 	}
 	servers[workBuddyPluginName] = entry
 	return writeWorkBuddyJSON(mcpFile, config)
@@ -621,6 +626,9 @@ func workBuddyMCPDiagnostic(path string, configuration workBuddyConfiguration) d
 	entry, entryOK := servers[workBuddyPluginName].(map[string]any)
 	if !entryOK {
 		return diagnostic{Status: "failed", Detail: "PowerContext WorkBuddy MCP server is not registered in mcp.json"}
+	}
+	if isRemoteAuthenticatedWorkBuddyMCP(entry) {
+		return diagnostic{OK: true, Status: "ok", Detail: "existing remote PowerContext WorkBuddy MCP server is registered"}
 	}
 	if entry["description"] != workBuddyMCPDescription || entry["url"] != configuration.ServerURL+"/mcp" {
 		return diagnostic{Status: "failed", Detail: "PowerContext WorkBuddy MCP server does not match its configuration"}
@@ -803,6 +811,18 @@ func isOwnedWorkBuddyMCP(entry map[string]any) bool {
 	kind, _ := entry["type"].(string)
 	return kind == "http" && headersOK && isWorkBuddyAuthorizationTemplate(authorization) &&
 		description == workBuddyMCPDescription
+}
+
+func isRemoteAuthenticatedWorkBuddyMCP(entry map[string]any) bool {
+	serverURL, urlOK := entry["url"].(string)
+	parsed, parseErr := url.Parse(serverURL)
+	headers, headersOK := entry["headers"].(map[string]any)
+	authorization, authorizationOK := headers["Authorization"].(string)
+	disabled, disabledOK := entry["disabled"].(bool)
+	kind, kindOK := entry["type"].(string)
+	return kindOK && kind == "http" && urlOK && parseErr == nil && parsed.Scheme == "https" && parsed.Host != "" &&
+		parsed.User == nil && parsed.RawQuery == "" && parsed.Fragment == "" && headersOK && authorizationOK &&
+		strings.TrimSpace(authorization) != "" && disabledOK && disabled
 }
 
 func isWorkBuddyAuthorizationTemplate(value string) bool {

--- a/internal/cli/integration_workbuddy.go
+++ b/internal/cli/integration_workbuddy.go
@@ -798,7 +798,7 @@ func isLegacyWorkBuddyMCP(entry map[string]any) bool {
 	url, _ := entry["url"].(string)
 	headers, headersOK := entry["headers"].(map[string]any)
 	description, _ := entry["description"].(string)
-	_, disabledOK := entry["disabled"].(bool)
+	disabled, disabledOK := entry["disabled"].(bool)
 	kind, _ := entry["type"].(string)
 	return kind == "http" && url == workBuddyLegacyMCPURL && headersOK && len(headers) == 0 &&
 		description == workBuddyMCPDescription && disabledOK && !disabled
@@ -818,7 +818,7 @@ func isRemoteAuthenticatedWorkBuddyMCP(entry map[string]any) bool {
 	parsed, parseErr := url.Parse(serverURL)
 	headers, headersOK := entry["headers"].(map[string]any)
 	authorization, authorizationOK := headers["Authorization"].(string)
-	disabled, disabledOK := entry["disabled"].(bool)
+	_, disabledOK := entry["disabled"].(bool)
 	kind, kindOK := entry["type"].(string)
 	return kindOK && kind == "http" && urlOK && parseErr == nil && parsed.Scheme == "https" && parsed.Host != "" &&
 		parsed.User == nil && parsed.RawQuery == "" && parsed.Fragment == "" && headersOK && authorizationOK &&

--- a/internal/cli/integration_workbuddy.go
+++ b/internal/cli/integration_workbuddy.go
@@ -798,7 +798,7 @@ func isLegacyWorkBuddyMCP(entry map[string]any) bool {
 	url, _ := entry["url"].(string)
 	headers, headersOK := entry["headers"].(map[string]any)
 	description, _ := entry["description"].(string)
-	disabled, disabledOK := entry["disabled"].(bool)
+	_, disabledOK := entry["disabled"].(bool)
 	kind, _ := entry["type"].(string)
 	return kind == "http" && url == workBuddyLegacyMCPURL && headersOK && len(headers) == 0 &&
 		description == workBuddyMCPDescription && disabledOK && !disabled
@@ -822,7 +822,7 @@ func isRemoteAuthenticatedWorkBuddyMCP(entry map[string]any) bool {
 	kind, kindOK := entry["type"].(string)
 	return kindOK && kind == "http" && urlOK && parseErr == nil && parsed.Scheme == "https" && parsed.Host != "" &&
 		parsed.User == nil && parsed.RawQuery == "" && parsed.Fragment == "" && headersOK && authorizationOK &&
-		strings.TrimSpace(authorization) != "" && disabledOK && disabled
+		strings.TrimSpace(authorization) != "" && disabledOK
 }
 
 func isWorkBuddyAuthorizationTemplate(value string) bool {

--- a/internal/cli/integration_workbuddy_test.go
+++ b/internal/cli/integration_workbuddy_test.go
@@ -208,7 +208,7 @@ func TestSetupWorkBuddyRejectsRemotePlaintextBeforePythonLookup(t *testing.T) {
 	}
 }
 
-func TestSetupWorkBuddyRefusesCredentialBearingMCPEntryBeforeMutation(t *testing.T) {
+func TestSetupWorkBuddyPreservesRemoteAuthenticatedMCPConfiguration(t *testing.T) {
 	checkout := filepath.Join(t.TempDir(), "powercontext")
 	writeWorkBuddyPlugin(t, checkout)
 	home := filepath.Join(t.TempDir(), "workbuddy")
@@ -222,12 +222,18 @@ func TestSetupWorkBuddyRefusesCredentialBearingMCPEntryBeforeMutation(t *testing
 	}
 	writeWorkBuddyTestJSON(t, filepath.Join(home, "mcp.json"), original)
 
-	_, _, err := executeSystemCLI(t, nil, &scriptedSystemCommands{t: t}, "setup", "workbuddy", "--source", checkout)
-	if err == nil || !strings.Contains(err.Error(), "not owned by PowerContext") {
-		t.Fatalf("setup error = %v", err)
+	if _, _, err := executeSystemCLI(t, nil, &scriptedSystemCommands{t: t}, "setup", "workbuddy", "--source", checkout); err != nil {
+		t.Fatal(err)
 	}
-	if got := readWorkBuddyJSON(t, filepath.Join(home, "mcp.json")); fmt.Sprint(got) != fmt.Sprint(original) {
-		t.Fatalf("MCP after refusal = %#v", got)
+	entry := readWorkBuddyJSON(t, filepath.Join(home, "mcp.json"))["mcpServers"].(map[string]any)[workBuddyPluginName].(map[string]any)
+	if entry["url"] != "https://memory.example.test/mcp" ||
+		entry["headers"].(map[string]any)["Authorization"] != "Bearer existing-token" ||
+		entry["disabled"] != false {
+		t.Fatalf("MCP after setup = %#v", entry)
+	}
+	configuration, readErr := os.ReadFile(filepath.Join(home, workBuddyConfigFilename))
+	if readErr != nil || strings.Contains(string(configuration), "existing-token") {
+		t.Fatalf("credential-free configuration = %q, error = %v", configuration, readErr)
 	}
 }
 

--- a/test/conformance/parity-inventory-rules.json
+++ b/test/conformance/parity-inventory-rules.json
@@ -130,7 +130,7 @@
         },
         "test_setup_workbuddy_preserves_remote_authenticated_mcp_configuration": {
           "evidence": [
-            "go:internal/cli/integration_workbuddy_test.go#TestSetupWorkBuddyRefusesCredentialBearingMCPEntryBeforeMutation"
+            "go:internal/cli/integration_workbuddy_test.go#TestSetupWorkBuddyPreservesRemoteAuthenticatedMCPConfiguration"
           ]
         },
         "test_setup_workbuddy_migrates_the_legacy_generated_mcp_entry": {

--- a/test/conformance/parity-inventory.json
+++ b/test/conformance/parity-inventory.json
@@ -8074,7 +8074,7 @@
         {
           "kind": "go",
           "file": "internal/cli/integration_workbuddy_test.go",
-          "test": "TestSetupWorkBuddyRefusesCredentialBearingMCPEntryBeforeMutation"
+          "test": "TestSetupWorkBuddyPreservesRemoteAuthenticatedMCPConfiguration"
         }
       ]
     },


### PR DESCRIPTION
## Summary
- preserve an existing HTTPS PowerContext MCP URL and Authorization during WorkBuddy setup, while enabling the entry
- keep the generated WorkBuddy configuration credential-free and recognize preserved remote MCP entries in diagnostics
- restore the upstream remote-auth regression mapping to a matching Go test and regenerate the parity inventory

## Validation
- `uv run --with pytest pytest integrations/workbuddy/tests -q` (17 passed)
- `go run ./tools/parity-inventory-generate -upstream C:\\Users\\alex\\AppData\\Local\\Temp\\powercontext-wp1-parity-target -check`
- Windows `go test ./internal/cli` remains blocked before test execution by the known missing `sqlite3.h` CGO development header; exact-Head Linux CI is required for the Go regression gate.

Progresses #3.