### PR TITLE
test: detect Runtime goroutine leaks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	go.opentelemetry.io/otel/metric v1.44.0
 	go.opentelemetry.io/otel/sdk v1.44.0
 	go.opentelemetry.io/otel/trace v1.44.0
+	go.uber.org/goleak v1.3.0
 	golang.org/x/mod v0.40.0
 	golang.org/x/term v0.45.0
 	golang.org/x/text v0.41.0

--- a/internal/runtime/goleak_test.go
+++ b/internal/runtime/goleak_test.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtime
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}


### PR DESCRIPTION
## Summary
- declare the already locked `go.uber.org/goleak` test dependency directly in the root module
- add a Runtime package `TestMain` gate that fails when any Runtime test leaves an unexpected goroutine behind

## Verification
- `go test ./internal/runtime -count=1`
- `go test -race ./internal/runtime -count=1`
- `go mod tidy` with no `go.mod`/`go.sum` diff
- `go mod verify`
- `go vet ./internal/runtime`
- `.\\.tools\\bin\\golangci-lint.exe run --timeout=10m ./internal/runtime`
- Temporary mutation added an unbounded `select {}` goroutine. The package test then failed with `goleak: found unexpected goroutines`; the mutation was removed before commit.

Part of #3; does not close the tracking issue.