### PR TITLE
test: reconcile native dependencies with SBOM

### DIFF
--- a/tools/release/evidence.go
+++ b/tools/release/evidence.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"encoding/json/jsontext"
 	"encoding/json/v2"
 	"errors"
 	"flag"
@@ -27,18 +28,26 @@ import (
 )
 
 type spdxDocument struct {
-	SPDXVersion string        `json:"spdxVersion"`
-	Packages    []spdxPackage `json:"packages"`
+	SPDXVersion string                    `json:"spdxVersion"`
+	Packages    []spdxPackage             `json:"packages"`
+	Extra       map[string]jsontext.Value `json:",embed"`
 }
 
 type spdxPackage struct {
-	ExternalReferences []spdxExternalReference `json:"externalRefs"`
+	Name               string                    `json:"name,omitempty"`
+	SPDXID             string                    `json:"SPDXID,omitempty"`
+	Version            string                    `json:"versionInfo,omitempty"`
+	DownloadLocation   string                    `json:"downloadLocation,omitempty"`
+	FilesAnalyzed      *bool                     `json:"filesAnalyzed,omitempty"`
+	ExternalReferences []spdxExternalReference   `json:"externalRefs,omitempty"`
+	Extra              map[string]jsontext.Value `json:",embed"`
 }
 
 type spdxExternalReference struct {
-	Category string `json:"referenceCategory"`
-	Type     string `json:"referenceType"`
-	Locator  string `json:"referenceLocator"`
+	Category string                    `json:"referenceCategory"`
+	Type     string                    `json:"referenceType"`
+	Locator  string                    `json:"referenceLocator"`
+	Extra    map[string]jsontext.Value `json:",embed"`
 }
 
 func runVerifyEvidence(arguments []string) error {
@@ -103,12 +112,15 @@ func verifyReleaseEvidence(root string) error {
 		}
 	}
 	for _, module := range manifest.Modules {
-		if module.Path == "" || module.Version == "" {
-			return errors.New("dependency manifest contains a Go module without a path or version")
-		}
 		purl := "pkg:golang/" + module.Path + "@" + module.Version
 		if _, ok := recorded[purl]; !ok {
 			return fmt.Errorf("SPDX SBOM is missing Go module %q at version %q", module.Path, module.Version)
+		}
+	}
+	for _, native := range manifest.Native {
+		purl := "pkg:generic/" + native.Path + "@" + native.Version
+		if _, ok := recorded[purl]; !ok {
+			return fmt.Errorf("SPDX SBOM is missing native dependency %q at version %q", native.Path, native.Version)
 		}
 	}
 	return nil

--- a/tools/release/main_test.go
+++ b/tools/release/main_test.go
@@ -82,15 +82,42 @@ func TestReleaseEvidenceVerifierRejectsSBOMModuleOmission(t *testing.T) {
 	}
 }
 
