### PR TITLE
test(conformance): record v0.1.0 release identity

### DIFF
--- a/test/conformance/parity-contract.json
+++ b/test/conformance/parity-contract.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "upstream": {
     "repository": "oceanbase/powercontext",
     "url": "https://github.com/oceanbase/powercontext",
@@ -9,6 +9,21 @@
     "commit": "3a6cb0151670eaff7dc0293466edd673124e80da",
     "baseline": "python-v0.0.2",
     "evidence_directory": "test/conformance/testdata/python-v0.0.2"
+  },
+  "release_target": {
+    "tag": "powercontext-v0.1.0",
+    "version": "0.1.0",
+    "commit": "7b736206a53a6de6f43d4b517893ee1a80e7183d",
+    "test_case_count": 812,
+    "test_file_count": 132,
+    "wheel": {
+      "filename": "powercontext-0.1.0-py3-none-any.whl",
+      "sha256": "94f8fef36d4afcee09dd5231fbe5edfe47e42e41994596b775e2f203ef6fac72"
+    },
+    "sdist": {
+      "filename": "powercontext-0.1.0.tar.gz",
+      "sha256": "18d47a335340b0870216e2cc0fb1fd8e4d865880155daeea3b01187c950fd746"
+    }
   },
   "exact_target_sha": "f2ec1f75e5e1b46ad0626ab8390801b88966b6f5",
   "target_test_case_count": 759,

--- a/test/conformance/parity_contract_test.go
+++ b/test/conformance/parity_contract_test.go
@@ -41,6 +41,21 @@ type parityContract struct {
 		Baseline          string `json:"baseline"`
 		EvidenceDirectory string `json:"evidence_directory"`
 	} `json:"frozen_release_oracle"`
+	ReleaseTarget struct {
+		Tag           string `json:"tag"`
+		Version       string `json:"version"`
+		Commit        string `json:"commit"`
+		TestCaseCount int    `json:"test_case_count"`
+		TestFileCount int    `json:"test_file_count"`
+		Wheel         struct {
+			Filename string `json:"filename"`
+			SHA256   string `json:"sha256"`
+		} `json:"wheel"`
+		Sdist struct {
+			Filename string `json:"filename"`
+			SHA256   string `json:"sha256"`
+		} `json:"sdist"`
+	} `json:"release_target"`
 	ExactTargetSHA      string `json:"exact_target_sha"`
 	TargetTestCaseCount int    `json:"target_test_case_count"`
 	ActiveParityTarget  string `json:"active_parity_target"`
