### PR TITLE
fix(adapters): bypass proxy for loopback PowerContext traffic

### DIFF
--- a/integrations/bub/src/powercontext_bub/client.py
+++ b/integrations/bub/src/powercontext_bub/client.py
@@ -24,7 +24,7 @@ from time import monotonic
 from typing import Any, Protocol, cast
 from urllib.error import HTTPError, URLError
 from urllib.parse import urlsplit, urlunsplit
-from urllib.request import HTTPRedirectHandler, Request, build_opener
+from urllib.request import HTTPRedirectHandler, ProxyHandler, Request, build_opener
 
 MAX_RESPONSE_BYTES = 1_048_576
 _READ_CHUNK_BYTES = 65_536
@@ -74,7 +74,23 @@ class _RejectRedirects(HTTPRedirectHandler):
         return None
 
 
-_URL_OPENER = build_opener(_RejectRedirects)
+class _LoopbackAwareProxyHandler(ProxyHandler):
+    """Bypass any configured proxy for loopback destinations.
+
+    urllib installs a ProxyHandler in every opener, so a loopback request is
+    routed through an environment or registry proxy whenever no_proxy omits
+    the host. Local PowerContext traffic must never leave the host, and each
+    request carries a bearer credential, so loopback targets are always
+    connected to directly. Remote HTTPS endpoints keep proxy behaviour.
+    """
+
+    def proxy_open(self, req: Request, proxy: str, type: str) -> object | None:  # noqa: A002 - urllib API name.
+        if _is_loopback_host(urlsplit(req.full_url).hostname or ""):
+            return None
+        return super().proxy_open(req, proxy, type)
+
+
+_URL_OPENER = build_opener(_RejectRedirects, _LoopbackAwareProxyHandler())
 
 
 class PowerContextHTTPClient:

--- a/integrations/bub/tests/test_client.py
+++ b/integrations/bub/tests/test_client.py
@@ -198,5 +198,36 @@ class ValidationTests(unittest.TestCase):
         self.assertFalse(math.isfinite(float("nan")))
 
 
+class ProxyHandlerTests(unittest.TestCase):
+    """The loopback-aware proxy handler must never route local traffic through a proxy."""
+
+    def setUp(self) -> None:
+        self.handler = client._LoopbackAwareProxyHandler()
+
+    def test_shared_loopback_destinations_connect_directly(self) -> None:
+        for host in _TRANSPORT_VECTORS["loopback"]:
+            with self.subTest(host=host):
+                request = client.Request(f"http://{host}:8000/v1/context/prepare", data=b"{}", method="POST")
+                direct_host = request.host
+                self.assertIsNone(self.handler.proxy_open(request, "http://127.0.0.1:9", "http"))
+                self.assertEqual(request.host, direct_host)
+
+    def test_shared_non_loopback_destinations_keep_proxy_behaviour(self) -> None:
+        with mock.patch("urllib.request.proxy_bypass", return_value=False):
+            for scheme in ("http", "https"):
+                for host in _TRANSPORT_VECTORS["non_loopback"]:
+                    with self.subTest(scheme=scheme, host=host):
+                        request = client.Request(
+                            f"{scheme}://{host}:8000/v1/context/prepare",
+                            data=b"{}",
+                            method="POST",
+                        )
+                        original_host = request.host
+                        self.handler.proxy_open(request, "http://127.0.0.1:9", scheme)
+                        self.assertEqual(request.host, "127.0.0.1:9")
+                        if scheme == "https":
+                            self.assertEqual(request._tunnel_host, original_host)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/integrations/claude-code/plugins/powercontext/hooks/user_prompt_submit.py
+++ b/integrations/claude-code/plugins/powercontext/hooks/user_prompt_submit.py
@@ -26,7 +26,8 @@ from pathlib import Path
 from time import monotonic
 from typing import TYPE_CHECKING, Any, Protocol, TypeVar, cast
 from urllib.error import HTTPError
-from urllib.request import HTTPRedirectHandler, Request, build_opener
+from urllib.parse import urlsplit
+from urllib.request import HTTPRedirectHandler, ProxyHandler, Request, build_opener
 
 if TYPE_CHECKING:
     from typing_extensions import override
@@ -40,7 +41,7 @@ else:
 _PLUGIN_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(_PLUGIN_ROOT))
 
