### PR TITLE
ci: add bounded process diagnostics

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -215,7 +215,39 @@ jobs:
         run: make unit-test
 
       - name: Run end-to-end tests
+        id: end_to_end_tests
+        env:
+          PROCESS_SMOKE_FAILURE_DIAGNOSTICS: ${{ runner.temp }}/powercontext-process-diagnostics/report.txt
         run: make e2e-test
+
+      - name: Write bounded process diagnostics
+        if: always()
+        shell: bash
+        env:
+          E2E_TESTS_OUTCOME: ${{ steps.end_to_end_tests.outcome }}
+        run: |
+          diagnostics="$RUNNER_TEMP/powercontext-process-diagnostics"
+          mkdir -p "$diagnostics"
+          {
+            printf 'commit=%s\n' "$GITHUB_SHA"
+            printf 'e2e_tests_outcome=%s\n' "$E2E_TESTS_OUTCOME"
+            if test -f "$diagnostics/report.txt"; then
+              sha256sum "$diagnostics/report.txt"
+            else
+              printf 'process_smoke_report=not-created\n'
+            fi
+          } > "$diagnostics/summary.txt"
+
+      - name: Upload process diagnostics
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: process-diagnostics-${{ github.sha }}
+          path: |
+            ${{ runner.temp }}/powercontext-process-diagnostics/summary.txt
+            ${{ runner.temp }}/powercontext-process-diagnostics/report.txt
+          if-no-files-found: error
+          retention-days: 14
 
       - name: Verify repository cleanliness after test execution
         if: always()

--- a/Makefile
+++ b/Makefile
@@ -249,7 +249,8 @@ unit-test: ## Run standard-tag unit tests.
 
 e2e-test: ## Run standard-tag process-level end-to-end tests.
 	CGO_ENABLED=1 $(GO) test -count=1 -tags '$(STANDARD_TAGS)' ./test/e2e
-	$(MAKE) smoke VERSION=ci COMMIT=$$(git rev-parse HEAD) BUILD_DATE=1970-01-01T00:00:00Z
+	$(MAKE) smoke VERSION=ci COMMIT=$$(git rev-parse HEAD) BUILD_DATE=1970-01-01T00:00:00Z \
+		PROCESS_SMOKE_FAILURE_DIAGNOSTICS="$(PROCESS_SMOKE_FAILURE_DIAGNOSTICS)"
 
 test-sqlite: ## Run all standard-tag tests against SQLite.
 	CGO_ENABLED=1 $(GO) test -tags '$(STANDARD_TAGS)' ./...
@@ -351,7 +352,8 @@ build-full: ## Build the Full native-asset server binary.
 		-o bin/powercontext-full ./cmd/powercontext
 
 smoke: build ## Build and smoke-test the standard server binary.
-	$(GO) run ./tools/process-smoke -binary bin/powercontext -env-file .env.example -version "$(VERSION)"
+	$(GO) run ./tools/process-smoke -binary bin/powercontext -env-file .env.example -version "$(VERSION)" \
+		$(if $(PROCESS_SMOKE_FAILURE_DIAGNOSTICS),-failure-diagnostics "$(PROCESS_SMOKE_FAILURE_DIAGNOSTICS)")
 
 smoke-full: build-full ## Build and smoke-test the Full server binary.
 	$(GO) run ./tools/process-smoke -binary bin/powercontext-full -env-file .env.example -version "$(VERSION)"

