### PR TITLE
test(conformance): map review tool annotations parity

### DIFF
--- a/test/conformance/parity-inventory-rules.json
+++ b/test/conformance/parity-inventory-rules.json
@@ -191,7 +191,14 @@
     },
     "tests/test_mcp.py": {
       "mode": "go-port",
-      "reason": "MCP ToolAnnotations and Review write side-effect metadata map to the Go MCP server."
+      "reason": "MCP ToolAnnotations and Review write side-effect metadata map to the Go MCP server.",
+      "cases": {
+        "test_mcp_describes_review_write_side_effects_for_host_approval": {
+          "evidence": [
+            "go:internal/mcpapi/server_test.go#TestReviewWriteToolAnnotationsMatchUpstreamHostApprovalSemantics"
+          ]
+        }
+      }
     },
     "tests/test_server.py": {
       "mode": "go-port",

--- a/test/conformance/parity-inventory.json
+++ b/test/conformance/parity-inventory.json
@@ -4,8 +4,8 @@
   "oracle_commit": "3a6cb0151670eaff7dc0293466edd673124e80da",
   "python_test_file_count": 132,
   "python_test_case_count": 812,
-  "mapped_case_count": 712,
-  "pending_case_count": 100,
+  "mapped_case_count": 713,
+  "pending_case_count": 99,
   "entries": [
     {
       "python": {
@@ -10739,8 +10739,15 @@
         "line": 348
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/mcpapi/server_test.go",
+          "test": "TestReviewWriteToolAnnotationsMatchUpstreamHostApprovalSemantics"
+        }
+      ]
     },
     {
       "python": {


### PR DESCRIPTION
## Tracking

- Tracking issue: #3
- Relationship: Part of #3

## Problem and rationale

The signed v0.1.0 parity inventory still marks `tests/test_mcp.py::test_mcp_describes_review_write_side_effects_for_host_approval` as pending even though the Go MCP server already has case-specific public-boundary evidence for the same three Review write tools and all four ToolAnnotations fields. This change records that exact evidence instead of leaving the completed WP1 behavior uncounted.

## Changes

- Map the upstream Review ToolAnnotations case to `TestReviewWriteToolAnnotationsMatchUpstreamHostApprovalSemantics`.
- Regenerate the active parity inventory from the exact v0.1.0 release checkout.
- Move the inventory checkpoint from 712 mapped / 100 pending to 713 mapped / 99 pending.

## Behavior and compatibility

- User-visible behavior: none; this is traceability evidence for behavior already shipped.
- Public API or protocol impact: none.
- Breaking changes or migration requirements: none.
- Explicit non-goals: no new MCP behavior, no tracing/readiness mapping without exact evidence, and no changes to open WorkBuddy or retained-adapter PRs.

## Generated, dependency, and workflow impact

- [x] `parity-inventory.json` was regenerated from `parity-inventory-rules.json` and the exact upstream release commit.
- [x] No dependency changed; `go.mod` and `go.sum` are unchanged.
- [x] No CI or release workflow changed.
- [x] No credential, private Source/Memory content, or unredacted production log is included.

## Validation

Exact submitted Head: `f3ff77fe6c05870337ef42774dacd73ac5363da2`
Exact upstream checkout: `7b736206a53a6de6f43d4b517893ee1a80e7183d`

```text
go run ./tools/parity-inventory-generate -upstream <exact-v0.1.0-checkout> -check
PASS

go test -count=1 ./tools/parity-inventory-generate
PASS

go test -count=1 ./internal/mcpapi
PASS

git diff origin/main...HEAD --check
PASS
```

- [x] `git diff --check`
- [x] `git status --short` was inspected after validation; the submitted worktree is clean.
- [x] Formatter equivalent: the repository generator emitted the JSON and `git diff --check` passed; no Go source changed.
- [x] Generated-consumer equivalent: the parity generator self-tests and exact-upstream `-check` passed; no generated SDK or consumer package changed.
- [x] Compatibility evidence: the generator resolved the case-specific Go test declaration against the exact release inventory.
- [x] Relevant MCP and parity-generator tests were run.
- [x] Full `server` and full `test/conformance` package tests were not represented as locally passing: the Windows host lacks `sqlite3.h`. Linux exact-Head CI is required for those packages.

## AI usage

AI assistance was used to compare the exact upstream test with the Go MCP test, update the mapping source, regenerate the inventory, and prepare this PR. The final diff was independently constrained to two traceability files and verified by the repository generator and MCP tests.