### PR TITLE
ci: add bounded OceanBase diagnostics

### DIFF
--- a/.github/workflows/migration-gates.yml
+++ b/.github/workflows/migration-gates.yml
@@ -370,9 +370,34 @@ jobs:
         uses: ./.github/actions/setup-go-env
 
       - name: Run real OceanBase schema and cursor tests
+        id: oceanbase_tests
         env:
           POWERCONTEXT_TEST_OCEANBASE_URL: mysql+aoceanbase://root%40test:powercontext-e2e@127.0.0.1:2881/powercontext?charset=utf8mb4
         run: make test-oceanbase-live
+
+      - name: Write bounded OceanBase diagnostics
+        if: always()
+        shell: bash
+        env:
+          OCEANBASE_TESTS_OUTCOME: ${{ steps.oceanbase_tests.outcome }}
+        run: |
+          diagnostics="$RUNNER_TEMP/powercontext-oceanbase-diagnostics"
+          mkdir -p "$diagnostics"
+          {
+            printf 'commit=%s\n' "$GITHUB_SHA"
+            printf 'oceanbase_tests_outcome=%s\n' "$OCEANBASE_TESTS_OUTCOME"
+            printf 'oceanbase_image=ghcr.io/oceanbase/oceanbase-ce@sha256:31086a6900c21c479c2bcd942b6a28c53b17a51f4e9b9eb8eafcc596adfcd2e3\n'
+            sha256sum go.mod go.sum
+          } > "$diagnostics/summary.txt"
+
+      - name: Upload OceanBase diagnostics
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: oceanbase-diagnostics-${{ github.sha }}
+          path: ${{ runner.temp }}/powercontext-oceanbase-diagnostics/summary.txt
+          if-no-files-found: error
+          retention-days: 14
 
   platform:
     name: Standard (${{ matrix.target }})

--- a/tools/release/workflow_test.go
+++ b/tools/release/workflow_test.go
@@ -914,6 +914,88 @@ func TestHostAdapterFailureDiagnosticsAreBoundedAndSanitized(t *testing.T) {
 	}
 }
 
+func TestOceanBaseFailureDiagnosticsAreBoundedAndSanitized(t *testing.T) {
+	repository := filepath.Clean(filepath.Join("..", ".."))
+	payload, err := os.ReadFile(filepath.Join(repository, ".github", "workflows", "migration-gates.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var workflow struct {
+		Jobs map[string]struct {
+			Steps []struct {
+				ID   string            `yaml:"id"`
+				Name string            `yaml:"name"`
+				If   string            `yaml:"if"`
+				Uses string            `yaml:"uses"`
+				With map[string]string `yaml:"with"`
+				Env  map[string]string `yaml:"env"`
+				Run  string            `yaml:"run"`
+			} `yaml:"steps"`
+		} `yaml:"jobs"`
+	}
+	if err := yaml.Unmarshal(payload, &workflow); err != nil {
+		t.Fatal(err)
+	}
+	oceanBase, ok := workflow.Jobs["oceanbase-live"]
+	if !ok {
+		t.Fatal("migration-gates.yml has no oceanbase-live job")
+	}
+	var summary, upload *struct {
+		Name string
+		If   string
+		Uses string
+		With map[string]string
+		Env  map[string]string
+		Run  string
+	}
+	testStepFound := false
+	for index := range oceanBase.Steps {
+		step := oceanBase.Steps[index]
+		if step.ID == "oceanbase_tests" {
+			testStepFound = true
+		}
+		if step.Name == "Write bounded OceanBase diagnostics" {
+			summary = &struct {
+				Name string
+				If   string
+				Uses string
+				With map[string]string
+				Env  map[string]string
+				Run  string
+			}{step.Name, step.If, step.Uses, step.With, step.Env, step.Run}
+		}
+		if step.Name == "Upload OceanBase diagnostics" {
+			upload = &struct {
+				Name string
+				If   string
+				Uses string
+				With map[string]string
+				Env  map[string]string
+				Run  string
+			}{step.Name, step.If, step.Uses, step.With, step.Env, step.Run}
+		}
+	}
+	if !testStepFound || summary == nil || summary.If != "always()" ||
+		summary.Env["OCEANBASE_TESTS_OUTCOME"] != "${{ steps.oceanbase_tests.outcome }}" ||
+		!strings.Contains(summary.Run, "powercontext-oceanbase-diagnostics") ||
+		!strings.Contains(summary.Run, "go.mod") || !strings.Contains(summary.Run, "go.sum") ||
+		!strings.Contains(summary.Run, "ghcr.io/oceanbase/oceanbase-ce@sha256:31086a6900c21c479c2bcd942b6a28c53b17a51f4e9b9eb8eafcc596adfcd2e3") {
+		t.Fatalf("OceanBase summary step = %#v", summary)
+	}
+	for _, forbidden := range []string{"POWERCONTEXT_TEST_OCEANBASE_URL", "OB_TENANT_PASSWORD", "docker ", "cat "} {
+		if strings.Contains(summary.Run, forbidden) {
+			t.Fatalf("OceanBase summary exposes %q: %s", forbidden, summary.Run)
+		}
+	}
+	if upload == nil || upload.If != "failure()" || upload.Uses != "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a" {
+		t.Fatalf("OceanBase upload step = %#v", upload)
+	}
+	if upload.With["path"] != "${{ runner.temp }}/powercontext-oceanbase-diagnostics/summary.txt" ||
+		upload.With["if-no-files-found"] != "error" || upload.With["retention-days"] != "14" {
+		t.Fatalf("OceanBase upload contract = %#v", upload.With)
+	}
+}
+
 func TestMigrationAPICompatRunsThePinnedPublicBaseline(t *testing.T) {
 	repository := filepath.Clean(filepath.Join("..", ".."))
 	payload, err := os.ReadFile(filepath.Join(repository, ".github", "workflows", "migration-gates.yml"))


### PR DESCRIPTION
## Summary
- record the OceanBase test outcome, fixed service image identity, and Go module hashes
- upload a single bounded summary only when OceanBase live compatibility fails
- keep the connection URL, tenant password, container environment, SQL parameters, and logs outside the artifact
- pin the contract with a workflow test

## Validation
- focused release workflow diagnostics tests
- full tools/release package test with the documented Windows executable-mode assertion excluded
- go vet ./tools/release
- actionlint .github/workflows/migration-gates.yml
- git diff --check

Progresses #3.