### PR TITLE
test: inventory generator contracts

### DIFF
--- a/test/generator-inventory.json
+++ b/test/generator-inventory.json
@@ -1,0 +1,47 @@
+{
+  "schema_version": 1,
+  "generators": [
+    {
+      "name": "openapi-go-client",
+      "command": "go run ./tools/api-generate",
+      "inputs": ["openapi/powercontext.yaml"],
+      "outputs": ["api/v1/oas_schemas_gen.go", "client/invoker_gen.go"],
+      "evidence": ["tools/generated-consumers/main_test.go#func TestOpenAPIGeneratorProducesGoldenBuildableConsumer("]
+    },
+    {
+      "name": "mcp-schema",
+      "command": "go run ./tools/mcp-schema-generate",
+      "inputs": ["openapi/powercontext.yaml"],
+      "outputs": ["internal/mcpapi/schemas_gen.go"],
+      "evidence": ["tools/generated-consumers/main_test.go#func TestMCPSchemaGeneratorProducesGoldenBuildableConsumer("]
+    },
+    {
+      "name": "traceability",
+      "command": "go run ./tools/traceability-generate",
+      "inputs": ["test/conformance/testdata/python-v0.0.2/manifest.json", "test/conformance/traceability-rules.json"],
+      "outputs": ["test/conformance/traceability.json"],
+      "evidence": ["tools/generated-consumers/main_test.go#func TestTraceabilityGeneratorProducesGoldenConsumableTable("]
+    },
+    {
+      "name": "frozen-oracle-fixture",
+      "command": "go run ./tools/fixture-generate",
+      "inputs": ["test/conformance/python_oracle_fixture.py"],
+      "outputs": ["test/conformance/testdata/python-v0.0.2/manifest.json"],
+      "evidence": ["tools/release/workflow_test.go#func TestFrozenOracleGeneratorsUseTemporaryGoldenOutput("]
+    },
+    {
+      "name": "parity-inventory",
+      "command": "go run ./tools/parity-inventory-generate",
+      "inputs": ["test/conformance/parity-contract.json", "test/conformance/parity-inventory-rules.json"],
+      "outputs": ["test/conformance/parity-inventory.json"],
+      "evidence": ["tools/release/workflow_test.go#go run ./tools/parity-inventory-generate"]
+    },
+    {
+      "name": "dsh-operations",
+      "command": "node scripts/gen-operations.mjs",
+      "inputs": ["integrations/dsh/plugins/powercontext/openapi/powercontext.yaml", "integrations/dsh/plugins/powercontext/scripts/gen-operations.mjs"],
+      "outputs": ["integrations/dsh/plugins/powercontext/src/operations.generated.ts"],
+      "evidence": ["integrations/dsh/plugins/powercontext/tests/gen-check.spec.ts#it('writes and checks a fresh generated table through the public CLI'"]
+    }
+  ]
+}

--- a/tools/generated-consumers/main_test.go
+++ b/tools/generated-consumers/main_test.go
@@ -16,11 +16,13 @@ package generatedconsumers
 
 import (
 	"bytes"
+	"encoding/json/v2"
 	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
 )
 
@@ -199,6 +201,56 @@ func validateTraceabilityEntry(entry traceabilityEntry) error {
 	return nil
 }
 `
+
+type generatorInventory struct {
+	SchemaVersion int              `json:"schema_version"`
+	Generators    []generatorEntry `json:"generators"`
+}
+
+type generatorEntry struct {
+	Name     string   `json:"name"`
+	Command  string   `json:"command"`
+	Inputs   []string `json:"inputs"`
+	Outputs  []string `json:"outputs"`
+	Evidence []string `json:"evidence"`
+}
+
+func TestGeneratorInventoryListsCheckedContracts(t *testing.T) {
+	repository := repositoryRoot(t)
+	payload, err := os.ReadFile(filepath.Join(repository, "test", "generator-inventory.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var inventory generatorInventory
+	if err := json.Unmarshal(payload, &inventory, json.RejectUnknownMembers(true)); err != nil {
+		t.Fatal(err)
+	}
+	if inventory.SchemaVersion != 1 || len(inventory.Generators) == 0 {
+		t.Fatalf("generator inventory = %#v", inventory)
+	}
+	seen := map[string]bool{}
+	for _, generator := range inventory.Generators {
+		if generator.Name == "" || generator.Command == "" || seen[generator.Name] || len(generator.Inputs) == 0 || len(generator.Outputs) == 0 || len(generator.Evidence) == 0 {
+			t.Fatalf("generator entry = %#v", generator)
+		}
+		seen[generator.Name] = true
+		for _, path := range append(slices.Clone(generator.Inputs), generator.Outputs...) {
+			if _, err := os.Stat(filepath.Join(repository, filepath.FromSlash(path))); err != nil {
+				t.Fatalf("%s declared path %q: %v", generator.Name, path, err)
+			}
+		}
+		for _, evidence := range generator.Evidence {
+			path, needle, ok := strings.Cut(evidence, "#")
+			if !ok || path == "" || needle == "" {
+				t.Fatalf("%s evidence %q is invalid", generator.Name, evidence)
+			}
+			contents, err := os.ReadFile(filepath.Join(repository, filepath.FromSlash(path)))
+			if err != nil || !bytes.Contains(contents, []byte(needle)) {
+				t.Fatalf("%s evidence %q is not a real test: %v", generator.Name, evidence, err)
+			}
+		}
+	}
+}
 
 func TestOpenAPIGeneratorProducesGoldenBuildableConsumer(t *testing.T) {
 	repository := repositoryRoot(t)


### PR DESCRIPTION
## Summary
- add a machine-checked inventory of the supported Go and DSH generator contracts
- bind every inventory entry to inputs, checked outputs, a stable command, and real source-level test evidence
- fail the generated-consumers gate when an inventory declaration drifts from the repository

## Validation
- go test ./tools/generated-consumers -count=1
- go vet ./tools/generated-consumers
- git diff --check

Progresses #3.