-from claude_code_settings import ClaudeCodePluginSettings  # noqa: E402
+from claude_code_settings import ClaudeCodePluginSettings, _is_loopback_host  # noqa: E402
 from hooks import prepared_context as _prepared_context  # noqa: E402
 from scripts.project_scope import resolve_scope_id  # noqa: E402
 
@@ -84,7 +85,24 @@ class _RejectRedirects(HTTPRedirectHandler):
         return None
 
 
-_URL_OPENER = build_opener(_RejectRedirects)
+class _LoopbackAwareProxyHandler(ProxyHandler):
+    """Bypass any configured proxy for loopback destinations.
+
+    urllib installs a ProxyHandler in every opener, so a loopback request is
+    routed through an environment or registry proxy whenever no_proxy omits
+    the host. Local PowerContext traffic must never leave the host, and each
+    request carries a bearer credential, so loopback targets are always
+    connected to directly. Remote HTTPS endpoints keep proxy behaviour.
+    """
+
+    @override
+    def proxy_open(self, req: Request, proxy: str, type: str) -> object | None:  # noqa: A002 - urllib API name.
+        if _is_loopback_host(urlsplit(req.full_url).hostname or ""):
+            return None
+        return super().proxy_open(req, proxy, type)
+
+
+_URL_OPENER = build_opener(_RejectRedirects, _LoopbackAwareProxyHandler())
 
 
 class _HttpStatusError(RuntimeError):

--- a/integrations/claude-code/tests/test_hook.py
+++ b/integrations/claude-code/tests/test_hook.py
@@ -22,10 +22,16 @@ import time
 from collections.abc import Iterator
 from contextlib import contextmanager
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
 from types import ModuleType
 from typing import Any
 
 import pytest
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+_TRANSPORT_VECTORS = json.loads(
+    (REPOSITORY_ROOT / "test" / "transport" / "testdata" / "loopback_hosts.json").read_text(encoding="utf-8")
+)
 
 
 @contextmanager
@@ -550,3 +556,35 @@ def test_hook_rejects_an_oversized_response_body(hook_module: ModuleType) -> Non
             OversizedResponse(),
             deadline=time.monotonic() + 2,
         )
+
+
+@pytest.mark.parametrize("host", _TRANSPORT_VECTORS["loopback"])
+def test_proxy_handler_bypasses_shared_loopback_hosts(hook_module: ModuleType, host: str) -> None:
+    handler = hook_module._LoopbackAwareProxyHandler()
+    dead_proxy = "http://127.0.0.1:9"
+
+    loopback = hook_module.Request(f"http://{host}:8000/v1/context/prepare", data=b"{}", method="POST")
+    direct_host = loopback.host
+    assert handler.proxy_open(loopback, dead_proxy, "http") is None
+    assert loopback.host == direct_host
+
+
+@pytest.mark.parametrize("host", _TRANSPORT_VECTORS["non_loopback"])
+@pytest.mark.parametrize("scheme", ("http", "https"))
+def test_proxy_handler_preserves_remote_proxy_for_shared_non_loopback_hosts(
+    hook_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    host: str,
+    scheme: str,
+) -> None:
+    monkeypatch.setattr("urllib.request.proxy_bypass", lambda _host: False)
+    handler = hook_module._LoopbackAwareProxyHandler()
+    dead_proxy = "http://127.0.0.1:9"
+
+    remote = hook_module.Request(f"{scheme}://{host}:8000/v1/context/prepare", data=b"{}", method="POST")
+    original_host = remote.host
+    handler.proxy_open(remote, dead_proxy, scheme)
+
+    assert remote.host == "127.0.0.1:9"
+    if scheme == "https":
+        assert remote._tunnel_host == original_host

--- a/integrations/codex/plugins/powercontext/hooks/recall.py
+++ b/integrations/codex/plugins/powercontext/hooks/recall.py
@@ -28,7 +28,8 @@ from pathlib import Path
 from time import monotonic
 from typing import Any, Protocol, cast
 from urllib.error import HTTPError
-from urllib.request import HTTPRedirectHandler, Request, build_opener
+from urllib.parse import urlsplit
+from urllib.request import HTTPRedirectHandler, ProxyHandler, Request, build_opener
 
 from typing_extensions import override
 
@@ -37,7 +38,7 @@ sys.path.insert(0, str(_PLUGIN_ROOT))
 
 from hooks import prepared_context as _prepared_context  # noqa: E402
 from scripts.project_scope import resolve_scope_id  # noqa: E402
