### PR TITLE
test(conformance): migrate inventory to v0.1.0

### DIFF
--- a/.github/workflows/migration-gates.yml
+++ b/.github/workflows/migration-gates.yml
@@ -206,15 +206,25 @@ jobs:
       - name: Verify Oracle identity
         run: test "$(git -C _oracle rev-parse HEAD)" = 3a6cb0151670eaff7dc0293466edd673124e80da
 
-      - name: Check out the active parity target
+      - name: Check out the previous parity target
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           repository: oceanbase/powercontext
           ref: f2ec1f75e5e1b46ad0626ab8390801b88966b6f5
+          path: _previous_target
+
+      - name: Verify previous parity target identity
+        run: test "$(git -C _previous_target rev-parse HEAD)" = f2ec1f75e5e1b46ad0626ab8390801b88966b6f5
+
+      - name: Check out the active parity target
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          repository: oceanbase/powercontext
+          ref: 7b736206a53a6de6f43d4b517893ee1a80e7183d
           path: _target
 
       - name: Verify parity target identity
-        run: test "$(git -C _target rev-parse HEAD)" = f2ec1f75e5e1b46ad0626ab8390801b88966b6f5
+        run: test "$(git -C _target rev-parse HEAD)" = 7b736206a53a6de6f43d4b517893ee1a80e7183d
 
       - name: Set up the Go environment
         uses: ./.github/actions/setup-go-env
@@ -274,7 +284,12 @@ jobs:
           cmp "$parity_inventory" "test/conformance/parity-inventory.json"
           go run ./tools/fixture-generate -python _oracle -check
           go run ./tools/traceability-generate -check
-          go run ./tools/parity-inventory-generate -upstream _target -check
+          go run ./tools/parity-inventory-generate \
+            -upstream _target \
+            -check \
+            -check-delta \
+            -previous-upstream _previous_target \
+            -release-upstream _target
 
       - name: Run Python to Go to Python compatibility tests
         env:

--- a/.github/workflows/windows-contract.yml
+++ b/.github/workflows/windows-contract.yml
@@ -48,6 +48,10 @@ jobs:
             'client/invoker_gen.go',
             'internal/mcpapi/schemas_gen.go',
             'integrations/dsh/plugins/powercontext/src/operations.generated.ts',
+            'test/conformance/parity-contract.json',
+            'test/conformance/parity-inventory-rules.json',
+            'test/conformance/parity-inventory.json',
+            'test/conformance/target-delta.json',
             'test/conformance/testdata/python-v0.0.2/manifest.json',
             'artifact/memory/prompts/conversation.txt',
             'evaluation/tests/contract/fixtures/swebench_pro_public_v2.jsonl'
@@ -86,6 +90,10 @@ jobs:
             'integrations/dsh/plugins/powercontext/src/operations.generated.ts',
             'integrations/opencode/plugins/powercontext/src/operations.generated.ts',
             'integrations/pi/plugins/powercontext/src/operations.generated.ts',
+            'test/conformance/parity-contract.json',
+            'test/conformance/parity-inventory-rules.json',
+            'test/conformance/parity-inventory.json',
+            'test/conformance/target-delta.json',
             'test/conformance/testdata/python-v0.0.2'
           )
           & git diff --exit-code -- @contractPaths

--- a/test/conformance/README.md
+++ b/test/conformance/README.md
@@ -4,9 +4,9 @@ This directory makes the Python `v0.0.2` implementation at commit
 `3a6cb0151670eaff7dc0293466edd673124e80da` an executable Oracle rather than
 an informal reference.
 
-- `parity-contract.json` records the upstream parity identity as four
-  separate concepts: the upstream repository, the exact target SHA, the
-  frozen release Oracle, and the active parity target. `parity_contract_test.go`
+- `parity-contract.json` records the upstream parity identity as separate
+  concepts: the upstream repository, the exact target SHA, the signed release
+  target and assets, the frozen release Oracle, and the active parity target. `parity_contract_test.go`
   proves the frozen Oracle commit is identical across the contract, the Go
   test constant, `manifest.json`, and the `frozen-oracle` CI checkout, and
   rejects any conflation between the frozen Oracle and the parity targets.
@@ -20,7 +20,7 @@ an informal reference.
   functions and records whether its evidence is case-specific or supporting.
   It is generated from `traceability-rules.json`; do not edit the generated
   table by hand.
-- `parity-inventory.json` inventories all 759 Python test cases at the
+- `parity-inventory.json` inventories all 812 Python test cases at the
   active parity target recorded in `parity-contract.json`. Every case
   carries a mode (`go-port`, `cross-layer`, or `retained-host`) and a
   status: `mapped` cases have case-specific evidence that resolves against
@@ -31,6 +31,12 @@ an informal reference.
   pinned at the contract target SHA; do not edit the generated inventory
   by hand, and update the pinned mapped/pending counts only together with
   the rule changes that move cases between the two states.
+- `target-delta.json` records the exact 73 added and 20 removed cases between
+  the former `f2ec1f75` target and the signed v0.1.0 release. Every removed
+  case has a reviewed `removed`, `renamed`, or `superseded` disposition plus
+  replacement case or still-resolvable Go/retained-host evidence. The parity
+  generator recomputes both case sets from exact Git checkouts and rejects
+  ledger, replacement, or evidence drift.
 - `authority_test.go` proves Python SQLite → Go read/write → Python back-read.
 - `review_database_test.go` proves Python Candidate → Go revise/approve →
   Python Artifact back-read and continued Candidate writes against the same
@@ -49,22 +55,27 @@ go run ./tools/traceability-generate
 go run ./tools/traceability-generate -check
 ```
 
-Regenerate or check the active parity target inventory against an upstream
-checkout pinned at the contract target SHA (the generator verifies
-`git rev-parse HEAD` before extracting):
+Regenerate or check the active parity target inventory and reviewed target
+delta against upstream checkouts pinned to the previous and release commits
+(the generator verifies both `git rev-parse HEAD` values before extracting):
 
 ```sh
