### PR TITLE
build: pin Modern Go Guidelines CLI

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,9 @@ make e2e-test
 `make lint` installs the pinned golangci-lint release under `.tools/bin`. Its embedded gofmt, gofumpt, and goimports
 versions are the formatting authority; no mutable global linter installation is required.
 
+`make modern-go` installs the pinned Modern Go Guidelines CLI under `.tools/bin` and lists the guidelines for the Go
+version declared by the current toolchain. Run it before changing Go code when the agent-provided skill is unavailable.
+
 Run `make coverage` when a change affects executable Go behavior. It uses race-enabled atomic coverage and rejects a
 material regression from the recorded baseline.
 

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,9 @@ LICENSE_EYE_STAMP = $(TOOLS_BIN)/.license-eye-$(LICENSE_EYE_VERSION)-$(PROJECT_G
 ACTIONLINT_VERSION := v1.7.12
 ACTIONLINT := $(TOOLS_BIN)/actionlint$(shell $(GO) env GOEXE)
 ACTIONLINT_STAMP = $(TOOLS_BIN)/.actionlint-$(ACTIONLINT_VERSION)-$(PROJECT_GO_TOOLCHAIN)
+MODERN_GO_VERSION := v0.1.1
+MODERN_GO := $(TOOLS_BIN)/go-modern-guidelines$(shell $(GO) env GOEXE)
+MODERN_GO_STAMP = $(TOOLS_BIN)/.go-modern-guidelines-$(MODERN_GO_VERSION)-$(PROJECT_GO_TOOLCHAIN)
 
 COVERAGE_DIR ?= coverage
 COVERAGE_PROFILE ?= $(COVERAGE_DIR)/coverage.out
@@ -70,7 +73,7 @@ PUBLIC_API_PACKAGES := \
 	$(MODULE_PATH)/source \
 	$(MODULE_PATH)/trigger
 
-.PHONY: help lint-tools lint lint-fix api-compat-tools api-baseline api-compat govulncheck-tools license-eye-tools actionlint-tools actionlint dependency-security generate check-generated module-check module-inventory module-integrity contract-test license-check license-fix license-dependencies fmt fmt-check vet build-all coverage coverage-check governance-check \
+.PHONY: help lint-tools lint lint-fix api-compat-tools api-baseline api-compat govulncheck-tools license-eye-tools actionlint-tools actionlint modern-go-tools modern-go dependency-security generate check-generated module-check module-inventory module-integrity contract-test license-check license-fix license-dependencies fmt fmt-check vet build-all coverage coverage-check governance-check \
 	test unit-test e2e-test test-sqlite race-debt-check race-debt-functional test-race test-full test-oceanbase-live real-provider-test \
 	pi-test docs-sync docs-test docs-build harness-sync harness-check harness-compose-check \
 	harness-compose-acceptance harness-compose-down build build-full smoke smoke-full check \
@@ -168,6 +171,21 @@ actionlint-tools: $(ACTIONLINT_STAMP) ## Install the pinned GitHub Actions workf
 
 actionlint: actionlint-tools ## Lint GitHub Actions workflows with the pinned repository-local tool.
 	"$(ACTIONLINT)"
+
+$(MODERN_GO): Makefile go.mod go.sum
+	@mkdir -p "$(TOOLS_BIN)"
+	GOTOOLCHAIN="$(PROJECT_GO_TOOLCHAIN)+auto" GOBIN="$(TOOLS_BIN)" \
+		$(GO) install github.com/JetBrains/go-modern-guidelines@$(MODERN_GO_VERSION)
+
+$(MODERN_GO_STAMP): $(MODERN_GO)
+	@"$(MODERN_GO)" --version | grep -qx "$(MODERN_GO_VERSION)"
+	@$(RM) $(TOOLS_BIN)/.go-modern-guidelines-*
+	@touch "$@"
+
+modern-go-tools: $(MODERN_GO_STAMP) ## Install the pinned Modern Go Guidelines CLI under .tools/bin.
+
+modern-go: modern-go-tools ## List Modern Go guidelines for the project Go version.
+	"$(MODERN_GO)" list --go-version "$$( $(GO) env GOVERSION | sed 's/^go//' )"
 
 dependency-security: govulncheck-tools ## Scan an unstripped standard Server build for known vulnerabilities.
 	mkdir -p bin

--- a/tools/release/workflow_test.go
+++ b/tools/release/workflow_test.go
@@ -1291,6 +1291,10 @@ func TestMakefilePinsWorkflowGoToolsInTheRepositoryToolDirectory(t *testing.T) {
 		"license-check: license-eye-tools",
 		"license-fix: license-eye-tools",
 		"actionlint: actionlint-tools",
+		"MODERN_GO_VERSION := v0.1.1",
+		"github.com/JetBrains/go-modern-guidelines@$(MODERN_GO_VERSION)",
+		"modern-go-tools:",
+		"modern-go: modern-go-tools",
 	} {
 		if !strings.Contains(contents, required) {
 			t.Errorf("Makefile is missing pinned repository-local tool contract %q", required)


### PR DESCRIPTION
## Summary
- install Modern Go Guidelines v0.1.1 into the repository-local tool directory
- add make modern-go-tools and make modern-go
- document the local command and pin its Makefile contract
- keep the tool advisory rather than adding a release or CI gate

## Validation
- focused release tool-pin contract
- full tools/release package test with the documented Windows executable-mode assertion excluded
- go vet ./tools/release
- pinned golangci-lint fmt --diff
- isolated go install of github.com/JetBrains/go-modern-guidelines@v0.1.1
- git diff --check

Progresses #3.