-from settings import CodexPluginSettings  # noqa: E402
+from settings import CodexPluginSettings, _is_loopback_host  # noqa: E402
 
 _MAX_CONTEXT_BYTES = _prepared_context.MAX_CONTEXT_BYTES
 _InvalidResponseError = _prepared_context.InvalidPreparedContextResponse
@@ -79,7 +80,24 @@ class _RejectRedirects(HTTPRedirectHandler):
         return None
 
 
-_URL_OPENER = build_opener(_RejectRedirects)
+class _LoopbackAwareProxyHandler(ProxyHandler):
+    """Bypass any configured proxy for loopback destinations.
+
+    urllib installs a ProxyHandler in every opener, so a loopback request is
+    routed through an environment or registry proxy whenever no_proxy omits
+    the host. Local PowerContext traffic must never leave the host, and each
+    request carries a bearer credential, so loopback targets are always
+    connected to directly. Remote HTTPS endpoints keep proxy behaviour.
+    """
+
+    @override
+    def proxy_open(self, req: Request, proxy: str, type: str) -> object | None:  # noqa: A002 - urllib API name.
+        if _is_loopback_host(urlsplit(req.full_url).hostname or ""):
+            return None
+        return super().proxy_open(req, proxy, type)
+
+
+_URL_OPENER = build_opener(_RejectRedirects, _LoopbackAwareProxyHandler())
 
 
 class _HttpStatusError(RuntimeError):

--- a/integrations/codex/tests/test_recall.py
+++ b/integrations/codex/tests/test_recall.py
@@ -30,6 +30,11 @@ from typing import Any
 
 import pytest
 
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+_TRANSPORT_VECTORS = json.loads(
+    (REPOSITORY_ROOT / "test" / "transport" / "testdata" / "loopback_hosts.json").read_text(encoding="utf-8")
+)
+
 
 @contextmanager
 def _serve(handler: type[BaseHTTPRequestHandler]) -> Iterator[str]:
