### PR TITLE
feat(cli): harden OpenCode autoload lifecycle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -325,3 +325,9 @@ source / artifact / trigger / inference
   quoted and escaped literals, rejected expansion and control input, invalid
   UTF-8, marker text inside values, repeated markers, and both human and JSON
   output.
+- When a host autoloads a plugin from a global directory, publish its constant
+  ownership manifest before atomically replacing the bundle and treat an
+  existing unowned bundle as a conflict. Verify an interrupted first install
+  leaves only recoverable ownership state, a retry repairs it, and a bounded
+  no-model activation lifecycle covers configured, active, inactive, exited,
+  timeout, and cleanup outcomes through real child-process boundaries.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -330,4 +330,7 @@ source / artifact / trigger / inference
   existing unowned bundle as a conflict. Verify an interrupted first install
   leaves only recoverable ownership state, a retry repairs it, and a bounded
   no-model activation lifecycle covers configured, active, inactive, exited,
-  timeout, and cleanup outcomes through real child-process boundaries.
+  timeout, and cleanup outcomes through real child-process boundaries. In a
+  packaged release-consumer test, prove the installed bundle bytes and manifest
+  originate from the release archive rather than asserting a retired installer
+  command.

--- a/internal/cli/doctor_integrations_test.go
+++ b/internal/cli/doctor_integrations_test.go
@@ -150,18 +150,15 @@ func TestDoctorIntegrationsFailsWhenPresentOpenCodeSkillIsBroken(t *testing.T) {
 	}
 	commands := &environmentAwareCommands{scriptedSystemCommands: base}
 	commands.runEnv = func(
-		ctx context.Context,
+		_ context.Context,
 		environment map[string]string,
-		executable string,
-		arguments ...string,
+		_ string,
+		_ ...string,
 	) ([]byte, error) {
-		output, err := base.Run(ctx, executable, arguments...)
-		if err == nil {
-			if writeErr := os.WriteFile(environment[openCodeProbePath], []byte(environment[openCodeProbeNonce]), 0o600); writeErr != nil {
-				t.Fatal(writeErr)
-			}
+		if writeErr := os.WriteFile(environment[openCodeProbePath], []byte(environment[openCodeProbeNonce]), 0o600); writeErr != nil {
+			t.Fatal(writeErr)
 		}
-		return output, err
+		return nil, nil
 	}
 	stdout, _, err := executeSystemCLI(t, nil, commands, "doctor", "integrations", "--json")
 	if err == nil || !ErrorAlreadyReported(err) || ExitCode(err) != 1 {

--- a/internal/cli/integration_hosts_test.go
+++ b/internal/cli/integration_hosts_test.go
@@ -22,8 +22,10 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strconv"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestSetupAndDoctorExposeCurrentHostMatrix(t *testing.T) {
@@ -400,14 +402,13 @@ func TestOpenCodeDiagnosticsRequireActivationAndOwnedSkill(t *testing.T) {
 				},
 			}
 			commands := &environmentAwareCommands{scriptedSystemCommands: base}
-			commands.runEnv = func(ctx context.Context, environment map[string]string, executable string, arguments ...string) ([]byte, error) {
-				output, err := base.Run(ctx, executable, arguments...)
-				if err == nil && test.activate {
+			commands.runEnv = func(_ context.Context, environment map[string]string, _ string, _ ...string) ([]byte, error) {
+				if test.activate {
 					if writeErr := os.WriteFile(environment[openCodeProbePath], []byte(environment[openCodeProbeNonce]), 0o600); writeErr != nil {
 						t.Fatal(writeErr)
 					}
 				}
-				return output, err
+				return nil, nil
 			}
 			checks := runOpenCodeDiagnostics(t.Context(), commands)
 			if checks["plugin"].Status != test.wantStatus || checks["skill"].Status != "ok" {
@@ -417,6 +418,69 @@ func TestOpenCodeDiagnosticsRequireActivationAndOwnedSkill(t *testing.T) {
 				t.Fatalf("inactive detail = %q", checks["plugin"].Detail)
 			}
 		})
+	}
+}
+
+func TestOpenCodeDiagnosticsAcceptsAnOwnedAutoloadBundle(t *testing.T) {
+	plugin := writeOpenCodePlugin(t, filepath.Join(t.TempDir(), "checkout"))
+	config := filepath.Join(t.TempDir(), "config")
+	bundle := filepath.Join(config, "plugins", openCodePluginName+".js")
+	if err := installOpenCodePlugin(filepath.Join(plugin, "lib", "index.js"), bundle); err != nil {
+		t.Fatal(err)
+	}
+	skill := filepath.Join(config, "skills", "project-context")
+	if err := installOpenCodeSkill(filepath.Join(plugin, "skills", "project-context"), skill); err != nil {
+		t.Fatal(err)
+	}
+	base := &scriptedSystemCommands{
+		t: t, paths: map[string]string{"opencode": "/resolved/bin/opencode"},
+		results: []systemCommandResult{
+			{output: "1.18.21\n"},
+			{output: "config     " + config + "\n"},
+			{output: `{}`},
+		},
+	}
+	commands := &environmentAwareCommands{scriptedSystemCommands: base}
+	commands.runEnv = func(_ context.Context, environment map[string]string, _ string, _ ...string) ([]byte, error) {
+		return nil, os.WriteFile(environment[openCodeProbePath], []byte(environment[openCodeProbeNonce]), 0o600)
+	}
+
+	checks := runOpenCodeDiagnostics(t.Context(), commands)
+	if checks["plugin"].Status != "ok" || checks["skill"].Status != "ok" {
+		t.Fatalf("diagnostics = %#v", checks)
+	}
+}
+
+func TestOpenCodeActivationProbeUsesHeadlessServerWithoutModel(t *testing.T) {
+	plugin := writeOpenCodePlugin(t, filepath.Join(t.TempDir(), "checkout"))
+	commands := &scriptedSystemCommands{
+		t:       t,
+		results: []systemCommandResult{{output: fmt.Sprintf(`{"plugin":[%q]}`, plugin)}},
+	}
+	var observed []string
+	runner := func(_ context.Context, command []string, environment map[string]string, timeout time.Duration) error {
+		observed = slices.Clone(command)
+		if timeout <= 0 {
+			t.Fatalf("probe timeout = %s", timeout)
+		}
+		return os.WriteFile(environment[openCodeProbePath], []byte(environment[openCodeProbeNonce]), 0o600)
+	}
+
+	configured, activated, err := probeOpenCodeActivationWithRunner(
+		t.Context(), commands, "/usr/bin/opencode", runner,
+	)
+	if err != nil || !configured || !activated {
+		t.Fatalf("configured = %v, activated = %v, error = %v", configured, activated, err)
+	}
+	if len(observed) != 6 || observed[0] != "/usr/bin/opencode" || observed[1] != "serve" ||
+		observed[2] != "--hostname" || observed[3] != "127.0.0.1" || observed[4] != "--port" {
+		t.Fatalf("probe command = %v", observed)
+	}
+	if _, portErr := strconv.Atoi(observed[5]); portErr != nil {
+		t.Fatalf("probe port = %q", observed[5])
+	}
+	if slices.Contains(observed, "--model") {
+		t.Fatalf("probe command invokes a model: %v", observed)
 	}
 }
 
