### PR TITLE
ci: upload bounded frozen oracle diagnostics

### DIFF
--- a/.github/workflows/migration-gates.yml
+++ b/.github/workflows/migration-gates.yml
@@ -293,6 +293,40 @@ jobs:
             --go-executable bin/powercontext \
             --go-cwd .
 
+      - name: Write bounded frozen Oracle diagnostics
+        if: always()
+        shell: bash
+        run: |
+          diagnostics="$RUNNER_TEMP/powercontext-oracle-diagnostics"
+          mkdir -p "$diagnostics"
+          {
+            printf 'oracle_commit='
+            git -C _oracle rev-parse HEAD 2>/dev/null || printf 'unavailable'
+            printf 'target_commit='
+            git -C _target rev-parse HEAD 2>/dev/null || printf 'unavailable'
+            for path in \
+              "$RUNNER_TEMP/powercontext-oracle-fixtures/authority-rows.json" \
+              "$RUNNER_TEMP/powercontext-oracle-fixtures/domain-contract.json" \
+              "$RUNNER_TEMP/powercontext-oracle-fixtures/handoff-report-digests.json" \
+              "$RUNNER_TEMP/powercontext-oracle-fixture-manifest/manifest.json" \
+              "$RUNNER_TEMP/powercontext-parity-inventory.json"; do
+              if test -f "$path"; then
+                sha256sum "$path"
+              fi
+            done
+            printf 'worktree_path_count='
+            git status --porcelain | wc -l | tr -d '[:space:]'
+          } > "$diagnostics/summary.txt"
+
+      - name: Upload frozen Oracle diagnostics
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: frozen-oracle-diagnostics-${{ github.sha }}
+          path: ${{ runner.temp }}/powercontext-oracle-diagnostics/summary.txt
+          if-no-files-found: error
+          retention-days: 14
+
   oceanbase-live:
     name: OceanBase live compatibility
     runs-on: ubuntu-24.04

--- a/tools/release/workflow_test.go
+++ b/tools/release/workflow_test.go
@@ -740,6 +740,75 @@ func TestFrozenOracleGeneratorsUseTemporaryGoldenOutput(t *testing.T) {
 	t.Fatal("frozen-oracle job has no fixture regeneration step")
 }
 
+func TestFrozenOracleFailureDiagnosticsAreBoundedAndSanitized(t *testing.T) {
+	repository := filepath.Clean(filepath.Join("..", ".."))
+	payload, err := os.ReadFile(filepath.Join(repository, ".github", "workflows", "migration-gates.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var workflow struct {
+		Jobs map[string]struct {
+			Steps []struct {
+				Name string            `yaml:"name"`
+				If   string            `yaml:"if"`
+				Uses string            `yaml:"uses"`
+				With map[string]string `yaml:"with"`
+				Run  string            `yaml:"run"`
+			} `yaml:"steps"`
+		} `yaml:"jobs"`
+	}
+	if err := yaml.Unmarshal(payload, &workflow); err != nil {
+		t.Fatal(err)
+	}
+	oracle, ok := workflow.Jobs["frozen-oracle"]
+	if !ok {
+		t.Fatal("migration-gates.yml has no frozen-oracle job")
+	}
+	var summary, upload *struct {
+		Name string
+		If   string
+		Uses string
+		With map[string]string
+		Run  string
+	}
+	for index := range oracle.Steps {
+		step := oracle.Steps[index]
+		if step.Name == "Write bounded frozen Oracle diagnostics" {
+			summary = &struct {
+				Name string
+				If   string
+				Uses string
+				With map[string]string
+				Run  string
+			}{step.Name, step.If, step.Uses, step.With, step.Run}
+		}
+		if step.Name == "Upload frozen Oracle diagnostics" {
+			upload = &struct {
+				Name string
+				If   string
+				Uses string
+				With map[string]string
+				Run  string
+			}{step.Name, step.If, step.Uses, step.With, step.Run}
+		}
+	}
+	if summary == nil || summary.If != "always()" || !strings.Contains(summary.Run, "powercontext-oracle-diagnostics") {
+		t.Fatalf("frozen Oracle summary step = %#v", summary)
+	}
+	for _, forbidden := range []string{"_oracle/.venv", "fixture_root/authority.db", "fixture_root/scheduler.db", "cat "} {
+		if strings.Contains(summary.Run, forbidden) {
+			t.Fatalf("frozen Oracle summary exposes %q: %s", forbidden, summary.Run)
+		}
+	}
+	if upload == nil || upload.If != "failure()" || upload.Uses != "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a" {
+		t.Fatalf("frozen Oracle upload step = %#v", upload)
+	}
+	if upload.With["path"] != "${{ runner.temp }}/powercontext-oracle-diagnostics/summary.txt" ||
+		upload.With["if-no-files-found"] != "error" || upload.With["retention-days"] != "14" {
+		t.Fatalf("frozen Oracle upload contract = %#v", upload.With)
+	}
+}
+
 func TestMigrationAPICompatRunsThePinnedPublicBaseline(t *testing.T) {
 	repository := filepath.Clean(filepath.Join("..", ".."))
 	payload, err := os.ReadFile(filepath.Join(repository, ".github", "workflows", "migration-gates.yml"))


### PR DESCRIPTION
## Summary
- create a bounded frozen-Oracle/differential diagnostic summary on every job outcome
- upload only that hash-and-identity summary when the frozen Oracle job fails
- keep fixture contents, SQLite databases, venv files, logs, Source/Memory content, and credentials out of artifacts

## Verification
- `go test ./tools/release -run '^(TestFrozenOracleGeneratorsUseTemporaryGoldenOutput|TestFrozenOracleFailureDiagnosticsAreBoundedAndSanitized)$' -count=1`
- `go test ./tools/release -skip '^TestReleaseArchiveKeepsStableExecutablePathAndMode$' -count=1`
- pinned `actionlint` directly from `.tools/bin`
- pinned `golangci-lint run --timeout=10m ./tools/release`: 0 issues
- `git diff --check`

The skipped local release archive executable-mode test also fails on clean main under Windows because executable bits read back as `0644`; Linux/macOS CI executes the complete unfiltered test package.

Part of #3; does not close the tracking issue.