### PR TITLE
fix(workbuddy): bypass proxy for loopback PowerContext traffic

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -293,11 +293,14 @@ source / artifact / trigger / inference
   value or another option before any read or write. Verify the real CLI exits
   nonzero with an actionable diagnostic even when an option-named file would
   otherwise make the malformed command succeed.
-- When isolated host adapters vendor the same transport policy, drive every
-  configuration and directly constructible client boundary from one shared
-  host-vector fixture. Verify the complete IPv4 `127.0.0.0/8` range, IPv6
-  loopback, remote plaintext rejection, and each explicit trusted-transport
-  exception in the adapter's native test suite.
+- When isolated host adapters vendor the same transport policy or construct
+  proxy-aware HTTP clients, drive every configuration and directly constructible
+  client boundary from one shared host-vector fixture. Bypass environment and OS
+  proxies for loopback routes before bearer credentials can leave the host while
+  preserving configured proxies for non-loopback routes. Verify the complete IPv4
+  `127.0.0.0/8` range, IPv6 loopback, remote plaintext rejection, and each explicit
+  trusted-transport exception, and prove proxy controls after clearing inherited
+  proxy and no-proxy variables case-insensitively.
 - When setup owns a credential-free authorization environment reference, treat
   every syntactically valid generated `${NAME:-}` reference as owned rather
   than only the default name. Verify repeated setup with a custom authorization

--- a/integrations/workbuddy/plugins/powercontext/hooks/workbuddy_powercontext_hook.py
+++ b/integrations/workbuddy/plugins/powercontext/hooks/workbuddy_powercontext_hook.py
@@ -29,7 +29,8 @@ from pathlib import Path
 from time import monotonic
 from typing import TYPE_CHECKING, Any, Protocol, TypeVar, cast
 from urllib.error import HTTPError
-from urllib.request import HTTPRedirectHandler, Request, build_opener
+from urllib.parse import urlsplit
+from urllib.request import HTTPRedirectHandler, ProxyHandler, Request, build_opener
 
 if TYPE_CHECKING:
     from typing_extensions import override
@@ -46,7 +47,12 @@ sys.path.insert(0, str(_PLUGIN_ROOT))
 sys.path.insert(0, str(_HOOKS_ROOT))
 
 import prepared_context as _prepared_context  # noqa: E402
-from workbuddy_settings import WorkBuddyConfigurationError, WorkBuddyPluginSettings, load_settings  # noqa: E402
+from workbuddy_settings import (  # noqa: E402
+    WorkBuddyConfigurationError,
+    WorkBuddyPluginSettings,
+    is_loopback_host,
+    load_settings,
+)
 
 if (_HOOKS_ROOT / "powercontext_project_scope.py").is_file():
     from powercontext_project_scope import resolve_scope_id
@@ -91,7 +97,24 @@ class _RejectRedirects(HTTPRedirectHandler):
         return None
 
 
-_URL_OPENER = build_opener(_RejectRedirects)
+class _LoopbackAwareProxyHandler(ProxyHandler):
+    """Bypass any configured proxy for loopback destinations.
+
+    urllib installs a ProxyHandler in every opener, so a loopback request is
+    routed through an environment or registry proxy whenever no_proxy omits
+    the host. Local PowerContext traffic must never leave the host, and each
+    request carries a bearer credential, so loopback targets are always
+    connected to directly. Remote HTTPS endpoints keep proxy behaviour.
+    """
+
+    @override
+    def proxy_open(self, req: Request, proxy: str, type: str) -> object | None:  # noqa: A002 - urllib API name.
+        if is_loopback_host(urlsplit(req.full_url).hostname or ""):
+            return None
+        return super().proxy_open(req, proxy, type)
+
+
+_URL_OPENER = build_opener(_RejectRedirects, _LoopbackAwareProxyHandler())
 
 
 class _HttpStatusError(RuntimeError):