@@ -622,28 +686,36 @@ func TestPiDiagnosticsReportInstalledPackageAsJSON(t *testing.T) {
 	}
 }
 
-func TestSetupOpenCodeProtectsAndPublishesOwnedSkill(t *testing.T) {
+func TestSetupOpenCodeInstallsAutoloadBundleAndOwnedSkill(t *testing.T) {
 	checkout := filepath.Join(t.TempDir(), "checkout")
 	plugin := writeOpenCodePlugin(t, checkout)
 	config := filepath.Join(t.TempDir(), "config")
 	t.Setenv("POWERCONTEXT_HOME", filepath.Join(t.TempDir(), "data"))
 	commands := &scriptedSystemCommands{
 		t: t, paths: map[string]string{"opencode": "/usr/bin/opencode"},
-		results: []systemCommandResult{{output: "1.18.21\n"}, {output: "config     " + config + "\n"}, {}},
+		results: []systemCommandResult{{output: "1.18.21\n"}, {output: "config     " + config + "\n"}},
 	}
 	if _, _, err := executeSystemCLI(t, nil, commands, "setup", "opencode", "--source", checkout); err != nil {
 		t.Fatal(err)
+	}
+	bundle := filepath.Join(config, "plugins", openCodePluginName+".js")
+	content, err := os.ReadFile(bundle)
+	if err != nil || string(content) != "export default {}\n" {
+		t.Fatalf("plugin content = %q, error = %v", content, err)
+	}
+	if !ownedOpenCodePlugin(bundle) {
+		t.Fatalf("plugin %q is not marked as PowerContext-owned", bundle)
 	}
 	skill := filepath.Join(config, "skills", "project-context")
 	if !ownedOpenCodeSkill(skill) {
 		t.Fatalf("skill %q is not marked as PowerContext-owned", skill)
 	}
-	content, err := os.ReadFile(filepath.Join(skill, "SKILL.md"))
+	content, err = os.ReadFile(filepath.Join(skill, "SKILL.md"))
 	if err != nil || string(content) != "project context\n" {
 		t.Fatalf("skill content = %q, error = %v", content, err)
 	}
-	if got := commands.calls[2].String(); got != "/usr/bin/opencode plugin "+plugin+" --global --force" {
-		t.Fatalf("install command = %q", got)
+	if len(commands.calls) != 2 {
+		t.Fatalf("unexpected OpenCode commands = %v; source plugin = %s", commands.calls, plugin)
 	}
 }
 
@@ -666,6 +738,73 @@ func TestSetupOpenCodeRefusesUnownedSkillBeforePluginMutation(t *testing.T) {
 	_, _, err := executeSystemCLI(t, nil, commands, "setup", "opencode", "--source", checkout)
 	if err == nil || !strings.Contains(err.Error(), "not owned by PowerContext") || len(commands.calls) != 2 {
 		t.Fatalf("error = %v, commands = %v", err, commands.calls)
+	}
+}
+
+func TestSetupOpenCodeRefusesUnownedPluginBeforeSkillMutation(t *testing.T) {
+	checkout := filepath.Join(t.TempDir(), "checkout")
+	writeOpenCodePlugin(t, checkout)
+	config := filepath.Join(t.TempDir(), "config")
+	bundle := filepath.Join(config, "plugins", openCodePluginName+".js")
+	writeTestFile(t, bundle, "user owned\n")
+	t.Setenv("POWERCONTEXT_HOME", filepath.Join(t.TempDir(), "data"))
+	commands := &scriptedSystemCommands{
+		t: t, paths: map[string]string{"opencode": "/usr/bin/opencode"},
+		results: []systemCommandResult{{output: "1.18.21\n"}, {output: "config " + config + "\n"}},
+	}
+	_, _, err := executeSystemCLI(t, nil, commands, "setup", "opencode", "--source", checkout)
+	if err == nil || !strings.Contains(err.Error(), "not owned by PowerContext") || len(commands.calls) != 2 {
+		t.Fatalf("error = %v, commands = %v", err, commands.calls)
+	}
+	content, readErr := os.ReadFile(bundle)
+	if readErr != nil || string(content) != "user owned\n" {
+		t.Fatalf("plugin content = %q, error = %v", content, readErr)
+	}
+	if _, statErr := os.Stat(filepath.Join(config, "skills", "project-context")); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("Skill was mutated before plugin conflict was reported: %v", statErr)
+	}
+}
+
+func TestInterruptedOpenCodePluginInstallRecoversOnRetry(t *testing.T) {
+	source := filepath.Join(t.TempDir(), "index.js")
+	writeTestFile(t, source, "export default {}\n")
+	target := filepath.Join(t.TempDir(), "config", "plugins", openCodePluginName+".js")
+	replacements := 0
+	interruptedRename := func(oldPath, newPath string) error {
+		replacements++
+		if replacements == 2 {
+			return errors.New("interrupted")
+		}
+		return os.Rename(oldPath, newPath)
+	}
+
+	err := installOpenCodePluginWithRename(source, target, interruptedRename)
+	if err == nil {
+		t.Fatal("interrupted install succeeded")
+	}
+	manifest := filepath.Join(filepath.Dir(target), openCodePluginOwner)
+	if !ownedOpenCodePlugin(target) {
+		t.Fatalf("ownership manifest %q was not published before the interrupted bundle replacement", manifest)
+	}
+	if _, statErr := os.Stat(target); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("plugin target survived interrupted first install: %v", statErr)
+	}
+	entries, readErr := os.ReadDir(filepath.Dir(target))
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	for _, entry := range entries {
+		if strings.HasSuffix(entry.Name(), ".tmp") {
+			t.Fatalf("temporary plugin path survived interruption: %s", entry.Name())
+		}
+	}
+
+	if retryErr := installOpenCodePlugin(source, target); retryErr != nil {
+		t.Fatal(retryErr)
+	}
+	content, readErr := os.ReadFile(target)
+	if readErr != nil || string(content) != "export default {}\n" || !ownedOpenCodePlugin(target) {
+		t.Fatalf("repaired plugin content = %q, owned = %v, error = %v", content, ownedOpenCodePlugin(target), readErr)
 	}
 }
 
