### PR TITLE
ci: add bounded host adapter diagnostics

### DIFF
--- a/.github/workflows/migration-gates.yml
+++ b/.github/workflows/migration-gates.yml
@@ -466,6 +466,7 @@ jobs:
           enable-cache: true
 
       - name: Test Python host adapters
+        id: python_adapters
         run: |
           uv run --project integrations/codex/plugins/powercontext --locked --with pytest \
             pytest integrations/codex/tests
@@ -492,9 +493,11 @@ jobs:
             integrations/openclaw/plugins/memory-powercontext/pnpm-lock.yaml
 
       - name: Build the PowerContext Server for DSH end-to-end tests
+        id: dsh_server
         run: go build -tags sqlite_fts5 -o "$RUNNER_TEMP/powercontext-dsh-e2e" ./cmd/powercontext
 
       - name: Test and rebuild the DSH adapter
+        id: dsh_adapter
         working-directory: integrations/dsh/plugins/powercontext
         env:
           POWERCONTEXT_GO_BINARY: ${{ runner.temp }}/powercontext-dsh-e2e
@@ -507,6 +510,7 @@ jobs:
           git diff --exit-code -- src/operations.generated.ts lib
 
       - name: Test the Pi adapter
+        id: pi_adapter
         working-directory: integrations/pi/plugins/powercontext
         run: |
           pnpm install --frozen-lockfile
@@ -514,6 +518,7 @@ jobs:
           pnpm test
 
       - name: Test and rebuild the OpenCode adapter
+        id: opencode_adapter
         working-directory: integrations/opencode/plugins/powercontext
         run: |
           pnpm install --frozen-lockfile
@@ -523,6 +528,7 @@ jobs:
           git diff --exit-code -- lib
 
       - name: Test and rebuild the OpenClaw adapter
+        id: openclaw_adapter
         working-directory: integrations/openclaw/plugins/memory-powercontext
         run: |
           pnpm install --frozen-lockfile
@@ -530,6 +536,48 @@ jobs:
           pnpm test
           pnpm build
           git diff --exit-code -- dist
+
+      - name: Write bounded host adapter diagnostics
+        if: always()
+        shell: bash
+        env:
+          PYTHON_ADAPTERS_OUTCOME: ${{ steps.python_adapters.outcome }}
+          DSH_SERVER_OUTCOME: ${{ steps.dsh_server.outcome }}
+          DSH_ADAPTER_OUTCOME: ${{ steps.dsh_adapter.outcome }}
+          PI_ADAPTER_OUTCOME: ${{ steps.pi_adapter.outcome }}
+          OPENCODE_ADAPTER_OUTCOME: ${{ steps.opencode_adapter.outcome }}
+          OPENCLAW_ADAPTER_OUTCOME: ${{ steps.openclaw_adapter.outcome }}
+        run: |
+          diagnostics="$RUNNER_TEMP/powercontext-host-adapter-diagnostics"
+          mkdir -p "$diagnostics"
+          {
+            printf 'commit=%s\n' "$GITHUB_SHA"
+            printf 'python_adapters_outcome=%s\n' "$PYTHON_ADAPTERS_OUTCOME"
+            printf 'dsh_server_outcome=%s\n' "$DSH_SERVER_OUTCOME"
+            printf 'dsh_adapter_outcome=%s\n' "$DSH_ADAPTER_OUTCOME"
+            printf 'pi_adapter_outcome=%s\n' "$PI_ADAPTER_OUTCOME"
+            printf 'opencode_adapter_outcome=%s\n' "$OPENCODE_ADAPTER_OUTCOME"
+            printf 'openclaw_adapter_outcome=%s\n' "$OPENCLAW_ADAPTER_OUTCOME"
+            for path in \
+              integrations/bub/uv.lock \
+              integrations/codex/plugins/powercontext/uv.lock \
+              integrations/langgraph/uv.lock \
+              integrations/dsh/plugins/powercontext/pnpm-lock.yaml \
+              integrations/pi/plugins/powercontext/pnpm-lock.yaml \
+              integrations/opencode/plugins/powercontext/pnpm-lock.yaml \
+              integrations/openclaw/plugins/memory-powercontext/pnpm-lock.yaml; do
+              sha256sum "$path"
+            done
+          } > "$diagnostics/summary.txt"
+
+      - name: Upload host adapter diagnostics
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: host-adapter-diagnostics-${{ github.sha }}
+          path: ${{ runner.temp }}/powercontext-host-adapter-diagnostics/summary.txt
+          if-no-files-found: error
+          retention-days: 14
 
   evaluation:
     name: Evaluation control plane and console

--- a/tools/release/workflow_test.go
+++ b/tools/release/workflow_test.go
@@ -809,6 +809,111 @@ func TestFrozenOracleFailureDiagnosticsAreBoundedAndSanitized(t *testing.T) {
 	}
 }
 
