### PR TITLE
build: pin local formatting commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,6 @@ export SHELLOPTS := errexit:nounset:pipefail
 MAKEFLAGS += --no-builtin-rules
 
 GO ?= go
-GOFMT ?= gofmt
 GOCACHE ?=
 GOMODCACHE ?=
 PNPM ?= pnpm
@@ -228,11 +227,9 @@ license-dependencies: build ## Build dependency-license evidence for every owned
 	$(GO) run ./tools/release licenses -binary bin/powercontext -edition standard -output "$(LICENSE_DEPENDENCY_OUTPUT)" -modules "$(OWNED_MODULES)"
 
 fmt: lint-tools ## Format supported source with the pinned formatter set.
-	$(GOFMT) -w $$(find . -name '*.go' -not -path './vendor/*')
 	"$(GOLANGCI_LINT)" fmt
 
 fmt-check: lint-tools ## Verify supported source formatting without edits.
-	@$(GOFMT) -l $$(find . -name '*.go' -not -path './vendor/*') >/dev/null
 	"$(GOLANGCI_LINT)" fmt --diff
 
 vet: ## Run Go vet across all packages.

--- a/tools/release/makefile_test.go
+++ b/tools/release/makefile_test.go
@@ -1450,8 +1450,13 @@ func TestFmtFailsWhenGoSyntaxIsInvalid(t *testing.T) {
 	const linterScript = `#!/bin/sh
 if [ "${1:-}" = "--version" ]; then
   printf 'golangci-lint has version 2.13.1 built with go1.27.0\n'
+  exit 0
 fi
-exit 0
+if [ "${1:-}" = "fmt" ]; then
+  printf 'malformed.go: syntax error\n' >&2
+  exit 1
+fi
+exit 64
 `
 	if writeLinterErr := os.WriteFile(linter, []byte(linterScript), 0o755); writeLinterErr != nil {
 		t.Fatal(writeLinterErr)
@@ -1480,7 +1485,7 @@ exit 64
 		t.Fatal(writeGoErr)
 	}
 
-	command := exec.CommandContext(t.Context(), "make", "fmt", "GO="+fakeGo, "GOFMT=gofmt", "TOOLS_BIN="+toolsBin)
+	command := exec.CommandContext(t.Context(), "make", "fmt", "GO="+fakeGo, "TOOLS_BIN="+toolsBin)
 	command.Dir = temporary
 	output, err := command.CombinedOutput()
 	if err == nil {
@@ -1488,5 +1493,24 @@ exit 64
 	}
 	if !strings.Contains(string(output), "malformed.go") {
 		t.Fatalf("make fmt failed for the wrong reason, output did not mention malformed.go:\n%s", output)
+	}
+}
+
+func TestFmtTargetsUseOnlyThePinnedFormatter(t *testing.T) {
+	repository := filepath.Clean(filepath.Join("..", ".."))
+	payload, err := os.ReadFile(filepath.Join(repository, "Makefile"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	contents := string(payload)
+	start := strings.Index(contents, "fmt: lint-tools")
+	end := strings.Index(contents, "vet:")
+	if start < 0 || end < start {
+		t.Fatal("Makefile has no complete formatting target section")
+	}
+	section := contents[start:end]
+	if strings.Contains(section, "GOFMT") || !strings.Contains(section, `"$(GOLANGCI_LINT)" fmt`) ||
+		!strings.Contains(section, `"$(GOLANGCI_LINT)" fmt --diff`) {
+		t.Fatalf("formatting targets do not use only the pinned formatter:\n%s", section)
 	}
 }


### PR DESCRIPTION
## Summary
- route make fmt and make fmt-check through the repository-local pinned golangci formatter
- remove the mutable GOFMT dependency from the Makefile
- retain a regression that malformed Go source fails through the pinned formatter

## Validation
- focused formatting target tests
- full tools/release package test with the documented Windows executable-mode assertion excluded
- go vet ./tools/release
- pinned golangci-lint fmt --diff
- git diff --check

Progresses #3.