--- a/integrations/workbuddy/plugins/powercontext/hooks/workbuddy_settings.py
+++ b/integrations/workbuddy/plugins/powercontext/hooks/workbuddy_settings.py
@@ -294,7 +294,7 @@ def _http_base_url(value: str) -> str:
         raise WorkBuddyConfigurationError("PowerContext Server URL must use HTTP or HTTPS")
     if parsed.query or parsed.fragment:
         raise WorkBuddyConfigurationError("PowerContext Server URL must not contain a query or fragment")
-    if parsed.scheme == "http" and not _is_loopback_host(parsed.hostname):
+    if parsed.scheme == "http" and not is_loopback_host(parsed.hostname):
         raise WorkBuddyConfigurationError("unencrypted PowerContext URLs must be loopback addresses")
     path = parsed.path.rstrip("/")
     if path.endswith("/mcp"):
@@ -302,7 +302,7 @@ def _http_base_url(value: str) -> str:
     return urlunsplit((parsed.scheme, parsed.netloc, path, "", "")).rstrip("/")
 
 
-def _is_loopback_host(value: str) -> bool:
+def is_loopback_host(value: str) -> bool:
     host = value.lower()
     if host in _LOOPBACK_HOSTS:
         return True
@@ -312,4 +312,4 @@ def _is_loopback_host(value: str) -> bool:
         return False
 
 
-__all__ = ["WorkBuddyConfigurationError", "WorkBuddyPluginSettings", "load_settings"]
+__all__ = ["WorkBuddyConfigurationError", "WorkBuddyPluginSettings", "is_loopback_host", "load_settings"]

--- a/integrations/workbuddy/tests/test_configuration_contract.py
+++ b/integrations/workbuddy/tests/test_configuration_contract.py
@@ -24,6 +24,10 @@ import pytest
 
 
 PLUGIN_ROOT = Path(__file__).resolve().parents[1] / "plugins" / "powercontext"
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+_TRANSPORT_VECTORS = json.loads(
+    (REPOSITORY_ROOT / "test" / "transport" / "testdata" / "loopback_hosts.json").read_text(encoding="utf-8")
+)
 
 
 def load_settings_module() -> ModuleType:
@@ -62,22 +66,34 @@ def test_config_declares_bounded_request_limits(tmp_path: Path) -> None:
     assert settings.source_max_bytes == 16384
 
 
-def test_config_accepts_the_ipv4_loopback_range(tmp_path: Path) -> None:
+@pytest.mark.parametrize("host", _TRANSPORT_VECTORS["loopback"])
+def test_config_accepts_shared_loopback_hosts(tmp_path: Path, host: str) -> None:
     settings_module = load_settings_module()
     payload = configuration()
-    payload["server_url"] = "http://127.2.3.4:8000/"
+    payload["server_url"] = f"http://{host}:8000/"
     configuration_path = tmp_path / "powercontext.json"
     configuration_path.write_text(json.dumps(payload), encoding="utf-8")
 
     settings = settings_module.load_settings(configuration_path)
 