@@ -699,3 +704,35 @@ def test_prompt_capture_can_be_disabled(
     monkeypatch.setenv("POWERCONTEXT_CODEX_CAPTURE_PROMPTS", "false")
 
     assert recall_module.CodexPluginSettings().capture_prompts is False
+
+
+@pytest.mark.parametrize("host", _TRANSPORT_VECTORS["loopback"])
+def test_proxy_handler_bypasses_shared_loopback_hosts(recall_module: ModuleType, host: str) -> None:
+    handler = recall_module._LoopbackAwareProxyHandler()
+    dead_proxy = "http://127.0.0.1:9"
+
+    loopback = recall_module.Request(f"http://{host}:8000/v1/context/prepare", data=b"{}", method="POST")
+    direct_host = loopback.host
+    assert handler.proxy_open(loopback, dead_proxy, "http") is None
+    assert loopback.host == direct_host
+
+
+@pytest.mark.parametrize("host", _TRANSPORT_VECTORS["non_loopback"])
+@pytest.mark.parametrize("scheme", ("http", "https"))
+def test_proxy_handler_preserves_remote_proxy_for_shared_non_loopback_hosts(
+    recall_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    host: str,
+    scheme: str,
+) -> None:
+    monkeypatch.setattr("urllib.request.proxy_bypass", lambda _host: False)
+    handler = recall_module._LoopbackAwareProxyHandler()
+    dead_proxy = "http://127.0.0.1:9"
+
+    remote = recall_module.Request(f"{scheme}://{host}:8000/v1/context/prepare", data=b"{}", method="POST")
+    original_host = remote.host
+    handler.proxy_open(remote, dead_proxy, scheme)
+
+    assert remote.host == "127.0.0.1:9"
+    if scheme == "https":
+        assert remote._tunnel_host == original_host

--- a/integrations/hermes/plugins/powercontext/client.py
+++ b/integrations/hermes/plugins/powercontext/client.py
@@ -23,7 +23,7 @@ from http.client import HTTPResponse
 from typing import TYPE_CHECKING, Any, TypeVar
 from urllib.error import HTTPError, URLError
 from urllib.parse import urlsplit, urlunsplit
-from urllib.request import HTTPRedirectHandler, Request, build_opener
+from urllib.request import HTTPRedirectHandler, ProxyHandler, Request, build_opener
 
 if TYPE_CHECKING:
     from typing_extensions import override
@@ -57,6 +57,23 @@ class _NoRedirectHandler(HTTPRedirectHandler):
     @override
     def redirect_request(self, req: Request, fp: Any, code: int, msg: str, headers: Any, newurl: str) -> Request | None:
         return None
+
+
+class _LoopbackAwareProxyHandler(ProxyHandler):
+    """Bypass any configured proxy for loopback destinations.
+
+    urllib installs a ProxyHandler in every opener, so a loopback request is
+    routed through an environment or registry proxy whenever no_proxy omits
+    the host. Local PowerContext traffic must never leave the host, and each
+    request carries a bearer credential, so loopback targets are always
+    connected to directly. Remote HTTPS endpoints keep proxy behaviour.
+    """
+
+    @override
+    def proxy_open(self, req: Request, proxy: str, type: str) -> object | None:  # noqa: A002 - urllib API name.
+        if _is_loopback_host(urlsplit(req.full_url).hostname or ""):
+            return None
+        return super().proxy_open(req, proxy, type)
 
 
 Transport = Callable[[Request, float], HTTPResponse]
@@ -97,7 +114,7 @@ class PowerContextClient:
         self.base_url = _http_base_url(base_url)
         self.authorization = authorization.strip() if authorization else None
         self.timeout = timeout
-        self._opener = build_opener(_NoRedirectHandler())
+        self._opener = build_opener(_NoRedirectHandler(), _LoopbackAwareProxyHandler())
         self._transport = transport
 
     def _request(  # noqa: C901

--- a/integrations/hermes/tests/test_provider.py
+++ b/integrations/hermes/tests/test_provider.py
@@ -615,3 +615,43 @@ def test_cli_registers_provider_commands(hermes_modules):
     assert args.query == "deployment"
     assert args.limit == 3
     assert callable(args.func)
+
+
+@pytest.mark.parametrize("host", _TRANSPORT_VECTORS["loopback"])
+def test_proxy_handler_bypasses_shared_loopback_hosts(hermes_modules, host: str) -> None:
+    del hermes_modules
+    client_module = importlib.import_module("plugins.powercontext.client")
+    from urllib.request import Request
+
+    handler = client_module._LoopbackAwareProxyHandler()
+    dead_proxy = "http://127.0.0.1:9"
+
+    loopback = Request(f"http://{host}:8000/v1/context/prepare", data=b"{}", method="POST")
+    direct_host = loopback.host
+    assert handler.proxy_open(loopback, dead_proxy, "http") is None
+    assert loopback.host == direct_host
+
+
+@pytest.mark.parametrize("host", _TRANSPORT_VECTORS["non_loopback"])
+@pytest.mark.parametrize("scheme", ("http", "https"))
+def test_proxy_handler_preserves_remote_proxy_for_shared_non_loopback_hosts(
+    hermes_modules,
+    monkeypatch: pytest.MonkeyPatch,
+    host: str,
+    scheme: str,
+) -> None:
+    del hermes_modules
+    client_module = importlib.import_module("plugins.powercontext.client")
+    from urllib.request import Request
+
+    monkeypatch.setattr("urllib.request.proxy_bypass", lambda _host: False)
+    handler = client_module._LoopbackAwareProxyHandler()
+    dead_proxy = "http://127.0.0.1:9"
+
+    remote = Request(f"{scheme}://{host}:8000/v1/context/prepare", data=b"{}", method="POST")
+    original_host = remote.host
+    handler.proxy_open(remote, dead_proxy, scheme)
+
+    assert remote.host == "127.0.0.1:9"
+    if scheme == "https":
+        assert remote._tunnel_host == original_host


### PR DESCRIPTION
## Summary

Extends the loopback proxy fix merged in [#154](https://github.com/ob-labs/powercontext-go/pull/154) to the remaining four adapters that shipped the same `urllib.request.build_opener()` defect: Claude Code, Codex, Bub, and Hermes. This is part of the defect remediation discovered during [#144](https://github.com/ob-labs/powercontext-go/issues/144) acceptance work and does **not** close #144.

`build_opener()` installs a `ProxyHandler` by default and inherits environment or operating-system proxy settings. If `no_proxy` omits a loopback host, a request carrying `Authorization: Bearer` can be routed to the proxy before it reaches the local PowerContext Server.

The branch was rebuilt on current `main` after #154 merged. `origin/main` is an ancestor of the submitted Head and the PR contains only its own eight adapter files.

## Changes

| Adapter | Production boundary | Loopback source |
|---|---|---|
| Claude Code | `hooks/user_prompt_submit.py` opener | existing `claude_code_settings._is_loopback_host` |
| Codex | `hooks/recall.py` opener | existing `settings._is_loopback_host` |
| Bub | module `_URL_OPENER` | same-module `_is_loopback_host` |
| Hermes | `PowerContextClient` opener | same-module `_is_loopback_host` |

Each adapter installs `_LoopbackAwareProxyHandler` before its authenticated requests are sent:

- every shared loopback authority connects directly without proxy rewriting;
- non-loopback HTTP keeps configured proxy routing;
- non-loopback HTTPS keeps configured proxy routing and its original CONNECT tunnel destination.

The four native test suites now drive both directly constructible configuration/client boundaries from `test/transport/testdata/loopback_hosts.json`, covering representative complete IPv4 `127.0.0.0/8`, `localhost`/`LOCALHOST`, IPv6 `::1`, and all shared non-loopback vectors. Remote proxy tests force `urllib.request.proxy_bypass` to `False` so host `no_proxy` or OS settings cannot create false positives.

## Observable impact and compatibility

- Local authenticated PowerContext traffic from these four adapters cannot be redirected through environment or OS proxies merely because `no_proxy` is incomplete.
- Remote HTTP/HTTPS proxy behaviour is preserved.
- No Go API, OpenAPI operation, persistence format, Go module dependency, generated artifact, workflow, or release-package contract changes.
- No cross-adapter runtime dependency is introduced; each adapter retains its isolated implementation and tests.

## Security

The repair prevents Bearer-authorized loopback requests from reaching a configured proxy. Tests use synthetic request bodies and credentials only; no real credentials, prompts, context, scope IDs, or private URLs are recorded.

## CI failure analysis

The previous Head `158d168b9ae57f532a616c3175f2d5ee786f7334` had one failing check: `Full build tags (darwin-amd64)`. Its complete job log shows `tools/generated-consumers` timing out while fetching multiple modules from `https://proxy.golang.org`; Host adapters and every other check passed. The same generated-consumer command succeeds on the rebuilt current-main branch, so no unrelated generator or retry policy is changed. The submitted Head receives a fresh full CI run; the old Head's results are not reused.

## Non-goals

- No Go Server or Go Client transport change.
- No migration of the Python adapters to Go.
- No weakening of plaintext non-loopback policy or authentication.
- No generic network retry added to generated-consumer tests for a single external timeout.

## Verification

Exact submitted Head: `251afdf863ea0b661b8362d484a8ec53553e1e4e`

```text
uv run --python 3.14 --with pytest pytest integrations/claude-code/tests/test_hook.py -q
36 passed

uv run --python 3.14 --project integrations/codex/plugins/powercontext --locked --with pytest pytest integrations/codex/tests/test_recall.py -q
39 passed

uv run --python 3.14 --project integrations/bub --locked --with pytest pytest integrations/bub/tests/test_client.py -q
11 passed, 46 subtests passed

uv run --python 3.14 --with pytest --with pydantic --with httpx pytest integrations/hermes/tests -q
42 passed
```

Python 3.12 proxy matrices:

```text
Claude Code: 18 passed
Codex:       18 passed
Bub:         2 passed, 18 subtests passed
Hermes:      18 passed
```

Previously failing path on the rebuilt branch:

```text
GOWORK=off go test -count=1 ./tools/generated-consumers
ok github.com/ob-labs/powercontext-go/tools/generated-consumers 14.431s
```

Additional verification:

```text
python -m compileall -q <four adapter source and test roots>
git diff --check origin/main...HEAD
git merge-tree --write-tree origin/main HEAD
```

An independent read-only review of Base `059f68fa5f988fb381878e618c6a5fb7d9e011fe` through this Head reported `Critical=0`, `Important=0`, `Minor=0`, `Ready to merge: Yes`.

## AI assistance disclosure

Codex assisted with exact-Head CI diagnosis, branch reconstruction, test hardening, and patch preparation. Verification uses the explicit local commands above, independent review, and the repository's new exact-Head CI before merge.