### PR TITLE
test(conformance): map managed config parity cases

### DIFF
--- a/test/conformance/parity-inventory-rules.json
+++ b/test/conformance/parity-inventory-rules.json
@@ -32,7 +32,34 @@
     },
     "tests/test_config_cli.py": {
       "mode": "go-port",
-      "reason": "Managed environment initialization, validation, credential input, and redacted display map to the Go CLI."
+      "reason": "Managed environment initialization, validation, credential input, and redacted display map to the Go CLI.",
+      "cases": {
+        "test_init_validate_and_show_round_trip_managed_environment": {
+          "evidence": [
+            "go:internal/cli/config_command_test.go#TestConfigInitShowAndValidateManageOneCredentialFreeEnvironmentFile"
+          ]
+        },
+        "test_configuration_rejects_relative_persistent_storage": {
+          "evidence": [
+            "go:internal/cli/config_command_test.go#TestConfigValidateRejectsRelativeSQLitePersistencePath"
+          ]
+        },
+        "test_show_redacts_standard_credential_container_variables": {
+          "evidence": [
+            "go:internal/cli/config_command_test.go#TestConfigShowRedactsStandardSensitiveAssignments"
+          ]
+        },
+        "test_managed_marker_text_inside_a_credential_is_not_treated_as_structure": {
+          "evidence": [
+            "go:internal/cli/config_command_test.go#TestConfigInitForceTreatsMarkerTextInsideCredentialAsLiteral"
+          ]
+        },
+        "test_show_reports_malformed_managed_markers_without_a_traceback": {
+          "evidence": [
+            "go:internal/cli/config_command_test.go#TestConfigShowRejectsRepeatedManagedMarkers"
+          ]
+        }
+      }
     },
     "tests/test_dashboard.py": {
       "mode": "go-port",
@@ -40,7 +67,64 @@
     },
     "tests/test_env_file.py": {
       "mode": "go-port",
-      "reason": "Shell-compatible managed environment parsing and stale-value clearing map to the Go CLI configuration parser."
+      "reason": "Shell-compatible managed environment parsing and stale-value clearing map to the Go CLI configuration parser.",
+      "cases": {
+        "test_hash_inside_a_value_is_preserved": {
+          "evidence": [
+            "go:internal/cli/config_command_test.go#TestParseConfigEnvironmentAcceptsShellCompatibleAssignments"
+          ]
+        },
+        "test_comment_after_an_assignment_is_removed": {
+          "evidence": [
+            "go:internal/cli/config_command_test.go#TestParseConfigEnvironmentAcceptsShellCompatibleAssignments"
+          ]
+        },
+        "test_quoted_values_keep_hashes_and_spaces": {
+          "evidence": [
+            "go:internal/cli/config_command_test.go#TestParseConfigEnvironmentAcceptsShellCompatibleAssignments"
+          ]
+        },
+        "test_value_may_start_with_hash_like_shell": {
+          "evidence": [
+            "go:internal/cli/config_command_test.go#TestParseConfigEnvironmentSupportsShellLiteralSyntax"
+          ]
+        },
+        "test_backslash_escaped_space_preserves_hash_value": {
+          "evidence": [
+            "go:internal/cli/config_command_test.go#TestParseConfigEnvironmentSupportsShellLiteralSyntax"
+          ]
+        },
+        "test_unescaped_tab_starts_a_comment_boundary": {
+          "evidence": [
+            "go:internal/cli/config_command_test.go#TestParseConfigEnvironmentSupportsShellLiteralSyntax"
+          ]
+        },
+        "test_export_accepts_shell_whitespace": {
+          "evidence": [
+            "go:internal/cli/config_command_test.go#TestParseConfigEnvironmentSupportsShellLiteralSyntax"
+          ]
+        },
+        "test_shell_expansion_is_rejected_instead_of_loaded_literally": {
+          "evidence": [
+            "go:internal/cli/config_command_test.go#TestParseConfigEnvironmentRejectsExpansionAndControlInput"
+          ]
+        },
+        "test_quoted_and_escaped_expansion_characters_are_literal": {
+          "evidence": [
+            "go:internal/cli/config_command_test.go#TestParseConfigEnvironmentSupportsShellLiteralSyntax"
+          ]
+        },
+        "test_invalid_utf8_is_reported_as_an_environment_file_error": {
+          "evidence": [
+            "go:internal/cli/config_command_test.go#TestConfigShowRejectsInvalidUTF8"
+          ]
+        },
+        "test_environment_context_can_clear_stale_values": {
+          "evidence": [
+            "go:internal/cli/config_command_test.go#TestConfigInitForceRemovesStandaloneManagedAssignments"
+          ]
+        }
+      }
     },
     "tests/test_full_capability_docs.py": {
       "mode": "cross-layer",

--- a/test/conformance/parity-inventory.json
+++ b/test/conformance/parity-inventory.json
@@ -4,8 +4,8 @@
   "oracle_commit": "3a6cb0151670eaff7dc0293466edd673124e80da",
   "python_test_file_count": 132,
   "python_test_case_count": 812,
-  "mapped_case_count": 686,
-  "pending_case_count": 126,
+  "mapped_case_count": 702,
+  "pending_case_count": 110,
   "entries": [
     {
       "python": {
@@ -8455,8 +8455,15 @@
         "line": 93
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/config_command_test.go",
+          "test": "TestConfigInitShowAndValidateManageOneCredentialFreeEnvironmentFile"
+        }
+      ]
     },
     {
       "python": {
@@ -8485,8 +8492,15 @@
         "line": 162
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/config_command_test.go",
+          "test": "TestConfigValidateRejectsRelativeSQLitePersistencePath"
+        }
+      ]
     },
     {
       "python": {
@@ -8545,8 +8559,15 @@
         "line": 252
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/config_command_test.go",
+          "test": "TestConfigShowRedactsStandardSensitiveAssignments"
+        }
+      ]
     },
     {
       "python": {
@@ -8565,8 +8586,15 @@
         "line": 302
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/config_command_test.go",
+          "test": "TestConfigInitForceTreatsMarkerTextInsideCredentialAsLiteral"
+        }
+      ]
     },
     {
       "python": {
@@ -8575,8 +8603,15 @@
         "line": 320
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/config_command_test.go",
+          "test": "TestConfigShowRejectsRepeatedManagedMarkers"
+        }
+      ]
     },
     {
       "python": {
@@ -9151,8 +9186,15 @@
         "line": 29
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/config_command_test.go",
+          "test": "TestParseConfigEnvironmentAcceptsShellCompatibleAssignments"
+        }
+      ]
     },
     {
       "python": {
@@ -9161,8 +9203,15 @@
         "line": 33
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/config_command_test.go",
+          "test": "TestParseConfigEnvironmentAcceptsShellCompatibleAssignments"
+        }
+      ]
     },
     {
       "python": {
@@ -9171,8 +9220,15 @@
         "line": 37
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/config_command_test.go",
+          "test": "TestParseConfigEnvironmentAcceptsShellCompatibleAssignments"
+        }
+      ]
     },
     {
       "python": {
@@ -9211,8 +9267,15 @@
         "line": 55
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/config_command_test.go",
+          "test": "TestParseConfigEnvironmentSupportsShellLiteralSyntax"
+        }
+      ]
     },
     {
       "python": {
@@ -9221,8 +9284,15 @@
         "line": 59
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/config_command_test.go",
+          "test": "TestParseConfigEnvironmentSupportsShellLiteralSyntax"
+        }
+      ]
     },
     {
       "python": {
@@ -9261,8 +9331,15 @@
         "line": 75
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/config_command_test.go",
+          "test": "TestParseConfigEnvironmentSupportsShellLiteralSyntax"
+        }
+      ]
     },
     {
       "python": {
@@ -9281,8 +9358,15 @@
         "line": 84
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/config_command_test.go",
+          "test": "TestParseConfigEnvironmentSupportsShellLiteralSyntax"
+        }
+      ]
     },
     {
       "python": {
@@ -9291,8 +9375,15 @@
         "line": 89
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/config_command_test.go",
+          "test": "TestParseConfigEnvironmentRejectsExpansionAndControlInput"
+        }
+      ]
     },
     {
       "python": {
@@ -9301,8 +9392,15 @@
         "line": 94
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/config_command_test.go",
+          "test": "TestParseConfigEnvironmentSupportsShellLiteralSyntax"
+        }
+      ]
     },
     {
       "python": {
@@ -9311,8 +9409,15 @@
         "line": 102
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/config_command_test.go",
+          "test": "TestConfigShowRejectsInvalidUTF8"
+        }
+      ]
     },
     {
       "python": {
@@ -9321,8 +9426,15 @@
         "line": 110
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/config_command_test.go",
+          "test": "TestConfigInitForceRemovesStandaloneManagedAssignments"
+        }
+      ]
     },
     {
       "python": {


### PR DESCRIPTION
## Summary
- map 16 v0.1.0 managed config/environment Python cases to existing Go CLI regressions
- regenerate the signed v0.1.0 inventory from 686 mapped / 126 pending to 702 mapped / 110 pending
- intentionally leave provider/prompt/parser edge cases without equivalent Go regression evidence pending

## Evidence
Mapped cases cover managed environment init/show/validate round-trip, relative SQLite persistence rejection, sensitive redaction, marker safety, shell-compatible quote/hash/comment/export parsing, expansion rejection, invalid UTF-8, and stale managed assignment cleanup.

## Validation
- `go test ./tools/parity-inventory-generate -count=1`
- `go vet ./tools/parity-inventory-generate`
- `go run ./tools/parity-inventory-generate -upstream C:\\Users\\alex\\AppData\\Local\\Temp\\powercontext-v010-target-worktree -check -check-delta -previous-upstream C:\\Users\\alex\\AppData\\Local\\Temp\\powercontext-wp1-parity-target -release-upstream C:\\Users\\alex\\AppData\\Local\\Temp\\powercontext-v010-target-worktree`

Progresses #3.