@@ -1028,4 +1167,14 @@ func (e *environmentAwareCommands) RunEnv(
 	arguments ...string,
 ) ([]byte, error) {
 	return e.runEnv(ctx, environment, executable, arguments...)
+}
+
+func (e *environmentAwareCommands) runOpenCodeProbe(
+	ctx context.Context,
+	command []string,
+	environment map[string]string,
+	_ time.Duration,
+) error {
+	_, err := e.runEnv(ctx, environment, command[0], command[1:]...)
+	return err
 }

--- a/internal/cli/integration_opencode.go
+++ b/internal/cli/integration_opencode.go
@@ -22,24 +22,42 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
+	"net"
+	"net/http"
 	"net/url"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 )
 
 const (
-	openCodePluginName = "powercontext-opencode"
-	openCodeRelative   = "integrations/opencode/plugins/powercontext"
-	openCodeSkillOwner = ".powercontext.json"
-	openCodeProbePath  = "POWERCONTEXT_OPENCODE_ACTIVATION_PROBE_PATH"
-	openCodeProbeNonce = "POWERCONTEXT_OPENCODE_ACTIVATION_PROBE_NONCE"
+	openCodePluginName      = "powercontext-opencode"
+	openCodeRelative        = "integrations/opencode/plugins/powercontext"
+	openCodePluginBundle    = "lib/index.js"
+	openCodePluginOwner     = ".powercontext-opencode.json"
+	openCodeSkillOwner      = ".powercontext.json"
+	openCodeProbePath       = "POWERCONTEXT_OPENCODE_ACTIVATION_PROBE_PATH"
+	openCodeProbeNonce      = "POWERCONTEXT_OPENCODE_ACTIVATION_PROBE_NONCE"
+	openCodePluginOwnership = "{\n  \"schema\": 1,\n  \"owner\": \"powercontext\",\n  \"integration\": \"opencode-plugin\"\n}\n"
+	openCodeProbeTimeout    = 15 * time.Second
 )
