### PR TITLE
feat(runtime): trace scheduled background operations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,6 +157,11 @@ source / artifact / trigger / inference
   readiness against child completion, retain the most recent bounded log tail,
   include the exit code or signal, and prove the failure path with a real
   short-lived child whose diagnostic follows over-limit output.
+- When a scheduled operation is traced outside a request, create one explicit
+  transport-owned root and finish it from the scheduler's aggregate outcome.
+  Keep every runtime stage beneath that root, make cancellation dominate
+  failure/success/noop, and verify both trace-parent isolation and that scope
+  IDs or protected inputs never become exported attributes.
 - When a test invokes a freshly built external binary, disable result caching
   or key it to the binary content. Verify the gate reruns after the binary
   changes without changing the test package.

--- a/internal/observability/tracing/server.go
+++ b/internal/observability/tracing/server.go
@@ -131,6 +131,31 @@ func StartOperation(
 	return spanCtx, &Operation{span: span}
 }
 
+// StartBackgroundOperation creates an internal operation root without
+// inheriting an ambient request trace. Background workers must not masquerade
+// as transport children, and they never receive a request ID attribute.
+func StartBackgroundOperation(
+	ctx context.Context,
+	provider trace.TracerProvider,
+	name string,
+	operation string,
+) (context.Context, *Operation) {
+	if provider == nil {
+		provider = otel.GetTracerProvider()
+	}
+	spanCtx, span := provider.Tracer(instrumentationName).Start(
+		ctx,
+		name,
+		trace.WithNewRoot(),
+		trace.WithSpanKind(trace.SpanKindInternal),
+		trace.WithAttributes(
+			attribute.String("powercontext.operation.name", operation),
+			attribute.String("powercontext.operation.unit", "background"),
+		),
+	)
+	return spanCtx, &Operation{span: span}
+}
+
 func (o *Operation) Finish(outcome string, err error) {
 	if o == nil || o.span == nil || !o.done.CompareAndSwap(false, true) {
 		return

--- a/internal/runtime/experience_incubation.go
+++ b/internal/runtime/experience_incubation.go
@@ -104,6 +104,23 @@ func (a *ExperienceIncubationApplication) incubate(
 	ctx context.Context,
 	scope string,
 	limit int64,
+) (result ExperienceIncubationResult, err error) {
+	err = a.runtime.runStage(ctx, "experience.incubation", nil, func(stageCtx context.Context, span StageSpan) error {
+		var operationErr error
+		result, operationErr = a.incubateWindow(stageCtx, scope, limit)
+		setStageAttributes(span, map[string]TraceAttribute{
+			"powercontext.experience.incubation.source_count":    result.ProcessedSourceCount,
+			"powercontext.experience.incubation.candidate_count": result.CandidateCount,
+		})
+		return operationErr
+	})
+	return result, err
+}
+
+func (a *ExperienceIncubationApplication) incubateWindow(
+	ctx context.Context,
+	scope string,
+	limit int64,
 ) (ExperienceIncubationResult, error) {
 	ctx = a.runtime.withModelUsage(ctx, scope, stats.ExperienceGeneration, "")
 	backend, err := a.backends(scope)

--- a/internal/runtime/experience_incubation_test.go
+++ b/internal/runtime/experience_incubation_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 	"testing"
 
 	"github.com/ob-labs/powercontext-go/artifact/experience"
@@ -131,7 +132,11 @@ func TestScheduledExperienceIncubationUsesFixedSourceWindowBudget(t *testing.T) 
 		previous: source.NewCursor(0), next: source.NewCursor(1), high: 1,
 		values: []source.Value{incubationSource(t, "task-1")}, available: []source.Ref{ref},
 	}
-	lifecycle := New()
+	tracing := &recordingStageTracing{}
+	lifecycle, err := NewConfigured(RuntimeOptions{Tracing: tracing}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 	application, err := NewExperienceIncubationApplication(
 		lifecycle, func(string) (ExperienceIncubationBackend, error) { return backend, nil },
 		incubationPipelineFunc(func(context.Context, []source.Value) ([]experience.CandidateInput, error) {
@@ -151,6 +156,19 @@ func TestScheduledExperienceIncubationUsesFixedSourceWindowBudget(t *testing.T) 
 	}
 	if len(backend.observedLimits) != 1 || backend.observedLimits[0] != experience.IncubationWindowLimit {
 		t.Fatalf("observed limits = %v", backend.observedLimits)
+	}
+	tracing.mu.Lock()
+	defer tracing.mu.Unlock()
+	if len(tracing.backgrounds) != 1 || tracing.backgrounds[0].outcome != ScheduledProcessingSuccess {
+		t.Fatalf("backgrounds = %#v", tracing.backgrounds)
+	}
+	if len(tracing.stages) != 3 || tracing.stages[2].name != "experience.incubation" ||
+		tracing.stages[2].outcome != "success" ||
+		!reflect.DeepEqual(tracing.stages[2].attributes, map[string]TraceAttribute{
+			"powercontext.experience.incubation.source_count":    1,
+			"powercontext.experience.incubation.candidate_count": 0,
+		}) {
+		t.Fatalf("stages = %#v", tracing.stages)
 	}
 }
 

--- a/internal/runtime/lifecycle.go
+++ b/internal/runtime/lifecycle.go
@@ -228,6 +228,40 @@ func (r *Runtime) Background(ctx context.Context, fn func(context.Context) error
 	})
 }
 
+// BackgroundOperation serializes one named background operation and lets the
+// owning transport trace it as a root. The callback returns its observable
+// outcome separately because scheduled scope failures may be isolated rather
+// than returned as the dispatch error.
+func (r *Runtime) BackgroundOperation(
+	ctx context.Context,
+	name string,
+	fn func(context.Context) (string, error),
+) (err error) {
+	if name == "" {
+		return errors.New("runtime: background operation name must not be empty")
+	}
+	if fn == nil {
+		return errors.New("runtime: background operation callback must not be nil")
+	}
+	backgroundCtx, span := safelyStartBackground(ctx, r.tracing, name, nil)
+	outcome := "failure"
+	defer func() { safelyFinishStage(span, outcome, err) }()
+	err = r.Background(backgroundCtx, func(operationCtx context.Context) error {
+		outcome, err = fn(operationCtx)
+		return err
+	})
+	if outcome == "" {
+		outcome = "failure"
+		if err == nil {
+			outcome = "success"
+		}
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) || context.Cause(backgroundCtx) != nil {
+		outcome = "cancelled"
+	}
+	return err
+}
+
 // Close atomically rejects new operations and waits for every admitted read,
 // writer, lock waiter, and background processor. If ctx is canceled before the
 // drain completes, admission is restored so the owner can retry shutdown.

--- a/internal/runtime/memory_commands.go
+++ b/internal/runtime/memory_commands.go
@@ -39,7 +39,19 @@ func (a *MemoryApplication) Flush(ctx context.Context, scopeID string) (MemoryFl
 // flush performs an already-admitted, already-serialized Source window. It is
 // shared with the scheduled processor so shutdown never requires recursive
 // lifecycle admission.
-func (a *MemoryApplication) flush(ctx context.Context, scope string) (MemoryFlushResult, error) {
+func (a *MemoryApplication) flush(ctx context.Context, scope string) (result MemoryFlushResult, err error) {
+	err = a.runtime.runStage(ctx, "memory.flush", nil, func(stageCtx context.Context, span StageSpan) error {
+		var operationErr error
+		result, operationErr = a.flushWindow(stageCtx, scope)
+		setStageAttributes(span, map[string]TraceAttribute{
+			"powercontext.memory.flush.source_count": result.ProcessedSourceCount,
+		})
+		return operationErr
+	})
+	return result, err
+}
+
+func (a *MemoryApplication) flushWindow(ctx context.Context, scope string) (MemoryFlushResult, error) {
 	ctx = a.runtime.withModelUsage(ctx, scope, stats.MemoryExtraction, stats.MemoryIndexing)
 	if a.flushes == nil {
 		return MemoryFlushResult{}, &StateError{Code: "memory-flush"}

--- a/internal/runtime/scheduled_processor.go
+++ b/internal/runtime/scheduled_processor.go
@@ -118,10 +118,11 @@ func (p *ScheduledProcessor) process(
 	operation string,
 	processScope func(context.Context, string) ScheduledObservation,
 ) error {
-	return p.runtime.Background(ctx, func(ctx context.Context) error {
+	return p.runtime.BackgroundOperation(ctx, operation, func(ctx context.Context) (string, error) {
+		outcome := ScheduledProcessingNoop
 		scopes, err := p.scopes.ScopeIDs(ctx)
 		if err != nil {
-			return err
+			return ScheduledProcessingFailure, err
 		}
 		for _, rawScope := range scopes {
 			if p.runtime.isClosing() {
@@ -129,13 +130,17 @@ func (p *ScheduledProcessor) process(
 			}
 			scope, err := ValidateScopeID(rawScope)
 			if err != nil {
-				p.notify(ctx, ScheduledObservation{Operation: operation, Outcome: ScheduledProcessingFailure, Err: err})
+				observation := ScheduledObservation{Operation: operation, Outcome: ScheduledProcessingFailure, Err: err}
+				p.notify(ctx, observation)
+				outcome = scheduledAggregateOutcome(outcome, observation.Outcome)
 				continue
 			}
 			lease, releaseLease := p.runtime.scopes.lease(scope)
 			if resolveErr := p.runtime.resolveScope(ctx); resolveErr != nil {
 				releaseLease()
-				p.notify(ctx, ScheduledObservation{Operation: operation, Outcome: ScheduledProcessingFailure, Err: resolveErr})
+				observation := ScheduledObservation{Operation: operation, Outcome: ScheduledProcessingFailure, Err: resolveErr}
+				p.notify(ctx, observation)
+				outcome = scheduledAggregateOutcome(outcome, observation.Outcome)
 				continue
 			}
 			var release func()
@@ -148,19 +153,29 @@ func (p *ScheduledProcessor) process(
 			})
 			if err != nil {
 				releaseLease()
-				outcome := ScheduledProcessingFailure
+				lockOutcome := ScheduledProcessingFailure
 				if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-					outcome = ScheduledProcessingCancelled
+					lockOutcome = ScheduledProcessingCancelled
 				}
-				p.notify(ctx, ScheduledObservation{Operation: operation, Outcome: outcome, Err: err})
-				return err
+				observation := ScheduledObservation{Operation: operation, Outcome: lockOutcome, Err: err}
+				p.notify(ctx, observation)
+				return observation.Outcome, err
 			}
 			observation := processScope(ctx, scope)
 			release()
 			releaseLease()
+			if observation.Outcome == ScheduledProcessingCancelled {
+				if observation.Err == nil {
+					observation.Err = context.Canceled
+				}
+				p.notify(ctx, observation)
+				outcome = scheduledAggregateOutcome(outcome, observation.Outcome)
+				return outcome, observation.Err
+			}
 			p.notify(ctx, observation)
+			outcome = scheduledAggregateOutcome(outcome, observation.Outcome)
 		}
-		return nil
+		return outcome, nil
 	})
 }
 
@@ -187,6 +202,27 @@ func scheduledOutcome(processed bool, err error) string {
 		return ScheduledProcessingSuccess
 	}
 	return ScheduledProcessingNoop
+}
+
+func scheduledAggregateOutcome(current, next string) string {
+	if scheduledOutcomePriority(next) > scheduledOutcomePriority(current) {
+		return next
+	}
+	return current
+}
+
+func scheduledOutcomePriority(outcome string) int {
+	switch outcome {
+	case ScheduledProcessingCancelled:
+		return 4
+	case ScheduledProcessingSuccess:
+		return 2
+	case ScheduledProcessingNoop:
+		return 1
+	default:
+		// Failure is the conservative default for an unknown observation.
+		return 3
+	}
 }
 
 func elapsed(now, started time.Time) time.Duration {

--- a/internal/runtime/scheduled_processor_test.go
+++ b/internal/runtime/scheduled_processor_test.go
@@ -1,0 +1,188 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtime
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/ob-labs/powercontext-go/artifact/memory"
+	"github.com/ob-labs/powercontext-go/source"
+)
+
+func TestScheduledProcessorRecordsBackgroundRootsAndOutcomes(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name        string
+		operation   string
+		outcomes    []string
+		wantOutcome string
+		wantErr     error
+	}{
+		{
+			name: "source window success", operation: ProcessSourceWindowOperation,
+			outcomes: []string{ScheduledProcessingSuccess}, wantOutcome: ScheduledProcessingSuccess,
+		},
+		{
+			name: "source window noop", operation: ProcessSourceWindowOperation,
+			outcomes: []string{ScheduledProcessingNoop}, wantOutcome: ScheduledProcessingNoop,
+		},
+		{
+			name: "source window failure", operation: ProcessSourceWindowOperation,
+			outcomes: []string{ScheduledProcessingFailure}, wantOutcome: ScheduledProcessingFailure,
+		},
+		{
+			name: "source window cancellation", operation: ProcessSourceWindowOperation,
+			outcomes: []string{ScheduledProcessingCancelled}, wantOutcome: ScheduledProcessingCancelled, wantErr: context.Canceled,
+		},
+		{
+			name: "experience success", operation: IncubateExperienceOperation,
+			outcomes: []string{ScheduledProcessingSuccess}, wantOutcome: ScheduledProcessingSuccess,
+		},
+		{
+			name: "experience noop", operation: IncubateExperienceOperation,
+			outcomes: []string{ScheduledProcessingNoop}, wantOutcome: ScheduledProcessingNoop,
+		},
+		{
+			name: "experience failure", operation: IncubateExperienceOperation,
+			outcomes: []string{ScheduledProcessingFailure}, wantOutcome: ScheduledProcessingFailure,
+		},
+		{
+			name: "experience cancellation", operation: IncubateExperienceOperation,
+			outcomes: []string{ScheduledProcessingCancelled}, wantOutcome: ScheduledProcessingCancelled, wantErr: context.Canceled,
+		},
+		{
+			name: "failure outranks success", operation: ProcessSourceWindowOperation,
+			outcomes: []string{ScheduledProcessingSuccess, ScheduledProcessingFailure}, wantOutcome: ScheduledProcessingFailure,
+		},
+		{
+			name: "success outranks noop", operation: ProcessSourceWindowOperation,
+			outcomes: []string{ScheduledProcessingNoop, ScheduledProcessingSuccess}, wantOutcome: ScheduledProcessingSuccess,
+		},
+		{
+			name: "cancellation outranks failure", operation: IncubateExperienceOperation,
+			outcomes: []string{ScheduledProcessingFailure, ScheduledProcessingCancelled}, wantOutcome: ScheduledProcessingCancelled, wantErr: context.Canceled,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			tracing := &recordingStageTracing{}
+			lifecycle, err := NewConfigured(RuntimeOptions{Tracing: tracing}, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			processor := &ScheduledProcessor{runtime: lifecycle, scopes: staticScopes(testScopes(test.outcomes))}
+			index := 0
+			err = processor.process(t.Context(), test.operation, func(context.Context, string) ScheduledObservation {
+				outcome := test.outcomes[index]
+				index++
+				observation := ScheduledObservation{Operation: test.operation, Outcome: outcome}
+				if outcome == ScheduledProcessingCancelled {
+					observation.Err = context.Canceled
+				}
+				if outcome == ScheduledProcessingFailure {
+					observation.Err = errors.New("scheduled failure")
+				}
+				return observation
+			})
+			if !errors.Is(err, test.wantErr) {
+				t.Fatalf("process error = %v, want %v", err, test.wantErr)
+			}
+
+			tracing.mu.Lock()
+			defer tracing.mu.Unlock()
+			if len(tracing.backgrounds) != 1 {
+				t.Fatalf("background roots = %#v, want one", tracing.backgrounds)
+			}
+			root := tracing.backgrounds[0]
+			if root.name != test.operation || root.outcome != test.wantOutcome || root.err != test.wantErr || root.attributes != nil {
+				t.Fatalf("background root = %#v", root)
+			}
+			wantStageNames := make([]string, 0, len(test.outcomes)*2)
+			for range test.outcomes {
+				wantStageNames = append(wantStageNames, "scope.context", "scope.lock")
+			}
+			stageNames := make([]string, len(tracing.stages))
+			for index, stage := range tracing.stages {
+				stageNames[index] = stage.name
+				for _, value := range stage.attributes {
+					if value == "private-scheduled-scope" {
+						t.Fatal("scheduled trace leaked raw scope")
+					}
+				}
+			}
+			if !reflect.DeepEqual(stageNames, wantStageNames) {
+				t.Fatalf("stage names = %v, want %v", stageNames, wantStageNames)
+			}
+		})
+	}
+}
+
+func testScopes(outcomes []string) []string {
+	values := make([]string, len(outcomes))
+	for index := range outcomes {
+		values[index] = "private-scheduled-scope"
+	}
+	return values
+}
+
+func TestScheduledSourceWindowNoopRecordsFlushStage(t *testing.T) {
+	t.Parallel()
+	tracing := &recordingStageTracing{}
+	lifecycle, err := NewConfigured(RuntimeOptions{Tracing: tracing}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	application, err := NewMemoryApplicationWithFlush(
+		lifecycle,
+		func(string) (*memory.Service, error) { return nil, nil },
+		func(string) (MemoryFlushBackend, error) { return scheduledNoopFlushBackend{}, nil },
+		"memory",
+		1,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	processor, err := NewScheduledProcessor(lifecycle, staticScopes{"private-scheduled-scope"}, application, nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := processor.ProcessSourceWindows(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	tracing.mu.Lock()
+	defer tracing.mu.Unlock()
+	if len(tracing.backgrounds) != 1 || tracing.backgrounds[0].outcome != ScheduledProcessingNoop {
+		t.Fatalf("backgrounds = %#v", tracing.backgrounds)
+	}
+	if len(tracing.stages) != 3 || tracing.stages[2].name != "memory.flush" ||
+		!reflect.DeepEqual(tracing.stages[2].attributes, map[string]TraceAttribute{
+			"powercontext.memory.flush.source_count": 0,
+		}) {
+		t.Fatalf("stages = %#v", tracing.stages)
+	}
+}
+
+type scheduledNoopFlushBackend struct{}
+
+func (scheduledNoopFlushBackend) ObserveWindow(context.Context, string, int64) (source.Cursor, source.Cursor, *int64, int64, []source.Value, error) {
+	return source.NewCursor(0), source.NewCursor(0), nil, 0, nil, nil
+}
+
+func (scheduledNoopFlushBackend) ApplyWindow(context.Context, string, memory.WritePlan, source.Cursor, *int64) (*memory.Memory, error) {
+	return nil, errors.New("ApplyWindow must not run for a noop Source window")
+}

--- a/internal/runtime/tracing.go
+++ b/internal/runtime/tracing.go
@@ -35,6 +35,13 @@ type StageTracing interface {
 	StartStage(context.Context, string, map[string]TraceAttribute) (context.Context, StageSpan)
 }
 
+// BackgroundTracing is an optional consumer-owned boundary for work that has
+// no request parent. Runtime remains transport-agnostic while a consumer such
+// as the server can export an independent operation root.
+type BackgroundTracing interface {
+	StartBackground(context.Context, string, map[string]TraceAttribute) (context.Context, StageSpan)
+}
+
 type StageTracingFunc func(context.Context, string, map[string]TraceAttribute) (context.Context, StageSpan)
 
 func (f StageTracingFunc) StartStage(
@@ -98,6 +105,29 @@ func safelyStartStage(
 		stageContext = started
 	}
 	return stageContext, span
+}
+
+func safelyStartBackground(
+	ctx context.Context,
+	tracing StageTracing,
+	name string,
+	attributes map[string]TraceAttribute,
+) (backgroundContext context.Context, span StageSpan) {
+	backgroundContext = ctx
+	background, ok := tracing.(BackgroundTracing)
+	if !ok || background == nil {
+		return backgroundContext, nil
+	}
+	defer func() {
+		if recover() != nil {
+			backgroundContext, span = ctx, nil
+		}
+	}()
+	started, span := background.StartBackground(ctx, name, cloneTraceAttributes(attributes))
+	if started != nil {
+		backgroundContext = started
+	}
+	return backgroundContext, span
 }
 
 func setStageAttributes(span StageSpan, attributes map[string]TraceAttribute) {

--- a/internal/runtime/tracing_test.go
+++ b/internal/runtime/tracing_test.go
@@ -35,10 +35,11 @@ type recordedRuntimeStage struct {
 }
 
 type recordingStageTracing struct {
-	mu      sync.Mutex
-	stages  []*recordedRuntimeStage
-	panic   bool
-	started chan string
+	mu          sync.Mutex
+	stages      []*recordedRuntimeStage
+	backgrounds []*recordedRuntimeStage
+	panic       bool
+	started     chan string
 }
 
 func (t *recordingStageTracing) StartStage(
@@ -60,6 +61,21 @@ func (t *recordingStageTracing) StartStage(
 		}
 	}
 	return ctx, stage
+}
+
+func (t *recordingStageTracing) StartBackground(
+	ctx context.Context,
+	name string,
+	attributes map[string]TraceAttribute,
+) (context.Context, StageSpan) {
+	if t.panic {
+		panic("tracer unavailable")
+	}
+	background := &recordedRuntimeStage{owner: t, name: name, attributes: cloneTraceAttributes(attributes)}
+	t.mu.Lock()
+	t.backgrounds = append(t.backgrounds, background)
+	t.mu.Unlock()
+	return ctx, background
 }
 
 func (s *recordedRuntimeStage) SetAttributes(attributes map[string]TraceAttribute) {
@@ -238,6 +254,44 @@ func TestRuntimeStageTracerFailureDoesNotChangeOperation(t *testing.T) {
 		return nil
 	}); err != nil || !called {
 		t.Fatalf("operation changed by tracer failure: called=%t err=%v", called, err)
+	}
+}
+
+func TestRuntimeBackgroundTracerFailureDoesNotChangeOperation(t *testing.T) {
+	t.Parallel()
+	runtime, err := NewConfigured(RuntimeOptions{Tracing: &recordingStageTracing{panic: true}}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	called := false
+	err = runtime.BackgroundOperation(t.Context(), ProcessSourceWindowOperation, func(context.Context) (string, error) {
+		called = true
+		return ScheduledProcessingSuccess, nil
+	})
+	if err != nil || !called {
+		t.Fatalf("background operation changed by tracer failure: called=%t err=%v", called, err)
+	}
+}
+
+func TestRuntimeBackgroundOperationDefaultsToFailureWhenCallbackReturnsAnError(t *testing.T) {
+	t.Parallel()
+	tracing := &recordingStageTracing{}
+	runtime, err := NewConfigured(RuntimeOptions{Tracing: tracing}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	failure := errors.New("background failure")
+	err = runtime.BackgroundOperation(t.Context(), ProcessSourceWindowOperation, func(context.Context) (string, error) {
+		return "", failure
+	})
+	if !errors.Is(err, failure) {
+		t.Fatalf("background operation error = %v", err)
+	}
+	tracing.mu.Lock()
+	defer tracing.mu.Unlock()
+	if len(tracing.backgrounds) != 1 || tracing.backgrounds[0].outcome != "failure" ||
+		!errors.Is(tracing.backgrounds[0].err, failure) {
+		t.Fatalf("background roots = %#v", tracing.backgrounds)
 	}
 }
 

--- a/server/runtime_tracing.go
+++ b/server/runtime_tracing.go
@@ -41,4 +41,17 @@ func (t runtimeStageTracing) StartStage(
 	return spanContext, operation
 }
 
-var _ pcruntime.StageTracing = runtimeStageTracing{}
+func (t runtimeStageTracing) StartBackground(
+	ctx context.Context,
+	name string,
+	attributes map[string]pcruntime.TraceAttribute,
+) (context.Context, pcruntime.StageSpan) {
+	spanContext, operation := requesttrace.StartBackgroundOperation(ctx, t.provider, name, name)
+	operation.SetAttributes(attributes)
+	return spanContext, operation
+}
+
+var (
+	_ pcruntime.StageTracing      = runtimeStageTracing{}
+	_ pcruntime.BackgroundTracing = runtimeStageTracing{}
+)

--- a/server/runtime_tracing_test.go
+++ b/server/runtime_tracing_test.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"testing"
 
+	"go.opentelemetry.io/otel/attribute"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 
@@ -59,4 +60,75 @@ func TestRuntimeStageSpansInheritApplicationContextWithoutRawScope(t *testing.T)
 			t.Fatalf("%s leaked raw Scope: %s", name, serialized.String())
 		}
 	}
+}
+
+func TestRuntimeBackgroundOperationStartsIndependentRootWithoutRawScope(t *testing.T) {
+	t.Parallel()
+	for _, operation := range []string{
+		pcruntime.ProcessSourceWindowOperation,
+		pcruntime.IncubateExperienceOperation,
+	} {
+		t.Run(operation, func(t *testing.T) {
+			recorder := tracetest.NewSpanRecorder()
+			provider := sdktrace.NewTracerProvider(
+				sdktrace.WithSampler(sdktrace.AlwaysSample()),
+				sdktrace.WithSpanProcessor(recorder),
+			)
+			t.Cleanup(func() { _ = provider.Shutdown(context.Background()) })
+			runtime, err := pcruntime.NewConfigured(pcruntime.RuntimeOptions{
+				Tracing: newRuntimeStageTracing(provider),
+			}, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			ctx, parent := provider.Tracer("test").Start(t.Context(), "HTTP capture_content_source")
+			err = runtime.BackgroundOperation(ctx, operation, func(ctx context.Context) (string, error) {
+				return pcruntime.ScheduledProcessingSuccess,
+					runtime.ScopedWrite(ctx, "project:private-scheduled-scope", func(context.Context, string) error { return nil })
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			parent.End()
+
+			spans := recorder.Ended()
+			root := endedSpan(t, spans, operation)
+			if root.Parent().IsValid() {
+				t.Fatalf("background root inherited parent %s", root.Parent().SpanID())
+			}
+			if got := root.Attributes(); !hasTraceAttributes(got, map[string]string{
+				"powercontext.operation.name":    operation,
+				"powercontext.operation.unit":    "background",
+				"powercontext.operation.outcome": pcruntime.ScheduledProcessingSuccess,
+			}) {
+				t.Fatalf("background root attributes = %#v", got)
+			}
+			contextStage := endedSpan(t, spans, "scope.context")
+			if contextStage.Parent().SpanID() != root.SpanContext().SpanID() {
+				t.Fatalf("scope context parent = %s, want background root %s", contextStage.Parent().SpanID(), root.SpanContext().SpanID())
+			}
+			for _, span := range []sdktrace.ReadOnlySpan{root, contextStage, endedSpan(t, spans, "scope.lock")} {
+				serialized := strings.Builder{}
+				for _, attribute := range span.Attributes() {
+					serialized.WriteString(attribute.Value.String())
+				}
+				if strings.Contains(serialized.String(), "private-scheduled-scope") {
+					t.Fatalf("%s leaked raw Scope: %s", span.Name(), serialized.String())
+				}
+			}
+		})
+	}
+}
+
+func hasTraceAttributes(attributes []attribute.KeyValue, want map[string]string) bool {
+	values := make(map[string]string, len(attributes))
+	for _, attribute := range attributes {
+		values[string(attribute.Key)] = attribute.Value.AsString()
+	}
+	for key, expected := range want {
+		if values[key] != expected {
+			return false
+		}
+	}
+	return true
 }

--- a/test/conformance/parity-inventory-rules.json
+++ b/test/conformance/parity-inventory-rules.json
@@ -20,7 +20,52 @@
     },
     "tests/builtin/runtime/test_scheduler.py": {
       "mode": "go-port",
-      "reason": "Scheduled Source-window and Experience-incubation trace outcomes map to Go runtime scheduler orchestration."
+      "reason": "Scheduled Source-window and Experience-incubation trace outcomes map to Go runtime scheduler orchestration.",
+      "cases": {
+        "test_scheduled_processor_records_root_and_flush_spans": {
+          "evidence": [
+            "go:internal/runtime/scheduled_processor_test.go#TestScheduledProcessorRecordsBackgroundRootsAndOutcomes",
+            "go:internal/runtime/scheduled_processor_test.go#TestScheduledSourceWindowNoopRecordsFlushStage"
+          ]
+        },
+        "test_scheduled_processor_records_success_outcome": {
+          "evidence": [
+            "go:internal/runtime/scheduled_processor_test.go#TestScheduledProcessorRecordsBackgroundRootsAndOutcomes",
+            "go:server/runtime_tracing_test.go#TestRuntimeBackgroundOperationStartsIndependentRootWithoutRawScope"
+          ]
+        },
+        "test_scheduled_processor_records_failure_and_swallows_error": {
+          "evidence": [
+            "go:internal/runtime/scheduled_processor_test.go#TestScheduledProcessorRecordsBackgroundRootsAndOutcomes"
+          ]
+        },
+        "test_scheduled_processor_records_cancellation": {
+          "evidence": [
+            "go:internal/runtime/scheduled_processor_test.go#TestScheduledProcessorRecordsBackgroundRootsAndOutcomes"
+          ]
+        },
+        "test_scheduled_experience_records_root_and_incubation_spans": {
+          "evidence": [
+            "go:internal/runtime/experience_incubation_test.go#TestScheduledExperienceIncubationUsesFixedSourceWindowBudget",
+            "go:server/runtime_tracing_test.go#TestRuntimeBackgroundOperationStartsIndependentRootWithoutRawScope"
+          ]
+        },
+        "test_scheduled_experience_records_noop_outcome": {
+          "evidence": [
+            "go:internal/runtime/scheduled_processor_test.go#TestScheduledProcessorRecordsBackgroundRootsAndOutcomes"
+          ]
+        },
+        "test_scheduled_experience_records_failure_and_swallows_error": {
+          "evidence": [
+            "go:internal/runtime/scheduled_processor_test.go#TestScheduledProcessorRecordsBackgroundRootsAndOutcomes"
+          ]
+        },
+        "test_scheduled_experience_records_cancellation": {
+          "evidence": [
+            "go:internal/runtime/scheduled_processor_test.go#TestScheduledProcessorRecordsBackgroundRootsAndOutcomes"
+          ]
+        }
+      }
     },
     "tests/claude_code_plugin/test_hook.py": {
       "mode": "retained-host",
@@ -28,7 +73,21 @@
     },
     "tests/e2e/test_observability.py": {
       "mode": "cross-layer",
-      "reason": "Independent scheduled trace roots cross runtime scheduling, tracing, and exported observability evidence."
+      "reason": "Independent scheduled trace roots cross runtime scheduling, tracing, and exported observability evidence.",
+      "cases": {
+        "test_scheduled_source_window_starts_an_independent_trace_root": {
+          "evidence": [
+            "go:internal/runtime/scheduled_processor_test.go#TestScheduledProcessorRecordsBackgroundRootsAndOutcomes",
+            "go:server/runtime_tracing_test.go#TestRuntimeBackgroundOperationStartsIndependentRootWithoutRawScope"
+          ]
+        },
+        "test_scheduled_experience_starts_an_independent_trace_root": {
+          "evidence": [
+            "go:internal/runtime/experience_incubation_test.go#TestScheduledExperienceIncubationUsesFixedSourceWindowBudget",
+            "go:server/runtime_tracing_test.go#TestRuntimeBackgroundOperationStartsIndependentRootWithoutRawScope"
+          ]
+        }
+      }
     },
     "tests/test_config_cli.py": {
       "mode": "go-port",

--- a/test/conformance/parity-inventory.json
+++ b/test/conformance/parity-inventory.json
@@ -4,8 +4,8 @@
   "oracle_commit": "3a6cb0151670eaff7dc0293466edd673124e80da",
   "python_test_file_count": 132,
   "python_test_case_count": 812,
-  "mapped_case_count": 702,
-  "pending_case_count": 110,
+  "mapped_case_count": 712,
+  "pending_case_count": 100,
   "entries": [
     {
       "python": {
@@ -3290,8 +3290,20 @@
         "line": 305
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/runtime/scheduled_processor_test.go",
+          "test": "TestScheduledProcessorRecordsBackgroundRootsAndOutcomes"
+        },
+        {
+          "kind": "go",
+          "file": "internal/runtime/scheduled_processor_test.go",
+          "test": "TestScheduledSourceWindowNoopRecordsFlushStage"
+        }
+      ]
     },
     {
       "python": {
@@ -3300,8 +3312,20 @@
         "line": 332
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/runtime/scheduled_processor_test.go",
+          "test": "TestScheduledProcessorRecordsBackgroundRootsAndOutcomes"
+        },
+        {
+          "kind": "go",
+          "file": "server/runtime_tracing_test.go",
+          "test": "TestRuntimeBackgroundOperationStartsIndependentRootWithoutRawScope"
+        }
+      ]
     },
     {
       "python": {
@@ -3310,8 +3334,15 @@
         "line": 351
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/runtime/scheduled_processor_test.go",
+          "test": "TestScheduledProcessorRecordsBackgroundRootsAndOutcomes"
+        }
+      ]
     },
     {
       "python": {
@@ -3320,8 +3351,15 @@
         "line": 368
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/runtime/scheduled_processor_test.go",
+          "test": "TestScheduledProcessorRecordsBackgroundRootsAndOutcomes"
+        }
+      ]
     },
     {
       "python": {
@@ -3330,8 +3368,20 @@
         "line": 388
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/runtime/experience_incubation_test.go",
+          "test": "TestScheduledExperienceIncubationUsesFixedSourceWindowBudget"
+        },
+        {
+          "kind": "go",
+          "file": "server/runtime_tracing_test.go",
+          "test": "TestRuntimeBackgroundOperationStartsIndependentRootWithoutRawScope"
+        }
+      ]
     },
     {
       "python": {
@@ -3340,8 +3390,15 @@
         "line": 420
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/runtime/scheduled_processor_test.go",
+          "test": "TestScheduledProcessorRecordsBackgroundRootsAndOutcomes"
+        }
+      ]
     },
     {
       "python": {
@@ -3350,8 +3407,15 @@
         "line": 441
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/runtime/scheduled_processor_test.go",
+          "test": "TestScheduledProcessorRecordsBackgroundRootsAndOutcomes"
+        }
+      ]
     },
     {
       "python": {
@@ -3360,8 +3424,15 @@
         "line": 458
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/runtime/scheduled_processor_test.go",
+          "test": "TestScheduledProcessorRecordsBackgroundRootsAndOutcomes"
+        }
+      ]
     },
     {
       "python": {
@@ -5270,8 +5341,20 @@
         "line": 694
       },
       "mode": "cross-layer",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/runtime/scheduled_processor_test.go",
+          "test": "TestScheduledProcessorRecordsBackgroundRootsAndOutcomes"
+        },
+        {
+          "kind": "go",
+          "file": "server/runtime_tracing_test.go",
+          "test": "TestRuntimeBackgroundOperationStartsIndependentRootWithoutRawScope"
+        }
+      ]
     },
     {
       "python": {
@@ -5280,8 +5363,20 @@
         "line": 725
       },
       "mode": "cross-layer",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/runtime/experience_incubation_test.go",
+          "test": "TestScheduledExperienceIncubationUsesFixedSourceWindowBudget"
+        },
+        {
+          "kind": "go",
+          "file": "server/runtime_tracing_test.go",
+          "test": "TestRuntimeBackgroundOperationStartsIndependentRootWithoutRawScope"
+        }
+      ]
     },
     {
       "python": {


### PR DESCRIPTION
## Tracking

- Tracking issue: #3
- Relationship: `Part of #3`

## Problem and rationale

The v0.1.0 scheduler contract requires independent Source-window and Experience-incubation trace roots with explicit success, noop, failure, and cancellation outcomes. Go previously serialized dispatch through `Runtime.Background`, but it exposed no background trace-root boundary and could swallow a cancellation returned by an isolated scope processor.

## Changes

- Add an optional consumer-owned Runtime `BackgroundTracing` boundary and outcome-aware `BackgroundOperation` lifecycle operation.
- Emit server OTel background roots with `WithNewRoot`; normal Runtime stages remain children of those roots.
- Trace actual `memory.flush` and `experience.incubation` use cases as bounded child stages with only result counts.
- Aggregate multi-scope outcomes as `cancelled > failure > success > noop`, and propagate cancellation to the dispatch boundary while retaining isolated non-cancellation failures.
- Add Runtime and server tracing regression tests, including tracer failure isolation and the generic empty-outcome/error default.
- Map the eight scheduler and two scheduled-observability release cases. The generated inventory changes from 702 mapped / 110 pending to 712 mapped / 100 pending.

## Behavior and compatibility

- User-visible behavior: scheduled OTel traces now have a distinct internal root and bounded stage hierarchy.
- Public API or protocol impact: none; the new contract is internal to Runtime and the server tracing consumer.
- Breaking changes or migration requirements: none.
- Explicit non-goals: no HTTP/OpenAPI/persistence format/scope-ID changes, no retained-adapter work, and no embedding transport changes.

## Generated, dependency, and workflow impact

- [x] Parity inventory was regenerated from the exact v0.1.0 target and checked with its delta ledger.
- [x] No dependency changed.
- [x] No CI job topology or release contract changed.
- [x] No credential, private Source/Memory content, or unredacted production log is included.

## Validation

```text
gofmt -d <all changed Go files>
git diff origin/main...HEAD --check
go test ./internal/runtime -count=1
go vet ./internal/runtime
go test ./internal/observability/tracing -count=1
go vet ./internal/observability/tracing
go test ./tools/parity-inventory-generate -count=1
go vet ./tools/parity-inventory-generate
go run ./tools/parity-inventory-generate -upstream <exact-v0.1.0-LF-checkout> -check -check-delta -previous-upstream <exact-previous-target> -release-upstream <exact-v0.1.0-LF-checkout>
actionlint .github/workflows/migration-gates.yml .github/workflows/windows-contract.yml
go run ./tools/governance-check
go test ./tools/release -run 'TestMigration.*|TestFrozen.*|TestWindows.*' -count=1
```

- [x] `git diff --check`
- [x] `git status --short` was inspected after validation.
- [x] Formatter evidence is recorded above.
- [x] Generated-consumer checks are not applicable: this changes Runtime tracing and the generated parity inventory, not a Go consumer generator.
- [x] Compatibility evidence is recorded through the exact release inventory/delta check and Runtime outcome tests.
- [x] Relevant tracing, scheduler, generated-contract, and workflow checks were run.
- [x] `go test ./server -run '^TestRuntimeBackgroundOperationStartsIndependentRootWithoutRawScope$' -count=1` is not represented as passing locally: both Windows and available WSL lack `sqlite3.h`. Exact-Head Linux CI must execute it.

## AI usage

AI assistance implemented the approved bounded scheduler tracing contract. The upstream v0.1.0 scheduler and observability tests were compared against current Go behavior; the implementation was independently verified with focused Runtime tests, exact inventory generation, lint, and workflow contract checks.