### PR TITLE
test: build generated Go consumers

### DIFF
--- a/tools/generated-consumers/main_test.go
+++ b/tools/generated-consumers/main_test.go
@@ -221,6 +221,7 @@ func TestOpenAPIGeneratorProducesGoldenBuildableConsumer(t *testing.T) {
 
 	runGo(t, consumer, "mod", "tidy")
 	runGo(t, consumer, "mod", "verify")
+	runGo(t, consumer, "build", "./...")
 	runGo(t, consumer, "test", "-count=1", "./...")
 }
 
@@ -241,6 +242,7 @@ func TestMCPSchemaGeneratorProducesGoldenBuildableConsumer(t *testing.T) {
 
 	runGo(t, consumer, "mod", "tidy")
 	runGo(t, consumer, "mod", "verify")
+	runGo(t, consumer, "build", "./...")
 	runGo(t, consumer, "test", "-count=1", "./...")
 }
 
@@ -259,6 +261,7 @@ func TestTraceabilityGeneratorProducesGoldenConsumableTable(t *testing.T) {
 
 	compareFile(t, filepath.Join(repository, "test", "conformance", "traceability.json"), generated)
 	prepareTraceabilityConsumer(t, consumer)
+	runGo(t, consumer, "build", "./...")
 	runGo(t, consumer, "test", "-count=1", "./...")
 	runGo(t, consumer, "vet", "./...")
 	runConsumerLint(t, repository, consumer)


### PR DESCRIPTION
## Summary
- require every fresh Go consumer generated from OpenAPI, MCP schema, and traceability public entrypoints to run `go build ./...` before tests
- preserve existing golden comparison, `go mod tidy`, `go mod verify`, test, vet, and consumer lint coverage

## Verification
- `go test -count=1 ./tools/generated-consumers`
- `go mod verify`
- `git diff --check`
- Temporary mutation replaced the OpenAPI consumer `go build` subcommand with an invalid one; the test failed at that explicit build step. The mutation was removed before commit.

Part of #3; does not close the tracking issue.