### PR TITLE
test: guard retained operation mirrors

### DIFF
--- a/test/generator-inventory.json
+++ b/test/generator-inventory.json
@@ -40,7 +40,11 @@
       "name": "dsh-operations",
       "command": "node scripts/gen-operations.mjs",
       "inputs": ["integrations/dsh/plugins/powercontext/openapi/powercontext.yaml", "integrations/dsh/plugins/powercontext/scripts/gen-operations.mjs"],
-      "outputs": ["integrations/dsh/plugins/powercontext/src/operations.generated.ts"],
+      "outputs": [
+        "integrations/dsh/plugins/powercontext/src/operations.generated.ts",
+        "integrations/pi/plugins/powercontext/src/operations.generated.ts",
+        "integrations/opencode/plugins/powercontext/src/operations.generated.ts"
+      ],
       "evidence": ["integrations/dsh/plugins/powercontext/tests/gen-check.spec.ts#it('writes and checks a fresh generated table through the public CLI'"]
     }
   ]

--- a/tools/generated-consumers/main_test.go
+++ b/tools/generated-consumers/main_test.go
@@ -17,6 +17,7 @@ package generatedconsumers
 import (
 	"bytes"
 	"encoding/json/v2"
+	"fmt"
 	"io/fs"
 	"os"
 	"os/exec"
@@ -250,6 +251,51 @@ func TestGeneratorInventoryListsCheckedContracts(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestRetainedAdapterOperationMirrorsMatchDSHGeneratorOutput(t *testing.T) {
+	repository := repositoryRoot(t)
+	paths := []string{
+		"integrations/dsh/plugins/powercontext/src/operations.generated.ts",
+		"integrations/pi/plugins/powercontext/src/operations.generated.ts",
+		"integrations/opencode/plugins/powercontext/src/operations.generated.ts",
+	}
+	if err := validateOperationMirrors(repository, paths); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestOperationMirrorValidationRejectsDrift(t *testing.T) {
+	directory := t.TempDir()
+	paths := []string{"dsh.ts", "pi.ts", "opencode.ts"}
+	for _, path := range paths {
+		writeFile(t, filepath.Join(directory, path), "export const OPERATIONS = {}\n")
+	}
+	writeFile(t, filepath.Join(directory, "opencode.ts"), "export const OPERATIONS = { drift: true }\n")
+	if err := validateOperationMirrors(directory, paths); err == nil {
+		t.Fatal("operation mirror drift was accepted")
+	}
+}
+
+func validateOperationMirrors(root string, paths []string) error {
+	if len(paths) < 2 {
+		return fmt.Errorf("operation mirror count = %d, want at least 2", len(paths))
+	}
+	reference, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(paths[0])))
+	if err != nil {
+		return err
+	}
+	reference = bytes.ReplaceAll(reference, []byte("\r\n"), []byte("\n"))
+	for _, path := range paths[1:] {
+		payload, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(path)))
+		if err != nil {
+			return err
+		}
+		if !bytes.Equal(reference, bytes.ReplaceAll(payload, []byte("\r\n"), []byte("\n"))) {
+			return fmt.Errorf("operation mirror %q differs from %q", path, paths[0])
+		}
+	}
+	return nil
 }
 
 func TestOpenAPIGeneratorProducesGoldenBuildableConsumer(t *testing.T) {


### PR DESCRIPTION
## Summary
- bind Pi and OpenCode operation mirrors to the DSH public generator output
- reject normalized source drift with a discriminative mutant test
- record every mirrored TypeScript output in the generator inventory

## Validation
- go test ./tools/generated-consumers -count=1
- go vet ./tools/generated-consumers
- git diff --check

Progresses #3.