### PR TITLE
test(opencode): wait for probe helper startup

### DIFF
--- a/internal/cli/integration_opencode_process_test.go
+++ b/internal/cli/integration_opencode_process_test.go
@@ -43,10 +43,15 @@ func TestRunOpenCodeProbeExecutesRequestWaitsForNonceAndStopsProcess(t *testing.
 	t.Cleanup(func() { stopOpenCodeProbeHelper(t, pidPath) })
 	requests := 0
 	requester := func(_ context.Context, endpoint string) error {
-		requests++
 		if endpoint != "http://127.0.0.1:"+strconv.Itoa(port)+"/session" {
 			t.Fatalf("probe endpoint = %q", endpoint)
 		}
+		if _, err := os.Stat(pidPath); errors.Is(err, os.ErrNotExist) {
+			return nil
+		} else if err != nil {
+			return err
+		}
+		requests++
 		value := "wrong-nonce"
 		if requests > 1 {
 			value = "expected-nonce"

--- a/internal/cli/integration_opencode_process_test.go
+++ b/internal/cli/integration_opencode_process_test.go
@@ -46,10 +46,10 @@ func TestRunOpenCodeProbeExecutesRequestWaitsForNonceAndStopsProcess(t *testing.
 		if endpoint != "http://127.0.0.1:"+strconv.Itoa(port)+"/session" {
 			t.Fatalf("probe endpoint = %q", endpoint)
 		}
-		if _, err := os.Stat(pidPath); errors.Is(err, os.ErrNotExist) {
+		if _, probeStatErr := os.Stat(pidPath); errors.Is(probeStatErr, os.ErrNotExist) {
 			return nil
-		} else if err != nil {
-			return err
+		} else if probeStatErr != nil {
+			return probeStatErr
 		}
 		requests++
 		value := "wrong-nonce"


### PR DESCRIPTION
## Summary
- make the real OpenCode activation probe regression wait until the helper process has published its PID before writing the success nonce
- prevent coverage-mode startup scheduling from terminating the helper before the test observes the child-process lifecycle

## Root Cause
The coverage job showed the requester wrote the expected nonce before the child test process had executed its PID write, then the probe stopped the child and the test read a missing PID file. The test now treats the PID file as the child-entry synchronization point.

## Validation
- `gofmt` on `internal/cli/integration_opencode_process_test.go`
- exact-Head Linux coverage and CLI test gates are required because the local checkout predates this file and the local Windows CLI package lacks `sqlite3.h`.

Progresses #3.