-func TestReleaseEvidenceVerifierRejectsLicenseRecordMissingFromNotice(t *testing.T) {
+func TestReleaseEvidenceVerifierRejectsSBOMNativeDependencyOmission(t *testing.T) {
 	root := t.TempDir()
-	writeReleaseEvidenceFixture(t, root, false, `{
+	writeReleaseEvidenceFixture(t, root, true, `{
   "spdxVersion": "SPDX-2.3",
   "packages": [{"externalRefs": [{
     "referenceCategory": "PACKAGE-MANAGER",
     "referenceType": "purl",
     "referenceLocator": "pkg:golang/example.com/covered@v1.2.3"
   }]}]
+}`)
+
+	output, commandErr := runReleaseEvidenceVerifier(t, root)
+	if commandErr == nil {
+		t.Fatalf("release evidence verifier accepted an SBOM without the native dependency:\n%s", output)
+	}
+	if !strings.Contains(string(output), "missing native dependency") {
+		t.Fatalf("release evidence verifier did not report the omitted native dependency:\n%s", output)
+	}
+}
+
+func TestReleaseEvidenceVerifierRejectsLicenseRecordMissingFromNotice(t *testing.T) {
+	root := t.TempDir()
+	writeReleaseEvidenceFixture(t, root, false, `{
+  "spdxVersion": "SPDX-2.3",
+  "packages": [
+    {"externalRefs": [{
+      "referenceCategory": "PACKAGE-MANAGER",
+      "referenceType": "purl",
+      "referenceLocator": "pkg:golang/example.com/covered@v1.2.3"
+    }]},
+    {"externalRefs": [{
+      "referenceCategory": "PACKAGE-MANAGER",
+      "referenceType": "purl",
+      "referenceLocator": "pkg:generic/example.com/native@v4.5.6"
+    }]}
+  ]
 }`)
 
 	output, commandErr := runReleaseEvidenceVerifier(t, root)
@@ -106,11 +133,18 @@ func TestReleaseEvidenceVerifierAcceptsReconciledEvidence(t *testing.T) {
 	root := t.TempDir()
 	writeReleaseEvidenceFixture(t, root, true, `{
   "spdxVersion": "SPDX-2.3",
-  "packages": [{"externalRefs": [{
-    "referenceCategory": "PACKAGE-MANAGER",
-    "referenceType": "purl",
-    "referenceLocator": "pkg:golang/example.com/covered@v1.2.3"
-  }]}]
+  "packages": [
+    {"externalRefs": [{
+      "referenceCategory": "PACKAGE-MANAGER",
+      "referenceType": "purl",
+      "referenceLocator": "pkg:golang/example.com/covered@v1.2.3"
+    }]},
+    {"externalRefs": [{
+      "referenceCategory": "PACKAGE-MANAGER",
+      "referenceType": "purl",
+      "referenceLocator": "pkg:generic/example.com/native@v4.5.6"
+    }]}
+  ]
 }`)
 
 	output, commandErr := runReleaseEvidenceVerifier(t, root)
@@ -245,6 +279,59 @@ printf '%s' '{"spdxVersion":"SPDX-2.3","name":"private-path","documentNamespace"
 		if !strings.Contains(value, required) {
 			t.Fatalf("SBOM is missing %q: %s", required, value)
 		}
+	}
+}
+
+func TestNativeDependenciesAreAddedToSBOMWithoutDroppingSyftFields(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "SBOM.spdx.json")
+	contents := `{
+  "spdxVersion": "SPDX-2.3",
+  "documentNamespace": "https://example.com/syft/document",
+  "packages": [{
+    "name": "existing-go-module",
+    "versionInfo": "v1.2.3",
+    "externalRefs": [{
+      "referenceCategory": "PACKAGE-MANAGER",
+      "referenceType": "purl",
+      "referenceLocator": "pkg:golang/example.com/covered@v1.2.3"
+    }]
+  }]
+}`
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	native := []dependencyRecord{{Path: "example.com/native", Version: "v4.5.6"}}
+	if err := addNativeDependenciesToSBOM(path, native); err != nil {
+		t.Fatal(err)
+	}
+
+	payload, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var document struct {
+		DocumentNamespace string `json:"documentNamespace"`
+		Packages          []struct {
+			Name               string `json:"name"`
+			Version            string `json:"versionInfo"`
+			ExternalReferences []struct {
+				Locator string `json:"referenceLocator"`
+			} `json:"externalRefs"`
+		} `json:"packages"`
+	}
+	if err := json.Unmarshal(payload, &document); err != nil {
+		t.Fatal(err)
+	}
+	if document.DocumentNamespace != "https://example.com/syft/document" || len(document.Packages) != 2 {
+		t.Fatalf("augmented SPDX document = %#v", document)
+	}
+	if document.Packages[0].Name != "existing-go-module" ||
+		document.Packages[0].ExternalReferences[0].Locator != "pkg:golang/example.com/covered@v1.2.3" {
+		t.Fatalf("existing SPDX package changed: %#v", document.Packages[0])
+	}
+	if document.Packages[1].Name != "example.com/native" || document.Packages[1].Version != "v4.5.6" ||
+		document.Packages[1].ExternalReferences[0].Locator != "pkg:generic/example.com/native@v4.5.6" {
+		t.Fatalf("native SPDX package = %#v", document.Packages[1])
 	}
 }
 

--- a/tools/release/package.go
+++ b/tools/release/package.go
@@ -212,6 +212,9 @@ func packageRelease(options packageOptions) (packageResult, error) {
 	if generateErr := generateSBOM(options.Syft, root, temporarySBOM, assets.Syft.Version, buildTime); generateErr != nil {
 		return packageResult{}, generateErr
 	}
+	if augmentErr := addNativeDependenciesToSBOM(temporarySBOM, dependencies.Native); augmentErr != nil {
+		return packageResult{}, augmentErr
+	}
 	if copyErr := copyRegularFile(temporarySBOM, filepath.Join(root, "SBOM.spdx.json"), 0o644); copyErr != nil {
 		return packageResult{}, copyErr
 	}

--- a/tools/release/sbom.go
+++ b/tools/release/sbom.go
@@ -15,7 +15,10 @@
 package main
 
 import (
+	"crypto/sha256"
 	"encoding/json"
+	"encoding/json/jsontext"
+	jsonv2 "encoding/json/v2"
 	"errors"
 	"fmt"
 	"os"
@@ -58,4 +61,43 @@ func generateSBOM(syft, root, output, syftVersion string, created time.Time) err
 		"Tool: syft-" + syftVersion,
 	}
 	return writeJSON(output, document)
+}
+
+func addNativeDependenciesToSBOM(path string, dependencies []dependencyRecord) error {
+	contents, err := readBoundedFile(path, maxMetadataBytes)
+	if err != nil {
+		return err
+	}
+	var document spdxDocument
+	if decodeErr := jsonv2.Unmarshal(contents, &document); decodeErr != nil || !strings.HasPrefix(document.SPDXVersion, "SPDX-") {
+		return errors.New("Syft did not produce a valid SPDX JSON document")
+	}
+	recorded := make(map[string]struct{})
+	for _, packageRecord := range document.Packages {
+		for _, reference := range packageRecord.ExternalReferences {
+			if reference.Category == "PACKAGE-MANAGER" && reference.Type == "purl" {
+				recorded[reference.Locator] = struct{}{}
+			}
+		}
+	}
+	for _, dependency := range dependencies {
+		purl := "pkg:generic/" + dependency.Path + "@" + dependency.Version
+		if _, exists := recorded[purl]; exists {
+			continue
+		}
+		digest := sha256.Sum256([]byte(dependency.Path + "\x00" + dependency.Version))
+		document.Packages = append(document.Packages, spdxPackage{
+			Name: dependency.Path, SPDXID: fmt.Sprintf("SPDXRef-Native-%x", digest[:8]),
+			Version: dependency.Version, DownloadLocation: "NOASSERTION", FilesAnalyzed: new(false),
+			ExternalReferences: []spdxExternalReference{{
+				Category: "PACKAGE-MANAGER", Type: "purl", Locator: purl,
+			}},
+		})
+		recorded[purl] = struct{}{}
+	}
+	encoded, err := jsonv2.Marshal(&document, jsonv2.Deterministic(true), jsontext.WithIndent("  "))
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, append(encoded, '\n'), 0o644)
 }


### PR DESCRIPTION
## Summary
- add every redistributed native dependency from `DEPENDENCIES.json` to the generated SPDX SBOM as a stable `pkg:generic` package
- preserve all Syft-owned document/package/reference fields while augmenting the SBOM
- make release evidence verification reject missing native dependency purls as well as missing Go module purls

## Verification
- focused release evidence and SBOM augmentation tests
- `go test ./tools/release -skip '^TestReleaseArchiveKeepsStableExecutablePathAndMode$' -count=1`
- `golangci-lint run --timeout=10m ./tools/release` using the pinned repository tool: 0 issues
- `git diff --check HEAD^..HEAD`
- RED proof: the new verifier test initially accepted an SBOM missing the native dependency; the augmentation test initially failed to compile because the behavior did not exist

The excluded local test is a Windows filesystem-mode limitation: the identical test fails on clean main because `os.WriteFile(..., 0755)` reads back as `0644`. Linux/macOS CI runs the full unfiltered release test package and remains authoritative for executable archive modes.

Part of #3; does not close the tracking issue.