@@ -67,11 +82,11 @@ func TestParityContractRejectsAmbiguousJSON(t *testing.T) {
 	}{
 		{
 			name:   "duplicate member",
-			mutant: strings.Replace(string(contents), `"schema_version": 1,`, `"schema_version": 999, "schema_version": 1,`, 1),
+			mutant: strings.Replace(string(contents), `"schema_version": 2,`, `"schema_version": 999, "schema_version": 2,`, 1),
 		},
 		{
 			name:   "unknown member",
-			mutant: strings.Replace(string(contents), `"schema_version": 1,`, `"schema_version": 1, "future_semantics": true,`, 1),
+			mutant: strings.Replace(string(contents), `"schema_version": 2,`, `"schema_version": 2, "future_semantics": true,`, 1),
 		},
 	}
 	for _, test := range tests {
@@ -108,8 +123,8 @@ func TestParityContractRecordsSeparateConcepts(t *testing.T) {
 	contract := readParityContract(t)
 	root := repositoryRoot(t)
 
-	if contract.SchemaVersion != 1 {
-		t.Fatalf("parity contract schema version = %d, want 1", contract.SchemaVersion)
+	if contract.SchemaVersion != 2 {
+		t.Fatalf("parity contract schema version = %d, want 2", contract.SchemaVersion)
 	}
 
 	// Concept 1: the upstream repository identity.
@@ -169,6 +184,31 @@ func TestParityContractRecordsSeparateConcepts(t *testing.T) {
 	}
 	if active == oracle {
 		t.Errorf("active parity target collapses into the frozen release Oracle %s; parity work must measure a newer upstream state", oracle)
+	}
+}
+
+func TestParityContractRecordsSignedV010ReleaseIdentity(t *testing.T) {
+	contract := readParityContract(t)
+	release := contract.ReleaseTarget
+	if release.Tag != "powercontext-v0.1.0" {
+		t.Errorf("release tag = %q, want powercontext-v0.1.0", release.Tag)
+	}
+	if release.Version != "0.1.0" {
+		t.Errorf("release version = %q, want 0.1.0", release.Version)
+	}
+	if release.Commit != "7b736206a53a6de6f43d4b517893ee1a80e7183d" {
+		t.Errorf("release commit = %q, want exact v0.1.0 release commit", release.Commit)
+	}
+	if release.TestCaseCount != 812 || release.TestFileCount != 132 {
+		t.Errorf("release inventory = %d cases in %d files, want 812 cases in 132 files", release.TestCaseCount, release.TestFileCount)
+	}
+	if release.Wheel.Filename != "powercontext-0.1.0-py3-none-any.whl" ||
+		release.Wheel.SHA256 != "94f8fef36d4afcee09dd5231fbe5edfe47e42e41994596b775e2f203ef6fac72" {
+		t.Errorf("wheel identity = %#v", release.Wheel)
+	}
+	if release.Sdist.Filename != "powercontext-0.1.0.tar.gz" ||
+		release.Sdist.SHA256 != "18d47a335340b0870216e2cc0fb1fd8e4d865880155daeea3b01187c950fd746" {
+		t.Errorf("sdist identity = %#v", release.Sdist)
 	}
 }
 

--- a/tools/parity-inventory-generate/main.go
+++ b/tools/parity-inventory-generate/main.go
@@ -51,6 +51,21 @@ type parityContract struct {
 		Baseline          string `json:"baseline"`
 		EvidenceDirectory string `json:"evidence_directory"`
 	} `json:"frozen_release_oracle"`
+	ReleaseTarget struct {
+		Tag           string `json:"tag"`
+		Version       string `json:"version"`
+		Commit        string `json:"commit"`
+		TestCaseCount int    `json:"test_case_count"`
+		TestFileCount int    `json:"test_file_count"`
+		Wheel         struct {
+			Filename string `json:"filename"`
+			SHA256   string `json:"sha256"`
+		} `json:"wheel"`
+		Sdist struct {
+			Filename string `json:"filename"`
+			SHA256   string `json:"sha256"`
+		} `json:"sdist"`
+	} `json:"release_target"`
 	ExactTargetSHA      string `json:"exact_target_sha"`
 	TargetTestCaseCount int    `json:"target_test_case_count"`
 	ActiveParityTarget  string `json:"active_parity_target"`
@@ -151,7 +166,7 @@ func run(root, contractPath, traceabilityPath, rulesPath, outputPath, upstream s
 	if err := readJSON(filepath.Join(root, contractPath), &contract); err != nil {
 		return fmt.Errorf("read parity contract: %w", err)
 	}
-	if contract.SchemaVersion != 1 || contract.ExactTargetSHA == "" || contract.FrozenOracle.Commit == "" {
+	if contract.SchemaVersion != 2 || contract.ExactTargetSHA == "" || contract.FrozenOracle.Commit == "" {
 		return fmt.Errorf("parity contract is missing the target SHA or frozen Oracle commit")
 	}
 	if upstream == "" {


### PR DESCRIPTION
## Summary
- extend the parity contract with the signed PowerContext v0.1.0 tag, version, exact commit, release test inventory, and wheel/sdist SHA-256 identities
- upgrade the contract schema and generator parser while retaining the current f2ec active parity target until the 812-case inventory and target-delta ledger land together
- add a contract regression that rejects drift in the v0.1.0 release identity

## Verified Release Inputs
- tag `powercontext-v0.1.0` resolves to `7b736206a53a6de6f43d4b517893ee1a80e7183d`
- wheel SHA-256 `94f8fef36d4afcee09dd5231fbe5edfe47e42e41994596b775e2f203ef6fac72`
- sdist SHA-256 `18d47a335340b0870216e2cc0fb1fd8e4d865880155daeea3b01187c950fd746`
- generator-equivalent discovery finds 812 cases in 132 files

## Validation
- `go test ./tools/parity-inventory-generate -count=1`
- `go run ./tools/parity-inventory-generate -upstream C:\\Users\\alex\\AppData\\Local\\Temp\\powercontext-wp1-parity-target -check`
- Windows contract test is blocked before execution by the known missing `sqlite3.h` CGO development header; exact-Head Linux CI is required.

Progresses #3.