-git -C ../powercontext checkout f2ec1f75e5e1b46ad0626ab8390801b88966b6f5
-go run ./tools/parity-inventory-generate -upstream ../powercontext
-go run ./tools/parity-inventory-generate -upstream ../powercontext -check
+go run ./tools/parity-inventory-generate \
+  -upstream ../powercontext-v0.1.0
+go run ./tools/parity-inventory-generate \
+  -upstream ../powercontext-v0.1.0 \
+  -check \
+  -check-delta \
+  -previous-upstream ../powercontext-f2ec1f75 \
+  -release-upstream ../powercontext-v0.1.0
 ```
 
-The frozen-Oracle CI job checks out both the exact Oracle commit and the
-active parity target, runs the Oracle suite, regenerates the deterministic
-fixtures, verifies both generated inventories byte-for-byte, and enables
-both Python back-read tests. A changed Oracle commit requires deliberate
-fixture regeneration and review; changing only a hash to silence drift is
-not valid.
+The frozen-Oracle CI job checks out the exact Oracle, previous target, and
+active release target commits; runs the Oracle suite; regenerates the
+deterministic fixtures; verifies both generated inventories and the reviewed
+target delta; and enables both Python back-read tests. A changed Oracle commit
+requires deliberate fixture regeneration and review; changing only a hash to
+silence drift is not valid.
 
 The rules carry a monotonically increasing checkpoint for case-specific
 evidence. A changed Oracle case must add or update its exact `cases` mapping;

--- a/test/conformance/parity-contract.json
+++ b/test/conformance/parity-contract.json
@@ -25,7 +25,7 @@
       "sha256": "18d47a335340b0870216e2cc0fb1fd8e4d865880155daeea3b01187c950fd746"
     }
   },
-  "exact_target_sha": "f2ec1f75e5e1b46ad0626ab8390801b88966b6f5",
-  "target_test_case_count": 759,
-  "active_parity_target": "f2ec1f75e5e1b46ad0626ab8390801b88966b6f5"
+  "exact_target_sha": "7b736206a53a6de6f43d4b517893ee1a80e7183d",
+  "target_test_case_count": 812,
+  "active_parity_target": "7b736206a53a6de6f43d4b517893ee1a80e7183d"
 }

--- a/test/conformance/parity-inventory-rules.json
+++ b/test/conformance/parity-inventory-rules.json
@@ -1,7 +1,63 @@
 {
   "schema_version": 1,
-  "comment": "Mode assignments for the delta between the frozen v0.0.2 Oracle (622 cases) and the active parity target (759 cases). Cases listed under \"cases\" carry resolvable evidence and become status=mapped; every other delta case becomes status=pending with the file mode and is expected to gain evidence as the relevant port lands (for example WP2 for the transport surface). Frozen Oracle cases inherit their mappings from traceability.json and never appear here.",
+  "comment": "Mode assignments for the delta between the frozen v0.0.2 Oracle (622 cases) and the signed v0.1.0 active parity target (812 cases). Cases listed under \"cases\" carry resolvable evidence and become status=mapped; every other delta case becomes status=pending with the file mode and is expected to gain evidence as the relevant port lands. Frozen Oracle cases inherit their mappings from traceability.json and never appear here.",
   "files": {
+    "tests/builtin/inference/test_pydantic_ai.py": {
+      "mode": "go-port",
+      "reason": "Builtin Pydantic AI embedding-provider error classification maps to the Go model-provider boundary."
+    },
+    "tests/builtin/persistence/test_sqlite_memory_vector_index.py": {
+      "mode": "go-port",
+      "reason": "SQLite vector-index dimension and probe behavior maps to the Go SQLite persistence implementation."
+    },
+    "tests/builtin/runtime/test_composition_embedding.py": {
+      "mode": "go-port",
+      "reason": "Embedding model composition and configured dimension propagation map to Go runtime/provider construction."
+    },
+    "tests/builtin/runtime/test_readiness.py": {
+      "mode": "go-port",
+      "reason": "Dependency readiness and redacted provider configuration reasons map to the Go Server readiness boundary."
+    },
+    "tests/builtin/runtime/test_scheduler.py": {
+      "mode": "go-port",
+      "reason": "Scheduled Source-window and Experience-incubation trace outcomes map to Go runtime scheduler orchestration."
+    },
+    "tests/claude_code_plugin/test_hook.py": {
+      "mode": "retained-host",
+      "reason": "Claude Code prompt hook behavior is owned by the retained Claude Code adapter."
+    },
+    "tests/e2e/test_observability.py": {
+      "mode": "cross-layer",
+      "reason": "Independent scheduled trace roots cross runtime scheduling, tracing, and exported observability evidence."
+    },
+    "tests/test_config_cli.py": {
+      "mode": "go-port",
+      "reason": "Managed environment initialization, validation, credential input, and redacted display map to the Go CLI."
+    },
+    "tests/test_dashboard.py": {
+      "mode": "go-port",
+      "reason": "Skill publication and stale registry discovery behavior map to the Go endpoint and dashboard-facing API."
+    },
+    "tests/test_env_file.py": {
+      "mode": "go-port",
+      "reason": "Shell-compatible managed environment parsing and stale-value clearing map to the Go CLI configuration parser."
+    },
+    "tests/test_full_capability_docs.py": {
+      "mode": "cross-layer",
+      "reason": "Executable full-capability documentation binds CLI capture, Memory evidence, and cursor behavior across layers."
+    },
+    "tests/test_mcp.py": {
+      "mode": "go-port",
+      "reason": "MCP ToolAnnotations and Review write side-effect metadata map to the Go MCP server."
+    },
+    "tests/test_server.py": {
+      "mode": "go-port",
+      "reason": "Server factory provider rejection and redacted readiness behavior map to Go Server construction."
+    },
+    "tests/test_server_tracing.py": {
+      "mode": "go-port",
+      "reason": "Background and runtime trace-root outcomes map to Go Server tracing orchestration."
+    },
     "e2e/bub/tests/test_bub_transport_trust.py": {
       "mode": "retained-host",
       "reason": "Bub plugin transport trust behavior owned by the retained Bub adapter.",
@@ -494,17 +550,6 @@
         "test_server_allows_a_non_loopback_bind_with_an_explicit_opt_in": {
           "evidence": [
             "go:server/config_test.go#TestLoadConfigAllowsExplicitUnauthenticatedNonLoopbackBind"
-          ]
-        },
-        "test_vendored_plugin_shares_the_loopback_host_set": {
-          "mode": "cross-layer",
-          "reason": "Asserts retained plugins share the core loopback host set; crosses the Go core and retained adapters.",
-          "evidence": [
-            "go:test/transport/policy_test.go#TestSharedLoopbackHostVectors",
-            "py:integrations/codex/tests/test_contract.py#test_codex_settings_accept_shared_loopback_hosts",
-            "py:integrations/codex/tests/test_contract.py#test_codex_settings_reject_shared_non_loopback_plaintext_hosts",
-            "py:integrations/claude-code/tests/test_contract.py#test_settings_accept_shared_loopback_hosts",
-            "py:integrations/claude-code/tests/test_contract.py#test_settings_reject_shared_non_loopback_plaintext_hosts"
           ]
         },
         "test_vendored_plugin_matches_the_shared_plaintext_policy": {

--- a/test/conformance/parity-inventory.json
+++ b/test/conformance/parity-inventory.json
@@ -1,11 +1,11 @@
 {
   "schema_version": 1,
-  "target_commit": "f2ec1f75e5e1b46ad0626ab8390801b88966b6f5",
+  "target_commit": "7b736206a53a6de6f43d4b517893ee1a80e7183d",
   "oracle_commit": "3a6cb0151670eaff7dc0293466edd673124e80da",
-  "python_test_file_count": 127,
-  "python_test_case_count": 759,
-  "mapped_case_count": 699,
-  "pending_case_count": 60,
+  "python_test_file_count": 132,
+  "python_test_case_count": 812,
+  "mapped_case_count": 686,
+  "pending_case_count": 126,
   "entries": [
     {
       "python": {
@@ -1642,8 +1642,18 @@
     {
       "python": {
         "file": "tests/builtin/inference/test_pydantic_ai.py",
-        "name": "test_instrumented_embedding_spans_nest_under_the_active_span_without_recording_text",
+        "name": "test_embedding_adapter_maps_a_rejected_request_to_a_stable_reason_without_leaking_body",
         "line": 412
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/builtin/inference/test_pydantic_ai.py",
+        "name": "test_instrumented_embedding_spans_nest_under_the_active_span_without_recording_text",
+        "line": 430
       },
       "mode": "go-port",
       "status": "mapped",
@@ -1660,7 +1670,7 @@
       "python": {
         "file": "tests/builtin/inference/test_pydantic_ai.py",
         "name": "test_embedding_adapter_maps_empty_provider_data_to_unavailable",
-        "line": 441
+        "line": 459
       },
       "mode": "go-port",
       "status": "mapped",
@@ -2405,6 +2415,46 @@
     },
     {
       "python": {
+        "file": "tests/builtin/persistence/test_sqlite_memory_vector_index.py",
+        "name": "test_vector_index_probe_clears_a_leftover_probe_row",
+        "line": 41
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/builtin/persistence/test_sqlite_memory_vector_index.py",
+        "name": "test_vector_index_probe_reports_a_table_dimension_mismatch",
+        "line": 65
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/builtin/persistence/test_sqlite_memory_vector_index.py",
+        "name": "test_vector_index_probe_surfaces_the_underlying_cause",
+        "line": 88
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/builtin/persistence/test_sqlite_memory_vector_index.py",
+        "name": "test_vector_index_probe_reports_the_provider_limit_for_a_fresh_oversized_dimension",
+        "line": 112
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
         "file": "tests/builtin/persistence/test_sqlite_profile.py",
         "name": "test_sqlite_config_requires_the_async_dialect",
         "line": 32
@@ -2723,6 +2773,26 @@
           "test": "TestReviewApprovalRollsBackWhenCandidateStatusUpdateFails"
         }
       ]
+    },
+    {
+      "python": {
+        "file": "tests/builtin/runtime/test_composition_embedding.py",
+        "name": "test_embedding_models_send_the_configured_dimension_to_the_provider",
+        "line": 35
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/builtin/runtime/test_composition_embedding.py",
+        "name": "test_embedding_models_without_configuration_return_no_models",
+        "line": 55
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
     },
     {
       "python": {
@@ -3061,7 +3131,7 @@
       "python": {
         "file": "tests/builtin/runtime/test_readiness.py",
         "name": "test_builtin_runtime_reports_runtime_and_database_readiness",
-        "line": 29
+        "line": 32
       },
       "mode": "go-port",
       "status": "mapped",
@@ -3076,9 +3146,29 @@
     },
     {
       "python": {
+        "file": "tests/builtin/runtime/test_readiness.py",
+        "name": "test_dependency_readiness_probe_surfaces_a_stable_redacted_configuration_reason",
+        "line": 49
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/builtin/runtime/test_readiness.py",
+        "name": "test_dependency_readiness_probe_redacts_plain_configuration_errors",
+        "line": 61
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
         "file": "tests/builtin/runtime/test_scheduler.py",
         "name": "test_scheduler_persists_one_stable_source_window_job",
-        "line": 108
+        "line": 184
       },
       "mode": "go-port",
       "status": "mapped",
@@ -3095,7 +3185,7 @@
       "python": {
         "file": "tests/builtin/runtime/test_scheduler.py",
         "name": "test_scheduler_creates_missing_database_parent_directory",
-        "line": 127
+        "line": 203
       },
       "mode": "go-port",
       "status": "mapped",
@@ -3112,7 +3202,7 @@
       "python": {
         "file": "tests/builtin/runtime/test_scheduler.py",
         "name": "test_scheduler_interval_activates_the_source_window_policy",
-        "line": 142
+        "line": 218
       },
       "mode": "go-port",
       "status": "mapped",
@@ -3129,7 +3219,7 @@
       "python": {
         "file": "tests/builtin/runtime/test_scheduler.py",
         "name": "test_scheduler_interval_activates_experience_incubation",
-        "line": 155
+        "line": 231
       },
       "mode": "go-port",
       "status": "mapped",
@@ -3146,7 +3236,7 @@
       "python": {
         "file": "tests/builtin/runtime/test_scheduler.py",
         "name": "test_scheduler_persists_and_reconciles_independent_jobs",
-        "line": 172
+        "line": 248
       },
       "mode": "go-port",
       "status": "mapped",
@@ -3163,7 +3253,7 @@
       "python": {
         "file": "tests/builtin/runtime/test_scheduler.py",
         "name": "test_scheduled_noop_logs_a_bounded_outcome",
-        "line": 193
+        "line": 269
       },
       "mode": "go-port",
       "status": "mapped",
@@ -3180,7 +3270,7 @@
       "python": {
         "file": "tests/builtin/runtime/test_scheduler.py",
         "name": "test_scheduled_experience_logs_candidate_count_without_scope",
-        "line": 209
+        "line": 285
       },
       "mode": "go-port",
       "status": "mapped",
@@ -3196,8 +3286,88 @@
     {
       "python": {
         "file": "tests/builtin/runtime/test_scheduler.py",
+        "name": "test_scheduled_processor_records_root_and_flush_spans",
+        "line": 305
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/builtin/runtime/test_scheduler.py",
+        "name": "test_scheduled_processor_records_success_outcome",
+        "line": 332
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/builtin/runtime/test_scheduler.py",
+        "name": "test_scheduled_processor_records_failure_and_swallows_error",
+        "line": 351
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/builtin/runtime/test_scheduler.py",
+        "name": "test_scheduled_processor_records_cancellation",
+        "line": 368
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/builtin/runtime/test_scheduler.py",
+        "name": "test_scheduled_experience_records_root_and_incubation_spans",
+        "line": 388
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/builtin/runtime/test_scheduler.py",
+        "name": "test_scheduled_experience_records_noop_outcome",
+        "line": 420
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/builtin/runtime/test_scheduler.py",
+        "name": "test_scheduled_experience_records_failure_and_swallows_error",
+        "line": 441
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/builtin/runtime/test_scheduler.py",
+        "name": "test_scheduled_experience_records_cancellation",
+        "line": 458
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/builtin/runtime/test_scheduler.py",
         "name": "test_scheduler_requires_file_storage_and_one_live_owner",
-        "line": 225
+        "line": 478
       },
       "mode": "go-port",
       "status": "mapped",
@@ -3767,25 +3937,8 @@
     {
       "python": {
         "file": "tests/claude_code_plugin/test_hook.py",
-        "name": "test_context_request_uses_prepare_once",
-        "line": 329
-      },
-      "mode": "retained-host",
-      "status": "mapped",
-      "source": "oracle-traceability",
-      "evidence": [
-        {
-          "kind": "py",
-          "file": "integrations/claude-code/tests/test_hook.py",
-          "test": "test_context_request_uses_prepare_once"
-        }
-      ]
-    },
-    {
-      "python": {
-        "file": "tests/claude_code_plugin/test_hook.py",
         "name": "test_capture_prompt_is_idempotent_and_is_not_a_task_outcome",
-        "line": 361
+        "line": 329
       },
       "mode": "retained-host",
       "status": "mapped",
@@ -3802,7 +3955,7 @@
       "python": {
         "file": "tests/claude_code_plugin/test_hook.py",
         "name": "test_http_failures_are_non_blocking_and_content_free",
-        "line": 412
+        "line": 380
       },
       "mode": "retained-host",
       "status": "mapped",
@@ -3818,42 +3971,18 @@
     {
       "python": {
         "file": "tests/claude_code_plugin/test_hook.py",
-        "name": "test_unknown_schema_and_oversized_content_are_not_injected",
-        "line": 440
+        "name": "test_unknown_schema_is_not_injected",
+        "line": 408
       },
       "mode": "retained-host",
-      "status": "mapped",
-      "source": "oracle-traceability",
-      "evidence": [
-        {
-          "kind": "py",
-          "file": "integrations/claude-code/tests/test_hook.py",
-          "test": "test_unknown_schema_and_oversized_content_are_not_injected"
-        }
-      ]
-    },
-    {
-      "python": {
-        "file": "tests/claude_code_plugin/test_hook.py",
-        "name": "test_malformed_prepared_context_is_not_injected",
-        "line": 473
-      },
-      "mode": "retained-host",
-      "status": "mapped",
-      "source": "oracle-traceability",
-      "evidence": [
-        {
-          "kind": "py",
-          "file": "integrations/claude-code/tests/test_hook.py",
-          "test": "test_malformed_prepared_context_is_not_injected"
-        }
-      ]
+      "status": "pending",
+      "source": "rules"
     },
     {
       "python": {
         "file": "tests/claude_code_plugin/test_hook.py",
         "name": "test_hook_refuses_redirects",
-        "line": 494
+        "line": 431
       },
       "mode": "retained-host",
       "status": "mapped",
@@ -3863,23 +3992,6 @@
           "kind": "py",
           "file": "integrations/claude-code/tests/test_hook.py",
           "test": "test_hook_refuses_redirects"
-        }
-      ]
-    },
-    {
-      "python": {
-        "file": "tests/claude_code_plugin/test_hook.py",
-        "name": "test_hook_rejects_an_oversized_response_body",
-        "line": 536
-      },
-      "mode": "retained-host",
-      "status": "mapped",
-      "source": "oracle-traceability",
-      "evidence": [
-        {
-          "kind": "py",
-          "file": "integrations/claude-code/tests/test_hook.py",
-          "test": "test_hook_rejects_an_oversized_response_body"
         }
       ]
     },
@@ -4311,25 +4423,8 @@
     {
       "python": {
         "file": "tests/codex_plugin/test_recall.py",
-        "name": "test_context_request_uses_the_prepare_endpoint_once",
-        "line": 444
-      },
-      "mode": "retained-host",
-      "status": "mapped",
-      "source": "oracle-traceability",
-      "evidence": [
-        {
-          "kind": "py",
-          "file": "integrations/codex/tests/test_recall.py",
-          "test": "test_context_request_uses_the_prepare_endpoint_once"
-        }
-      ]
-    },
-    {
-      "python": {
-        "file": "tests/codex_plugin/test_recall.py",
         "name": "test_context_prepare_404_is_reported_as_a_version_mismatch",
-        "line": 483
+        "line": 444
       },
       "mode": "retained-host",
       "status": "mapped",
@@ -4346,7 +4441,7 @@
       "python": {
         "file": "tests/codex_plugin/test_recall.py",
         "name": "test_capture_prompt_is_idempotent_and_preserves_provenance",
-        "line": 507
+        "line": 468
       },
       "mode": "retained-host",
       "status": "mapped",
@@ -4363,7 +4458,7 @@
       "python": {
         "file": "tests/codex_plugin/test_recall.py",
         "name": "test_flush_reaches_the_captured_source_position",
-        "line": 563
+        "line": 524
       },
       "mode": "retained-host",
       "status": "mapped",
@@ -4380,7 +4475,7 @@
       "python": {
         "file": "tests/codex_plugin/test_recall.py",
         "name": "test_flush_is_bounded_by_settings",
-        "line": 595
+        "line": 556
       },
       "mode": "retained-host",
       "status": "mapped",
@@ -4397,7 +4492,7 @@
       "python": {
         "file": "tests/codex_plugin/test_recall.py",
         "name": "test_hook_refuses_redirects",
-        "line": 619
+        "line": 580
       },
       "mode": "retained-host",
       "status": "mapped",
@@ -4414,7 +4509,7 @@
       "python": {
         "file": "tests/codex_plugin/test_recall.py",
         "name": "test_hook_aborts_a_slow_response_at_the_request_deadline",
-        "line": 660
+        "line": 621
       },
       "mode": "retained-host",
       "status": "mapped",
@@ -4431,7 +4526,7 @@
       "python": {
         "file": "tests/codex_plugin/test_recall.py",
         "name": "test_prompt_capture_can_be_disabled",
-        "line": 695
+        "line": 656
       },
       "mode": "retained-host",
       "status": "mapped",
@@ -5060,7 +5155,7 @@
       "python": {
         "file": "tests/e2e/test_observability.py",
         "name": "test_observability_signals_correlate_without_counting_the_mcp_bridge",
-        "line": 200
+        "line": 234
       },
       "mode": "cross-layer",
       "status": "mapped",
@@ -5082,7 +5177,7 @@
       "python": {
         "file": "tests/e2e/test_observability.py",
         "name": "test_database_failure_log_does_not_include_memory_content",
-        "line": 290
+        "line": 324
       },
       "mode": "cross-layer",
       "status": "mapped",
@@ -5099,7 +5194,7 @@
       "python": {
         "file": "tests/e2e/test_observability.py",
         "name": "test_inference_spans_join_the_operation_trace_only_when_instrumented",
-        "line": 333
+        "line": 367
       },
       "mode": "cross-layer",
       "status": "mapped",
@@ -5121,7 +5216,7 @@
       "python": {
         "file": "tests/e2e/test_observability.py",
         "name": "test_memory_read_stage_spans_are_bounded_and_nested",
-        "line": 360
+        "line": 397
       },
       "mode": "cross-layer",
       "status": "mapped",
@@ -5138,7 +5233,7 @@
       "python": {
         "file": "tests/e2e/test_observability.py",
         "name": "test_scope_lock_stage_span_reports_contention_and_closes_at_acquisition",
-        "line": 562
+        "line": 599
       },
       "mode": "cross-layer",
       "status": "mapped",
@@ -5155,7 +5250,7 @@
       "python": {
         "file": "tests/e2e/test_observability.py",
         "name": "test_scope_lock_is_released_when_stage_teardown_fails",
-        "line": 620
+        "line": 657
       },
       "mode": "cross-layer",
       "status": "mapped",
@@ -5171,8 +5266,28 @@
     {
       "python": {
         "file": "tests/e2e/test_observability.py",
+        "name": "test_scheduled_source_window_starts_an_independent_trace_root",
+        "line": 694
+      },
+      "mode": "cross-layer",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/e2e/test_observability.py",
+        "name": "test_scheduled_experience_starts_an_independent_trace_root",
+        "line": 725
+      },
+      "mode": "cross-layer",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/e2e/test_observability.py",
         "name": "test_vector_search_exports_embedding_under_memory_search_without_recording_text",
-        "line": 641
+        "line": 758
       },
       "mode": "cross-layer",
       "status": "mapped",
@@ -5194,7 +5309,7 @@
       "python": {
         "file": "tests/e2e/test_observability.py",
         "name": "test_injected_always_on_embedding_skips_readiness_but_traces_vector_search",
-        "line": 710
+        "line": 827
       },
       "mode": "cross-layer",
       "status": "mapped",
@@ -5809,7 +5924,7 @@
       "python": {
         "file": "tests/integrations/test_hermes_provider.py",
         "name": "test_prefetch_uses_profile_and_user_scoped_context",
-        "line": 156
+        "line": 155
       },
       "mode": "retained-host",
       "status": "mapped",
@@ -5826,7 +5941,7 @@
       "python": {
         "file": "tests/integrations/test_hermes_provider.py",
         "name": "test_evaluation_trace_is_partitioned_by_session_and_records_parent",
-        "line": 169
+        "line": 168
       },
       "mode": "retained-host",
       "status": "pending",
@@ -5836,7 +5951,7 @@
       "python": {
         "file": "tests/integrations/test_hermes_provider.py",
         "name": "test_evaluation_trace_slash_command_reads_named_session",
-        "line": 207
+        "line": 206
       },
       "mode": "retained-host",
       "status": "pending",
@@ -5846,7 +5961,7 @@
       "python": {
         "file": "tests/integrations/test_hermes_provider.py",
         "name": "test_register_does_not_install_session_bound_slash_handlers",
-        "line": 231
+        "line": 230
       },
       "mode": "retained-host",
       "status": "pending",
@@ -5856,7 +5971,7 @@
       "python": {
         "file": "tests/integrations/test_hermes_provider.py",
         "name": "test_powercontext_subcommands_are_available_to_hermes_completer",
-        "line": 257
+        "line": 256
       },
       "mode": "retained-host",
       "status": "pending",
@@ -5866,7 +5981,7 @@
       "python": {
         "file": "tests/integrations/test_hermes_provider.py",
         "name": "test_standalone_command_companion_registers_before_agent_and_forwards",
-        "line": 273
+        "line": 272
       },
       "mode": "retained-host",
       "status": "pending",
@@ -5876,7 +5991,7 @@
       "python": {
         "file": "tests/integrations/test_hermes_provider.py",
         "name": "test_standalone_command_companion_keeps_interleaved_sessions_isolated",
-        "line": 321
+        "line": 320
       },
       "mode": "retained-host",
       "status": "pending",
@@ -5886,7 +6001,7 @@
       "python": {
         "file": "tests/integrations/test_hermes_provider.py",
         "name": "test_queue_prefetch_honors_max_bytes_environment_override",
-        "line": 386
+        "line": 385
       },
       "mode": "retained-host",
       "status": "mapped",
@@ -5903,7 +6018,7 @@
       "python": {
         "file": "tests/integrations/test_hermes_provider.py",
         "name": "test_queue_prefetch_does_not_wait_for_http",
-        "line": 400
+        "line": 399
       },
       "mode": "retained-host",
       "status": "mapped",
@@ -5920,7 +6035,7 @@
       "python": {
         "file": "tests/integrations/test_hermes_provider.py",
         "name": "test_json_config_is_loaded_from_hermes_home",
-        "line": 425
+        "line": 424
       },
       "mode": "retained-host",
       "status": "mapped",
@@ -5936,25 +6051,8 @@
     {
       "python": {
         "file": "tests/integrations/test_hermes_provider.py",
-        "name": "test_cli_reads_the_same_json_config_path",
-        "line": 451
-      },
-      "mode": "retained-host",
-      "status": "mapped",
-      "source": "oracle-traceability",
-      "evidence": [
-        {
-          "kind": "py",
-          "file": "integrations/hermes/tests/test_provider.py",
-          "test": "test_cli_reads_the_same_json_config_path"
-        }
-      ]
-    },
-    {
-      "python": {
-        "file": "tests/integrations/test_hermes_provider.py",
         "name": "test_memory_setup_schema_exposes_powercontext_configuration",
-        "line": 460
+        "line": 450
       },
       "mode": "retained-host",
       "status": "mapped",
@@ -5971,7 +6069,7 @@
       "python": {
         "file": "tests/integrations/test_hermes_provider.py",
         "name": "test_memory_setup_saves_powercontext_json_and_preserves_existing_values",
-        "line": 476
+        "line": 466
       },
       "mode": "retained-host",
       "status": "mapped",
@@ -5988,7 +6086,7 @@
       "python": {
         "file": "tests/integrations/test_hermes_provider.py",
         "name": "test_sync_turn_is_flushed_before_session_end",
-        "line": 499
+        "line": 489
       },
       "mode": "retained-host",
       "status": "mapped",
@@ -6005,7 +6103,7 @@
       "python": {
         "file": "tests/integrations/test_hermes_provider.py",
         "name": "test_sync_turn_does_not_wait_for_http",
-        "line": 511
+        "line": 501
       },
       "mode": "retained-host",
       "status": "mapped",
@@ -6022,7 +6120,7 @@
       "python": {
         "file": "tests/integrations/test_hermes_provider.py",
         "name": "test_session_end_skips_flush_when_memory_extraction_is_disabled",
-        "line": 536
+        "line": 526
       },
       "mode": "retained-host",
       "status": "mapped",
@@ -6039,7 +6137,7 @@
       "python": {
         "file": "tests/integrations/test_hermes_provider.py",
         "name": "test_pre_compress_persists_context_before_compression",
-        "line": 546
+        "line": 536
       },
       "mode": "retained-host",
       "status": "mapped",
@@ -6056,7 +6154,7 @@
       "python": {
         "file": "tests/integrations/test_hermes_provider.py",
         "name": "test_pre_compress_is_disabled_by_default",
-        "line": 565
+        "line": 555
       },
       "mode": "retained-host",
       "status": "mapped",
@@ -6073,7 +6171,7 @@
       "python": {
         "file": "tests/integrations/test_hermes_provider.py",
         "name": "test_pre_compress_filters_roles_and_redacts_secrets",
-        "line": 573
+        "line": 563
       },
       "mode": "retained-host",
       "status": "mapped",
@@ -6090,7 +6188,7 @@
       "python": {
         "file": "tests/integrations/test_hermes_provider.py",
         "name": "test_pre_compress_captures_only_new_overlapping_windows",
-        "line": 593
+        "line": 583
       },
       "mode": "retained-host",
       "status": "mapped",
@@ -6107,7 +6205,7 @@
       "python": {
         "file": "tests/integrations/test_hermes_provider.py",
         "name": "test_memory_write_retires_mapped_entries_for_replace_and_remove",
-        "line": 628
+        "line": 618
       },
       "mode": "retained-host",
       "status": "mapped",
@@ -6124,7 +6222,7 @@
       "python": {
         "file": "tests/integrations/test_hermes_provider.py",
         "name": "test_memory_write_matches_partial_old_text_for_replace_and_remove",
-        "line": 661
+        "line": 650
       },
       "mode": "retained-host",
       "status": "mapped",
@@ -6141,7 +6239,7 @@
       "python": {
         "file": "tests/integrations/test_hermes_provider.py",
         "name": "test_memory_write_does_not_retire_unmapped_same_text",
-        "line": 687
+        "line": 675
       },
       "mode": "retained-host",
       "status": "mapped",
@@ -6158,7 +6256,7 @@
       "python": {
         "file": "tests/integrations/test_hermes_provider.py",
         "name": "test_memory_map_refreshes_revision_after_multiple_writes",
-        "line": 706
+        "line": 693
       },
       "mode": "retained-host",
       "status": "mapped",
@@ -6175,7 +6273,7 @@
       "python": {
         "file": "tests/integrations/test_hermes_provider.py",
         "name": "test_memory_write_skips_replace_and_remove_without_old_text",
-        "line": 745
+        "line": 720
       },
       "mode": "retained-host",
       "status": "mapped",
@@ -6191,25 +6289,8 @@
     {
       "python": {
         "file": "tests/integrations/test_hermes_provider.py",
-        "name": "test_memory_write_worker_is_daemon_bounded_and_reports_overflow",
-        "line": 755
-      },
-      "mode": "retained-host",
-      "status": "mapped",
-      "source": "oracle-traceability",
-      "evidence": [
-        {
-          "kind": "py",
-          "file": "integrations/hermes/tests/test_provider.py",
-          "test": "test_memory_write_worker_is_daemon_bounded_and_reports_overflow"
-        }
-      ]
-    },
-    {
-      "python": {
-        "file": "tests/integrations/test_hermes_provider.py",
         "name": "test_memory_tools_map_to_powercontext_operations",
-        "line": 776
+        "line": 730
       },
       "mode": "retained-host",
       "status": "mapped",
@@ -6226,7 +6307,7 @@
       "python": {
         "file": "tests/integrations/test_hermes_provider.py",
         "name": "test_extended_tools_are_registered_and_scope_bound",
-        "line": 808
+        "line": 762
       },
       "mode": "retained-host",
       "status": "pending",
@@ -6236,7 +6317,7 @@
       "python": {
         "file": "tests/integrations/test_hermes_provider.py",
         "name": "test_extended_slash_commands_dispatch_json_operations",
-        "line": 837
+        "line": 790
       },
       "mode": "retained-host",
       "status": "pending",
@@ -6246,7 +6327,7 @@
       "python": {
         "file": "tests/integrations/test_hermes_provider.py",
         "name": "test_slash_commands_parse_unwrapped_citation_json_from_readme",
-        "line": 857
+        "line": 810
       },
       "mode": "retained-host",
       "status": "pending",
@@ -6256,7 +6337,7 @@
       "python": {
         "file": "tests/integrations/test_hermes_provider.py",
         "name": "test_workstream_binding_is_shared_with_hermes_scope",
-        "line": 895
+        "line": 848
       },
       "mode": "retained-host",
       "status": "pending",
@@ -6266,7 +6347,7 @@
       "python": {
         "file": "tests/integrations/test_hermes_provider.py",
         "name": "test_workstream_clear_restores_default_scope",
-        "line": 927
+        "line": 879
       },
       "mode": "retained-host",
       "status": "pending",
@@ -6276,7 +6357,7 @@
       "python": {
         "file": "tests/integrations/test_hermes_provider.py",
         "name": "test_workstream_bind_isolates_queued_background_work",
-        "line": 968
+        "line": 918
       },
       "mode": "retained-host",
       "status": "pending",
@@ -6286,7 +6367,7 @@
       "python": {
         "file": "tests/integrations/test_hermes_provider.py",
         "name": "test_backend_failure_fails_open",
-        "line": 1026
+        "line": 974
       },
       "mode": "retained-host",
       "status": "mapped",
@@ -6303,7 +6384,7 @@
       "python": {
         "file": "tests/integrations/test_hermes_provider.py",
         "name": "test_cli_registers_provider_commands",
-        "line": 1039
+        "line": 987
       },
       "mode": "retained-host",
       "status": "mapped",
@@ -6320,7 +6401,7 @@
       "python": {
         "file": "tests/integrations/test_hermes_provider.py",
         "name": "test_http_client_dispatches_operation_paths_and_get_query",
-        "line": 1054
+        "line": 1002
       },
       "mode": "retained-host",
       "status": "pending",
@@ -6399,28 +6480,8 @@
     {
       "python": {
         "file": "tests/langchain_middleware/test_packaging.py",
-        "name": "test_license_file_is_present_in_project",
-        "line": 52
-      },
-      "mode": "retained-host",
-      "status": "pending",
-      "source": "rules"
-    },
-    {
-      "python": {
-        "file": "tests/langchain_middleware/test_packaging.py",
-        "name": "test_wheel_bundles_middleware_license_and_dependencies",
-        "line": 57
-      },
-      "mode": "retained-host",
-      "status": "pending",
-      "source": "rules"
-    },
-    {
-      "python": {
-        "file": "tests/langchain_middleware/test_scope.py",
-        "name": "test_scope_type_is_owned_by_langchain_package",
-        "line": 22
+        "name": "test_wheel_bundles_middleware_license",
+        "line": 51
       },
       "mode": "retained-host",
       "status": "pending",
@@ -6430,7 +6491,7 @@
       "python": {
         "file": "tests/langchain_middleware/test_scope.py",
         "name": "test_missing_scope_names_langchain_configuration",
-        "line": 26
+        "line": 22
       },
       "mode": "retained-host",
       "status": "pending",
@@ -6440,7 +6501,7 @@
       "python": {
         "file": "tests/langchain_middleware/test_scope.py",
         "name": "test_normalize_git_remote_removes_credentials",
-        "line": 41
+        "line": 37
       },
       "mode": "retained-host",
       "status": "pending",
@@ -6450,7 +6511,7 @@
       "python": {
         "file": "tests/langchain_middleware/test_scope.py",
         "name": "test_resolve_scope_id_rejects_windows_local_remote",
-        "line": 46
+        "line": 42
       },
       "mode": "retained-host",
       "status": "pending",
@@ -6479,25 +6540,8 @@
     {
       "python": {
         "file": "tests/langgraph_adapter/test_packaging.py",
-        "name": "test_license_file_is_present_in_project",
-        "line": 57
-      },
-      "mode": "retained-host",
-      "status": "mapped",
-      "source": "oracle-traceability",
-      "evidence": [
-        {
-          "kind": "py",
-          "file": "integrations/langgraph/tests/test_packaging.py",
-          "test": "test_license_file_is_present_in_project"
-        }
-      ]
-    },
-    {
-      "python": {
-        "file": "tests/langgraph_adapter/test_packaging.py",
         "name": "test_wheel_bundles_license_and_metadata",
-        "line": 62
+        "line": 56
       },
       "mode": "retained-host",
       "status": "mapped",
@@ -6864,7 +6908,7 @@
       "python": {
         "file": "tests/pydantic_ai_adapter/test_capability.py",
         "name": "test_empty_context_is_not_injected",
-        "line": 72
+        "line": 70
       },
       "mode": "retained-host",
       "status": "pending",
@@ -6874,7 +6918,7 @@
       "python": {
         "file": "tests/pydantic_ai_adapter/test_capability.py",
         "name": "test_unreachable_server_fails_open_for_recall",
-        "line": 96
+        "line": 93
       },
       "mode": "retained-host",
       "status": "pending",
@@ -6884,7 +6928,7 @@
       "python": {
         "file": "tests/pydantic_ai_adapter/test_capability.py",
         "name": "test_authentication_failure_logs_one_credential_free_configuration_warning",
-        "line": 123
+        "line": 120
       },
       "mode": "retained-host",
       "status": "pending",
@@ -6963,7 +7007,7 @@
     {
       "python": {
         "file": "tests/pydantic_ai_adapter/test_capture.py",
-        "name": "test_shared_capture_caches_codex_auth_until_the_file_changes",
+        "name": "test_capture_failure_does_not_change_tool_or_model_results_or_log_arbitrary_exception_messages",
         "line": 292
       },
       "mode": "retained-host",
@@ -6973,38 +7017,8 @@
     {
       "python": {
         "file": "tests/pydantic_ai_adapter/test_capture.py",
-        "name": "test_capture_failure_does_not_change_tool_or_model_results_or_log_arbitrary_exception_messages",
-        "line": 329
-      },
-      "mode": "retained-host",
-      "status": "pending",
-      "source": "rules"
-    },
-    {
-      "python": {
-        "file": "tests/pydantic_ai_adapter/test_capture.py",
         "name": "test_flush_failure_does_not_change_model_result",
-        "line": 376
-      },
-      "mode": "retained-host",
-      "status": "pending",
-      "source": "rules"
-    },
-    {
-      "python": {
-        "file": "tests/pydantic_ai_adapter/test_packaging.py",
-        "name": "test_integration_wheels_require_the_first_core_release_with_shared_capture",
-        "line": 78
-      },
-      "mode": "retained-host",
-      "status": "pending",
-      "source": "rules"
-    },
-    {
-      "python": {
-        "file": "tests/pydantic_ai_adapter/test_packaging.py",
-        "name": "test_openai_install_command_is_consistent_across_public_guides",
-        "line": 85
+        "line": 339
       },
       "mode": "retained-host",
       "status": "pending",
@@ -7014,7 +7028,7 @@
       "python": {
         "file": "tests/pydantic_ai_adapter/test_packaging.py",
         "name": "test_documented_openai_agent_constructs_from_installed_wheels",
-        "line": 96
+        "line": 68
       },
       "mode": "retained-host",
       "status": "pending",
@@ -7094,7 +7108,7 @@
       "python": {
         "file": "tests/pydantic_ai_adapter/test_toolset.py",
         "name": "test_toolset_exposes_exact_schemas_instructions_request_mapping_and_full_responses",
-        "line": 32
+        "line": 31
       },
       "mode": "retained-host",
       "status": "pending",
@@ -7104,17 +7118,7 @@
       "python": {
         "file": "tests/pydantic_ai_adapter/test_toolset.py",
         "name": "test_toolset_converts_client_failure_to_model_retry",
-        "line": 117
-      },
-      "mode": "retained-host",
-      "status": "pending",
-      "source": "rules"
-    },
-    {
-      "python": {
-        "file": "tests/pydantic_ai_adapter/test_toolset.py",
-        "name": "test_toolset_uses_one_raw_token_client_per_run_and_closes_it",
-        "line": 139
+        "line": 116
       },
       "mode": "retained-host",
       "status": "pending",
@@ -7608,7 +7612,7 @@
       "python": {
         "file": "tests/test_ci_release_verification.py",
         "name": "test_release_smoke_resolves_console_script_from_verification_python",
-        "line": 39
+        "line": 37
       },
       "mode": "go-port",
       "status": "mapped",
@@ -7623,82 +7627,9 @@
     },
     {
       "python": {
-        "file": "tests/test_ci_release_verification.py",
-        "name": "test_pypi_release_requires_wheel_and_sdist",
-        "line": 52
-      },
-      "mode": "go-port",
-      "status": "mapped",
-      "source": "oracle-traceability",
-      "evidence": [
-        {
-          "kind": "go",
-          "file": "tools/release/main_test.go",
-          "test": "TestReleaseWorkflowPublishesCompleteAssetsAndAllowsPrereleases"
-        },
-        {
-          "kind": "go",
-          "file": "tools/release/main_test.go",
-          "test": "TestNativeAssetManifestSupportsReleaseMatrix"
-        }
-      ]
-    },
-    {
-      "python": {
-        "file": "tests/test_ci_release_verification.py",
-        "name": "test_pypi_verification_retries_until_release_is_complete",
-        "line": 71
-      },
-      "mode": "go-port",
-      "status": "mapped",
-      "source": "oracle-traceability",
-      "evidence": [
-        {
-          "kind": "go",
-          "file": "tools/release/main_test.go",
-          "test": "TestReleaseWorkflowPublishesCompleteAssetsAndAllowsPrereleases"
-        }
-      ]
-    },
-    {
-      "python": {
-        "file": "tests/test_ci_release_verification.py",
-        "name": "test_github_release_requires_published_state_and_expected_assets",
-        "line": 95
-      },
-      "mode": "go-port",
-      "status": "mapped",
-      "source": "oracle-traceability",
-      "evidence": [
-        {
-          "kind": "go",
-          "file": "tools/release/main_test.go",
-          "test": "TestReleaseWorkflowPublishesCompleteAssetsAndAllowsPrereleases"
-        }
-      ]
-    },
-    {
-      "python": {
-        "file": "tests/test_ci_release_verification.py",
-        "name": "test_github_release_allows_prereleases",
-        "line": 114
-      },
-      "mode": "go-port",
-      "status": "mapped",
-      "source": "oracle-traceability",
-      "evidence": [
-        {
-          "kind": "go",
-          "file": "tools/release/main_test.go",
-          "test": "TestReleaseWorkflowPublishesCompleteAssetsAndAllowsPrereleases"
-        }
-      ]
-    },
-    {
-      "python": {
         "file": "tests/test_cli.py",
         "name": "test_cli_help_exits_successfully",
-        "line": 128
+        "line": 129
       },
       "mode": "go-port",
       "status": "mapped",
@@ -7715,7 +7646,7 @@
       "python": {
         "file": "tests/test_cli.py",
         "name": "test_skill_cli_exposes_the_target_based_export_command",
-        "line": 136
+        "line": 137
       },
       "mode": "go-port",
       "status": "mapped",
@@ -7732,7 +7663,7 @@
       "python": {
         "file": "tests/test_cli.py",
         "name": "test_cli_version_reports_the_installed_distribution",
-        "line": 151
+        "line": 152
       },
       "mode": "go-port",
       "status": "mapped",
@@ -7749,7 +7680,7 @@
       "python": {
         "file": "tests/test_cli.py",
         "name": "test_cli_exposes_installed_role_commands",
-        "line": 158
+        "line": 159
       },
       "mode": "go-port",
       "status": "mapped",
@@ -7766,7 +7697,7 @@
       "python": {
         "file": "tests/test_cli.py",
         "name": "test_client_settings_load_environment",
-        "line": 167
+        "line": 168
       },
       "mode": "go-port",
       "status": "mapped",
@@ -7788,7 +7719,7 @@
       "python": {
         "file": "tests/test_cli.py",
         "name": "test_client_settings_reject_invalid_values",
-        "line": 178
+        "line": 179
       },
       "mode": "go-port",
       "status": "mapped",
@@ -7805,7 +7736,7 @@
       "python": {
         "file": "tests/test_cli.py",
         "name": "test_server_command_layers_partial_cli_overrides_over_environment_settings",
-        "line": 203
+        "line": 204
       },
       "mode": "go-port",
       "status": "mapped",
@@ -7821,8 +7752,38 @@
     {
       "python": {
         "file": "tests/test_cli.py",
+        "name": "test_server_command_uses_env_file_instead_of_stale_shell_environment",
+        "line": 232
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_cli.py",
+        "name": "test_server_command_clears_stale_server_values_missing_from_env_file",
+        "line": 269
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_cli.py",
+        "name": "test_server_command_reports_a_missing_env_file_without_starting",
+        "line": 293
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_cli.py",
         "name": "test_server_command_rejects_an_unauthenticated_non_loopback_host_override",
-        "line": 246
+        "line": 325
       },
       "mode": "go-port",
       "status": "mapped",
@@ -7839,7 +7800,7 @@
       "python": {
         "file": "tests/test_cli.py",
         "name": "test_server_command_reports_a_friendly_error_when_auth_lacks_a_token",
-        "line": 269
+        "line": 348
       },
       "mode": "go-port",
       "status": "mapped",
@@ -7861,7 +7822,7 @@
       "python": {
         "file": "tests/test_cli.py",
         "name": "test_server_command_lets_a_loopback_override_repair_an_unsafe_environment_host",
-        "line": 291
+        "line": 370
       },
       "mode": "go-port",
       "status": "mapped",
@@ -7878,7 +7839,7 @@
       "python": {
         "file": "tests/test_cli.py",
         "name": "test_server_command_does_not_load_client_settings",
-        "line": 313
+        "line": 392
       },
       "mode": "go-port",
       "status": "mapped",
@@ -7895,7 +7856,7 @@
       "python": {
         "file": "tests/test_cli.py",
         "name": "test_cli_reports_server_errors_with_request_context_without_a_traceback",
-        "line": 329
+        "line": 408
       },
       "mode": "go-port",
       "status": "mapped",
@@ -7912,7 +7873,7 @@
       "python": {
         "file": "tests/test_cli.py",
         "name": "test_client_command_prints_human_readable_output_by_default",
-        "line": 355
+        "line": 434
       },
       "mode": "go-port",
       "status": "mapped",
@@ -7929,7 +7890,7 @@
       "python": {
         "file": "tests/test_cli.py",
         "name": "test_stats_command_builds_request_and_prints_summary",
-        "line": 379
+        "line": 458
       },
       "mode": "go-port",
       "status": "mapped",
@@ -7946,7 +7907,7 @@
       "python": {
         "file": "tests/test_cli.py",
         "name": "test_client_generation_commands_build_requests_from_explicit_options",
-        "line": 413
+        "line": 492
       },
       "mode": "go-port",
       "status": "mapped",
@@ -7963,7 +7924,7 @@
       "python": {
         "file": "tests/test_cli.py",
         "name": "test_client_candidate_revision_commands_build_typed_proposals",
-        "line": 491
+        "line": 570
       },
       "mode": "go-port",
       "status": "mapped",
@@ -7980,7 +7941,7 @@
       "python": {
         "file": "tests/test_cli.py",
         "name": "test_client_generation_commands_reject_invalid_reference_options",
-        "line": 599
+        "line": 678
       },
       "mode": "go-port",
       "status": "mapped",
@@ -7997,7 +7958,7 @@
       "python": {
         "file": "tests/test_cli.py",
         "name": "test_client_external_skill_import_preserves_exact_identity_and_intent",
-        "line": 609
+        "line": 688
       },
       "mode": "go-port",
       "status": "mapped",
@@ -8014,7 +7975,7 @@
       "python": {
         "file": "tests/test_cli.py",
         "name": "test_client_skill_export_uses_configured_authentication",
-        "line": 648
+        "line": 727
       },
       "mode": "go-port",
       "status": "mapped",
@@ -8459,6 +8420,216 @@
     },
     {
       "python": {
+        "file": "tests/test_config_cli.py",
+        "name": "test_init_asks_for_protocol_endpoint_key_and_plain_model_name",
+        "line": 26
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_config_cli.py",
+        "name": "test_arbitrary_model_providers_and_environment_variables_are_not_rejected",
+        "line": 57
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_config_cli.py",
+        "name": "test_provider_base_url_rejects_embedded_credentials",
+        "line": 81
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_config_cli.py",
+        "name": "test_init_validate_and_show_round_trip_managed_environment",
+        "line": 93
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_config_cli.py",
+        "name": "test_init_rejects_configuration_that_server_settings_reject",
+        "line": 123
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_config_cli.py",
+        "name": "test_init_rejects_provider_models_that_cannot_be_constructed",
+        "line": 138
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_config_cli.py",
+        "name": "test_configuration_rejects_relative_persistent_storage",
+        "line": 162
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_config_cli.py",
+        "name": "test_standard_provider_requires_a_credential",
+        "line": 177
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_config_cli.py",
+        "name": "test_custom_connection_is_not_reclassified_from_its_model_prefix",
+        "line": 192
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_config_cli.py",
+        "name": "test_init_refuses_to_replace_an_existing_environment_without_force",
+        "line": 217
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_config_cli.py",
+        "name": "test_environment_parser_rejects_duplicate_assignments",
+        "line": 232
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_config_cli.py",
+        "name": "test_validate_reports_invalid_numeric_values_without_a_traceback",
+        "line": 237
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_config_cli.py",
+        "name": "test_show_redacts_standard_credential_container_variables",
+        "line": 252
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_config_cli.py",
+        "name": "test_init_records_generated_credential_names_for_show_redaction",
+        "line": 267
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_config_cli.py",
+        "name": "test_managed_marker_text_inside_a_credential_is_not_treated_as_structure",
+        "line": 302
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_config_cli.py",
+        "name": "test_show_reports_malformed_managed_markers_without_a_traceback",
+        "line": 320
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_config_cli.py",
+        "name": "test_custom_connection_marks_prompted_credential_for_show_redaction",
+        "line": 332
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_config_cli.py",
+        "name": "test_init_hides_and_redacts_marked_additional_credentials",
+        "line": 373
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_config_cli.py",
+        "name": "test_collect_provider_variable_hides_input_for_credential_names",
+        "line": 396
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_config_cli.py",
+        "name": "test_collect_additional_provider_variables_hides_and_records_marked_credentials",
+        "line": 411
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_config_cli.py",
+        "name": "test_collect_additional_provider_variables_keeps_unmarked_values_visible",
+        "line": 432
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
         "file": "tests/test_dashboard.py",
         "name": "test_dashboard_is_enabled_by_default_without_authentication_or_scopes",
         "line": 38
@@ -8560,8 +8731,28 @@
     {
       "python": {
         "file": "tests/test_dashboard.py",
+        "name": "test_publish_reports_success_when_post_publish_scan_fails",
+        "line": 412
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_dashboard.py",
+        "name": "test_publish_reports_stale_discovery_when_registry_database_is_unavailable",
+        "line": 517
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_dashboard.py",
         "name": "test_handoff_report_page_is_available_without_the_statistics_dashboard",
-        "line": 391
+        "line": 598
       },
       "mode": "go-port",
       "status": "mapped",
@@ -8583,7 +8774,7 @@
       "python": {
         "file": "tests/test_dashboard.py",
         "name": "test_handoff_report_page_contains_a_data_free_preview_template",
-        "line": 488
+        "line": 695
       },
       "mode": "go-port",
       "status": "mapped",
@@ -8952,6 +9143,206 @@
           "test": "TestDoctorDSHReportsInstalledPlugin"
         }
       ]
+    },
+    {
+      "python": {
+        "file": "tests/test_env_file.py",
+        "name": "test_hash_inside_a_value_is_preserved",
+        "line": 29
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_env_file.py",
+        "name": "test_comment_after_an_assignment_is_removed",
+        "line": 33
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_env_file.py",
+        "name": "test_quoted_values_keep_hashes_and_spaces",
+        "line": 37
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_env_file.py",
+        "name": "test_url_fragment_assignment_survives",
+        "line": 42
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_env_file.py",
+        "name": "test_export_prefix_keeps_hash_values",
+        "line": 46
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_env_file.py",
+        "name": "test_full_line_comments_are_ignored",
+        "line": 50
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_env_file.py",
+        "name": "test_value_may_start_with_hash_like_shell",
+        "line": 55
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_env_file.py",
+        "name": "test_backslash_escaped_space_preserves_hash_value",
+        "line": 59
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_env_file.py",
+        "name": "test_even_backslash_before_space_starts_a_comment_like_shell",
+        "line": 63
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_env_file.py",
+        "name": "test_backslash_escaped_quote_outside_quotes_is_literal",
+        "line": 67
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_env_file.py",
+        "name": "test_backslash_escaped_tab_preserves_hash_value",
+        "line": 71
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_env_file.py",
+        "name": "test_unescaped_tab_starts_a_comment_boundary",
+        "line": 75
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_env_file.py",
+        "name": "test_trailing_escaped_whitespace_is_preserved",
+        "line": 80
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_env_file.py",
+        "name": "test_export_accepts_shell_whitespace",
+        "line": 84
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_env_file.py",
+        "name": "test_shell_expansion_is_rejected_instead_of_loaded_literally",
+        "line": 89
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_env_file.py",
+        "name": "test_quoted_and_escaped_expansion_characters_are_literal",
+        "line": 94
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_env_file.py",
+        "name": "test_invalid_utf8_is_reported_as_an_environment_file_error",
+        "line": 102
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_env_file.py",
+        "name": "test_environment_context_can_clear_stale_values",
+        "line": 110
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_env_file.py",
+        "name": "test_unterminated_quote_is_rejected",
+        "line": 126
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_full_capability_docs.py",
+        "name": "test_full_capability_guide_binds_memory_evidence_to_the_captured_source",
+        "line": 27
+      },
+      "mode": "cross-layer",
+      "status": "pending",
+      "source": "rules"
     },
     {
       "python": {
@@ -10137,8 +10528,18 @@
     {
       "python": {
         "file": "tests/test_mcp.py",
-        "name": "test_mcp_exact_entry_tools_use_nested_citations",
+        "name": "test_mcp_describes_review_write_side_effects_for_host_approval",
         "line": 348
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_mcp.py",
+        "name": "test_mcp_exact_entry_tools_use_nested_citations",
+        "line": 370
       },
       "mode": "go-port",
       "status": "mapped",
@@ -10155,7 +10556,7 @@
       "python": {
         "file": "tests/test_mcp.py",
         "name": "test_mcp_bridge_reuses_logical_request_id_and_is_marked_internal",
-        "line": 367
+        "line": 389
       },
       "mode": "go-port",
       "status": "mapped",
@@ -10177,7 +10578,7 @@
       "python": {
         "file": "tests/test_mcp.py",
         "name": "test_mcp_access_log_counts_the_logical_tool_call_without_the_bridge",
-        "line": 424
+        "line": 446
       },
       "mode": "go-port",
       "status": "mapped",
@@ -10555,8 +10956,18 @@
     {
       "python": {
         "file": "tests/test_opencode_cli.py",
-        "name": "test_setup_opencode_refuses_unowned_skill",
+        "name": "test_interrupted_plugin_install_recovers_on_retry",
         "line": 224
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_opencode_cli.py",
+        "name": "test_setup_opencode_refuses_unowned_skill",
+        "line": 260
       },
       "mode": "go-port",
       "status": "mapped",
@@ -10573,7 +10984,7 @@
       "python": {
         "file": "tests/test_opencode_cli.py",
         "name": "test_activation_probe_uses_headless_server_without_model",
-        "line": 246
+        "line": 282
       },
       "mode": "go-port",
       "status": "mapped",
@@ -10590,7 +11001,7 @@
       "python": {
         "file": "tests/test_opencode_cli.py",
         "name": "test_run_opencode_probe_executes_request_waits_for_nonce_and_stops_process",
-        "line": 274
+        "line": 310
       },
       "mode": "go-port",
       "status": "mapped",
@@ -10607,7 +11018,7 @@
       "python": {
         "file": "tests/test_opencode_cli.py",
         "name": "test_run_opencode_probe_handles_process_exit_and_stops_process",
-        "line": 285
+        "line": 321
       },
       "mode": "go-port",
       "status": "mapped",
@@ -10624,7 +11035,7 @@
       "python": {
         "file": "tests/test_opencode_cli.py",
         "name": "test_run_opencode_probe_times_out_and_stops_process",
-        "line": 296
+        "line": 332
       },
       "mode": "go-port",
       "status": "mapped",
@@ -10641,7 +11052,7 @@
       "python": {
         "file": "tests/test_opencode_cli.py",
         "name": "test_setup_opencode_requires_built_bundle",
-        "line": 308
+        "line": 344
       },
       "mode": "go-port",
       "status": "mapped",
@@ -10658,7 +11069,7 @@
       "python": {
         "file": "tests/test_opencode_cli.py",
         "name": "test_setup_opencode_rejects_unsupported_version",
-        "line": 323
+        "line": 359
       },
       "mode": "go-port",
       "status": "mapped",
@@ -10675,7 +11086,7 @@
       "python": {
         "file": "tests/test_opencode_cli.py",
         "name": "test_doctor_opencode_reports_plugin_and_skill",
-        "line": 338
+        "line": 374
       },
       "mode": "go-port",
       "status": "mapped",
@@ -10692,7 +11103,7 @@
       "python": {
         "file": "tests/test_opencode_cli.py",
         "name": "test_doctor_opencode_rejects_configured_but_inactive_plugin",
-        "line": 364
+        "line": 400
       },
       "mode": "go-port",
       "status": "mapped",
@@ -10828,7 +11239,7 @@
       "python": {
         "file": "tests/test_server.py",
         "name": "test_settings_load_server_environment",
-        "line": 88
+        "line": 90
       },
       "mode": "go-port",
       "status": "mapped",
@@ -10845,7 +11256,7 @@
       "python": {
         "file": "tests/test_server.py",
         "name": "test_env_example_loads_server_settings",
-        "line": 146
+        "line": 148
       },
       "mode": "go-port",
       "status": "mapped",
@@ -10862,7 +11273,7 @@
       "python": {
         "file": "tests/test_server.py",
         "name": "test_server_settings_select_oceanbase",
-        "line": 164
+        "line": 171
       },
       "mode": "go-port",
       "status": "mapped",
@@ -10879,7 +11290,7 @@
       "python": {
         "file": "tests/test_server.py",
         "name": "test_server_settings_select_embedded_seekdb",
-        "line": 175
+        "line": 182
       },
       "mode": "go-port",
       "status": "mapped",
@@ -10896,7 +11307,7 @@
       "python": {
         "file": "tests/test_server.py",
         "name": "test_server_settings_default_blank_embedded_seekdb_path",
-        "line": 189
+        "line": 196
       },
       "mode": "go-port",
       "status": "mapped",
@@ -10913,7 +11324,7 @@
       "python": {
         "file": "tests/test_server.py",
         "name": "test_server_settings_override_embedded_seekdb_path",
-        "line": 201
+        "line": 208
       },
       "mode": "go-port",
       "status": "mapped",
@@ -10930,7 +11341,7 @@
       "python": {
         "file": "tests/test_server.py",
         "name": "test_server_settings_reject_custom_embedded_seekdb_database",
-        "line": 213
+        "line": 220
       },
       "mode": "go-port",
       "status": "mapped",
@@ -10947,7 +11358,7 @@
       "python": {
         "file": "tests/test_server.py",
         "name": "test_server_scheduler_uses_the_powercontext_data_directory",
-        "line": 222
+        "line": 229
       },
       "mode": "go-port",
       "status": "mapped",
@@ -10964,7 +11375,7 @@
       "python": {
         "file": "tests/test_server.py",
         "name": "test_settings_load_bearer_authentication_without_exposing_token",
-        "line": 237
+        "line": 244
       },
       "mode": "go-port",
       "status": "mapped",
@@ -10981,7 +11392,7 @@
       "python": {
         "file": "tests/test_server.py",
         "name": "test_enabled_bearer_authentication_requires_a_token",
-        "line": 249
+        "line": 256
       },
       "mode": "go-port",
       "status": "mapped",
@@ -10998,7 +11409,7 @@
       "python": {
         "file": "tests/test_server.py",
         "name": "test_liveness_adds_a_server_owned_request_id",
-        "line": 254
+        "line": 261
       },
       "mode": "go-port",
       "status": "mapped",
@@ -11015,7 +11426,7 @@
       "python": {
         "file": "tests/test_server.py",
         "name": "test_server_factory_optionally_requires_bearer_authentication",
-        "line": 272
+        "line": 279
       },
       "mode": "go-port",
       "status": "mapped",
@@ -11037,7 +11448,7 @@
       "python": {
         "file": "tests/test_server.py",
         "name": "test_readiness_reports_unavailable_bindings",
-        "line": 305
+        "line": 312
       },
       "mode": "go-port",
       "status": "mapped",
@@ -11054,7 +11465,7 @@
       "python": {
         "file": "tests/test_server.py",
         "name": "test_readiness_keeps_degraded_bindings_in_traffic",
-        "line": 322
+        "line": 329
       },
       "mode": "go-port",
       "status": "mapped",
@@ -11071,7 +11482,7 @@
       "python": {
         "file": "tests/test_server.py",
         "name": "test_server_factory_reports_database_failure_as_not_ready",
-        "line": 338
+        "line": 345
       },
       "mode": "go-port",
       "status": "mapped",
@@ -11088,7 +11499,7 @@
       "python": {
         "file": "tests/test_server.py",
         "name": "test_server_factory_reports_database_and_configured_generation_readiness",
-        "line": 366
+        "line": 373
       },
       "mode": "go-port",
       "status": "mapped",
@@ -11110,7 +11521,7 @@
       "python": {
         "file": "tests/test_server.py",
         "name": "test_server_factory_reports_generation_failure_as_degraded",
-        "line": 389
+        "line": 396
       },
       "mode": "go-port",
       "status": "mapped",
@@ -11132,7 +11543,7 @@
       "python": {
         "file": "tests/test_server.py",
         "name": "test_server_factory_caches_and_redacts_degraded_embedding_readiness",
-        "line": 417
+        "line": 424
       },
       "mode": "go-port",
       "status": "mapped",
@@ -11148,8 +11559,18 @@
     {
       "python": {
         "file": "tests/test_server.py",
-        "name": "test_server_factory_reports_transient_embedding_failures_as_degraded",
+        "name": "test_server_factory_reports_a_rejected_embedding_request_with_a_redacted_reason",
         "line": 457
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_server.py",
+        "name": "test_server_factory_reports_transient_embedding_failures_as_degraded",
+        "line": 488
       },
       "mode": "go-port",
       "status": "mapped",
@@ -11171,7 +11592,7 @@
       "python": {
         "file": "tests/test_server.py",
         "name": "test_server_provider_cache_shares_refreshes_and_retries_transient_failures_sooner",
-        "line": 485
+        "line": 516
       },
       "mode": "go-port",
       "status": "mapped",
@@ -11188,7 +11609,7 @@
       "python": {
         "file": "tests/test_server.py",
         "name": "test_server_factory_reports_missing_embedding_api_prefix_as_degraded",
-        "line": 530
+        "line": 561
       },
       "mode": "go-port",
       "status": "mapped",
@@ -11205,7 +11626,7 @@
       "python": {
         "file": "tests/test_server.py",
         "name": "test_unhandled_errors_return_the_server_request_id",
-        "line": 594
+        "line": 625
       },
       "mode": "go-port",
       "status": "mapped",
@@ -11222,7 +11643,7 @@
       "python": {
         "file": "tests/test_server.py",
         "name": "test_prepare_context_rejects_memory_specific_tuning_fields",
-        "line": 606
+        "line": 637
       },
       "mode": "go-port",
       "status": "mapped",
@@ -11239,7 +11660,7 @@
       "python": {
         "file": "tests/test_server.py",
         "name": "test_prepare_context_rejects_unicode_surrogates_without_crashing",
-        "line": 628
+        "line": 659
       },
       "mode": "go-port",
       "status": "mapped",
@@ -11261,7 +11682,7 @@
       "python": {
         "file": "tests/test_server.py",
         "name": "test_prepare_context_rejects_invalid_request_without_input_field",
-        "line": 653
+        "line": 684
       },
       "mode": "go-port",
       "status": "mapped",
@@ -11283,7 +11704,7 @@
       "python": {
         "file": "tests/test_server.py",
         "name": "test_stats_returns_inclusive_utc_periods_for_empty_scope",
-        "line": 677
+        "line": 708
       },
       "mode": "go-port",
       "status": "mapped",
@@ -11305,7 +11726,7 @@
       "python": {
         "file": "tests/test_server.py",
         "name": "test_application_failure_log_uses_operation_context",
-        "line": 732
+        "line": 763
       },
       "mode": "go-port",
       "status": "mapped",
@@ -11322,7 +11743,7 @@
       "python": {
         "file": "tests/test_server.py",
         "name": "test_logging_failure_does_not_change_the_response",
-        "line": 750
+        "line": 781
       },
       "mode": "go-port",
       "status": "mapped",
@@ -11599,7 +12020,7 @@
       "python": {
         "file": "tests/test_server_tracing.py",
         "name": "test_http_and_application_spans_preserve_incoming_context",
-        "line": 52
+        "line": 53
       },
       "mode": "go-port",
       "status": "mapped",
@@ -11616,7 +12037,7 @@
       "python": {
         "file": "tests/test_server_tracing.py",
         "name": "test_client_span_injects_w3c_trace_context",
-        "line": 84
+        "line": 85
       },
       "mode": "go-port",
       "status": "mapped",
@@ -11633,7 +12054,7 @@
       "python": {
         "file": "tests/test_server_tracing.py",
         "name": "test_tracing_context_is_not_recorded_by_default",
-        "line": 125
+        "line": 126
       },
       "mode": "go-port",
       "status": "mapped",
@@ -11650,7 +12071,7 @@
       "python": {
         "file": "tests/test_server_tracing.py",
         "name": "test_inference_instrumentation_follows_the_tracing_setting",
-        "line": 136
+        "line": 137
       },
       "mode": "go-port",
       "status": "mapped",
@@ -11667,7 +12088,7 @@
       "python": {
         "file": "tests/test_server_tracing.py",
         "name": "test_inference_instrumentation_records_no_content",
-        "line": 146
+        "line": 147
       },
       "mode": "go-port",
       "status": "mapped",
@@ -11689,7 +12110,7 @@
       "python": {
         "file": "tests/test_server_tracing.py",
         "name": "test_runtime_stage_records_attributes_and_inherits_current_span",
-        "line": 156
+        "line": 157
       },
       "mode": "go-port",
       "status": "mapped",
@@ -11711,7 +12132,7 @@
       "python": {
         "file": "tests/test_server_tracing.py",
         "name": "test_runtime_stage_records_failure_and_reraises_same_error",
-        "line": 185
+        "line": 186
       },
       "mode": "go-port",
       "status": "mapped",
@@ -11728,7 +12149,7 @@
       "python": {
         "file": "tests/test_server_tracing.py",
         "name": "test_runtime_stage_records_cancellation_and_reraises_same_error",
-        "line": 202
+        "line": 203
       },
       "mode": "go-port",
       "status": "mapped",
@@ -11745,7 +12166,7 @@
       "python": {
         "file": "tests/test_server_tracing.py",
         "name": "test_runtime_stage_isolates_tracer_failure",
-        "line": 218
+        "line": 219
       },
       "mode": "go-port",
       "status": "mapped",
@@ -11761,8 +12182,38 @@
     {
       "python": {
         "file": "tests/test_server_tracing.py",
+        "name": "test_runtime_stage_records_explicit_noop_and_failure_outcomes",
+        "line": 234
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_server_tracing.py",
+        "name": "test_background_stage_starts_a_fresh_trace_outside_an_ambient_span",
+        "line": 254
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_server_tracing.py",
+        "name": "test_background_isolates_child_spans_when_root_start_fails",
+        "line": 280
+      },
+      "mode": "go-port",
+      "status": "pending",
+      "source": "rules"
+    },
+    {
+      "python": {
+        "file": "tests/test_server_tracing.py",
         "name": "test_readiness_ignores_tracing_setup_failure",
-        "line": 233
+        "line": 311
       },
       "mode": "go-port",
       "status": "mapped",
@@ -11784,7 +12235,7 @@
       "python": {
         "file": "tests/test_server_tracing.py",
         "name": "test_tracing_export_requires_the_otlp_extra",
-        "line": 258
+        "line": 336
       },
       "mode": "go-port",
       "status": "mapped",
@@ -12979,45 +13430,8 @@
     {
       "python": {
         "file": "tests/test_transport.py",
-        "name": "test_vendored_plugin_shares_the_loopback_host_set",
-        "line": 209
-      },
-      "mode": "cross-layer",
-      "status": "mapped",
-      "source": "rules",
-      "evidence": [
-        {
-          "kind": "go",
-          "file": "test/transport/policy_test.go",
-          "test": "TestSharedLoopbackHostVectors"
-        },
-        {
-          "kind": "py",
-          "file": "integrations/codex/tests/test_contract.py",
-          "test": "test_codex_settings_accept_shared_loopback_hosts"
-        },
-        {
-          "kind": "py",
-          "file": "integrations/codex/tests/test_contract.py",
-          "test": "test_codex_settings_reject_shared_non_loopback_plaintext_hosts"
-        },
-        {
-          "kind": "py",
-          "file": "integrations/claude-code/tests/test_contract.py",
-          "test": "test_settings_accept_shared_loopback_hosts"
-        },
-        {
-          "kind": "py",
-          "file": "integrations/claude-code/tests/test_contract.py",
-          "test": "test_settings_reject_shared_non_loopback_plaintext_hosts"
-        }
-      ]
-    },
-    {
-      "python": {
-        "file": "tests/test_transport.py",
         "name": "test_vendored_plugin_matches_the_shared_plaintext_policy",
-        "line": 215
+        "line": 210
       },
       "mode": "cross-layer",
       "status": "mapped",

--- a/test/conformance/parity_contract_test.go
+++ b/test/conformance/parity_contract_test.go
@@ -185,6 +185,12 @@ func TestParityContractRecordsSeparateConcepts(t *testing.T) {
 	if active == oracle {
 		t.Errorf("active parity target collapses into the frozen release Oracle %s; parity work must measure a newer upstream state", oracle)
 	}
+	if active != target || active != contract.ReleaseTarget.Commit {
+		t.Errorf("active parity target = %s, exact target = %s, release target = %s", active, target, contract.ReleaseTarget.Commit)
+	}
+	if contract.TargetTestCaseCount != contract.ReleaseTarget.TestCaseCount {
+		t.Errorf("active target cases = %d, release target cases = %d", contract.TargetTestCaseCount, contract.ReleaseTarget.TestCaseCount)
+	}
 }
 
 func TestParityContractRecordsSignedV010ReleaseIdentity(t *testing.T) {
@@ -239,8 +245,13 @@ func TestParityContractMatchesFrozenOracleWorkflow(t *testing.T) {
 	if !ok {
 		t.Fatal("migration-gates.yml has no frozen-oracle job")
 	}
+	var delta struct {
+		FromCommit string `json:"from_commit"`
+	}
+	decodeJSONFile(t, filepath.Join(root, "test", "conformance", "target-delta.json"), &delta)
 	checkout, verify := "", ""
-	targetCheckout, targetVerify := "", ""
+	previousCheckout, previousVerify := "", ""
+	targetCheckout, targetVerify, deltaVerify := "", "", ""
 	for _, step := range job.Steps {
 		switch step.Name {
 		case "Check out frozen Python Oracle":
@@ -256,6 +267,16 @@ func TestParityContractMatchesFrozenOracleWorkflow(t *testing.T) {
 			if !validCheckoutIdentityCommand(step.Run, "_oracle", contract.FrozenReleaseOracle.Commit) {
 				t.Errorf("Verify Oracle identity step does not pin the contract frozen Oracle %q", contract.FrozenReleaseOracle.Commit)
 			}
+		case "Check out the previous parity target":
+			previousCheckout = step.Name
+			if step.With.Repository != contract.Upstream.Repository || step.With.Ref != delta.FromCommit {
+				t.Errorf("previous target checkout = %q@%q, want %q@%q", step.With.Repository, step.With.Ref, contract.Upstream.Repository, delta.FromCommit)
+			}
+		case "Verify previous parity target identity":
+			previousVerify = step.Name
+			if !validCheckoutIdentityCommand(step.Run, "_previous_target", delta.FromCommit) {
+				t.Errorf("previous target identity step does not pin ledger from_commit %q", delta.FromCommit)
+			}
 		case "Check out the active parity target":
 			targetCheckout = step.Name
 			if step.With.Repository != contract.Upstream.Repository {
@@ -269,6 +290,11 @@ func TestParityContractMatchesFrozenOracleWorkflow(t *testing.T) {
 			if !validCheckoutIdentityCommand(step.Run, "_target", contract.ExactTargetSHA) {
 				t.Errorf("Verify parity target identity step does not pin the contract exact target SHA %q", contract.ExactTargetSHA)
 			}
+		case "Regenerate and compare frozen fixtures":
+			if strings.Contains(step.Run, "-check-delta") && strings.Contains(step.Run, "-previous-upstream _previous_target") &&
+				strings.Contains(step.Run, "-release-upstream _target") {
+				deltaVerify = step.Name
+			}
 		}
 	}
 	if checkout == "" {
@@ -277,11 +303,20 @@ func TestParityContractMatchesFrozenOracleWorkflow(t *testing.T) {
 	if verify == "" {
 		t.Error("frozen-oracle job has no 'Verify Oracle identity' step")
 	}
+	if previousCheckout == "" {
+		t.Error("frozen-oracle job has no 'Check out the previous parity target' step")
+	}
+	if previousVerify == "" {
+		t.Error("frozen-oracle job has no 'Verify previous parity target identity' step")
+	}
 	if targetCheckout == "" {
 		t.Error("frozen-oracle job has no 'Check out the active parity target' step")
 	}
 	if targetVerify == "" {
 		t.Error("frozen-oracle job has no 'Verify parity target identity' step")
+	}
+	if deltaVerify == "" {
+		t.Error("frozen-oracle job does not verify the reviewed target delta")
 	}
 }
 

--- a/test/conformance/parity_inventory_test.go
+++ b/test/conformance/parity_inventory_test.go
@@ -38,7 +38,7 @@ type parityInventory struct {
 	Entries             []parityInventoryEntry `json:"entries"`
 }
 
-// TestParityInventoryMatchesContract guards the 759-case active parity target
+// TestParityInventoryMatchesContract guards the 812-case active parity target
 // inventory: it must agree with parity-contract.json on identity, keep every
 // frozen Oracle mapping verbatim, assign a mode to every delta case, resolve
 // every mapped evidence reference, and pin the mapped/pending split so silent
@@ -59,6 +59,12 @@ func TestParityInventoryMatchesContract(t *testing.T) {
 	decodeJSONFile(t, "parity-inventory.json", &inventory)
 	var trace traceTable
 	decodeJSONFile(t, "traceability.json", &trace)
+	var delta struct {
+		Removed []struct {
+			Case tracedPythonTest `json:"case"`
+		} `json:"removed"`
+	}
+	decodeJSONFile(t, "target-delta.json", &delta)
 
 	if inventory.SchemaVersion != 1 {
 		t.Fatalf("unsupported parity inventory schema %d", inventory.SchemaVersion)
@@ -82,6 +88,13 @@ func TestParityInventoryMatchesContract(t *testing.T) {
 	frozen := make(map[string]traceEntry, len(trace.Entries))
 	for _, entry := range trace.Entries {
 		frozen[entry.Python.File+"#"+entry.Python.Name] = entry
+	}
+	removedFrozen := make(map[string]struct{})
+	for _, disposition := range delta.Removed {
+		key := disposition.Case.File + "#" + disposition.Case.Name
+		if _, ok := frozen[key]; ok {
+			removedFrozen[key] = struct{}{}
+		}
 	}
 
 	root := filepath.Join("..", "..")
@@ -137,8 +150,13 @@ func TestParityInventoryMatchesContract(t *testing.T) {
 			assertEvidenceResolves(t, root, key, evidence)
 		}
 	}
-	if inherited != len(trace.Entries) {
-		t.Fatalf("inventory inherited %d frozen Oracle cases, traceability declares %d", inherited, len(trace.Entries))
+	for key := range removedFrozen {
+		if _, present := seen[key]; present {
+			t.Fatalf("ledger-removed frozen Oracle case %s remains in the release inventory", key)
+		}
+	}
+	if want := len(trace.Entries) - len(removedFrozen); inherited != want {
+		t.Fatalf("inventory inherited %d frozen Oracle cases, want %d after %d reviewed removals", inherited, want, len(removedFrozen))
 	}
 	if mapped != inventory.MappedCaseCount || pending != inventory.PendingCaseCount {
 		t.Fatalf("counted mapped %d/pending %d, summary says %d/%d",

--- a/test/conformance/target-delta.json
+++ b/test/conformance/target-delta.json
@@ -1,0 +1,215 @@
+{
+  "schema_version": 1,
+  "from_commit": "f2ec1f75e5e1b46ad0626ab8390801b88966b6f5",
+  "to_commit": "7b736206a53a6de6f43d4b517893ee1a80e7183d",
+  "added": [
+    {"file": "tests/builtin/inference/test_pydantic_ai.py", "name": "test_embedding_adapter_maps_a_rejected_request_to_a_stable_reason_without_leaking_body"},
+    {"file": "tests/builtin/persistence/test_sqlite_memory_vector_index.py", "name": "test_vector_index_probe_clears_a_leftover_probe_row"},
+    {"file": "tests/builtin/persistence/test_sqlite_memory_vector_index.py", "name": "test_vector_index_probe_reports_a_table_dimension_mismatch"},
+    {"file": "tests/builtin/persistence/test_sqlite_memory_vector_index.py", "name": "test_vector_index_probe_reports_the_provider_limit_for_a_fresh_oversized_dimension"},
+    {"file": "tests/builtin/persistence/test_sqlite_memory_vector_index.py", "name": "test_vector_index_probe_surfaces_the_underlying_cause"},
+    {"file": "tests/builtin/runtime/test_composition_embedding.py", "name": "test_embedding_models_send_the_configured_dimension_to_the_provider"},
+    {"file": "tests/builtin/runtime/test_composition_embedding.py", "name": "test_embedding_models_without_configuration_return_no_models"},
+    {"file": "tests/builtin/runtime/test_readiness.py", "name": "test_dependency_readiness_probe_redacts_plain_configuration_errors"},
+    {"file": "tests/builtin/runtime/test_readiness.py", "name": "test_dependency_readiness_probe_surfaces_a_stable_redacted_configuration_reason"},
+    {"file": "tests/builtin/runtime/test_scheduler.py", "name": "test_scheduled_experience_records_cancellation"},
+    {"file": "tests/builtin/runtime/test_scheduler.py", "name": "test_scheduled_experience_records_failure_and_swallows_error"},
+    {"file": "tests/builtin/runtime/test_scheduler.py", "name": "test_scheduled_experience_records_noop_outcome"},
+    {"file": "tests/builtin/runtime/test_scheduler.py", "name": "test_scheduled_experience_records_root_and_incubation_spans"},
+    {"file": "tests/builtin/runtime/test_scheduler.py", "name": "test_scheduled_processor_records_cancellation"},
+    {"file": "tests/builtin/runtime/test_scheduler.py", "name": "test_scheduled_processor_records_failure_and_swallows_error"},
+    {"file": "tests/builtin/runtime/test_scheduler.py", "name": "test_scheduled_processor_records_root_and_flush_spans"},
+    {"file": "tests/builtin/runtime/test_scheduler.py", "name": "test_scheduled_processor_records_success_outcome"},
+    {"file": "tests/claude_code_plugin/test_hook.py", "name": "test_unknown_schema_is_not_injected"},
+    {"file": "tests/e2e/test_observability.py", "name": "test_scheduled_experience_starts_an_independent_trace_root"},
+    {"file": "tests/e2e/test_observability.py", "name": "test_scheduled_source_window_starts_an_independent_trace_root"},
+    {"file": "tests/langchain_middleware/test_packaging.py", "name": "test_wheel_bundles_middleware_license"},
+    {"file": "tests/test_cli.py", "name": "test_server_command_clears_stale_server_values_missing_from_env_file"},
+    {"file": "tests/test_cli.py", "name": "test_server_command_reports_a_missing_env_file_without_starting"},
+    {"file": "tests/test_cli.py", "name": "test_server_command_uses_env_file_instead_of_stale_shell_environment"},
+    {"file": "tests/test_config_cli.py", "name": "test_arbitrary_model_providers_and_environment_variables_are_not_rejected"},
+    {"file": "tests/test_config_cli.py", "name": "test_collect_additional_provider_variables_hides_and_records_marked_credentials"},
+    {"file": "tests/test_config_cli.py", "name": "test_collect_additional_provider_variables_keeps_unmarked_values_visible"},
+    {"file": "tests/test_config_cli.py", "name": "test_collect_provider_variable_hides_input_for_credential_names"},
+    {"file": "tests/test_config_cli.py", "name": "test_configuration_rejects_relative_persistent_storage"},
+    {"file": "tests/test_config_cli.py", "name": "test_custom_connection_is_not_reclassified_from_its_model_prefix"},
+    {"file": "tests/test_config_cli.py", "name": "test_custom_connection_marks_prompted_credential_for_show_redaction"},
+    {"file": "tests/test_config_cli.py", "name": "test_environment_parser_rejects_duplicate_assignments"},
+    {"file": "tests/test_config_cli.py", "name": "test_init_asks_for_protocol_endpoint_key_and_plain_model_name"},
+    {"file": "tests/test_config_cli.py", "name": "test_init_hides_and_redacts_marked_additional_credentials"},
+    {"file": "tests/test_config_cli.py", "name": "test_init_records_generated_credential_names_for_show_redaction"},
+    {"file": "tests/test_config_cli.py", "name": "test_init_refuses_to_replace_an_existing_environment_without_force"},
+    {"file": "tests/test_config_cli.py", "name": "test_init_rejects_configuration_that_server_settings_reject"},
+    {"file": "tests/test_config_cli.py", "name": "test_init_rejects_provider_models_that_cannot_be_constructed"},
+    {"file": "tests/test_config_cli.py", "name": "test_init_validate_and_show_round_trip_managed_environment"},
+    {"file": "tests/test_config_cli.py", "name": "test_managed_marker_text_inside_a_credential_is_not_treated_as_structure"},
+    {"file": "tests/test_config_cli.py", "name": "test_provider_base_url_rejects_embedded_credentials"},
+    {"file": "tests/test_config_cli.py", "name": "test_show_redacts_standard_credential_container_variables"},
+    {"file": "tests/test_config_cli.py", "name": "test_show_reports_malformed_managed_markers_without_a_traceback"},
+    {"file": "tests/test_config_cli.py", "name": "test_standard_provider_requires_a_credential"},
+    {"file": "tests/test_config_cli.py", "name": "test_validate_reports_invalid_numeric_values_without_a_traceback"},
+    {"file": "tests/test_dashboard.py", "name": "test_publish_reports_stale_discovery_when_registry_database_is_unavailable"},
+    {"file": "tests/test_dashboard.py", "name": "test_publish_reports_success_when_post_publish_scan_fails"},
+    {"file": "tests/test_env_file.py", "name": "test_backslash_escaped_quote_outside_quotes_is_literal"},
+    {"file": "tests/test_env_file.py", "name": "test_backslash_escaped_space_preserves_hash_value"},
+    {"file": "tests/test_env_file.py", "name": "test_backslash_escaped_tab_preserves_hash_value"},
+    {"file": "tests/test_env_file.py", "name": "test_comment_after_an_assignment_is_removed"},
+    {"file": "tests/test_env_file.py", "name": "test_environment_context_can_clear_stale_values"},
+    {"file": "tests/test_env_file.py", "name": "test_even_backslash_before_space_starts_a_comment_like_shell"},
+    {"file": "tests/test_env_file.py", "name": "test_export_accepts_shell_whitespace"},
+    {"file": "tests/test_env_file.py", "name": "test_export_prefix_keeps_hash_values"},
+    {"file": "tests/test_env_file.py", "name": "test_full_line_comments_are_ignored"},
+    {"file": "tests/test_env_file.py", "name": "test_hash_inside_a_value_is_preserved"},
+    {"file": "tests/test_env_file.py", "name": "test_invalid_utf8_is_reported_as_an_environment_file_error"},
+    {"file": "tests/test_env_file.py", "name": "test_quoted_and_escaped_expansion_characters_are_literal"},
+    {"file": "tests/test_env_file.py", "name": "test_quoted_values_keep_hashes_and_spaces"},
+    {"file": "tests/test_env_file.py", "name": "test_shell_expansion_is_rejected_instead_of_loaded_literally"},
+    {"file": "tests/test_env_file.py", "name": "test_trailing_escaped_whitespace_is_preserved"},
+    {"file": "tests/test_env_file.py", "name": "test_unescaped_tab_starts_a_comment_boundary"},
+    {"file": "tests/test_env_file.py", "name": "test_unterminated_quote_is_rejected"},
+    {"file": "tests/test_env_file.py", "name": "test_url_fragment_assignment_survives"},
+    {"file": "tests/test_env_file.py", "name": "test_value_may_start_with_hash_like_shell"},
+    {"file": "tests/test_full_capability_docs.py", "name": "test_full_capability_guide_binds_memory_evidence_to_the_captured_source"},
+    {"file": "tests/test_mcp.py", "name": "test_mcp_describes_review_write_side_effects_for_host_approval"},
+    {"file": "tests/test_opencode_cli.py", "name": "test_interrupted_plugin_install_recovers_on_retry"},
+    {"file": "tests/test_server.py", "name": "test_server_factory_reports_a_rejected_embedding_request_with_a_redacted_reason"},
+    {"file": "tests/test_server_tracing.py", "name": "test_background_isolates_child_spans_when_root_start_fails"},
+    {"file": "tests/test_server_tracing.py", "name": "test_background_stage_starts_a_fresh_trace_outside_an_ambient_span"},
+    {"file": "tests/test_server_tracing.py", "name": "test_runtime_stage_records_explicit_noop_and_failure_outcomes"}
+  ],
+  "removed": [
+    {
+      "case": {"file": "tests/claude_code_plugin/test_hook.py", "name": "test_context_request_uses_prepare_once"},
+      "disposition": "removed",
+      "reason": "The release removed an internal call-count assertion while retaining the prepare-context behavior.",
+      "evidence": ["py:integrations/claude-code/tests/test_hook.py#test_context_request_uses_prepare_once"]
+    },
+    {
+      "case": {"file": "tests/claude_code_plugin/test_hook.py", "name": "test_hook_rejects_an_oversized_response_body"},
+      "disposition": "removed",
+      "reason": "The release removed the low-level response-reader test; the retained adapter still proves the bounded response contract.",
+      "evidence": ["py:integrations/claude-code/tests/test_hook.py#test_hook_rejects_an_oversized_response_body"]
+    },
+    {
+      "case": {"file": "tests/claude_code_plugin/test_hook.py", "name": "test_malformed_prepared_context_is_not_injected"},
+      "disposition": "removed",
+      "reason": "The release removed the parameterized internal parser test; retained host evidence preserves malformed-response fail-open behavior.",
+      "evidence": ["py:integrations/claude-code/tests/test_hook.py#test_malformed_prepared_context_is_not_injected"]
+    },
+    {
+      "case": {"file": "tests/claude_code_plugin/test_hook.py", "name": "test_unknown_schema_and_oversized_content_are_not_injected"},
+      "disposition": "superseded",
+      "reason": "The release split out a focused unknown-schema behavior while retained host evidence keeps the oversized boundary.",
+      "replacements": [{"file": "tests/claude_code_plugin/test_hook.py", "name": "test_unknown_schema_is_not_injected"}],
+      "evidence": ["py:integrations/claude-code/tests/test_hook.py#test_unknown_schema_and_oversized_content_are_not_injected"]
+    },
+    {
+      "case": {"file": "tests/codex_plugin/test_recall.py", "name": "test_context_request_uses_the_prepare_endpoint_once"},
+      "disposition": "removed",
+      "reason": "The release removed an internal call-count assertion while retaining Codex prepare-context behavior.",
+      "evidence": ["py:integrations/codex/tests/test_recall.py#test_context_request_uses_the_prepare_endpoint_once"]
+    },
+    {
+      "case": {"file": "tests/integrations/test_hermes_provider.py", "name": "test_cli_reads_the_same_json_config_path"},
+      "disposition": "removed",
+      "reason": "The release removed a private path-sharing assertion; the retained Hermes adapter still verifies the public configuration behavior.",
+      "evidence": ["py:integrations/hermes/tests/test_provider.py#test_cli_reads_the_same_json_config_path"]
+    },
+    {
+      "case": {"file": "tests/integrations/test_hermes_provider.py", "name": "test_memory_write_worker_is_daemon_bounded_and_reports_overflow"},
+      "disposition": "removed",
+      "reason": "The release removed worker implementation-detail assertions; retained Hermes evidence preserves bounded overflow behavior.",
+      "evidence": ["py:integrations/hermes/tests/test_provider.py#test_memory_write_worker_is_daemon_bounded_and_reports_overflow"]
+    },
+    {
+      "case": {"file": "tests/langchain_middleware/test_packaging.py", "name": "test_license_file_is_present_in_project"},
+      "disposition": "superseded",
+      "reason": "The release replaces source-tree license presence with the distributed wheel license contract.",
+      "replacements": [{"file": "tests/langchain_middleware/test_packaging.py", "name": "test_wheel_bundles_middleware_license"}]
+    },
+    {
+      "case": {"file": "tests/langchain_middleware/test_packaging.py", "name": "test_wheel_bundles_middleware_license_and_dependencies"},
+      "disposition": "superseded",
+      "reason": "The release narrows the packaging contract to the redistributed license artifact and removes obsolete dependency pins.",
+      "replacements": [{"file": "tests/langchain_middleware/test_packaging.py", "name": "test_wheel_bundles_middleware_license"}]
+    },
+    {
+      "case": {"file": "tests/langchain_middleware/test_scope.py", "name": "test_scope_type_is_owned_by_langchain_package"},
+      "disposition": "superseded",
+      "reason": "The release removes a private type-ownership assertion and retains the public scope configuration contract.",
+      "replacements": [{"file": "tests/langchain_middleware/test_scope.py", "name": "test_missing_scope_names_langchain_configuration"}]
+    },
+    {
+      "case": {"file": "tests/langgraph_adapter/test_packaging.py", "name": "test_license_file_is_present_in_project"},
+      "disposition": "superseded",
+      "reason": "The release replaces source-tree license presence with wheel license and metadata verification.",
+      "replacements": [{"file": "tests/langgraph_adapter/test_packaging.py", "name": "test_wheel_bundles_license_and_metadata"}],
+      "evidence": ["py:integrations/langgraph/tests/test_packaging.py#test_license_file_is_present_in_project"]
+    },
+    {
+      "case": {"file": "tests/pydantic_ai_adapter/test_capture.py", "name": "test_shared_capture_caches_codex_auth_until_the_file_changes"},
+      "disposition": "superseded",
+      "reason": "The release removes cache implementation assertions while retaining credential redaction as the observable contract.",
+      "replacements": [{"file": "tests/pydantic_ai_adapter/test_capture.py", "name": "test_shared_capture_redacts_codex_auth_values_outside_sensitive_keys"}]
+    },
+    {
+      "case": {"file": "tests/pydantic_ai_adapter/test_packaging.py", "name": "test_integration_wheels_require_the_first_core_release_with_shared_capture"},
+      "disposition": "superseded",
+      "reason": "The formal v0.1.0 release identity replaces the pre-release dependency-floor assertion; installed-wheel behavior remains covered.",
+      "replacements": [{"file": "tests/pydantic_ai_adapter/test_packaging.py", "name": "test_documented_openai_agent_constructs_from_installed_wheels"}],
+      "evidence": ["go:test/conformance/parity_contract_test.go#TestParityContractRecordsSignedV010ReleaseIdentity"]
+    },
+    {
+      "case": {"file": "tests/pydantic_ai_adapter/test_packaging.py", "name": "test_openai_install_command_is_consistent_across_public_guides"},
+      "disposition": "superseded",
+      "reason": "The release replaces source-text command equality with an installed-wheel documentation smoke test.",
+      "replacements": [{"file": "tests/pydantic_ai_adapter/test_packaging.py", "name": "test_documented_openai_agent_constructs_from_installed_wheels"}]
+    },
+    {
+      "case": {"file": "tests/pydantic_ai_adapter/test_toolset.py", "name": "test_toolset_uses_one_raw_token_client_per_run_and_closes_it"},
+      "disposition": "superseded",
+      "reason": "The release removes raw-client lifecycle implementation assertions and retains the public toolset request/response contract.",
+      "replacements": [{"file": "tests/pydantic_ai_adapter/test_toolset.py", "name": "test_toolset_exposes_exact_schemas_instructions_request_mapping_and_full_responses"}]
+    },
+    {
+      "case": {"file": "tests/test_ci_release_verification.py", "name": "test_github_release_allows_prereleases"},
+      "disposition": "superseded",
+      "reason": "Go release workflow tests own prerelease and published-asset verification for the shipped implementation.",
+      "evidence": ["go:tools/release/main_test.go#TestReleaseWorkflowPublishesCompleteAssetsAndAllowsPrereleases"]
+    },
+    {
+      "case": {"file": "tests/test_ci_release_verification.py", "name": "test_github_release_requires_published_state_and_expected_assets"},
+      "disposition": "superseded",
+      "reason": "Go release workflow tests own published-state and complete-asset verification for the shipped implementation.",
+      "evidence": ["go:tools/release/main_test.go#TestReleaseWorkflowPublishesCompleteAssetsAndAllowsPrereleases"]
+    },
+    {
+      "case": {"file": "tests/test_ci_release_verification.py", "name": "test_pypi_release_requires_wheel_and_sdist"},
+      "disposition": "superseded",
+      "reason": "The Go release contract records and verifies the complete distribution asset set.",
+      "evidence": [
+        "go:tools/release/main_test.go#TestReleaseWorkflowPublishesCompleteAssetsAndAllowsPrereleases",
+        "go:tools/release/main_test.go#TestNativeAssetManifestSupportsReleaseMatrix"
+      ]
+    },
+    {
+      "case": {"file": "tests/test_ci_release_verification.py", "name": "test_pypi_verification_retries_until_release_is_complete"},
+      "disposition": "superseded",
+      "reason": "The Go release workflow owns bounded publication verification for the shipped release process.",
+      "evidence": ["go:tools/release/main_test.go#TestReleaseWorkflowPublishesCompleteAssetsAndAllowsPrereleases"]
+    },
+    {
+      "case": {"file": "tests/test_transport.py", "name": "test_vendored_plugin_shares_the_loopback_host_set"},
+      "disposition": "superseded",
+      "reason": "The release replaces private host-set equality with observable plaintext-policy agreement over shared vectors.",
+      "replacements": [{"file": "tests/test_transport.py", "name": "test_vendored_plugin_matches_the_shared_plaintext_policy"}],
+      "evidence": [
+        "go:test/transport/policy_test.go#TestSharedLoopbackHostVectors",
+        "py:integrations/codex/tests/test_contract.py#test_codex_settings_accept_shared_loopback_hosts",
+        "py:integrations/codex/tests/test_contract.py#test_codex_settings_reject_shared_non_loopback_plaintext_hosts",
+        "py:integrations/claude-code/tests/test_contract.py#test_settings_accept_shared_loopback_hosts",
+        "py:integrations/claude-code/tests/test_contract.py#test_settings_reject_shared_non_loopback_plaintext_hosts"
+      ]
+    }
+  ]
+}

--- a/tools/parity-inventory-generate/main.go
+++ b/tools/parity-inventory-generate/main.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Command parity-inventory-generate builds the 759-case Python test
+// Command parity-inventory-generate builds the 812-case Python test
 // inventory at the active parity target recorded in
 // test/conformance/parity-contract.json. It walks an upstream checkout that
 // must sit exactly at the target commit, merges the frozen Oracle mappings
@@ -152,12 +152,33 @@ func main() {
 	rulesPath := flag.String("rules", "test/conformance/parity-inventory-rules.json", "parity inventory rules")
 	outputPath := flag.String("output", "test/conformance/parity-inventory.json", "generated parity inventory")
 	upstream := flag.String("upstream", "", "upstream Python checkout pinned at the contract target SHA (required)")
+	previousUpstream := flag.String("previous-upstream", "", "previous Python target checkout used to verify the reviewed target delta")
+	releaseUpstream := flag.String("release-upstream", "", "release Python target checkout used to verify the reviewed target delta")
+	deltaLedgerPath := flag.String("delta-ledger", "test/conformance/target-delta.json", "reviewed target delta ledger")
+	checkDelta := flag.Bool("check-delta", false, "verify the reviewed previous-to-release target delta")
 	root := flag.String("root", ".", "Go repository root")
 	check := flag.Bool("check", false, "verify generated output without rewriting")
 	flag.Parse()
-	if err := run(*root, *contractPath, *traceabilityPath, *rulesPath, *outputPath, *upstream, *check); err != nil {
+	cleanRoot := filepath.Clean(*root)
+	if err := run(cleanRoot, *contractPath, *traceabilityPath, *rulesPath, *outputPath, *upstream, *check); err != nil {
 		fmt.Fprintln(os.Stderr, "parity-inventory-generate:", err)
 		os.Exit(1)
+	}
+	if *checkDelta {
+		if *previousUpstream == "" || *releaseUpstream == "" {
+			fmt.Fprintln(os.Stderr, "parity-inventory-generate: -check-delta requires -previous-upstream and -release-upstream")
+			os.Exit(1)
+		}
+		if err := checkTargetDelta(
+			cleanRoot,
+			resolveOutputPath(cleanRoot, *contractPath),
+			resolveOutputPath(cleanRoot, *deltaLedgerPath),
+			filepath.Clean(*previousUpstream),
+			filepath.Clean(*releaseUpstream),
+		); err != nil {
+			fmt.Fprintln(os.Stderr, "parity-inventory-generate:", err)
+			os.Exit(1)
+		}
 	}
 }
 

--- a/tools/parity-inventory-generate/main_test.go
+++ b/tools/parity-inventory-generate/main_test.go
@@ -15,8 +15,11 @@
 package main
 
 import (
+	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -82,4 +85,211 @@ func TestResolveOutputPathKeepsAbsoluteAndRootsRelative(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestValidateTargetDeltaAcceptsExactReviewedLedger(t *testing.T) {
+	root := t.TempDir()
+	writeDeltaEvidence(t, root)
+	previous := []pythonTest{
+		{File: "tests/test_api.py", Name: "test_kept"},
+		{File: "tests/test_api.py", Name: "test_removed"},
+		{File: "tests/test_api.py", Name: "test_renamed_old"},
+	}
+	release := []pythonTest{
+		{File: "tests/test_api.py", Name: "test_kept"},
+		{File: "tests/test_api.py", Name: "test_added"},
+		{File: "tests/test_api.py", Name: "test_renamed_new"},
+	}
+	ledger := targetDeltaLedger{
+		SchemaVersion: 1,
+		FromCommit:    "previous",
+		ToCommit:      "release",
+		Added: []caseIdentity{
+			{File: "tests/test_api.py", Name: "test_added"},
+			{File: "tests/test_api.py", Name: "test_renamed_new"},
+		},
+		Removed: []removedCaseDisposition{
+			{
+				Case:        caseIdentity{File: "tests/test_api.py", Name: "test_removed"},
+				Disposition: "removed",
+				Reason:      "The release removed an implementation-detail assertion.",
+				Evidence:    []string{"go:evidence_test.go#TestSurvivingBehavior"},
+			},
+			{
+				Case:         caseIdentity{File: "tests/test_api.py", Name: "test_renamed_old"},
+				Disposition:  "renamed",
+				Reason:       "The release renamed the observable behavior test.",
+				Replacements: []caseIdentity{{File: "tests/test_api.py", Name: "test_renamed_new"}},
+			},
+		},
+	}
+
+	if err := validateTargetDelta(ledger, previous, release, "previous", "release", root); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestValidateTargetDeltaRejectsCaseSetDrift(t *testing.T) {
+	ledger := targetDeltaLedger{
+		SchemaVersion: 1,
+		FromCommit:    "previous",
+		ToCommit:      "release",
+		Added:         []caseIdentity{{File: "tests/test_api.py", Name: "test_wrong"}},
+		Removed: []removedCaseDisposition{{
+			Case:         caseIdentity{File: "tests/test_api.py", Name: "test_removed"},
+			Disposition:  "superseded",
+			Reason:       "A release test replaces the old case.",
+			Replacements: []caseIdentity{{File: "tests/test_api.py", Name: "test_added"}},
+		}},
+	}
+	previous := []pythonTest{{File: "tests/test_api.py", Name: "test_removed"}}
+	release := []pythonTest{{File: "tests/test_api.py", Name: "test_added"}}
+
+	err := validateTargetDelta(ledger, previous, release, "previous", "release", t.TempDir())
+	if err == nil || !strings.Contains(err.Error(), "added case set") {
+		t.Fatalf("validateTargetDelta error = %v", err)
+	}
+}
+
+func TestValidateTargetDeltaRejectsMissingReplacement(t *testing.T) {
+	ledger := targetDeltaLedger{
+		SchemaVersion: 1,
+		FromCommit:    "previous",
+		ToCommit:      "release",
+		Added:         []caseIdentity{{File: "tests/test_api.py", Name: "test_added"}},
+		Removed: []removedCaseDisposition{{
+			Case:         caseIdentity{File: "tests/test_api.py", Name: "test_removed"},
+			Disposition:  "renamed",
+			Reason:       "The release renamed the case.",
+			Replacements: []caseIdentity{{File: "tests/test_api.py", Name: "test_missing"}},
+		}},
+	}
+	previous := []pythonTest{{File: "tests/test_api.py", Name: "test_removed"}}
+	release := []pythonTest{{File: "tests/test_api.py", Name: "test_added"}}
+
+	err := validateTargetDelta(ledger, previous, release, "previous", "release", t.TempDir())
+	if err == nil || !strings.Contains(err.Error(), "replacement") {
+		t.Fatalf("validateTargetDelta error = %v", err)
+	}
+}
+
+func TestValidateTargetDeltaRejectsUnresolvedEvidence(t *testing.T) {
+	ledger := targetDeltaLedger{
+		SchemaVersion: 1,
+		FromCommit:    "previous",
+		ToCommit:      "release",
+		Removed: []removedCaseDisposition{{
+			Case:        caseIdentity{File: "tests/test_api.py", Name: "test_removed"},
+			Disposition: "removed",
+			Reason:      "The release removed an implementation-detail assertion.",
+			Evidence:    []string{"go:missing_test.go#TestMissing"},
+		}},
+	}
+	previous := []pythonTest{{File: "tests/test_api.py", Name: "test_removed"}}
+
+	err := validateTargetDelta(ledger, previous, nil, "previous", "release", t.TempDir())
+	if err == nil || !strings.Contains(err.Error(), "evidence") {
+		t.Fatalf("validateTargetDelta error = %v", err)
+	}
+}
+
+func writeDeltaEvidence(t *testing.T, root string) {
+	t.Helper()
+	contents := []byte("package evidence\n\nfunc TestSurvivingBehavior(t *testing.T) {}\n")
+	if err := os.WriteFile(filepath.Join(root, "evidence_test.go"), contents, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCheckTargetDeltaRejectsCheckoutIdentityDrift(t *testing.T) {
+	root := t.TempDir()
+	writeDeltaEvidence(t, root)
+	previous := writeDeltaCheckout(t, map[string]string{
+		"tests/test_api.py": "def test_kept(): pass\ndef test_removed(): pass\n",
+	})
+	release := writeDeltaCheckout(t, map[string]string{
+		"tests/test_api.py": "def test_kept(): pass\ndef test_added(): pass\n",
+	})
+	previousCommit := gitOutputForTest(t, previous, "rev-parse", "HEAD")
+	releaseCommit := gitOutputForTest(t, release, "rev-parse", "HEAD")
+	contractPath := filepath.Join(root, "parity-contract.json")
+	contract := fmt.Sprintf(`{"schema_version":2,"release_target":{"commit":%q}}`, releaseCommit)
+	if err := os.WriteFile(contractPath, []byte(contract), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	ledgerPath := filepath.Join(root, "target-delta.json")
+	ledger := fmt.Sprintf(`{
+  "schema_version": 1,
+  "from_commit": %q,
+  "to_commit": %q,
+  "added": [{"file":"tests/test_api.py","name":"test_added"}],
+  "removed": [{
+    "case":{"file":"tests/test_api.py","name":"test_removed"},
+    "disposition":"removed",
+    "reason":"The release removed an implementation-detail assertion.",
+    "evidence":["go:evidence_test.go#TestSurvivingBehavior"]
+  }]
+}
+`, previousCommit, releaseCommit)
+	if err := os.WriteFile(ledgerPath, []byte(ledger), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := checkTargetDelta(root, contractPath, ledgerPath, previous, release); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(release, "tests", "new_test.py"), []byte("def test_new(): pass\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runGitForTest(t, release, "add", ".")
+	runGitForTest(t, release, "commit", "-m", "drift")
+
+	err := checkTargetDelta(root, contractPath, ledgerPath, previous, release)
+	if err == nil || !strings.Contains(err.Error(), "release checkout HEAD") {
+		t.Fatalf("checkTargetDelta error = %v", err)
+	}
+}
+
+func writeDeltaCheckout(t *testing.T, files map[string]string) string {
+	t.Helper()
+	root := t.TempDir()
+	runGitForTest(t, root, "init")
+	for _, directory := range []string{"tests", "integrations", "e2e"} {
+		if err := os.MkdirAll(filepath.Join(root, directory), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(root, directory, ".gitkeep"), nil, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for name, contents := range files {
+		path := filepath.Join(root, filepath.FromSlash(name))
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	runGitForTest(t, root, "add", ".")
+	runGitForTest(t, root, "commit", "-m", "fixture")
+	return root
+}
+
+func runGitForTest(t *testing.T, root string, arguments ...string) {
+	t.Helper()
+	command := exec.Command("git", append([]string{"-c", "user.name=PowerContext", "-c", "user.email=powercontext@example.invalid", "-C", root}, arguments...)...)
+	if output, err := command.CombinedOutput(); err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(arguments, " "), err, output)
+	}
+}
+
+func gitOutputForTest(t *testing.T, root string, arguments ...string) string {
+	t.Helper()
+	command := exec.Command("git", append([]string{"-C", root}, arguments...)...)
+	output, err := command.Output()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return strings.TrimSpace(string(output))
 }

--- a/tools/parity-inventory-generate/target_delta.go
+++ b/tools/parity-inventory-generate/target_delta.go
@@ -1,0 +1,201 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"cmp"
+	"fmt"
+	"maps"
+	"slices"
+	"strings"
+)
+
+type caseIdentity struct {
+	File string `json:"file"`
+	Name string `json:"name"`
+}
+
+type removedCaseDisposition struct {
+	Case         caseIdentity   `json:"case"`
+	Disposition  string         `json:"disposition"`
+	Reason       string         `json:"reason"`
+	Replacements []caseIdentity `json:"replacements,omitempty"`
+	Evidence     []string       `json:"evidence,omitempty"`
+}
+
+type targetDeltaLedger struct {
+	SchemaVersion int                      `json:"schema_version"`
+	FromCommit    string                   `json:"from_commit"`
+	ToCommit      string                   `json:"to_commit"`
+	Added         []caseIdentity           `json:"added"`
+	Removed       []removedCaseDisposition `json:"removed"`
+}
+
+func checkTargetDelta(root, contractPath, ledgerPath, previousUpstream, releaseUpstream string) error {
+	var contract parityContract
+	if err := readJSON(contractPath, &contract); err != nil {
+		return fmt.Errorf("read parity contract: %w", err)
+	}
+	var ledger targetDeltaLedger
+	if err := readJSON(ledgerPath, &ledger); err != nil {
+		return fmt.Errorf("read target delta ledger: %w", err)
+	}
+	previousHead, err := upstreamHead(previousUpstream)
+	if err != nil {
+		return fmt.Errorf("resolve previous checkout identity: %w", err)
+	}
+	if previousHead != ledger.FromCommit {
+		return fmt.Errorf("previous checkout HEAD = %s, want ledger from_commit %s", previousHead, ledger.FromCommit)
+	}
+	releaseHead, err := upstreamHead(releaseUpstream)
+	if err != nil {
+		return fmt.Errorf("resolve release checkout identity: %w", err)
+	}
+	if releaseHead != contract.ReleaseTarget.Commit {
+		return fmt.Errorf("release checkout HEAD = %s, want contract release commit %s", releaseHead, contract.ReleaseTarget.Commit)
+	}
+	previousCases, err := extractUpstreamCases(previousUpstream)
+	if err != nil {
+		return fmt.Errorf("discover previous target cases: %w", err)
+	}
+	releaseCases, err := extractUpstreamCases(releaseUpstream)
+	if err != nil {
+		return fmt.Errorf("discover release target cases: %w", err)
+	}
+	return validateTargetDelta(
+		ledger,
+		previousCases,
+		releaseCases,
+		ledger.FromCommit,
+		contract.ReleaseTarget.Commit,
+		root,
+	)
+}
+
+func validateTargetDelta(
+	ledger targetDeltaLedger,
+	previousCases, releaseCases []pythonTest,
+	previousCommit, releaseCommit, root string,
+) error {
+	if ledger.SchemaVersion != 1 {
+		return fmt.Errorf("unsupported target delta schema %d", ledger.SchemaVersion)
+	}
+	if ledger.FromCommit != previousCommit || ledger.ToCommit != releaseCommit {
+		return fmt.Errorf(
+			"target delta identity = %s..%s, want %s..%s",
+			ledger.FromCommit, ledger.ToCommit, previousCommit, releaseCommit,
+		)
+	}
+	added, removed := targetCaseDelta(previousCases, releaseCases)
+	if err := validateIdentityList("added", ledger.Added, added); err != nil {
+		return err
+	}
+	removedIdentities := make([]caseIdentity, 0, len(ledger.Removed))
+	for _, disposition := range ledger.Removed {
+		removedIdentities = append(removedIdentities, disposition.Case)
+	}
+	if err := validateIdentityList("removed", removedIdentities, removed); err != nil {
+		return err
+	}
+
+	releaseSet := make(map[string]struct{}, len(releaseCases))
+	for _, test := range releaseCases {
+		releaseSet[caseIdentityKey(caseIdentity{File: test.File, Name: test.Name})] = struct{}{}
+	}
+	for _, disposition := range ledger.Removed {
+		key := caseIdentityKey(disposition.Case)
+		if !validDisposition(disposition.Disposition) {
+			return fmt.Errorf("removed case %s has invalid disposition %q", key, disposition.Disposition)
+		}
+		if strings.TrimSpace(disposition.Reason) == "" {
+			return fmt.Errorf("removed case %s has no reviewed reason", key)
+		}
+		if len(disposition.Replacements) == 0 && len(disposition.Evidence) == 0 {
+			return fmt.Errorf("removed case %s has no replacement evidence", key)
+		}
+		for _, replacement := range disposition.Replacements {
+			replacementKey := caseIdentityKey(replacement)
+			if _, ok := releaseSet[replacementKey]; !ok {
+				return fmt.Errorf("removed case %s replacement %s does not exist in the release target", key, replacementKey)
+			}
+		}
+		for _, reference := range disposition.Evidence {
+			if _, err := resolveEvidence(root, reference); err != nil {
+				return fmt.Errorf("removed case %s evidence %q: %w", key, reference, err)
+			}
+		}
+	}
+	return nil
+}
+
+func targetCaseDelta(previousCases, releaseCases []pythonTest) ([]caseIdentity, []caseIdentity) {
+	previous := make(map[string]caseIdentity, len(previousCases))
+	for _, test := range previousCases {
+		identity := caseIdentity{File: test.File, Name: test.Name}
+		previous[caseIdentityKey(identity)] = identity
+	}
+	release := make(map[string]caseIdentity, len(releaseCases))
+	for _, test := range releaseCases {
+		identity := caseIdentity{File: test.File, Name: test.Name}
+		release[caseIdentityKey(identity)] = identity
+	}
+	added := make(map[string]caseIdentity)
+	for key, identity := range release {
+		if _, ok := previous[key]; !ok {
+			added[key] = identity
+		}
+	}
+	removed := make(map[string]caseIdentity)
+	for key, identity := range previous {
+		if _, ok := release[key]; !ok {
+			removed[key] = identity
+		}
+	}
+	return slices.SortedFunc(maps.Values(added), compareCaseIdentity),
+		slices.SortedFunc(maps.Values(removed), compareCaseIdentity)
+}
+
+func validateIdentityList(name string, got, want []caseIdentity) error {
+	if !slices.IsSortedFunc(got, compareCaseIdentity) {
+		return fmt.Errorf("target delta %s cases are not sorted", name)
+	}
+	if len(got) != len(want) {
+		return fmt.Errorf("target delta %s case set has %d cases, want %d", name, len(got), len(want))
+	}
+	for index := range want {
+		if got[index] != want[index] {
+			return fmt.Errorf(
+				"target delta %s case set differs at %d: got %s, want %s",
+				name, index, caseIdentityKey(got[index]), caseIdentityKey(want[index]),
+			)
+		}
+	}
+	return nil
+}
+
+func compareCaseIdentity(left, right caseIdentity) int {
+	if order := cmp.Compare(left.File, right.File); order != 0 {
+		return order
+	}
+	return cmp.Compare(left.Name, right.Name)
+}
+
+func caseIdentityKey(identity caseIdentity) string {
+	return identity.File + "#" + identity.Name
+}
+
+func validDisposition(value string) bool {
+	return value == "removed" || value == "renamed" || value == "superseded"
+}

--- a/tools/release/workflow_test.go
+++ b/tools/release/workflow_test.go
@@ -929,6 +929,7 @@ func TestFrozenTextAssetsDeclareLFCheckout(t *testing.T) {
 		"artifact/memory/prompts/extraction.schema.json",
 		"evaluation/tests/contract/fixtures/swebench_pro_public_v2.jsonl",
 		"api/v1/oas_client_gen.go",
+		"test/conformance/target-delta.json",
 	}
 	for _, path := range paths {
 		t.Run(path, func(t *testing.T) {


### PR DESCRIPTION
## Summary
- move the active parity target from `f2ec1f75` to signed v0.1.0 commit `7b736206`
- generate the 812-case / 132-file inventory with 682 mapped and 130 pending cases
- add a reviewed 73-added / 20-removed target-delta ledger with required replacement or resolvable evidence for every removed case
- make the parity generator verify exact previous/release checkout identities, complete delta sets, ledger dispositions, replacements, and evidence
- update the frozen-oracle workflow to check out both previous and release targets and run the delta drift gate
- retain the immutable `python-v0.0.2` fixture directory unchanged

## Validation
- `go test ./tools/parity-inventory-generate -count=1`
- `go vet ./tools/parity-inventory-generate`
- `go run ./tools/parity-inventory-generate -upstream C:\\Users\\alex\\AppData\\Local\\Temp\\powercontext-v010-target-worktree -check -check-delta -previous-upstream C:\\Users\\alex\\AppData\\Local\\Temp\\powercontext-wp1-parity-target -release-upstream C:\\Users\\alex\\AppData\\Local\\Temp\\powercontext-v010-target-worktree`
- `go test ./tools/release -run "^(TestFrozenOracleGeneratorsUseTemporaryGoldenOutput|TestFrozenTextAssetsDeclareLFCheckout)$" -count=1`
- `go test ./test/conformance -run "^(TestParityContract|TestParityInventoryMatchesContract)$"` is blocked locally before execution by the known missing `sqlite3.h` CGO development header; exact-Head Linux CI is required.

Progresses #3.