### PR TITLE
fix(cli): harden managed config parsing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -319,3 +319,9 @@ source / artifact / trigger / inference
   against the same resolved path rather than the raw input path. Verify a
   symlinked temporary-root path and an ordinary path so platform aliases such
   as macOS `/var` cannot cause a false setup failure.
+- When a CLI reads a shell-style environment file, parse assignments without
+  evaluating shell expansion, recognize managed markers only as complete
+  lines, and redact credential-bearing URLs, headers, and cookies. Verify
+  quoted and escaped literals, rejected expansion and control input, invalid
+  UTF-8, marker text inside values, repeated markers, and both human and JSON
+  output.

--- a/internal/cli/config_command.go
+++ b/internal/cli/config_command.go
@@ -25,6 +25,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
@@ -37,7 +38,12 @@ const (
 	configManagedEnd   = "# <<< powercontext managed configuration <<<"
 )
 
-var configEnvironmentName = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+var (
+	configEnvironmentName  = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+	configAssignmentName   = regexp.MustCompile(`^(?:export[ \t]+)?([A-Za-z_][A-Za-z0-9_]*)=`)
+	configManagedBeginLine = regexp.MustCompile(`(?m)^[ \t]*` + regexp.QuoteMeta(configManagedBegin) + `[ \t\r]*$`)
+	configManagedEndLine   = regexp.MustCompile(`(?m)^[ \t]*` + regexp.QuoteMeta(configManagedEnd) + `[ \t\r]*$`)
+)
 
 func newConfigCommand(state *commandState) *cobra.Command {
 	command := &cobra.Command{Use: "config", Short: "Create, inspect, and validate PowerContext environment files.", Args: cobra.NoArgs}
@@ -223,26 +229,37 @@ func readConfigDocument(path string) (string, bool, error) {
 	if err != nil {
 		return "", false, errors.New("cannot read configuration file")
 	}
+	if !utf8.Valid(payload) {
+		return "", false, errors.New("configuration file is not valid UTF-8")
+	}
 	return string(payload), true, nil
 }
 
 func updateConfigDocument(content string, values map[string]string) (string, error) {
-	beginCount := strings.Count(content, configManagedBegin)
-	endCount := strings.Count(content, configManagedEnd)
-	if beginCount != endCount || beginCount > 1 {
+	beginMarkers := configManagedBeginLine.FindAllStringIndex(content, -1)
+	endMarkers := configManagedEndLine.FindAllStringIndex(content, -1)
+	if len(beginMarkers) != len(endMarkers) || len(beginMarkers) > 1 {
 		return "", errors.New("environment contains mismatched or repeated PowerContext managed markers")
 	}
 	block := renderConfigBlock(values)
-	if beginCount == 1 {
-		begin := strings.Index(content, configManagedBegin)
-		end := strings.Index(content[begin:], configManagedEnd)
-		if end < 0 {
-			return "", errors.New("environment contains mismatched PowerContext managed markers")
+	if len(beginMarkers) == 1 {
+		if endMarkers[0][0] < beginMarkers[0][1] {
+			return "", errors.New("PowerContext managed markers are out of order")
 		}
-		end += begin + len(configManagedEnd)
-		return joinConfigDocument(content[:begin], block, content[end:]), nil
+		return joinConfigDocument(content[:beginMarkers[0][0]], block, content[endMarkers[0][1]:]), nil
 	}
-	return joinConfigDocument(content, block), nil
+	retained := make([]string, 0)
+	for line := range strings.SplitSeq(strings.ReplaceAll(content, "\r\n", "\n"), "\n") {
+		match := configAssignmentName.FindStringSubmatch(strings.TrimSpace(line))
+		if match == nil {
+			retained = append(retained, line)
+			continue
+		}
+		if _, managed := values[match[1]]; !managed {
+			retained = append(retained, line)
+		}
+	}
+	return joinConfigDocument(strings.Join(retained, "\n"), block), nil
 }
 
 func renderConfigBlock(values map[string]string) string {
@@ -266,63 +283,117 @@ func joinConfigDocument(parts ...string) string {
 }
 
 func parseConfigEnvironment(content string) (map[string]string, error) {
+	if !utf8.ValidString(content) {
+		return nil, errors.New("environment is not valid UTF-8")
+	}
 	values := make(map[string]string)
-	for lineNumber, raw := range strings.Split(strings.ReplaceAll(content, "\r\n", "\n"), "\n") {
-		line := strings.TrimSpace(raw)
-		if line == "" || strings.HasPrefix(line, "#") || line == configManagedBegin || line == configManagedEnd {
+	lineNumber := 0
+	for raw := range strings.SplitSeq(strings.ReplaceAll(content, "\r\n", "\n"), "\n") {
+		lineNumber++
+		line := strings.TrimLeft(strings.TrimSuffix(raw, "\r"), " \t")
+		if line == "" || strings.HasPrefix(line, "#") {
 			continue
 		}
-		line = strings.TrimSpace(strings.TrimPrefix(line, "export "))
-		name, value, found := strings.Cut(line, "=")
+		if after, found := strings.CutPrefix(line, "export"); found && len(after) > 0 && (after[0] == ' ' || after[0] == '\t') {
+			line = strings.TrimLeft(after, " \t")
+		}
+		if strings.ContainsRune(line, '\x00') {
+			return nil, fmt.Errorf("invalid NUL character at line %d", lineNumber)
+		}
+		words, err := splitConfigShellWords(line)
+		if err != nil {
+			return nil, fmt.Errorf("invalid environment assignment at line %d: %w", lineNumber, err)
+		}
+		if len(words) != 1 {
+			return nil, fmt.Errorf("invalid environment assignment at line %d", lineNumber)
+		}
+		name, value, found := strings.Cut(words[0], "=")
 		if !found || !configEnvironmentName.MatchString(name) {
-			return nil, fmt.Errorf("invalid environment assignment at line %d", lineNumber+1)
+			return nil, fmt.Errorf("invalid environment assignment at line %d", lineNumber)
 		}
 		if _, exists := values[name]; exists {
 			return nil, fmt.Errorf("duplicate environment assignment: %s", name)
 		}
-		decoded, err := decodeConfigValue(strings.TrimSpace(value))
-		if err != nil {
-			return nil, fmt.Errorf("invalid environment assignment at line %d", lineNumber+1)
-		}
-		values[name] = decoded
+		values[name] = value
 	}
 	return values, nil
 }
 
-func decodeConfigValue(value string) (string, error) {
-	if value == "" {
-		return "", nil
-	}
-	if strings.HasPrefix(value, "'") {
-		if len(value) < 2 || !strings.HasSuffix(value, "'") {
-			return "", errors.New("unterminated single-quoted value")
+func splitConfigShellWords(line string) ([]string, error) {
+	characters := []rune(line)
+	words := make([]string, 0, 1)
+	word := make([]rune, 0, len(characters))
+	var quote rune
+	wordStarted := false
+	for index := 0; index < len(characters); index++ {
+		character := characters[index]
+		switch {
+		case quote == '\'':
+			if character == quote {
+				quote = 0
+			} else {
+				word = append(word, character)
+			}
+			wordStarted = true
+		case quote == '"':
+			switch {
+			case character == quote:
+				quote = 0
+			case character == '\\' && index+1 < len(characters) && strings.ContainsRune("$`\"\\", characters[index+1]):
+				index++
+				word = append(word, characters[index])
+			case character == '$' || character == '`':
+				return nil, errors.New("shell expansion is not supported; quote or escape the value to keep it literal")
+			default:
+				word = append(word, character)
+			}
+			wordStarted = true
+		case character == '\'' || character == '"':
+			quote = character
+			wordStarted = true
+		case character == '\\':
+			if index+1 >= len(characters) {
+				return nil, errors.New("no escaped character")
+			}
+			index++
+			word = append(word, characters[index])
+			wordStarted = true
+		case character == ' ' || character == '\t':
+			if wordStarted {
+				words = append(words, string(word))
+				word = word[:0]
+				wordStarted = false
+			}
+		case character == '#' && !wordStarted:
+			return words, nil
+		case character == '$' || character == '`' ||
+			(character == '~' && (len(word) == 0 || word[len(word)-1] == '=' || word[len(word)-1] == ':')):
+			return nil, errors.New("shell expansion is not supported; quote or escape the value to keep it literal")
+		default:
+			word = append(word, character)
+			wordStarted = true
 		}
-		return value[1 : len(value)-1], nil
 	}
-	if strings.HasPrefix(value, "\"") {
-		decoded, err := strconv.Unquote(value)
-		if err != nil {
-			return "", err
-		}
-		return decoded, nil
+	if quote != 0 {
+		return nil, errors.New("no closing quotation")
 	}
-	if index := strings.Index(value, " #"); index >= 0 {
-		value = strings.TrimSpace(value[:index])
+	if wordStarted {
+		words = append(words, string(word))
 	}
-	return value, nil
+	return words, nil
 }
 
 func managedCredentialNames(content string) (map[string]bool, error) {
-	begin := strings.Index(content, configManagedBegin)
-	end := strings.Index(content, configManagedEnd)
-	if begin < 0 && end < 0 {
+	beginMarkers := configManagedBeginLine.FindAllStringIndex(content, -1)
+	endMarkers := configManagedEndLine.FindAllStringIndex(content, -1)
+	if len(beginMarkers) == 0 && len(endMarkers) == 0 {
 		return map[string]bool{}, nil
 	}
-	if begin < 0 || end < begin {
-		return nil, errors.New("environment contains mismatched PowerContext managed markers")
+	if len(beginMarkers) != 1 || len(endMarkers) != 1 || endMarkers[0][0] < beginMarkers[0][1] {
+		return nil, errors.New("environment contains mismatched or repeated PowerContext managed markers")
 	}
 	credentials := make(map[string]bool)
-	for _, line := range strings.Split(content[begin:end], "\n") {
+	for line := range strings.SplitSeq(content[beginMarkers[0][1]:endMarkers[0][0]], "\n") {
 		line = strings.TrimSpace(line)
 		if !strings.HasPrefix(line, "# credentials=") {
 			continue
@@ -338,20 +409,31 @@ func managedCredentialNames(content string) (map[string]bool, error) {
 
 func redactedConfigValue(name, value string, credentials map[string]bool) string {
 	upper := strings.ToUpper(name)
-	if credentials[name] || strings.Contains(upper, "TOKEN") || strings.Contains(upper, "KEY") || strings.Contains(upper, "PASSWORD") || strings.Contains(upper, "SECRET") {
+	if credentials[name] || upper == "POWERCONTEXT_SERVER_DATABASE_URL" || upper == "POWERCONTEXT_SERVER_AUTH_TOKEN" ||
+		upper == "POWERCONTEXT_CLIENT_API_TOKEN" || strings.HasSuffix(upper, "_KEY") || strings.HasSuffix(upper, "_PASSWORD") ||
+		strings.HasSuffix(upper, "_SECRET") || strings.HasSuffix(upper, "_TOKEN") || strings.Contains(upper, "_KEY_") ||
+		strings.HasSuffix(upper, "_HEADERS") || strings.HasSuffix(upper, "_HEADER") || strings.HasSuffix(upper, "_COOKIES") ||
+		strings.HasSuffix(upper, "_COOKIE") {
 		return "<redacted>"
 	}
 	return value
 }
 
 func validateConfigPersistence(values map[string]string) error {
-	if values["POWERCONTEXT_SERVER_DATABASE_KIND"] == "seekdb" {
+	kind := strings.TrimSpace(values["POWERCONTEXT_SERVER_DATABASE_KIND"])
+	if kind == "seekdb" {
 		if path := strings.TrimSpace(values["POWERCONTEXT_SERVER_DATABASE_PATH"]); path != "" && !filepath.IsAbs(filepath.FromSlash(path)) {
 			return errors.New("seekDB path must be absolute")
 		}
 		return nil
 	}
-	url := values["POWERCONTEXT_SERVER_DATABASE_URL"]
+	if kind != "" && kind != "sqlite" {
+		return nil
+	}
+	url := strings.TrimSpace(values["POWERCONTEXT_SERVER_DATABASE_URL"])
+	if url == "" {
+		return nil
+	}
 	const prefix = "sqlite+aiosqlite:///"
 	if !strings.HasPrefix(url, prefix) {
 		return errors.New("SQLite URL must use sqlite+aiosqlite")

--- a/internal/cli/config_command_test.go
+++ b/internal/cli/config_command_test.go
@@ -15,6 +15,7 @@
 package cli
 
 import (
+	"encoding/json/v2"
 	"os"
 	"path/filepath"
 	"strings"
@@ -127,5 +128,172 @@ func TestParseConfigEnvironmentAcceptsShellCompatibleAssignments(t *testing.T) {
 	if values["QUOTED"] != "value with spaces" || values["SINGLE"] != "literal # value" ||
 		values["PLAIN"] != "value" || values["EMPTY"] != "" {
 		t.Fatalf("parsed values = %#v", values)
+	}
+}
+
+func TestConfigShowRedactsStandardSensitiveAssignments(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "sensitive.env")
+	content := strings.Join([]string{
+		"POWERCONTEXT_SERVER_DATABASE_KIND=oceanbase",
+		"POWERCONTEXT_SERVER_DATABASE_URL='mysql+aoceanbase://root:db-secret@127.0.0.1:2881/powercontext?charset=utf8mb4'",
+		"OTEL_EXPORTER_OTLP_HEADERS=authorization=Bearer-demo-secret",
+		"PLAIN=value",
+		"",
+	}, "\n")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	human, _, humanErr := executeSystemCLI(t, nil, &scriptedSystemCommands{t: t}, "config", "show", "--env-file", path)
+	if humanErr != nil {
+		t.Fatal(humanErr)
+	}
+	if strings.Contains(human, "db-secret") || strings.Contains(human, "demo-secret") ||
+		!strings.Contains(human, "POWERCONTEXT_SERVER_DATABASE_URL=<redacted>") ||
+		!strings.Contains(human, "OTEL_EXPORTER_OTLP_HEADERS=<redacted>") ||
+		!strings.Contains(human, "PLAIN=value") {
+		t.Fatalf("show output = %q", human)
+	}
+
+	machine, _, machineErr := executeSystemCLI(
+		t, nil, &scriptedSystemCommands{t: t}, "config", "show", "--env-file", path, "--json",
+	)
+	if machineErr != nil {
+		t.Fatal(machineErr)
+	}
+	var view map[string]string
+	if err := json.Unmarshal([]byte(machine), &view); err != nil {
+		t.Fatal(err)
+	}
+	if view["POWERCONTEXT_SERVER_DATABASE_URL"] != "<redacted>" ||
+		view["OTEL_EXPORTER_OTLP_HEADERS"] != "<redacted>" || view["PLAIN"] != "value" {
+		t.Fatalf("JSON show output = %#v", view)
+	}
+}
+
+func TestConfigInitForceTreatsMarkerTextInsideCredentialAsLiteral(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "marker-value.env")
+	content := renderConfigBlock(map[string]string{"OPENROUTER_API_KEY": configManagedBegin}) + "\n"
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, _, err := executeSystemCLI(
+		t, nil, &scriptedSystemCommands{t: t}, "config", "init", "--output", path, "--force", "--non-interactive",
+	); err != nil {
+		t.Fatalf("force init with marker-valued credential: %v", err)
+	}
+}
+
+func TestConfigShowRejectsRepeatedManagedMarkers(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "repeated-marker.env")
+	content := renderConfigBlock(map[string]string{"OPENROUTER_API_KEY": "secret"}) + "\n" + configManagedBegin + "\n"
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, err := executeSystemCLI(t, nil, &scriptedSystemCommands{t: t}, "config", "show", "--env-file", path)
+	if err == nil || !strings.Contains(err.Error(), "mismatched or repeated") {
+		t.Fatalf("show error = %v", err)
+	}
+}
+
+func TestParseConfigEnvironmentSupportsShellLiteralSyntax(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{name: "tab after export", content: "export\tTOKEN=abc\n", want: "abc"},
+		{name: "escaped space", content: "TOKEN=abc\\ #123\n", want: "abc #123"},
+		{name: "tab comment boundary", content: "TOKEN=abc\t#comment\n", want: "abc"},
+		{name: "single quoted expansion", content: "TOKEN='$ROOT/data'\n", want: "$ROOT/data"},
+		{name: "escaped expansion", content: "TOKEN=\\$ROOT/data\n", want: "$ROOT/data"},
+		{name: "hash starts value", content: "TOKEN=#literal\n", want: "#literal"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			values, err := parseConfigEnvironment(test.content)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if values["TOKEN"] != test.want {
+				t.Fatalf("TOKEN = %q, want %q", values["TOKEN"], test.want)
+			}
+		})
+	}
+}
+
+func TestParseConfigEnvironmentRejectsExpansionAndControlInput(t *testing.T) {
+	for _, value := range []string{"$ROOT/data", "${ROOT}/data", "$(command)", "`command`", "~/data", "value\x00tail"} {
+		t.Run(value, func(t *testing.T) {
+			if _, err := parseConfigEnvironment("TOKEN=" + value + "\n"); err == nil {
+				t.Fatalf("accepted unsafe value %q", value)
+			}
+		})
+	}
+}
+
+func TestConfigInitForceRemovesStandaloneManagedAssignments(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "legacy.env")
+	content := "UNRELATED_SETTING=keep\nPOWERCONTEXT_SERVER_HTTP_PORT=9999\n"
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, _, err := executeSystemCLI(
+		t, nil, &scriptedSystemCommands{t: t}, "config", "init", "--output", path, "--force", "--non-interactive",
+	); err != nil {
+		t.Fatal(err)
+	}
+	updated, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(updated), "UNRELATED_SETTING=keep") ||
+		strings.Count(string(updated), "POWERCONTEXT_SERVER_HTTP_PORT=") != 1 {
+		t.Fatalf("updated configuration = %q", updated)
+	}
+	if _, parseErr := parseConfigEnvironment(string(updated)); parseErr != nil {
+		t.Fatalf("updated configuration is not parseable: %v", parseErr)
+	}
+}
+
+func TestConfigValidateAcceptsSupportedNonSQLiteAndPartialSettings(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+	}{
+		{
+			name: "OceanBase",
+			content: "POWERCONTEXT_SERVER_DATABASE_KIND=oceanbase\n" +
+				"POWERCONTEXT_SERVER_DATABASE_URL='mysql+aoceanbase://root:test@127.0.0.1:2881/powercontext?charset=utf8mb4'\n",
+		},
+		{name: "partial defaults", content: "POWERCONTEXT_SERVER_HTTP_HOST=127.0.0.1\n"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "valid.env")
+			if err := os.WriteFile(path, []byte(test.content), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if _, _, err := executeSystemCLI(
+				t, nil, &scriptedSystemCommands{t: t}, "config", "validate", "--env-file", path,
+			); err != nil {
+				t.Fatalf("validate supported configuration: %v", err)
+			}
+		})
+	}
+}
+
+func TestConfigShowRejectsInvalidUTF8(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "invalid.env")
+	if err := os.WriteFile(path, []byte("TOKEN=\xff\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, err := executeSystemCLI(t, nil, &scriptedSystemCommands{t: t}, "config", "show", "--env-file", path)
+	if err == nil || !strings.Contains(err.Error(), "UTF-8") {
+		t.Fatalf("show error = %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- parse shell-compatible environment assignments without evaluating expansion
- recognize managed markers only as complete lines and remove legacy managed assignments on force init
- redact database URLs and credential container variables in human and JSON output
- accept supported non-SQLite and partial configurations while preserving absolute SQLite/seekDB validation
- reject invalid UTF-8 and add a reusable regression-prevention rule

## Regression proof
Before the fix, the focused tests failed for redaction, marker boundaries, shell escaping/expansion, legacy replacement, non-SQLite validation, and invalid UTF-8. After the fix:

- `go test ./internal/cli -run '^(TestCommandTreeContainsProductCommands|TestConfig|TestParseConfig)' -count=1`
- `go vet ./internal/cli`
- `.tools/bin/golangci-lint run ./internal/cli` (0 issues)

Part of #3. This does not close the epic.