### PR TITLE
feat(openapi): align contract version with v0.1.0

### DIFF
--- a/integrations/dsh/plugins/powercontext/openapi/powercontext.yaml
+++ b/integrations/dsh/plugins/powercontext/openapi/powercontext.yaml
@@ -16,7 +16,7 @@ openapi: 3.0.3
 info:
   title: PowerContext API
   description: Remote PowerContext transport. Runtime behavior is reported by /v1/capabilities.
-  version: 0.0.2
+  version: 0.1.0
 security:
   - BearerAuth: []
   - {}

--- a/openapi/contract_test.go
+++ b/openapi/contract_test.go
@@ -27,7 +27,7 @@ import (
 	v1 "github.com/ob-labs/powercontext-go/api/v1"
 )
 
-const frozenOpenAPISHA256 = "739e8fa4983399980d6c619490fe1806dc354ac173a5bb3c99250cb080d11b09"
+const activeOpenAPISHA256 = "08b9c71cf286307b4e4573fad7198fec37f963192bfa70f15bac33b228283798"
 
 func TestFrozenOpenAPIAndGeneratedHandlerStayInSync(t *testing.T) {
 	t.Parallel()
@@ -35,8 +35,11 @@ func TestFrozenOpenAPIAndGeneratedHandlerStayInSync(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got := fmt.Sprintf("%x", sha256.Sum256(contents)); got != frozenOpenAPISHA256 {
-		t.Fatalf("OpenAPI SHA-256 = %s, want frozen Oracle %s", got, frozenOpenAPISHA256)
+	if got := fmt.Sprintf("%x", sha256.Sum256(contents)); got != activeOpenAPISHA256 {
+		t.Fatalf("OpenAPI SHA-256 = %s, want active contract %s", got, activeOpenAPISHA256)
+	}
+	if !bytes.Contains(contents, []byte("\n  version: 0.1.0\n")) {
+		t.Fatal("OpenAPI info.version must match the v0.1.0 release")
 	}
 
 	operationIDs := make(map[string]struct{})

--- a/openapi/powercontext.yaml
+++ b/openapi/powercontext.yaml
@@ -16,7 +16,7 @@ openapi: 3.0.3
 info:
   title: PowerContext API
   description: Remote PowerContext transport. Runtime behavior is reported by /v1/capabilities.
-  version: 0.0.2
+  version: 0.1.0
 security:
   - BearerAuth: []
   - {}


### PR DESCRIPTION
## Summary
- update the authoritative OpenAPI `info.version` from 0.0.2 to the signed v0.1.0 release value
- keep the DSH bundled OpenAPI byte-identical to the authority
- pin the active OpenAPI SHA-256 and assert the version alongside the existing 53-operation handler contract

## Evidence
- exact upstream release commit `7b736206a53a6de6f43d4b517893ee1a80e7183d` differs from the current contract only at `info.version`
- both contracts expose 53 operationIds
- upstream v0.1.0 OpenAPI SHA-256: `08b9c71cf286307b4e4573fad7198fec37f963192bfa70f15bac33b228283798`
- historical `python-v0.0.2` manifest remains unchanged; it is independently immutable evidence

## Validation
- `go test ./openapi -count=1`
- `go run ./tools/mcp-schema-generate`
- `go test ./tools/mcp-schema-generate -count=1`
- `go generate ./openapi` (API/client generated output unchanged)

Progresses #3.