### PR TITLE
fix(scheduler): reject stale pickle stack markers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -289,6 +289,10 @@ source / artifact / trigger / inference
   the underlying error matchable and name concrete operator remediation without
   exposing configured values. Verify exit code 2 and that execution never
   reaches the operation runner.
+- When a bytecode parser retains stack markers across later stack mutations,
+  validate every stored marker against the current stack length before slicing
+  or indexing. Verify stale-marker tuple and map operations return the typed
+  parse error, then run the bounded decoder fuzz target without a panic.
 - When a CLI option consumes the following token as a value, reject a missing
   value or another option before any read or write. Verify the real CLI exits
   nonzero with an actionable diagnostic even when an option-named file would

--- a/internal/scheduler/pickle_reader.go
+++ b/internal/scheduler/pickle_reader.go
@@ -165,6 +165,9 @@ func (p *pickleParser) markTuple() error {
 	}
 	mark := p.marks[len(p.marks)-1]
 	p.marks = p.marks[:len(p.marks)-1]
+	if mark > len(p.stack) {
+		return invalidState("Pickle tuple mark is outside the stack")
+	}
 	value := append(pickleTuple(nil), p.stack[mark:]...)
 	p.stack = p.stack[:mark]
 	p.push(value)
@@ -177,7 +180,7 @@ func (p *pickleParser) setItems() error {
 	}
 	mark := p.marks[len(p.marks)-1]
 	p.marks = p.marks[:len(p.marks)-1]
-	if mark < 1 || (len(p.stack)-mark)%2 != 0 {
+	if mark < 1 || mark > len(p.stack) || (len(p.stack)-mark)%2 != 0 {
 		return invalidState("Pickle SETITEMS operands differ")
 	}
 	target, ok := p.stack[mark-1].(map[string]any)

--- a/internal/scheduler/pickle_test.go
+++ b/internal/scheduler/pickle_test.go
@@ -136,3 +136,23 @@ func TestReaderRejectsColumnMismatchAndOversizedBlob(t *testing.T) {
 		t.Fatalf("expected size rejection, got %v", err)
 	}
 }
+
+func TestRestrictedReaderRejectsStaleMarksBeforeSlicingStack(t *testing.T) {
+	t.Parallel()
+	for _, operation := range []struct {
+		name string
+		run  func(*pickleParser) error
+	}{
+		{name: "tuple", run: (*pickleParser).markTuple},
+		{name: "set items", run: (*pickleParser).setItems},
+	} {
+		t.Run(operation.name, func(t *testing.T) {
+			parser := &pickleParser{stack: make([]any, 9), marks: []int{10}}
+			err := operation.run(parser)
+			var invalid *InvalidJobStateError
+			if !errors.As(err, &invalid) {
+				t.Fatalf("stale mark error = %T %v", err, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Tracking

- Tracking issue: #3
- Relationship: `Part of #3`; CI stability prerequisite for WP1 scheduler tracing validation

## Problem and rationale

The restricted APScheduler pickle decoder retained MARK positions across later stack mutations. A stale MARK above the current stack length caused `markTuple` or `setItems` to slice/index out of range. The PR #147 module-integrity fuzz job reproduced this as an unclassified panic.

## Changes

- Reject stale MARK positions before tuple and dictionary construction.
- Add a table-driven regression for both MARK consumers that requires typed `InvalidJobStateError` rather than a panic.
- Add the reusable parser-marker fuzz prevention rule.

## Behavior and compatibility

- User-visible behavior: malformed APScheduler pickle state is rejected safely instead of panicking.
- Public API or protocol impact: none. Valid protocol-4/5 scheduler pickle inputs are unchanged.
- Breaking changes or migration requirements: none.
- Explicit non-goals: no scheduler runtime semantics, tracing, database schema, or WP1 feature behavior changes.

## Generated, dependency, and workflow impact

- [x] No generated contract changed.
- [x] No dependency changed.
- [x] No CI topology changed.
- [x] No sensitive data is included.

## Validation

```text
gofmt -w internal/scheduler/pickle_reader.go internal/scheduler/pickle_test.go
go test ./internal/scheduler -run '^TestRestrictedReaderRejectsStaleMarksBeforeSlicingStack$' -count=1
go vet ./internal/scheduler
go test ./internal/scheduler -run '^$' -fuzz '^FuzzRestrictedPickleJobDecoder$' -fuzztime=5s
```

The bounded local fuzz target completed roughly 2.8M inputs without a panic. Existing frozen APScheduler path tests require Linux path policy and remain required exact-Head CI evidence; they are not represented as passing locally.

- [x] `git diff --check`
- [x] `git status --short` was inspected after validation.
- [x] Formatter evidence is recorded above.
- [x] Generated-consumer checks are not applicable.
- [x] Compatibility evidence is the valid protocol reader suite plus exact-Head CI.
- [x] Fuzz regression proof is recorded above.

## AI usage

AI assistance diagnosed the fuzz panic from the exact GitHub job log, wrote the stale-mark regression, and verified the bounded fuzz target after the minimal parser-boundary repair.