-    assert settings.server_url == "http://127.2.3.4:8000"
+    assert settings.server_url == f"http://{host}:8000"
+
+
+@pytest.mark.parametrize("host", _TRANSPORT_VECTORS["non_loopback"])
+def test_config_rejects_shared_non_loopback_plaintext_hosts(tmp_path: Path, host: str) -> None:
+    settings_module = load_settings_module()
+    payload = configuration()
+    payload["server_url"] = f"http://{host}:8000"
+    configuration_path = tmp_path / "powercontext.json"
+    configuration_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(settings_module.WorkBuddyConfigurationError, match="loopback"):
+        settings_module.load_settings(configuration_path)
 
 
 @pytest.mark.parametrize(
     ("changes", "expected_message"),
     [
-        ({"server_url": "http://198.51.100.4:8000"}, "loopback"),
         ({"request_timeout_seconds": 0}, "timeout"),
         ({"request_timeout_seconds": 4.0}, "budget"),
         ({"prepare_max_bytes": 0}, "prepare"),

--- a/integrations/workbuddy/tests/test_service_chain.py
+++ b/integrations/workbuddy/tests/test_service_chain.py
@@ -18,7 +18,9 @@ import importlib.util
 import io
 import json
 import os
+import subprocess
 import sys
+import textwrap
 import threading
 from collections.abc import Iterator
 from contextlib import contextmanager
@@ -26,9 +28,82 @@ from hashlib import sha256
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from types import ModuleType
+from urllib.request import Request, proxy_bypass
 
 
 PLUGIN_ROOT = Path(__file__).resolve().parents[1] / "plugins" / "powercontext"
+_DEAD_PROXY = "http://127.0.0.1:9"
+_REMOTE_SERVER_URL = "https://powercontext.example.invalid"
+_PROXY_ENVIRONMENT_NAMES = frozenset({"http_proxy", "https_proxy", "ftp_proxy", "all_proxy", "no_proxy"})
+
+# ``_URL_OPENER`` is built once at import time and ``ProxyHandler`` reads the
+# proxy configuration while it is constructed, so the proxy environment has to
+# exist before the hook module is imported. Reloading the module inside the
+# current process cannot undo the handler that was already installed, therefore
+# every proxy regression test runs the hook entry point in a fresh interpreter.
+_PROXY_CHILD = textwrap.dedent(
+    '''
+    import importlib.util
+    import io
+    import json
+    import sys
+
+    tests_path, server_url, cwd = sys.argv[1:4]
+
+    def _load(path, name):
+        spec = importlib.util.spec_from_file_location(name, path)
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[name] = module
+        spec.loader.exec_module(module)
+        return module
+
+    tests = _load(tests_path, "powercontext_workbuddy_proxy_child")
+    hook = tests.load_hook_module()
+
+    settings = hook.WorkBuddyPluginSettings(
+        server_url=server_url,
+        scope_mode="project",
+        authorization_environment="WORKBUDDY_TOKEN",
+        authorization="Bearer workbuddy-runtime-token",
+        request_timeout_seconds=1.0,
+        request_budget_seconds=2.0,
+        prepare_max_bytes=64,
+        source_max_bytes=128,
+    )
+    payload = {"hook_event_name": "UserPromptSubmit", "cwd": cwd, "prompt": "Which policy applies?", "session_id": "session-1"}
+    real_stdout = sys.stdout
+    captured = io.StringIO()
+    sys.stdin = io.StringIO(json.dumps(payload))
+    sys.stdout = captured
+    exit_code = hook.main(settings)
+    sys.stdout = real_stdout
+    print("HOOK-EXIT", exit_code)
+    print("HOOK-STDOUT", captured.getvalue().strip())
+    '''
+)
+
+# The control probe proves that the injected proxy environment really intercepts
+# loopback traffic, so a passing hook run cannot be explained by a proxy that
+# never took effect.
+_CONTROL_CHILD = textwrap.dedent(
+    '''
+    import sys
+    from urllib.request import Request, build_opener
+
+    server_url = sys.argv[1]
+    request = Request(
+        server_url + "/v1/context/prepare",
+        data=b"{}",
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with build_opener().open(request, timeout=5) as response:
+            print("CONTROL-RESULT", "HTTP", response.status)
+    except Exception as error:
+        print("CONTROL-RESULT", type(error).__name__)
+    '''
+)
 
 
 def load_hook_module() -> ModuleType:
@@ -244,3 +319,104 @@ def test_hook_rejects_invalid_persisted_configuration_instead_of_falling_back_to
 
     assert hook.main() == 0
     assert stdout.getvalue() == ""
+
+
+def _run_proxy_child(script: str, *arguments: str) -> subprocess.CompletedProcess[str]:
+    """Run a child interpreter with a proxy environment that must not intercept loopback traffic."""
+    environment = dict(os.environ)
+    for name in _PROXY_ENVIRONMENT_NAMES:
+        environment.pop(name, None)
+    environment["http_proxy"] = _DEAD_PROXY
+    environment["https_proxy"] = _DEAD_PROXY
+    return subprocess.run(
+        [sys.executable, "-c", script, *arguments],
+        capture_output=True,
+        text=True,
+        env=environment,
+        cwd=PLUGIN_ROOT.parent.parent,
+        timeout=30,
+    )
+
+
+def test_proxy_environment_does_not_redirect_loopback_hook_traffic(tmp_path: Path) -> None:
+    """A configured proxy must never receive loopback PowerContext requests or the bearer credential."""
+    received: list[tuple[str, dict[str, str], dict[str, object]]] = []
+
+    class ProxyAwareService(BaseHTTPRequestHandler):
+        def do_POST(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler API.
+            content_length = int(self.headers["Content-Length"])
+            request = json.loads(self.rfile.read(content_length))
+            received.append((self.path, dict(self.headers), request))
+            if self.path == "/v1/context/prepare":
+                self._respond(200, {"schema": "powercontext.prepared-context.v1", "status": "ready", "content": "Use approved policy.", "content_bytes": 20})
+                return
+            if self.path == "/v1/sources/content":
+                self._respond(201, {"position": 3})
+                return
+            self._respond(404, {})
+
+        def log_message(self, _format: str, *_arguments: object) -> None:
+            return
+
+        def _respond(self, status: int, payload: dict[str, object]) -> None:
+            encoded = json.dumps(payload).encode("utf-8")
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(encoded)))
+            self.end_headers()
+            self.wfile.write(encoded)
+
+    with serve(ProxyAwareService) as server_url:
+        result = _run_proxy_child(_PROXY_CHILD, __file__, server_url, str(tmp_path))
+
+    assert result.returncode == 0, result.stderr
+    assert "HOOK-EXIT 0" in result.stdout, result.stdout
+    assert "Use approved policy." in result.stdout, result.stdout
+    assert "workbuddy-runtime-token" not in result.stdout, "hook output must not leak the bearer credential"
+    assert received, "the hook never reached the local service"
+    assert received[0][0] == "/v1/context/prepare"
+    assert received[0][1]["Authorization"] == "Bearer workbuddy-runtime-token"
+    assert received[1][0] == "/v1/sources/content"
+
+
+def test_control_probe_proves_proxy_environment_intercepts_loopback_traffic() -> None:
+    """The default urllib opener must fail through the dead proxy, proving the proxy really took effect."""
+
+    class NoopService(BaseHTTPRequestHandler):
+        def do_POST(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler API.
+            self.send_response(200)
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+
+        def log_message(self, _format: str, *_arguments: object) -> None:
+            return
+
+    with serve(NoopService) as server_url:
+        result = _run_proxy_child(_CONTROL_CHILD, server_url)
+
+    assert result.returncode == 0, result.stderr
+    assert "CONTROL-RESULT URLError" in result.stdout, result.stdout
+
+
+def test_loopback_aware_proxy_handler_preserves_remote_proxy_behaviour(monkeypatch) -> None:
+    """Loopback destinations bypass the proxy; remote destinations keep proxy behaviour."""
+    monkeypatch.setattr("urllib.request.proxy_bypass", lambda host: False)
+    hook = load_hook_module()
+    handler = hook._LoopbackAwareProxyHandler()
+
+    # Remote HTTPS keeps proxy behaviour: proxy_open rewrites the request into a
+    # CONNECT tunnel through the proxy instead of forcing a direct connection.
+    remote = Request(_REMOTE_SERVER_URL + "/v1/context/prepare", data=b"{}", method="POST")
+    handler.proxy_open(remote, _DEAD_PROXY, "https")
+    assert remote.host == "127.0.0.1:9", "remote HTTPS request must be routed through the proxy"
+    assert remote._tunnel_host == "powercontext.example.invalid", "original host must enter the tunnel"
+
+    # Remote HTTP keeps proxy behaviour as well.
+    http_remote = Request("http://example.invalid/v1/context/prepare", data=b"{}", method="POST")
+    handler.proxy_open(http_remote, _DEAD_PROXY, "http")
+    assert http_remote.host == "127.0.0.1:9", "remote HTTP request must be routed through the proxy"
+
+    # Loopback destinations bypass the proxy entirely: no rewrite happens.
+    loopback = Request("http://127.0.0.1:8000/v1/context/prepare", data=b"{}", method="POST")
+    assert handler.proxy_open(loopback, _DEAD_PROXY, "http") is None
+    assert loopback.host == "127.0.0.1:8000", "loopback request must keep its direct destination"

--- a/integrations/workbuddy/tests/test_service_chain.py
+++ b/integrations/workbuddy/tests/test_service_chain.py
@@ -28,12 +28,17 @@ from hashlib import sha256
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from types import ModuleType
-from urllib.request import Request, proxy_bypass
+from urllib.request import Request
+
+import pytest
 
 
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
 PLUGIN_ROOT = Path(__file__).resolve().parents[1] / "plugins" / "powercontext"
+_TRANSPORT_VECTORS = json.loads(
+    (REPOSITORY_ROOT / "test" / "transport" / "testdata" / "loopback_hosts.json").read_text(encoding="utf-8")
+)
 _DEAD_PROXY = "http://127.0.0.1:9"
-_REMOTE_SERVER_URL = "https://powercontext.example.invalid"
 _PROXY_ENVIRONMENT_NAMES = frozenset({"http_proxy", "https_proxy", "ftp_proxy", "all_proxy", "no_proxy"})
 
 # ``_URL_OPENER`` is built once at import time and ``ProxyHandler`` reads the
@@ -322,10 +327,11 @@ def test_hook_rejects_invalid_persisted_configuration_instead_of_falling_back_to
 
 
 def _run_proxy_child(script: str, *arguments: str) -> subprocess.CompletedProcess[str]:
-    """Run a child interpreter with a proxy environment that must not intercept loopback traffic."""
+    """Run a child interpreter under an isolated dead-proxy environment."""
     environment = dict(os.environ)
-    for name in _PROXY_ENVIRONMENT_NAMES:
-        environment.pop(name, None)
+    for name in tuple(environment):
+        if name.lower() in _PROXY_ENVIRONMENT_NAMES:
+            environment.pop(name)
     environment["http_proxy"] = _DEAD_PROXY
     environment["https_proxy"] = _DEAD_PROXY
     return subprocess.run(
@@ -379,8 +385,11 @@ def test_proxy_environment_does_not_redirect_loopback_hook_traffic(tmp_path: Pat
     assert received[1][0] == "/v1/sources/content"
 
 
-def test_control_probe_proves_proxy_environment_intercepts_loopback_traffic() -> None:
+def test_control_probe_intercepts_loopback_when_parent_bypasses_all_hosts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """The default urllib opener must fail through the dead proxy, proving the proxy really took effect."""
+    monkeypatch.setenv("NO_PROXY", "*")
 
     class NoopService(BaseHTTPRequestHandler):
         def do_POST(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler API.
@@ -398,25 +407,38 @@ def test_control_probe_proves_proxy_environment_intercepts_loopback_traffic() ->
     assert "CONTROL-RESULT URLError" in result.stdout, result.stdout
 
 
-def test_loopback_aware_proxy_handler_preserves_remote_proxy_behaviour(monkeypatch) -> None:
-    """Loopback destinations bypass the proxy; remote destinations keep proxy behaviour."""
+@pytest.mark.parametrize("host", _TRANSPORT_VECTORS["loopback"])
+def test_loopback_aware_proxy_handler_bypasses_shared_loopback_hosts(
+    monkeypatch: pytest.MonkeyPatch,
+    host: str,
+) -> None:
+    """Every shared loopback authority must connect directly without request rewriting."""
     monkeypatch.setattr("urllib.request.proxy_bypass", lambda host: False)
     hook = load_hook_module()
     handler = hook._LoopbackAwareProxyHandler()
 
-    # Remote HTTPS keeps proxy behaviour: proxy_open rewrites the request into a
-    # CONNECT tunnel through the proxy instead of forcing a direct connection.
-    remote = Request(_REMOTE_SERVER_URL + "/v1/context/prepare", data=b"{}", method="POST")
-    handler.proxy_open(remote, _DEAD_PROXY, "https")
-    assert remote.host == "127.0.0.1:9", "remote HTTPS request must be routed through the proxy"
-    assert remote._tunnel_host == "powercontext.example.invalid", "original host must enter the tunnel"
-
-    # Remote HTTP keeps proxy behaviour as well.
-    http_remote = Request("http://example.invalid/v1/context/prepare", data=b"{}", method="POST")
-    handler.proxy_open(http_remote, _DEAD_PROXY, "http")
-    assert http_remote.host == "127.0.0.1:9", "remote HTTP request must be routed through the proxy"
-
-    # Loopback destinations bypass the proxy entirely: no rewrite happens.
-    loopback = Request("http://127.0.0.1:8000/v1/context/prepare", data=b"{}", method="POST")
+    loopback = Request(f"http://{host}:8000/v1/context/prepare", data=b"{}", method="POST")
+    direct_host = loopback.host
     assert handler.proxy_open(loopback, _DEAD_PROXY, "http") is None
-    assert loopback.host == "127.0.0.1:8000", "loopback request must keep its direct destination"
+    assert loopback.host == direct_host, "loopback request must keep its direct destination"
+
+
+@pytest.mark.parametrize("host", _TRANSPORT_VECTORS["non_loopback"])
+@pytest.mark.parametrize("scheme", ("http", "https"))
+def test_loopback_aware_proxy_handler_preserves_remote_proxy_behaviour(
+    monkeypatch: pytest.MonkeyPatch,
+    host: str,
+    scheme: str,
+) -> None:
+    """Every shared non-loopback authority must retain configured proxy routing."""
+    monkeypatch.setattr("urllib.request.proxy_bypass", lambda host: False)
+    hook = load_hook_module()
+    handler = hook._LoopbackAwareProxyHandler()
+
+    remote = Request(f"{scheme}://{host}:8000/v1/context/prepare", data=b"{}", method="POST")
+    original_host = remote.host
+    handler.proxy_open(remote, _DEAD_PROXY, scheme)
+
+    assert remote.host == "127.0.0.1:9", "remote request must be routed through the proxy"
+    if scheme == "https":
+        assert remote._tunnel_host == original_host, "remote HTTPS request must tunnel to its original destination"


### PR DESCRIPTION
## Summary

Fixes the loopback proxy defect found while diagnosing [#144](https://github.com/ob-labs/powercontext-go/issues/144). This PR is part of #144 acceptance work and does **not** close that Issue; native WorkBuddy Hook and MCP service-chain acceptance remains separate.

`urllib.request.build_opener()` installs a `ProxyHandler` by default, which inherits environment and Windows registry proxy settings. When a proxy is configured and `no_proxy` omits the host, loopback HTTP requests can be routed through the proxy. Every PowerContext Hook request may carry an `Authorization: Bearer` credential, so loopback traffic must connect directly before that credential can leave the host.

## Changes

- `integrations/workbuddy/plugins/powercontext/hooks/workbuddy_settings.py`
  - expose `is_loopback_host` for the transport boundary while preserving the existing configuration policy;
- `integrations/workbuddy/plugins/powercontext/hooks/workbuddy_powercontext_hook.py`
  - install `_LoopbackAwareProxyHandler`;
  - bypass environment and OS proxies for every shared loopback authority;
  - preserve configured proxy routing and the original CONNECT tunnel destination for non-loopback HTTP/HTTPS;
- `integrations/workbuddy/tests/test_configuration_contract.py`
  - drive WorkBuddy configuration from the shared loopback/non-loopback host vectors;
- `integrations/workbuddy/tests/test_service_chain.py`
  - prove the real Hook reaches a local service under a forced proxy environment;
  - keep the control probe effective even when the parent process inherits uppercase `NO_PROXY=*`;
  - clear inherited proxy and no-proxy variables case-insensitively;
  - cover loopback bypass and remote proxy/CONNECT preservation across the shared host vectors;
- `AGENTS.md`
  - strengthen the existing host-adapter transport rule with proxy-routing and hermetic-control requirements.

## Observable impact and compatibility

- A WorkBuddy Hook configured for a loopback PowerContext Server now connects directly even when environment or Windows registry proxy settings would otherwise intercept it.
- Remote HTTP/HTTPS destinations retain their configured proxy behaviour; HTTPS retains its original CONNECT tunnel target.
- No Go API, OpenAPI operation, persistence format, Go module dependency, generated artifact, workflow, or release package contract changes.
- The Go Server and Go SDK do not gain a Python runtime dependency; only the existing optional WorkBuddy Python Hook is affected.

## Security

The change prevents loopback PowerContext requests and their Bearer authorization from being routed to a configured proxy. Tests use synthetic credentials only, assert that the credential reaches the intended local service, and assert that it is not emitted in Hook output.

## Non-goals

- No Go Server or Go Client transport rewrite.
- No WorkBuddy Hook migration from Python to Go.
- No weakening of plaintext non-loopback policy or authentication.
- The same urllib defect in Claude Code, Codex, Bub, and Hermes is handled separately by [#155](https://github.com/ob-labs/powercontext-go/pull/155).

## Verification

Exact submitted Head: `5b1ec74afa788dfd380a1f1ce4babccfc4994461`

Regression proof:

```text
pre-fix with inherited NO_PROXY=*:
CONTROL-RESULT HTTP 200
1 failed

post-fix:
CONTROL-RESULT URLError
1 passed
```

Commands run against the submitted Head:

```text
uv run --python 3.14 --with pytest pytest integrations/workbuddy/tests -q
49 passed in 5.76s

uv run --python 3.12 --with pytest pytest integrations/workbuddy/tests/test_configuration_contract.py integrations/workbuddy/tests/test_service_chain.py -k 'loopback_aware_proxy_handler or control_probe or config_' -q
39 passed, 5 deselected in 2.92s

uv run --python 3.13 --with pytest pytest integrations/workbuddy/tests/test_configuration_contract.py integrations/workbuddy/tests/test_service_chain.py -k 'loopback_aware_proxy_handler or control_probe or config_' -q
39 passed, 5 deselected in 3.04s

uv run --python 3.14 python -m compileall -q integrations/workbuddy/plugins integrations/workbuddy/tests
git diff --check origin/main...HEAD
```

The downloaded Windows Python 3.12/3.13 executables can bind a local listener on this host but time out connecting to their own `127.0.0.1` listener; an independent socket probe reproduced that environmental restriction. Therefore their real loopback service-chain cases are left to the exact-Head Linux Python 3.12 `Host adapters` CI job. A focused `go test ./internal/cli -run WorkBuddy -count=1` is also locally blocked by the existing Windows `sqlite3.h` toolchain gap; no Go code changed in this PR.

## AI assistance disclosure

Codex assisted with the exact-Head review, regression analysis, test hardening, and patch preparation. Verification used the explicit commands and outputs above, an independent read-only review of the final diff, and the repository's normal exact-Head CI before merge.