+
+type (
+	openCodeProbeRunner    func(context.Context, []string, map[string]string, time.Duration) error
+	openCodeProbeRequester func(context.Context, string) error
+)
+
+type openCodeProbeRunnerProvider interface {
+	runOpenCodeProbe(context.Context, []string, map[string]string, time.Duration) error
+}
 
 var (
 	openCodeVersionPattern = regexp.MustCompile(`^(\d+)\.(\d+)\.(\d+)`)
@@ -73,11 +91,15 @@ func newSetupOpenCodeCommand(state *commandState) *cobra.Command {
 			if err != nil {
 				return err
 			}
+			pluginTarget := filepath.Join(configDirectory, "plugins", openCodePluginName+".js")
 			skillPath := filepath.Join(configDirectory, "skills", "project-context")
+			if pluginErr := requireReplaceableOpenCodePlugin(pluginTarget); pluginErr != nil {
+				return pluginErr
+			}
 			if skillErr := requireReplaceableOpenCodeSkill(skillPath); skillErr != nil {
 				return skillErr
 			}
-			if _, installErr := state.system.Run(command.Context(), executable, "plugin", pluginPath, "--global", "--force"); installErr != nil {
+			if installErr := installOpenCodePlugin(filepath.Join(pluginPath, filepath.FromSlash(openCodePluginBundle)), pluginTarget); installErr != nil {
 				return installErr
 			}
 			if installErr := installOpenCodeSkill(filepath.Join(pluginPath, "skills", "project-context"), skillPath); installErr != nil {
@@ -290,6 +312,117 @@ func requireReplaceableOpenCodeSkill(target string) error {
 	return nil
 }
 
+func requireReplaceableOpenCodePlugin(target string) error {
+	if _, err := os.Stat(target); err == nil && !ownedOpenCodePlugin(target) {
+		return fmt.Errorf("OpenCode plugin path %s already exists and is not owned by PowerContext", displayPath(target))
+	} else if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return errors.New("cannot inspect OpenCode plugin path")
+	}
+	return nil
+}
+
+func installOpenCodePlugin(source, target string) error {
+	return installOpenCodePluginWithRename(source, target, os.Rename)
+}
+
+func installOpenCodePluginWithRename(source, target string, rename func(string, string) error) error {
+	if err := requireReplaceableOpenCodePlugin(target); err != nil {
+		return err
+	}
+	info, err := os.Stat(source)
+	if err != nil || !info.Mode().IsRegular() || info.Size() > maximumCommandOutput {
+		return errors.New("cannot read the OpenCode plugin bundle")
+	}
+	bundle, err := os.ReadFile(source)
+	if err != nil {
+		return errors.New("cannot read the OpenCode plugin bundle")
+	}
+	parent := filepath.Dir(target)
+	if mkdirErr := os.MkdirAll(parent, 0o755); mkdirErr != nil {
+		return errors.New("cannot create the OpenCode plugin directory")
+	}
+	staging, err := stageOpenCodeFile(parent, filepath.Base(target), bundle, info.Mode().Perm()&0o755)
+	if err != nil {
+		return errors.New("cannot stage the OpenCode plugin bundle")
+	}
+	defer func() { _ = os.Remove(staging) }()
+
+	manifest := filepath.Join(parent, openCodePluginOwner)
+	if !ownedOpenCodePlugin(target) {
+		manifestStaging, stageErr := stageOpenCodeFile(parent, openCodePluginOwner, []byte(openCodePluginOwnership), 0o644)
+		if stageErr != nil {
+			return errors.New("cannot stage the OpenCode plugin ownership manifest")
+		}
+		defer func() { _ = os.Remove(manifestStaging) }()
+		if removeErr := os.Remove(manifest); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
+			return errors.New("cannot replace the OpenCode plugin ownership manifest")
+		}
+		if renameErr := rename(manifestStaging, manifest); renameErr != nil {
+			return errors.New("cannot publish the OpenCode plugin ownership manifest")
+		}
+	}
+
+	backup := ""
+	if _, err := os.Stat(target); err == nil {
+		backupFile, createErr := os.CreateTemp(parent, "."+filepath.Base(target)+"-*.bak")
+		if createErr != nil {
+			return errors.New("cannot stage the existing OpenCode plugin bundle")
+		}
+		backup = backupFile.Name()
+		if closeErr := backupFile.Close(); closeErr != nil {
+			_ = os.Remove(backup)
+			return errors.New("cannot stage the existing OpenCode plugin bundle")
+		}
+		if removeErr := os.Remove(backup); removeErr != nil {
+			return errors.New("cannot stage the existing OpenCode plugin bundle")
+		}
+		if renameErr := rename(target, backup); renameErr != nil {
+			return errors.New("cannot preserve the existing OpenCode plugin bundle")
+		}
+	}
+	if renameErr := rename(staging, target); renameErr != nil {
+		if backup != "" {
+			_ = rename(backup, target)
+		}
+		return errors.New("cannot activate the OpenCode plugin bundle")
+	}
+	if backup != "" {
+		_ = os.Remove(backup)
+	}
+	return nil
+}
+
+func stageOpenCodeFile(directory, base string, content []byte, mode os.FileMode) (string, error) {
+	file, err := os.CreateTemp(directory, "."+base+"-*.tmp")
+	if err != nil {
+		return "", err
+	}
+	path := file.Name()
+	if mode == 0 {
+		mode = 0o644
+	}
+	if err := file.Chmod(mode); err != nil {
+		_ = file.Close()
+		_ = os.Remove(path)
+		return "", err
+	}
+	if _, err := file.Write(content); err != nil {
+		_ = file.Close()
+		_ = os.Remove(path)
+		return "", err
+	}
+	if err := file.Sync(); err != nil {
+		_ = file.Close()
+		_ = os.Remove(path)
+		return "", err
+	}
+	if err := file.Close(); err != nil {
+		_ = os.Remove(path)
+		return "", err
+	}
+	return path, nil
+}
+
 func installOpenCodeSkill(source, target string) error {
 	if err := requireReplaceableOpenCodeSkill(target); err != nil {
 		return err
@@ -381,6 +514,20 @@ func ownedOpenCodeSkill(path string) bool {
 		manifest.Owner == "powercontext" && manifest.Integration == "opencode"
 }
 
+func ownedOpenCodePlugin(path string) bool {
+	payload, err := os.ReadFile(filepath.Join(filepath.Dir(path), openCodePluginOwner))
+	if err != nil || len(payload) > 4096 {
+		return false
+	}
+	var manifest struct {
+		Schema      int    `json:"schema"`
+		Owner       string `json:"owner"`
+		Integration string `json:"integration"`
+	}
+	return json.Unmarshal(payload, &manifest) == nil && manifest.Schema == 1 &&
+		manifest.Owner == "powercontext" && manifest.Integration == "opencode-plugin"
+}
+
 func runOpenCodeDiagnostics(ctx context.Context, commands systemCommandExecutor) map[string]diagnostic {
 	executable, err := commands.LookPath("opencode")
 	if err != nil {
@@ -399,6 +546,8 @@ func runOpenCodeDiagnostics(ctx context.Context, commands systemCommandExecutor)
 		}
 	}
 	configured, activated, err := probeOpenCodeActivation(ctx, commands, executable)
+	pluginPath := filepath.Join(configDirectory, "plugins", openCodePluginName+".js")
+	configured = configured || ownedOpenCodePlugin(pluginPath)
 	pluginCheck := diagnostic{Status: "failed", Detail: "PowerContext OpenCode plugin is not configured"}
 	if err != nil {
 		pluginCheck.Detail = err.Error()
@@ -434,6 +583,19 @@ func probeOpenCodeActivation(
 	commands systemCommandExecutor,
 	executable string,
 ) (bool, bool, error) {
+	runner := openCodeProbeRunner(runOpenCodeProbeProcess)
+	if provider, ok := commands.(openCodeProbeRunnerProvider); ok {
+		runner = provider.runOpenCodeProbe
+	}
+	return probeOpenCodeActivationWithRunner(ctx, commands, executable, runner)
+}
+
+func probeOpenCodeActivationWithRunner(
+	ctx context.Context,
+	commands systemCommandExecutor,
+	executable string,
+	runner openCodeProbeRunner,
+) (bool, bool, error) {
 	directory, err := os.MkdirTemp("", "powercontext-opencode-probe-")
 	if err != nil {
 		return false, false, errors.New("cannot create OpenCode activation probe")
@@ -444,13 +606,147 @@ func probeOpenCodeActivation(
 		return false, false, errors.New("cannot create OpenCode activation nonce")
 	}
 	probePath := filepath.Join(directory, "active")
-	output, err := commands.RunEnv(ctx, map[string]string{openCodeProbePath: probePath, openCodeProbeNonce: nonce}, executable, "debug", "config")
+	output, err := commands.Run(ctx, executable, "debug", "config")
 	if err != nil {
+		return false, false, err
+	}
+	port, err := availableOpenCodeProbePort()
+	if err != nil {
+		return false, false, errors.New("cannot allocate an OpenCode activation probe port")
+	}
+	command := []string{executable, "serve", "--hostname", "127.0.0.1", "--port", strconv.Itoa(port)}
+	if err := runner(
+		ctx,
+		command,
+		map[string]string{openCodeProbePath: probePath, openCodeProbeNonce: nonce},
+		openCodeProbeTimeout,
+	); err != nil {
 		return false, false, err
 	}
 	configured := configuredOpenCodePlugin(output)
 	content, readErr := os.ReadFile(probePath)
 	return configured, readErr == nil && string(content) == nonce, nil
+}
+
+func availableOpenCodeProbePort() (int, error) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return 0, err
+	}
+	address, ok := listener.Addr().(*net.TCPAddr)
+	closeErr := listener.Close()
+	if !ok {
+		return 0, errors.New("OpenCode activation probe did not receive a TCP address")
+	}
+	if closeErr != nil {
+		return 0, closeErr
+	}
+	return address.Port, nil
+}
+
+func runOpenCodeProbeProcess(
+	ctx context.Context,
+	command []string,
+	environment map[string]string,
+	timeout time.Duration,
+) error {
+	return runOpenCodeProbeProcessWithRequest(ctx, command, environment, timeout, requestOpenCodeActivation)
+}
+
+func runOpenCodeProbeProcessWithRequest(
+	ctx context.Context,
+	command []string,
+	environment map[string]string,
+	timeout time.Duration,
+	requester openCodeProbeRequester,
+) error {
+	if len(command) == 0 || timeout <= 0 {
+		return errors.New("invalid OpenCode activation probe command")
+	}
+	deadlineCause := errors.New("OpenCode activation probe timed out")
+	probeContext, cancel := context.WithTimeoutCause(ctx, timeout, deadlineCause)
+	defer cancel()
+	process := exec.CommandContext(probeContext, command[0], command[1:]...)
+	process.Env = os.Environ()
+	for name, value := range environment {
+		if name == "" || strings.ContainsAny(name, "=\x00") || strings.ContainsRune(value, '\x00') {
+			return errors.New("invalid OpenCode activation probe environment")
+		}
+		process.Env = append(process.Env, name+"="+value)
+	}
+	process.Stdout = io.Discard
+	process.Stderr = io.Discard
+	if err := process.Start(); err != nil {
+		return errors.New("cannot start the OpenCode activation probe")
+	}
+	completed := make(chan error, 1)
+	go func() { completed <- process.Wait() }()
+	ticker := time.NewTicker(50 * time.Millisecond)
+	defer ticker.Stop()
+	probePath := environment[openCodeProbePath]
+	nonce := environment[openCodeProbeNonce]
+	port, err := openCodeProbeCommandPort(command)
+	if err != nil {
+		_ = stopOpenCodeProbeProcess(process.Process, completed)
+		return err
+	}
+	endpoint := fmt.Sprintf("http://127.0.0.1:%d/session", port)
+	for {
+		if content, readErr := os.ReadFile(probePath); readErr == nil && string(content) == nonce {
+			return stopOpenCodeProbeProcess(process.Process, completed)
+		}
+		select {
+		case <-completed:
+			if cause := context.Cause(probeContext); cause != nil {
+				return cause
+			}
+			return nil
+		case <-probeContext.Done():
+			_ = stopOpenCodeProbeProcess(process.Process, completed)
+			return context.Cause(probeContext)
+		case <-ticker.C:
+			_ = requester(probeContext, endpoint)
+		}
+	}
+}
+
+func requestOpenCodeActivation(ctx context.Context, endpoint string) error {
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return errors.New("cannot create the OpenCode activation request")
+	}
+	client := &http.Client{Timeout: time.Second}
+	response, err := client.Do(request)
+	if err != nil {
+		return err
+	}
+	_, _ = io.CopyN(io.Discard, response.Body, 1)
+	return response.Body.Close()
+}
+
+func openCodeProbeCommandPort(command []string) (int, error) {
+	for index, argument := range command {
+		if argument == "--port" && index+1 < len(command) {
+			port, err := strconv.Atoi(command[index+1])
+			if err == nil && port > 0 && port <= 65535 {
+				return port, nil
+			}
+			break
+		}
+	}
+	return 0, errors.New("OpenCode activation probe command has an invalid port")
+}
+
+func stopOpenCodeProbeProcess(process *os.Process, completed <-chan error) error {
+	if err := process.Kill(); err != nil && !errors.Is(err, os.ErrProcessDone) {
+		return errors.New("cannot stop the OpenCode activation probe")
+	}
+	select {
+	case <-completed:
+		return nil
+	case <-time.After(5 * time.Second):
+		return errors.New("OpenCode activation probe did not stop")
+	}
 }
 
 func configuredOpenCodePlugin(output []byte) bool {

--- a/internal/cli/integration_opencode_process_test.go
+++ b/internal/cli/integration_opencode_process_test.go
@@ -1,0 +1,180 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	openCodeProbeHelperEnabled = "POWERCONTEXT_OPENCODE_PROBE_HELPER"
+	openCodeProbeHelperMode    = "POWERCONTEXT_OPENCODE_PROBE_HELPER_MODE"
+	openCodeProbeHelperPID     = "POWERCONTEXT_OPENCODE_PROBE_HELPER_PID"
+)
+
+func TestRunOpenCodeProbeExecutesRequestWaitsForNonceAndStopsProcess(t *testing.T) {
+	directory := t.TempDir()
+	marker := filepath.Join(directory, "active")
+	pidPath := filepath.Join(directory, "pid")
+	port, err := availableOpenCodeProbePort()
+	if err != nil {
+		t.Fatal(err)
+	}
+	environment := openCodeProbeHelperEnvironment("success", marker, pidPath)
+	t.Cleanup(func() { stopOpenCodeProbeHelper(t, pidPath) })
+	requests := 0
+	requester := func(_ context.Context, endpoint string) error {
+		requests++
+		if endpoint != "http://127.0.0.1:"+strconv.Itoa(port)+"/session" {
+			t.Fatalf("probe endpoint = %q", endpoint)
+		}
+		value := "wrong-nonce"
+		if requests > 1 {
+			value = "expected-nonce"
+		}
+		return os.WriteFile(marker, []byte(value), 0o600)
+	}
+
+	if probeErr := runOpenCodeProbeProcessWithRequest(
+		t.Context(), openCodeProbeHelperCommand(port), environment, 5*time.Second, requester,
+	); probeErr != nil {
+		t.Fatalf("%v; requests = %d", probeErr, requests)
+	}
+	content, err := os.ReadFile(marker)
+	if err != nil || string(content) != "expected-nonce" {
+		t.Fatalf("activation marker = %q, error = %v", content, err)
+	}
+	assertOpenCodeProbeHelperStopped(t, pidPath)
+}
+
+func TestRunOpenCodeProbeHandlesProcessExitAndStopsProcess(t *testing.T) {
+	port, err := availableOpenCodeProbePort()
+	if err != nil {
+		t.Fatal(err)
+	}
+	directory := t.TempDir()
+	marker := filepath.Join(directory, "active")
+	pidPath := filepath.Join(directory, "pid")
+	environment := openCodeProbeHelperEnvironment("exit", marker, pidPath)
+	t.Cleanup(func() { stopOpenCodeProbeHelper(t, pidPath) })
+
+	if err := runOpenCodeProbeProcessWithRequest(
+		t.Context(), openCodeProbeHelperCommand(port), environment, 5*time.Second, func(context.Context, string) error { return nil },
+	); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(marker); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("activation marker exists after early process exit: %v", err)
+	}
+	assertOpenCodeProbeHelperStopped(t, pidPath)
+}
+
+func TestRunOpenCodeProbeTimesOutAndStopsProcess(t *testing.T) {
+	directory := t.TempDir()
+	marker := filepath.Join(directory, "active")
+	pidPath := filepath.Join(directory, "pid")
+	port, err := availableOpenCodeProbePort()
+	if err != nil {
+		t.Fatal(err)
+	}
+	environment := openCodeProbeHelperEnvironment("timeout", marker, pidPath)
+	t.Cleanup(func() { stopOpenCodeProbeHelper(t, pidPath) })
+	requests := 0
+
+	err = runOpenCodeProbeProcessWithRequest(
+		t.Context(), openCodeProbeHelperCommand(port), environment, 200*time.Millisecond,
+		func(context.Context, string) error { requests++; return nil },
+	)
+	if err == nil || !strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("probe error = %v", err)
+	}
+	if requests == 0 {
+		t.Fatal("activation request was never attempted before timeout")
+	}
+	assertOpenCodeProbeHelperStopped(t, pidPath)
+}
+
+func TestOpenCodeProbeHelperProcess(t *testing.T) {
+	if os.Getenv(openCodeProbeHelperEnabled) != "1" {
+		return
+	}
+	pidPath := os.Getenv(openCodeProbeHelperPID)
+	if err := os.WriteFile(pidPath, []byte(strconv.Itoa(os.Getpid())), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	mode := os.Getenv(openCodeProbeHelperMode)
+	if mode == "exit" {
+		return
+	}
+	select {}
+}
+
+func openCodeProbeHelperEnvironment(mode, marker, pidPath string) map[string]string {
+	return map[string]string{
+		openCodeProbeHelperEnabled: "1",
+		openCodeProbeHelperMode:    mode,
+		openCodeProbeHelperPID:     pidPath,
+		openCodeProbePath:          marker,
+		openCodeProbeNonce:         "expected-nonce",
+	}
+}
+
+func openCodeProbeHelperCommand(port int) []string {
+	return []string{
+		os.Args[0], "-test.run=^TestOpenCodeProbeHelperProcess$", "--",
+		"serve", "--hostname", "127.0.0.1", "--port", strconv.Itoa(port),
+	}
+}
+
+func assertOpenCodeProbeHelperStopped(t *testing.T, pidPath string) {
+	t.Helper()
+	payload, err := os.ReadFile(pidPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pid, err := strconv.Atoi(string(payload))
+	if err != nil {
+		t.Fatal(err)
+	}
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return
+	}
+	if err := process.Kill(); err == nil {
+		t.Fatalf("OpenCode probe process %d was still running", pid)
+	}
+}
+
+func stopOpenCodeProbeHelper(t *testing.T, pidPath string) {
+	t.Helper()
+	payload, err := os.ReadFile(pidPath)
+	if err != nil {
+		return
+	}
+	pid, err := strconv.Atoi(string(payload))
+	if err != nil {
+		return
+	}
+	if process, findErr := os.FindProcess(pid); findErr == nil {
+		_ = process.Kill()
+	}
+}

--- a/internal/cli/setup_select_test.go
+++ b/internal/cli/setup_select_test.go
@@ -230,15 +230,14 @@ func TestSetupSelectFailsOpenCodeRowWhenActivationVerificationFails(t *testing.T
 		results: []systemCommandResult{
 			{output: "1.18.21\n"},
 			{output: "config " + config + "\n"},
-			{},
 			{output: "1.18.21\n"},
 			{output: "config " + config + "\n"},
 			{output: fmt.Sprintf(`{"plugin":[%q]}`, plugin)},
 		},
 	}
 	commands := &environmentAwareCommands{scriptedSystemCommands: base}
-	commands.runEnv = func(ctx context.Context, _ map[string]string, executable string, arguments ...string) ([]byte, error) {
-		return base.Run(ctx, executable, arguments...)
+	commands.runEnv = func(context.Context, map[string]string, string, ...string) ([]byte, error) {
+		return nil, nil
 	}
 	stdout, _, err := executeSystemCLIWithInput(
 		t, commands, strings.NewReader(""),

--- a/test/conformance/parity-inventory-rules.json
+++ b/test/conformance/parity-inventory-rules.json
@@ -284,7 +284,29 @@
     },
     "tests/test_opencode_cli.py": {
       "mode": "go-port",
-      "reason": "OpenCode activation probe CLI commands; the CLI is Go (internal/cli)."
+      "reason": "OpenCode activation probe CLI commands; the CLI is Go (internal/cli).",
+      "cases": {
+        "test_activation_probe_uses_headless_server_without_model": {
+          "evidence": [
+            "go:internal/cli/integration_hosts_test.go#TestOpenCodeActivationProbeUsesHeadlessServerWithoutModel"
+          ]
+        },
+        "test_run_opencode_probe_executes_request_waits_for_nonce_and_stops_process": {
+          "evidence": [
+            "go:internal/cli/integration_opencode_process_test.go#TestRunOpenCodeProbeExecutesRequestWaitsForNonceAndStopsProcess"
+          ]
+        },
+        "test_run_opencode_probe_handles_process_exit_and_stops_process": {
+          "evidence": [
+            "go:internal/cli/integration_opencode_process_test.go#TestRunOpenCodeProbeHandlesProcessExitAndStopsProcess"
+          ]
+        },
+        "test_run_opencode_probe_times_out_and_stops_process": {
+          "evidence": [
+            "go:internal/cli/integration_opencode_process_test.go#TestRunOpenCodeProbeTimesOutAndStopsProcess"
+          ]
+        }
+      }
     },
     "tests/test_setup_select.py": {
       "mode": "go-port",

--- a/test/conformance/parity-inventory.json
+++ b/test/conformance/parity-inventory.json
@@ -4,8 +4,8 @@
   "oracle_commit": "3a6cb0151670eaff7dc0293466edd673124e80da",
   "python_test_file_count": 127,
   "python_test_case_count": 759,
-  "mapped_case_count": 695,
-  "pending_case_count": 64,
+  "mapped_case_count": 699,
+  "pending_case_count": 60,
   "entries": [
     {
       "python": {
@@ -10497,7 +10497,7 @@
         {
           "kind": "go",
           "file": "internal/cli/integration_hosts_test.go",
-          "test": "TestSetupOpenCodeProtectsAndPublishesOwnedSkill"
+          "test": "TestSetupOpenCodeInstallsAutoloadBundleAndOwnedSkill"
         }
       ]
     },
@@ -10576,8 +10576,15 @@
         "line": 246
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/integration_hosts_test.go",
+          "test": "TestOpenCodeActivationProbeUsesHeadlessServerWithoutModel"
+        }
+      ]
     },
     {
       "python": {
@@ -10586,8 +10593,15 @@
         "line": 274
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/integration_opencode_process_test.go",
+          "test": "TestRunOpenCodeProbeExecutesRequestWaitsForNonceAndStopsProcess"
+        }
+      ]
     },
     {
       "python": {
@@ -10596,8 +10610,15 @@
         "line": 285
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/integration_opencode_process_test.go",
+          "test": "TestRunOpenCodeProbeHandlesProcessExitAndStopsProcess"
+        }
+      ]
     },
     {
       "python": {
@@ -10606,8 +10627,15 @@
         "line": 296
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/integration_opencode_process_test.go",
+          "test": "TestRunOpenCodeProbeTimesOutAndStopsProcess"
+        }
+      ]
     },
     {
       "python": {

--- a/test/conformance/traceability-rules.json
+++ b/test/conformance/traceability-rules.json
@@ -2557,12 +2557,12 @@
     "tests/test_opencode_cli.py": {
       "mode": "go-port",
       "supporting_evidence": [
-        "go:internal/cli/integration_hosts_test.go#TestSetupOpenCodeProtectsAndPublishesOwnedSkill",
+        "go:internal/cli/integration_hosts_test.go#TestSetupOpenCodeInstallsAutoloadBundleAndOwnedSkill",
         "go:internal/cli/integration_hosts_test.go#TestSetupOpenCodeRefusesUnownedSkillBeforePluginMutation"
       ],
       "cases": {
         "test_setup_opencode_installs_plugin_and_owned_skill": [
-          "go:internal/cli/integration_hosts_test.go#TestSetupOpenCodeProtectsAndPublishesOwnedSkill"
+          "go:internal/cli/integration_hosts_test.go#TestSetupOpenCodeInstallsAutoloadBundleAndOwnedSkill"
         ],
         "test_remote_checkout_cache_is_scoped_by_source_and_resolved_commit": [
           "go:internal/cli/integration_hosts_test.go#TestOpenCodeRemoteCheckoutCacheIsSourceAndResolvedCommitScoped"

--- a/test/conformance/traceability.json
+++ b/test/conformance/traceability.json
@@ -8743,7 +8743,7 @@
         {
           "kind": "go",
           "file": "internal/cli/integration_hosts_test.go",
-          "test": "TestSetupOpenCodeProtectsAndPublishesOwnedSkill"
+          "test": "TestSetupOpenCodeInstallsAutoloadBundleAndOwnedSkill"
         }
       ]
     },

--- a/tools/release/main_test.go
+++ b/tools/release/main_test.go
@@ -491,7 +491,8 @@ func TestReleaseArchiveProvidesConsumableAdapterSources(t *testing.T) {
 	t.Setenv("PATH", binDirectory+string(os.PathListSeparator)+os.Getenv("PATH"))
 	t.Setenv("FAKE_HOST_LOG", commandLog)
 	t.Setenv("FAKE_PI_PACKAGE", filepath.Join(releaseRoot, "integrations", "pi", "plugins", "powercontext"))
-	t.Setenv("FAKE_OPENCODE_CONFIG", filepath.Join(t.TempDir(), "opencode"))
+	openCodeConfig := filepath.Join(t.TempDir(), "opencode")
+	t.Setenv("FAKE_OPENCODE_CONFIG", openCodeConfig)
 
 	for _, host := range []string{"codex", "claude-code", "dsh", "hermes", "opencode", "openclaw", "pi"} {
 		t.Run(host, func(t *testing.T) {
@@ -519,13 +520,33 @@ func TestReleaseArchiveProvidesConsumableAdapterSources(t *testing.T) {
 		"codex|plugin marketplace add " + releaseRoot,
 		"claude|plugin marketplace add " + releaseRoot,
 		"dsh|plugin --profile web add " + filepath.Join(releaseRoot, "integrations", "dsh", "plugins", "powercontext"),
-		"opencode|plugin " + filepath.Join(releaseRoot, "integrations", "opencode", "plugins", "powercontext"),
 		"openclaw|plugins install --link --force " + filepath.Join(releaseRoot, "integrations", "openclaw", "plugins", "memory-powercontext"),
 		"pi|install " + filepath.Join(releaseRoot, "integrations", "pi", "plugins", "powercontext"),
 	} {
 		if !strings.Contains(string(commands), expected) {
 			t.Errorf("packaged setup did not consume expected release adapter path %q:\n%s", expected, commands)
 		}
+	}
+	if strings.Contains(string(commands), "opencode|plugin ") {
+		t.Errorf("packaged setup used the retired OpenCode plugin installer:\n%s", commands)
+	}
+	sourceBundle := filepath.Join(releaseRoot, "integrations", "opencode", "plugins", "powercontext", "lib", "index.js")
+	installedBundle := filepath.Join(openCodeConfig, "plugins", "powercontext-opencode.js")
+	sourceContent, sourceErr := os.ReadFile(sourceBundle)
+	installedContent, installedErr := os.ReadFile(installedBundle)
+	if sourceErr != nil || installedErr != nil || !bytes.Equal(sourceContent, installedContent) {
+		t.Fatalf("packaged OpenCode autoload bundle source = %q/%v, installed = %q/%v", sourceContent, sourceErr, installedContent, installedErr)
+	}
+	var manifest struct {
+		Schema      int    `json:"schema"`
+		Owner       string `json:"owner"`
+		Integration string `json:"integration"`
+	}
+	manifestPath := filepath.Join(openCodeConfig, "plugins", ".powercontext-opencode.json")
+	manifestContent, manifestErr := os.ReadFile(manifestPath)
+	if manifestErr != nil || json.Unmarshal(manifestContent, &manifest) != nil || manifest.Schema != 1 ||
+		manifest.Owner != "powercontext" || manifest.Integration != "opencode-plugin" {
+		t.Fatalf("packaged OpenCode ownership manifest = %q, error = %v", manifestContent, manifestErr)
 	}
 }
 


### PR DESCRIPTION
## Summary
- replace `opencode plugin ... --global --force` with an owned global autoload bundle
- publish the constant plugin ownership manifest before atomic bundle replacement, preserving conflicts and repairing interrupted first installs
- replace the `debug config`-only activation check with a bounded localhost `opencode serve` lifecycle that requests `/session`, waits for a nonce, and cleans up child processes on success, early exit, and timeout
- recognize a verified owned autoload bundle as configured even when `debug config` does not list it
- map the four v0.1.0 OpenCode lifecycle cases and regenerate traceability/parity artifacts

## Validation
- `go test ./internal/cli -run '^(TestOpenCode|TestSetupOpenCode|TestInterruptedOpenCode|TestRunOpenCodeProbe|TestDoctorIntegrationsFailsWhenPresentOpenCodeSkillIsBroken|TestSetupSelectFailsOpenCodeRowWhenActivationVerificationFails)$' -count=1`
- `go test ./test/conformance -run '^(TestParityInventoryMatchesContract|TestTraceability)' -count=1`
- `go test ./tools/traceability-generate ./tools/parity-inventory-generate -count=1`
- `go run ./tools/traceability-generate -check`
- `go run ./tools/parity-inventory-generate -upstream D:\\test\\github\\worktrees\\powercontext-upstream-f2-contract-audit -check`
- `go vet ./internal/cli ./tools/traceability-generate ./tools/parity-inventory-generate`
- pinned golangci-lint scoped run: `0 issues`

`go test ./internal/cli -count=1` reaches a pre-existing Windows-only symlink privilege failure in `TestCheckoutTargetRejectsExistingSymlinkEscape`; the focused affected suite passes. CI covers supported hosts.

Part of #3. This does not close the epic.