+func TestHostAdapterFailureDiagnosticsAreBoundedAndSanitized(t *testing.T) {
+	repository := filepath.Clean(filepath.Join("..", ".."))
+	payload, err := os.ReadFile(filepath.Join(repository, ".github", "workflows", "migration-gates.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var workflow struct {
+		Jobs map[string]struct {
+			Steps []struct {
+				ID   string            `yaml:"id"`
+				Name string            `yaml:"name"`
+				If   string            `yaml:"if"`
+				Uses string            `yaml:"uses"`
+				With map[string]string `yaml:"with"`
+				Env  map[string]string `yaml:"env"`
+				Run  string            `yaml:"run"`
+			} `yaml:"steps"`
+		} `yaml:"jobs"`
+	}
+	if err := yaml.Unmarshal(payload, &workflow); err != nil {
+		t.Fatal(err)
+	}
+	hostAdapters, ok := workflow.Jobs["host-adapters"]
+	if !ok {
+		t.Fatal("migration-gates.yml has no host-adapters job")
+	}
+	adapterStepIDs := map[string]bool{}
+	var summary, upload *struct {
+		ID   string
+		Name string
+		If   string
+		Uses string
+		With map[string]string
+		Env  map[string]string
+		Run  string
+	}
+	for index := range hostAdapters.Steps {
+		step := hostAdapters.Steps[index]
+		if step.ID != "" {
+			adapterStepIDs[step.ID] = true
+		}
+		if step.Name == "Write bounded host adapter diagnostics" {
+			summary = &struct {
+				ID   string
+				Name string
+				If   string
+				Uses string
+				With map[string]string
+				Env  map[string]string
+				Run  string
+			}{step.ID, step.Name, step.If, step.Uses, step.With, step.Env, step.Run}
+		}
+		if step.Name == "Upload host adapter diagnostics" {
+			upload = &struct {
+				ID   string
+				Name string
+				If   string
+				Uses string
+				With map[string]string
+				Env  map[string]string
+				Run  string
+			}{step.ID, step.Name, step.If, step.Uses, step.With, step.Env, step.Run}
+		}
+	}
+	for _, id := range []string{"python_adapters", "dsh_server", "dsh_adapter", "pi_adapter", "opencode_adapter", "openclaw_adapter"} {
+		if !adapterStepIDs[id] {
+			t.Fatalf("host adapter step id %q is missing", id)
+		}
+	}
+	if summary == nil || summary.If != "always()" || !strings.Contains(summary.Run, "powercontext-host-adapter-diagnostics") ||
+		summary.Env["PYTHON_ADAPTERS_OUTCOME"] != "${{ steps.python_adapters.outcome }}" ||
+		summary.Env["DSH_SERVER_OUTCOME"] != "${{ steps.dsh_server.outcome }}" ||
+		summary.Env["DSH_ADAPTER_OUTCOME"] != "${{ steps.dsh_adapter.outcome }}" ||
+		summary.Env["PI_ADAPTER_OUTCOME"] != "${{ steps.pi_adapter.outcome }}" ||
+		summary.Env["OPENCODE_ADAPTER_OUTCOME"] != "${{ steps.opencode_adapter.outcome }}" ||
+		summary.Env["OPENCLAW_ADAPTER_OUTCOME"] != "${{ steps.openclaw_adapter.outcome }}" {
+		t.Fatalf("host adapter summary step = %#v", summary)
+	}
+	for _, forbidden := range []string{"cat ", "find ", "GITHUB_TOKEN", "POWERCONTEXT_GO_BINARY", "git diff"} {
+		if strings.Contains(summary.Run, forbidden) {
+			t.Fatalf("host adapter summary exposes %q: %s", forbidden, summary.Run)
+		}
+	}
+	for _, lockfile := range []string{
+		"integrations/bub/uv.lock",
+		"integrations/codex/plugins/powercontext/uv.lock",
+		"integrations/langgraph/uv.lock",
+		"integrations/dsh/plugins/powercontext/pnpm-lock.yaml",
+		"integrations/pi/plugins/powercontext/pnpm-lock.yaml",
+		"integrations/opencode/plugins/powercontext/pnpm-lock.yaml",
+		"integrations/openclaw/plugins/memory-powercontext/pnpm-lock.yaml",
+	} {
+		if !strings.Contains(summary.Run, lockfile) {
+			t.Fatalf("host adapter summary omits lockfile %q: %s", lockfile, summary.Run)
+		}
+	}
+	if upload == nil || upload.If != "failure()" || upload.Uses != "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a" {
+		t.Fatalf("host adapter upload step = %#v", upload)
+	}
+	if upload.With["path"] != "${{ runner.temp }}/powercontext-host-adapter-diagnostics/summary.txt" ||
+		upload.With["if-no-files-found"] != "error" || upload.With["retention-days"] != "14" {
+		t.Fatalf("host adapter upload contract = %#v", upload.With)
+	}
+}
+
 func TestMigrationAPICompatRunsThePinnedPublicBaseline(t *testing.T) {
 	repository := filepath.Clean(filepath.Join("..", ".."))
 	payload, err := os.ReadFile(filepath.Join(repository, ".github", "workflows", "migration-gates.yml"))


### PR DESCRIPTION
## Summary
- record each Host adapters execution boundary, including the DSH Server build
- write only the commit, outcome labels, and declared lockfile SHA-256 values
- upload the single text summary only when the job fails, with 14-day retention
- pin the failure-artifact contract with a workflow test

## Validation
- go test ./tools/release focused diagnostics contract
- go test ./tools/release with the documented Windows executable-mode assertion excluded
- go vet ./tools/release
- actionlint .github/workflows/migration-gates.yml
- git diff --check

The Windows-only excluded assertion checks Unix executable mode, which this checkout cannot represent; required Linux/macOS CI coverage remains enabled.

Progresses #3.