### PR TITLE
test(cli): synchronize OpenCode probe startup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -331,6 +331,8 @@ source / artifact / trigger / inference
   leaves only recoverable ownership state, a retry repairs it, and a bounded
   no-model activation lifecycle covers configured, active, inactive, exited,
   timeout, and cleanup outcomes through real child-process boundaries. In a
+  timeout regression test, wait for an explicit child-start barrier under the
+  test's individual bounded deadline before asserting cleanup. In a
   packaged release-consumer test, prove the installed bundle bytes and manifest
   originate from the release archive rather than asserting a retired installer
   command.

--- a/internal/cli/integration_opencode_process_test.go
+++ b/internal/cli/integration_opencode_process_test.go
@@ -101,8 +101,11 @@ func TestRunOpenCodeProbeTimesOutAndStopsProcess(t *testing.T) {
 	requests := 0
 
 	err = runOpenCodeProbeProcessWithRequest(
-		t.Context(), openCodeProbeHelperCommand(port), environment, 200*time.Millisecond,
-		func(context.Context, string) error { requests++; return nil },
+		t.Context(), openCodeProbeHelperCommand(port), environment, 2*time.Second,
+		func(context context.Context, _ string) error {
+			requests++
+			return waitForOpenCodeProbeHelperPID(context, pidPath)
+		},
 	)
 	if err == nil || !strings.Contains(err.Error(), "timed out") {
 		t.Fatalf("probe error = %v", err)
@@ -161,6 +164,23 @@ func assertOpenCodeProbeHelperStopped(t *testing.T, pidPath string) {
 	}
 	if err := process.Kill(); err == nil {
 		t.Fatalf("OpenCode probe process %d was still running", pid)
+	}
+}
+
+func waitForOpenCodeProbeHelperPID(ctx context.Context, pidPath string) error {
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		if _, err := os.Stat(pidPath); err == nil {
+			return nil
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+		select {
+		case <-ctx.Done():
+			return context.Cause(ctx)
+		case <-ticker.C:
+		}
 	}
 }
 

--- a/internal/cli/integration_opencode_process_test.go
+++ b/internal/cli/integration_opencode_process_test.go
@@ -42,7 +42,10 @@ func TestRunOpenCodeProbeExecutesRequestWaitsForNonceAndStopsProcess(t *testing.
 	environment := openCodeProbeHelperEnvironment("success", marker, pidPath)
 	t.Cleanup(func() { stopOpenCodeProbeHelper(t, pidPath) })
 	requests := 0
-	requester := func(_ context.Context, endpoint string) error {
+	requester := func(context context.Context, endpoint string) error {
+		if barrierErr := waitForOpenCodeProbeHelperPID(context, pidPath); barrierErr != nil {
+			return barrierErr
+		}
 		requests++
 		if endpoint != "http://127.0.0.1:"+strconv.Itoa(port)+"/session" {
 			t.Fatalf("probe endpoint = %q", endpoint)


### PR DESCRIPTION
## Summary
- make the real OpenCode timeout lifecycle test wait for the helper PID start barrier before checking cleanup
- increase only this cold-host timeout test from 200ms to a bounded 2 seconds after the Darwin main-CI evidence showed 200ms can expire before process startup
- record the reusable child-start-barrier rule

## Validation
- `go test ./internal/cli -run '^TestRunOpenCodeProbeTimesOutAndStopsProcess$' -count=1 -v`
- `go test ./internal/cli -run '^(TestOpenCode|TestSetupOpenCode|TestInterruptedOpenCode|TestRunOpenCodeProbe|TestDoctorIntegrationsFailsWhenPresentOpenCodeSkillIsBroken|TestSetupSelectFailsOpenCodeRowWhenActivationVerificationFails)$' -count=1`
- `go vet ./internal/cli`
- pinned golangci-lint scoped run: `0 issues`

The prior `200ms` test-only deadline failed on `darwin-amd64` before the helper could publish its PID; this is the focused regression proof. Part of #3 and does not close the epic.