--- a/tools/process-smoke/main.go
+++ b/tools/process-smoke/main.go
@@ -48,6 +48,8 @@ const (
 	smokeScope = "release-verification-private-scope"
 	smokeText  = "PowerContext release verification stores and retrieves this exact private memory."
 	smokeToken = "release-verification-private-token"
+
+	maximumFailureDiagnosticBytes = 32 << 10
 )
 
 var baseToolNames = []string{
@@ -74,10 +76,11 @@ var baseToolNames = []string{
 }
 
 type options struct {
-	binary  string
-	envFile string
-	version string
-	timeout time.Duration
+	binary             string
+	envFile            string
+	version            string
+	timeout            time.Duration
+	failureDiagnostics string
 }
 
 func main() {
@@ -85,11 +88,14 @@ func main() {
 	envFile := flag.String("env-file", "", "released .env.example with security-sensitive defaults")
 	version := flag.String("version", "devel", "exact version reported by the executable")
 	timeout := flag.Duration("timeout", 60*time.Second, "maximum duration of each server phase")
+	failureDiagnostics := flag.String("failure-diagnostics", "", "optional bounded redacted failure diagnostics output")
 	flag.Parse()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 3*(*timeout))
 	defer cancel()
-	if err := run(ctx, options{binary: *binary, envFile: *envFile, version: *version, timeout: *timeout}); err != nil {
+	if err := run(ctx, options{
+		binary: *binary, envFile: *envFile, version: *version, timeout: *timeout, failureDiagnostics: *failureDiagnostics,
+	}); err != nil {
 		fmt.Fprintln(os.Stderr, "process-smoke:", err)
 		os.Exit(1)
 	}
@@ -99,7 +105,7 @@ func main() {
 	)
 }
 
-func run(ctx context.Context, opts options) error {
+func run(ctx context.Context, opts options) (runErr error) {
 	if opts.timeout <= 0 {
 		return errors.New("timeout must be positive")
 	}
@@ -119,6 +125,14 @@ func run(ctx context.Context, opts options) error {
 		return fmt.Errorf("create smoke directory: %w", err)
 	}
 	defer func() { _ = os.RemoveAll(root) }() // best-effort cleanup of isolated, disposable state
+	defer func() {
+		if runErr == nil {
+			return
+		}
+		if diagnosticErr := writeFailureDiagnostics(opts.failureDiagnostics, root, runErr); diagnosticErr != nil {
+			runErr = errors.Join(runErr, diagnosticErr)
+		}
+	}()
 
 	baseEnvironment := isolatedEnvironment(os.Environ(), filepath.Join(root, "home"))
 	firstLog := filepath.Join(root, "server-public.log")
@@ -687,4 +701,27 @@ func withLog(cause error, path string) error {
 		return errors.Join(cause, fmt.Errorf("read failed server log: %w", err))
 	}
 	return fmt.Errorf("%w\nPowerContext Server log:\n%s", cause, contents)
+}
+
+func writeFailureDiagnostics(path, root string, cause error) error {
+	if path == "" || cause == nil {
+		return nil
+	}
+	diagnostic := "status=failed\n" + cause.Error()
+	for _, private := range []string{root, smokeScope, smokeText, smokeToken} {
+		if private != "" {
+			diagnostic = strings.ReplaceAll(diagnostic, private, "[redacted]")
+		}
+	}
+	const truncation = "\n[truncated]\n"
+	if len(diagnostic) > maximumFailureDiagnosticBytes {
+		diagnostic = diagnostic[:maximumFailureDiagnosticBytes-len(truncation)] + truncation
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return fmt.Errorf("create diagnostics directory: %w", err)
+	}
+	if err := os.WriteFile(path, []byte(diagnostic), 0o600); err != nil {
+		return fmt.Errorf("write failure diagnostics: %w", err)
+	}
+	return nil
 }

--- a/tools/process-smoke/main_test.go
+++ b/tools/process-smoke/main_test.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"slices"
@@ -32,6 +33,36 @@ POWERCONTEXT_CLIENT_SERVER_URL=http://127.0.0.1:8000
 func TestReleaseSecurityDefaultsAcceptRepositoryExample(t *testing.T) {
 	if err := verifySecurityDefaults(filepath.Join("..", "..", ".env.example")); err != nil {
 		t.Fatalf("verify repository security defaults: %v", err)
+	}
+}
+
+func TestWriteFailureDiagnosticsRedactsPrivateValuesAndBoundsOutput(t *testing.T) {
+	report := filepath.Join(t.TempDir(), "diagnostics.txt")
+	root := filepath.Join(t.TempDir(), "private-root")
+	cause := errors.New(strings.Join([]string{
+		"startup failed at " + root,
+		smokeScope,
+		smokeText,
+		smokeToken,
+		strings.Repeat("x", maximumFailureDiagnosticBytes+1024),
+	}, "\n"))
+	if err := writeFailureDiagnostics(report, root, cause); err != nil {
+		t.Fatal(err)
+	}
+	payload, err := os.ReadFile(report)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(payload) > maximumFailureDiagnosticBytes {
+		t.Fatalf("diagnostics length = %d, want at most %d", len(payload), maximumFailureDiagnosticBytes)
+	}
+	for _, private := range []string{root, smokeScope, smokeText, smokeToken} {
+		if strings.Contains(string(payload), private) {
+			t.Fatalf("diagnostics leaked %q: %s", private, payload)
+		}
+	}
+	if !strings.Contains(string(payload), "[redacted]") || !strings.Contains(string(payload), "[truncated]") {
+		t.Fatalf("diagnostics = %q, want redaction and truncation markers", payload)
 	}
 }
 

--- a/tools/release/workflow_test.go
+++ b/tools/release/workflow_test.go
@@ -71,7 +71,7 @@ func TestContinuousIntegrationPreservesPythonTopologyAndGoAssurance(t *testing.T
 			"name: Main", "go-compat:", "quality:", "run: make check", "run: make contract-test",
 			"license-dependencies:", "run: make license-dependencies",
 			"dependency-security:", "run: make dependency-security",
-			"tests:", "run: make unit-test", "run: make e2e-test", "pi-package:", "check-docs:",
+			"tests:", "run: make unit-test", "run: make e2e-test", "Write bounded process diagnostics", "Upload process diagnostics", "pi-package:", "check-docs:",
 			"migration-assurance:", "uses: ./.github/workflows/migration-gates.yml",
 		},
 		"migration-gates.yml": {


### PR DESCRIPTION
## Summary
- add an explicit, bounded process-smoke failure diagnostics output
- redact private smoke values and the temporary root before writing the report
- upload only the redacted report and a metadata summary when the main E2E job fails
- preserve normal local smoke behavior when no diagnostics path is supplied

## Validation
- go test ./tools/process-smoke -count=1
- go test ./tools/release with the documented Windows executable-mode assertion excluded
- go vet for the affected tool packages
- actionlint .github/workflows/master.yml
- git diff --check

Linux exact-Head CI is required for the real Make and process path because local Windows Make cannot create the configured shell process.

Progresses #3.