### PR TITLE
ci: verify upstream release contract drift

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -19,7 +19,7 @@ Four Go-specific workflows extend, rather than replace, that Python topology:
 
 | Go workflow | Purpose |
 | --- | --- |
-| `migration-gates.yml` | Reusable PR assurance called by `master.yml`: explicit owned-module integrity, fresh generated-consumer builds, public API compatibility, frozen Python Oracle and exact v0.1.0 release-fixture regeneration, Python↔Go interoperability, HTTP differential, race/fuzz, live OceanBase, host adapters, evaluation, four-platform standard/Full builds, CGO-disabled portable SDK cross-builds, and the isolated downstream public-consumer workflow. |
+| `migration-gates.yml` | Reusable PR assurance called by `master.yml`: explicit owned-module integrity, fresh generated-consumer builds, public API compatibility, online verification of the recorded upstream tag, release bytes, and PyPI provenance, frozen Python Oracle and exact v0.1.0 release-fixture regeneration, Python↔Go interoperability, HTTP differential, race/fuzz, live OceanBase, host adapters, evaluation, four-platform standard/Full builds, CGO-disabled portable SDK cross-builds, and the isolated downstream public-consumer workflow. |
 | `codeql.yml` | Go CodeQL analysis on pull requests, pushes to `main`, a weekly schedule, and manual dispatch. Pull request runs check out the exact submitted head commit before the explicit Go build. |
 | `provider-smoke.yml` | Explicitly dispatched, credentialed, bounded real-provider verification; never required on an ordinary pull request. |
 | `windows-contract.yml` | Windows checkout-only contract guard: verifies LF attributes, both versioned fixture SHA-256 inventories, and generated-contract cleanliness without claiming Windows binary support. |

--- a/.github/workflows/migration-gates.yml
+++ b/.github/workflows/migration-gates.yml
@@ -229,6 +229,11 @@ jobs:
       - name: Set up the Go environment
         uses: ./.github/actions/setup-go-env
 
+      - name: Verify release tag, assets, and provenance
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: make release-contract-check
+
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -331,6 +331,10 @@ source / artifact / trigger / inference
   terminal query instead of treating every character device as a TTY. Verify
   null devices and pipes remain non-interactive while a controlled terminal
   input still enables the prompt path.
+- When a CI verifier accepts endpoint overrides and may attach credentials,
+  require HTTPS before request construction. Verify a plaintext override fails
+  before the RoundTripper runs and that neither the credential nor remote body
+  appears in the returned error.
 - When setup returns a host-home path after resolving symlinks, compare tests
   against the same resolved path rather than the raw input path. Verify a
   symlinked temporary-root path and an ordinary path so platform aliases such

--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ PUBLIC_API_PACKAGES := \
 	$(MODULE_PATH)/source \
 	$(MODULE_PATH)/trigger
 
-.PHONY: help lint-tools lint lint-fix api-compat-tools api-baseline api-compat govulncheck-tools license-eye-tools actionlint-tools actionlint modern-go-tools modern-go dependency-security generate check-generated module-check module-inventory module-integrity contract-test license-check license-fix license-dependencies fmt fmt-check vet build-all coverage coverage-check governance-check \
+.PHONY: help lint-tools lint lint-fix api-compat-tools api-baseline api-compat govulncheck-tools license-eye-tools actionlint-tools actionlint modern-go-tools modern-go dependency-security generate check-generated release-contract-check module-check module-inventory module-integrity contract-test license-check license-fix license-dependencies fmt fmt-check vet build-all coverage coverage-check governance-check \
 	test unit-test e2e-test test-sqlite race-debt-check race-debt-functional test-race test-full test-oceanbase-live real-provider-test \
 	pi-test docs-sync docs-test docs-build harness-sync harness-check harness-compose-check \
 	harness-compose-acceptance harness-compose-down build build-full smoke smoke-full check \
@@ -202,6 +202,9 @@ check-generated: ## Verify generated contracts and traceability outputs are clea
 	$(GO) run ./tools/mcp-schema-generate
 	$(GO) run ./tools/traceability-generate -check
 	git diff --exit-code -- openapi api/v1 client/invoker_gen.go internal/mcpapi/schemas_gen.go integrations/dsh/plugins/powercontext/src/operations.generated.ts
+
+release-contract-check: ## Verify the recorded upstream tag, release assets, and PyPI provenance.
+	$(GO) run ./tools/release-contract-verify
 
 generated-consumers: lint-tools ## Generate, test, and lint fresh consumers from public generator CLIs.
 	POWERCONTEXT_GOLANGCI_LINT="$(GOLANGCI_LINT)" GOWORK=off $(GO) test -count=1 ./tools/generated-consumers

--- a/test/conformance/README.md
+++ b/test/conformance/README.md
@@ -6,7 +6,8 @@ an informal reference.
 
 - `parity-contract.json` records the upstream parity identity as separate
   concepts: the upstream repository, the exact target SHA, the signed release
-  target and assets, the frozen release Oracle, and the active parity target. `parity_contract_test.go`
+  target, assets, and PyPI publisher identity, the frozen release Oracle, and
+  the active parity target. `parity_contract_test.go`
   proves the frozen Oracle commit is identical across the contract, the Go
   test constant, `manifest.json`, and the `frozen-oracle` CI checkout, and
   rejects any conflation between the frozen Oracle and the parity targets.
@@ -14,6 +15,11 @@ an informal reference.
   run at the new commit is green, record the new exact target SHA and its
   test inventory together in one reviewed change, and keep the frozen
   Oracle untouched until a new versioned Oracle directory is accepted.
+  `make release-contract-check` resolves the recorded release tag, verifies GitHub
+  Release metadata and downloaded bytes, and checks PyPI metadata plus the
+  Integrity provenance subject against this contract. The command reads
+  `GITHUB_TOKEN` for authenticated GitHub API access; CI supplies the
+  repository token, while local anonymous runs may exhaust shared API limits.
 - `testdata/python-v0.0.2/manifest.json` freezes OpenAPI, SQLite schema,
   Prompt, fixture, and Python-test inventories.
 - `traceability.json` inventories every one of the 622 frozen Python test

--- a/test/conformance/parity-contract.json
+++ b/test/conformance/parity-contract.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 2,
+  "schema_version": 3,
   "upstream": {
     "repository": "oceanbase/powercontext",
     "url": "https://github.com/oceanbase/powercontext",
@@ -23,6 +23,14 @@
     "sdist": {
       "filename": "powercontext-0.1.0.tar.gz",
       "sha256": "18d47a335340b0870216e2cc0fb1fd8e4d865880155daeea3b01187c950fd746"
+    },
+    "provenance": {
+      "pypi_project": "powercontext",
+      "publisher": {
+        "kind": "GitHub",
+        "repository": "oceanbase/powercontext",
+        "workflow": "release.yml"
+      }
     }
   },
   "exact_target_sha": "7b736206a53a6de6f43d4b517893ee1a80e7183d",

--- a/test/conformance/parity_contract_test.go
+++ b/test/conformance/parity_contract_test.go
@@ -55,6 +55,14 @@ type parityContract struct {
 			Filename string `json:"filename"`
 			SHA256   string `json:"sha256"`
 		} `json:"sdist"`
+		Provenance struct {
+			PyPIProject string `json:"pypi_project"`
+			Publisher   struct {
+				Kind       string `json:"kind"`
+				Repository string `json:"repository"`
+				Workflow   string `json:"workflow"`
+			} `json:"publisher"`
+		} `json:"provenance"`
 	} `json:"release_target"`
 	ExactTargetSHA      string `json:"exact_target_sha"`
 	TargetTestCaseCount int    `json:"target_test_case_count"`
@@ -82,11 +90,11 @@ func TestParityContractRejectsAmbiguousJSON(t *testing.T) {
 	}{
 		{
 			name:   "duplicate member",
-			mutant: strings.Replace(string(contents), `"schema_version": 2,`, `"schema_version": 999, "schema_version": 2,`, 1),
+			mutant: strings.Replace(string(contents), `"schema_version": 3,`, `"schema_version": 999, "schema_version": 3,`, 1),
 		},
 		{
 			name:   "unknown member",
-			mutant: strings.Replace(string(contents), `"schema_version": 2,`, `"schema_version": 2, "future_semantics": true,`, 1),
+			mutant: strings.Replace(string(contents), `"schema_version": 3,`, `"schema_version": 3, "future_semantics": true,`, 1),
 		},
 	}
 	for _, test := range tests {
@@ -123,8 +131,8 @@ func TestParityContractRecordsSeparateConcepts(t *testing.T) {
 	contract := readParityContract(t)
 	root := repositoryRoot(t)
 
-	if contract.SchemaVersion != 2 {
-		t.Fatalf("parity contract schema version = %d, want 2", contract.SchemaVersion)
+	if contract.SchemaVersion != 3 {
+		t.Fatalf("parity contract schema version = %d, want 3", contract.SchemaVersion)
 	}
 
 	// Concept 1: the upstream repository identity.
@@ -216,6 +224,11 @@ func TestParityContractRecordsSignedV010ReleaseIdentity(t *testing.T) {
 		release.Sdist.SHA256 != "18d47a335340b0870216e2cc0fb1fd8e4d865880155daeea3b01187c950fd746" {
 		t.Errorf("sdist identity = %#v", release.Sdist)
 	}
+	if release.Provenance.PyPIProject != "powercontext" || release.Provenance.Publisher.Kind != "GitHub" ||
+		release.Provenance.Publisher.Repository != contract.Upstream.Repository ||
+		release.Provenance.Publisher.Workflow != "release.yml" {
+		t.Errorf("release provenance identity = %#v", release.Provenance)
+	}
 }
 
 func TestParityContractMatchesFrozenOracleWorkflow(t *testing.T) {
@@ -229,7 +242,8 @@ func TestParityContractMatchesFrozenOracleWorkflow(t *testing.T) {
 	var workflow struct {
 		Jobs map[string]struct {
 			Steps []struct {
-				Name string `yaml:"name"`
+				Name string            `yaml:"name"`
+				Env  map[string]string `yaml:"env"`
 				With struct {
 					Repository string `yaml:"repository"`
 					Ref        string `yaml:"ref"`
@@ -251,7 +265,7 @@ func TestParityContractMatchesFrozenOracleWorkflow(t *testing.T) {
 	decodeJSONFile(t, filepath.Join(root, "test", "conformance", "target-delta.json"), &delta)
 	checkout, verify := "", ""
 	previousCheckout, previousVerify := "", ""
-	targetCheckout, targetVerify, deltaVerify, releaseFixtureVerify := "", "", "", ""
+	targetCheckout, targetVerify, releaseVerify, deltaVerify, releaseFixtureVerify := "", "", "", "", ""
 	for _, step := range job.Steps {
 		switch step.Name {
 		case "Check out frozen Python Oracle":
@@ -290,6 +304,14 @@ func TestParityContractMatchesFrozenOracleWorkflow(t *testing.T) {
 			if !validCheckoutIdentityCommand(step.Run, "_target", contract.ExactTargetSHA) {
 				t.Errorf("Verify parity target identity step does not pin the contract exact target SHA %q", contract.ExactTargetSHA)
 			}
+		case "Verify release tag, assets, and provenance":
+			releaseVerify = step.Name
+			if strings.TrimSpace(step.Run) != "make release-contract-check" {
+				t.Errorf("release verification command = %q, want make release-contract-check", step.Run)
+			}
+			if step.Env["GITHUB_TOKEN"] != "${{ github.token }}" {
+				t.Errorf("release verification GITHUB_TOKEN = %q, want github.token", step.Env["GITHUB_TOKEN"])
+			}
 		case "Regenerate and compare frozen fixtures":
 			if strings.Contains(step.Run, "-check-delta") && strings.Contains(step.Run, "-previous-upstream _previous_target") &&
 				strings.Contains(step.Run, "-release-upstream _target") {
@@ -320,6 +342,9 @@ func TestParityContractMatchesFrozenOracleWorkflow(t *testing.T) {
 	}
 	if targetVerify == "" {
 		t.Error("frozen-oracle job has no 'Verify parity target identity' step")
+	}
+	if releaseVerify == "" {
+		t.Error("frozen-oracle job does not verify the release tag, assets, and provenance")
 	}
 	if deltaVerify == "" {
 		t.Error("frozen-oracle job does not verify the reviewed target delta")

--- a/tools/parity-inventory-generate/main.go
+++ b/tools/parity-inventory-generate/main.go
@@ -65,6 +65,14 @@ type parityContract struct {
 			Filename string `json:"filename"`
 			SHA256   string `json:"sha256"`
 		} `json:"sdist"`
+		Provenance struct {
+			PyPIProject string `json:"pypi_project"`
+			Publisher   struct {
+				Kind       string `json:"kind"`
+				Repository string `json:"repository"`
+				Workflow   string `json:"workflow"`
+			} `json:"publisher"`
+		} `json:"provenance"`
 	} `json:"release_target"`
 	ExactTargetSHA      string `json:"exact_target_sha"`
 	TargetTestCaseCount int    `json:"target_test_case_count"`
@@ -187,7 +195,7 @@ func run(root, contractPath, traceabilityPath, rulesPath, outputPath, upstream s
 	if err := readJSON(filepath.Join(root, contractPath), &contract); err != nil {
 		return fmt.Errorf("read parity contract: %w", err)
 	}
-	if contract.SchemaVersion != 2 || contract.ExactTargetSHA == "" || contract.FrozenOracle.Commit == "" {
+	if contract.SchemaVersion != 3 || contract.ExactTargetSHA == "" || contract.FrozenOracle.Commit == "" {
 		return fmt.Errorf("parity contract is missing the target SHA or frozen Oracle commit")
 	}
 	if upstream == "" {

--- a/tools/parity-inventory-generate/main_test.go
+++ b/tools/parity-inventory-generate/main_test.go
@@ -213,7 +213,7 @@ func TestCheckTargetDeltaRejectsCheckoutIdentityDrift(t *testing.T) {
 	previousCommit := gitOutputForTest(t, previous, "rev-parse", "HEAD")
 	releaseCommit := gitOutputForTest(t, release, "rev-parse", "HEAD")
 	contractPath := filepath.Join(root, "parity-contract.json")
-	contract := fmt.Sprintf(`{"schema_version":2,"release_target":{"commit":%q}}`, releaseCommit)
+	contract := fmt.Sprintf(`{"schema_version":3,"release_target":{"commit":%q}}`, releaseCommit)
 	if err := os.WriteFile(contractPath, []byte(contract), 0o600); err != nil {
 		t.Fatal(err)
 	}

--- a/tools/release-contract-verify/main.go
+++ b/tools/release-contract-verify/main.go
@@ -1,0 +1,520 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Command release-contract-verify compares the checked-in PowerContext
+// release contract with the current official GitHub release and PyPI
+// provenance records.
+package main
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json/v2"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+)
+
+const (
+	defaultContractPath = "test/conformance/parity-contract.json"
+	defaultGitHubAPI    = "https://api.github.com"
+	defaultPyPIBase     = "https://pypi.org"
+	maxJSONBytes        = 8 << 20
+	maxAssetBytes       = 64 << 20
+	maxAnnotatedTags    = 8
+	statementType       = "https://in-toto.io/Statement/v1"
+	publishPredicate    = "https://docs.pypi.org/attestations/publish/v1"
+)
+
+type releaseVerifierConfig struct {
+	ContractPath  string
+	GitHubAPIBase string
+	PyPIBase      string
+	GitHubToken   string
+	HTTPClient    *http.Client
+}
+
+type releaseAsset struct {
+	Filename string `json:"filename"`
+	SHA256   string `json:"sha256"`
+}
+
+type releaseContract struct {
+	SchemaVersion int `json:"schema_version"`
+	Upstream      struct {
+		Repository    string `json:"repository"`
+		URL           string `json:"url"`
+		DefaultBranch string `json:"default_branch"`
+	} `json:"upstream"`
+	FrozenReleaseOracle struct {
+		Commit            string `json:"commit"`
+		Baseline          string `json:"baseline"`
+		EvidenceDirectory string `json:"evidence_directory"`
+	} `json:"frozen_release_oracle"`
+	ReleaseTarget struct {
+		Tag           string       `json:"tag"`
+		Version       string       `json:"version"`
+		Commit        string       `json:"commit"`
+		TestCaseCount int          `json:"test_case_count"`
+		TestFileCount int          `json:"test_file_count"`
+		Wheel         releaseAsset `json:"wheel"`
+		Sdist         releaseAsset `json:"sdist"`
+		Provenance    struct {
+			PyPIProject string `json:"pypi_project"`
+			Publisher   struct {
+				Kind       string `json:"kind"`
+				Repository string `json:"repository"`
+				Workflow   string `json:"workflow"`
+			} `json:"publisher"`
+		} `json:"provenance"`
+	} `json:"release_target"`
+	ExactTargetSHA      string `json:"exact_target_sha"`
+	TargetTestCaseCount int    `json:"target_test_case_count"`
+	ActiveParityTarget  string `json:"active_parity_target"`
+}
+
+type gitObject struct {
+	Type string `json:"type"`
+	SHA  string `json:"sha"`
+}
+
+type gitReference struct {
+	Object gitObject `json:"object"`
+}
+
+type annotatedTag struct {
+	Object gitObject `json:"object"`
+}
+
+type githubRelease struct {
+	TagName string `json:"tag_name"`
+	Assets  []struct {
+		Name               string `json:"name"`
+		Digest             string `json:"digest"`
+		BrowserDownloadURL string `json:"browser_download_url"`
+	} `json:"assets"`
+}
+
+type pypiRelease struct {
+	Info struct {
+		Name    string `json:"name"`
+		Version string `json:"version"`
+	} `json:"info"`
+	URLs []struct {
+		Filename    string `json:"filename"`
+		PackageType string `json:"packagetype"`
+		Digests     struct {
+			SHA256 string `json:"sha256"`
+		} `json:"digests"`
+	} `json:"urls"`
+}
+
+type pypiProvenance struct {
+	Version            int `json:"version"`
+	AttestationBundles []struct {
+		Publisher struct {
+			Kind       string `json:"kind"`
+			Repository string `json:"repository"`
+			Workflow   string `json:"workflow"`
+		} `json:"publisher"`
+		Attestations []struct {
+			Version  int `json:"version"`
+			Envelope struct {
+				Statement string `json:"statement"`
+			} `json:"envelope"`
+		} `json:"attestations"`
+	} `json:"attestation_bundles"`
+}
+
+type inTotoStatement struct {
+	Type    string `json:"_type"`
+	Subject []struct {
+		Name   string            `json:"name"`
+		Digest map[string]string `json:"digest"`
+	} `json:"subject"`
+	PredicateType string `json:"predicateType"`
+}
+
+func main() {
+	contractPath := flag.String("contract", defaultContractPath, "release parity contract")
+	githubAPIBase := flag.String("github-api-base", defaultGitHubAPI, "GitHub API base URL")
+	pypiBase := flag.String("pypi-base", defaultPyPIBase, "PyPI API base URL")
+	timeout := flag.Duration("timeout", 2*time.Minute, "overall verification timeout")
+	flag.Parse()
+
+	ctx, cancel := context.WithTimeout(context.Background(), *timeout)
+	defer cancel()
+	err := verifyRelease(ctx, releaseVerifierConfig{
+		ContractPath:  *contractPath,
+		GitHubAPIBase: *githubAPIBase,
+		PyPIBase:      *pypiBase,
+		GitHubToken:   os.Getenv("GITHUB_TOKEN"),
+		HTTPClient:    http.DefaultClient,
+	})
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "release-contract-verify:", err)
+		os.Exit(1)
+	}
+	fmt.Println("verified release contract")
+}
+
+func verifyRelease(ctx context.Context, config releaseVerifierConfig) error {
+	contract, err := readReleaseContract(config.ContractPath)
+	if err != nil {
+		return fmt.Errorf("read release contract: %w", err)
+	}
+	client := config.HTTPClient
+	if client == nil {
+		client = http.DefaultClient
+	}
+	owner, repository, err := splitRepository(contract.Upstream.Repository)
+	if err != nil {
+		return err
+	}
+	githubBase, err := normalizedBaseURL(config.GitHubAPIBase, defaultGitHubAPI)
+	if err != nil {
+		return fmt.Errorf("GitHub API base: %w", err)
+	}
+	pypiBase, err := normalizedBaseURL(config.PyPIBase, defaultPyPIBase)
+	if err != nil {
+		return fmt.Errorf("PyPI API base: %w", err)
+	}
+
+	commit, err := resolveReleaseTag(ctx, client, githubBase, config.GitHubToken, owner, repository, contract.ReleaseTarget.Tag)
+	if err != nil {
+		return err
+	}
+	if commit != contract.ReleaseTarget.Commit {
+		return fmt.Errorf("release tag resolves to %s, want contract commit %s", commit, contract.ReleaseTarget.Commit)
+	}
+	if err := verifyGitHubRelease(ctx, client, githubBase, config.GitHubToken, owner, repository, contract); err != nil {
+		return err
+	}
+	if err := verifyPyPIRelease(ctx, client, pypiBase, contract); err != nil {
+		return err
+	}
+	return nil
+}
+
+func readReleaseContract(path string) (releaseContract, error) {
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		return releaseContract{}, err
+	}
+	var contract releaseContract
+	if err := json.Unmarshal(contents, &contract, json.RejectUnknownMembers(true)); err != nil {
+		return releaseContract{}, err
+	}
+	if contract.SchemaVersion != 3 {
+		return releaseContract{}, fmt.Errorf("unsupported schema version %d", contract.SchemaVersion)
+	}
+	if _, _, err := splitRepository(contract.Upstream.Repository); err != nil {
+		return releaseContract{}, err
+	}
+	if contract.ReleaseTarget.Tag == "" || contract.ReleaseTarget.Version == "" || contract.ReleaseTarget.Commit == "" {
+		return releaseContract{}, errors.New("release target tag, version, and commit are required")
+	}
+	if contract.ExactTargetSHA != contract.ReleaseTarget.Commit || contract.ActiveParityTarget != contract.ReleaseTarget.Commit {
+		return releaseContract{}, errors.New("release commit, exact target SHA, and active parity target must match")
+	}
+	if contract.ReleaseTarget.Wheel.Filename == contract.ReleaseTarget.Sdist.Filename {
+		return releaseContract{}, errors.New("wheel and sdist filenames must be distinct")
+	}
+	for _, asset := range []releaseAsset{contract.ReleaseTarget.Wheel, contract.ReleaseTarget.Sdist} {
+		if asset.Filename == "" || !validSHA256(asset.SHA256) {
+			return releaseContract{}, fmt.Errorf("release asset %q has an invalid SHA-256", asset.Filename)
+		}
+	}
+	provenance := contract.ReleaseTarget.Provenance
+	if provenance.PyPIProject == "" || provenance.Publisher.Kind == "" || provenance.Publisher.Repository == "" ||
+		provenance.Publisher.Workflow == "" {
+		return releaseContract{}, errors.New("release provenance identity is incomplete")
+	}
+	if provenance.Publisher.Repository != contract.Upstream.Repository {
+		return releaseContract{}, errors.New("release provenance repository does not match the upstream repository")
+	}
+	return contract, nil
+}
+
+func splitRepository(slug string) (string, string, error) {
+	owner, repository, found := strings.Cut(slug, "/")
+	if !found || owner == "" || repository == "" || strings.ContainsRune(repository, '/') || strings.IndexFunc(slug, func(r rune) bool {
+		return r == ' ' || r == '\t' || r == '\r' || r == '\n'
+	}) >= 0 {
+		return "", "", fmt.Errorf("upstream repository %q is not an owner/name slug", slug)
+	}
+	return owner, repository, nil
+}
+
+func normalizedBaseURL(value, fallback string) (string, error) {
+	if value == "" {
+		value = fallback
+	}
+	parsed, err := url.Parse(value)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" || parsed.User != nil {
+		return "", errors.New("must be an absolute credential-free HTTP(S) URL")
+	}
+	if parsed.Scheme != "https" {
+		return "", errors.New("must use HTTPS")
+	}
+	parsed.RawQuery = ""
+	parsed.Fragment = ""
+	return strings.TrimRight(parsed.String(), "/"), nil
+}
+
+func resolveReleaseTag(
+	ctx context.Context,
+	client *http.Client,
+	base, token, owner, repository, tag string,
+) (string, error) {
+	var reference gitReference
+	endpoint := fmt.Sprintf("%s/repos/%s/%s/git/ref/tags/%s", base, url.PathEscape(owner), url.PathEscape(repository), url.PathEscape(tag))
+	if err := fetchJSON(ctx, client, "GitHub tag reference", endpoint, token, &reference); err != nil {
+		return "", err
+	}
+	object := reference.Object
+	seen := make(map[string]struct{})
+	for range maxAnnotatedTags {
+		switch object.Type {
+		case "commit":
+			if object.SHA == "" {
+				return "", errors.New("GitHub tag reference has an empty commit SHA")
+			}
+			return object.SHA, nil
+		case "tag":
+			if object.SHA == "" {
+				return "", errors.New("GitHub annotated tag has an empty object SHA")
+			}
+			if _, duplicate := seen[object.SHA]; duplicate {
+				return "", errors.New("GitHub annotated tag chain contains a cycle")
+			}
+			seen[object.SHA] = struct{}{}
+			var annotated annotatedTag
+			endpoint = fmt.Sprintf("%s/repos/%s/%s/git/tags/%s", base, url.PathEscape(owner), url.PathEscape(repository), url.PathEscape(object.SHA))
+			if err := fetchJSON(ctx, client, "GitHub annotated tag", endpoint, token, &annotated); err != nil {
+				return "", err
+			}
+			object = annotated.Object
+		default:
+			return "", fmt.Errorf("GitHub tag points to unsupported object type %q", object.Type)
+		}
+	}
+	return "", fmt.Errorf("GitHub annotated tag chain exceeds %d objects", maxAnnotatedTags)
+}
+
+func verifyGitHubRelease(
+	ctx context.Context,
+	client *http.Client,
+	base, token, owner, repository string,
+	contract releaseContract,
+) error {
+	endpoint := fmt.Sprintf("%s/repos/%s/%s/releases/tags/%s", base, url.PathEscape(owner), url.PathEscape(repository), url.PathEscape(contract.ReleaseTarget.Tag))
+	var release githubRelease
+	if err := fetchJSON(ctx, client, "GitHub release", endpoint, token, &release); err != nil {
+		return err
+	}
+	if release.TagName != contract.ReleaseTarget.Tag {
+		return fmt.Errorf("GitHub release tag = %q, want %q", release.TagName, contract.ReleaseTarget.Tag)
+	}
+	for _, expected := range []releaseAsset{contract.ReleaseTarget.Wheel, contract.ReleaseTarget.Sdist} {
+		matches := make([]int, 0, 1)
+		for index, asset := range release.Assets {
+			if asset.Name == expected.Filename {
+				matches = append(matches, index)
+			}
+		}
+		if len(matches) == 0 {
+			return fmt.Errorf("GitHub release asset %s is missing", expected.Filename)
+		}
+		if len(matches) != 1 {
+			return fmt.Errorf("GitHub release asset %s appears %d times", expected.Filename, len(matches))
+		}
+		asset := release.Assets[matches[0]]
+		if asset.Digest != "sha256:"+expected.SHA256 {
+			return fmt.Errorf("GitHub release asset %s digest = %q, want sha256:%s", expected.Filename, asset.Digest, expected.SHA256)
+		}
+		if err := verifyDownloadedAsset(ctx, client, expected, asset.BrowserDownloadURL); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func verifyDownloadedAsset(ctx context.Context, client *http.Client, expected releaseAsset, location string) error {
+	parsed, err := url.Parse(location)
+	if err != nil || parsed.Scheme != "https" || parsed.Host == "" || parsed.User != nil {
+		return fmt.Errorf("GitHub release asset %s has an invalid download location", expected.Filename)
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, location, nil)
+	if err != nil {
+		return fmt.Errorf("download GitHub release asset %s: %w", expected.Filename, err)
+	}
+	request.Header.Set("User-Agent", "powercontext-go-release-contract-verify")
+	response, err := client.Do(request)
+	if err != nil {
+		return fmt.Errorf("download GitHub release asset %s: %w", expected.Filename, err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode != http.StatusOK {
+		return fmt.Errorf("GitHub release asset %s download returned HTTP %d", expected.Filename, response.StatusCode)
+	}
+	hash := sha256.New()
+	written, err := io.Copy(hash, io.LimitReader(response.Body, maxAssetBytes+1))
+	if err != nil {
+		return fmt.Errorf("hash GitHub release asset %s: %w", expected.Filename, err)
+	}
+	if written > maxAssetBytes {
+		return fmt.Errorf("GitHub release asset %s exceeds %d bytes", expected.Filename, maxAssetBytes)
+	}
+	actual := hex.EncodeToString(hash.Sum(nil))
+	if actual != expected.SHA256 {
+		return fmt.Errorf("downloaded GitHub release asset %s digest = %s, want %s", expected.Filename, actual, expected.SHA256)
+	}
+	return nil
+}
+
+func verifyPyPIRelease(ctx context.Context, client *http.Client, base string, contract releaseContract) error {
+	provenance := contract.ReleaseTarget.Provenance
+	endpoint := fmt.Sprintf("%s/pypi/%s/%s/json", base, url.PathEscape(provenance.PyPIProject), url.PathEscape(contract.ReleaseTarget.Version))
+	var release pypiRelease
+	if err := fetchJSON(ctx, client, "PyPI release metadata", endpoint, "", &release); err != nil {
+		return err
+	}
+	if !strings.EqualFold(release.Info.Name, provenance.PyPIProject) || release.Info.Version != contract.ReleaseTarget.Version {
+		return fmt.Errorf("PyPI release identity = %q@%q, want %q@%q", release.Info.Name, release.Info.Version, provenance.PyPIProject, contract.ReleaseTarget.Version)
+	}
+	expected := []struct {
+		Asset       releaseAsset
+		PackageType string
+	}{
+		{Asset: contract.ReleaseTarget.Wheel, PackageType: "bdist_wheel"},
+		{Asset: contract.ReleaseTarget.Sdist, PackageType: "sdist"},
+	}
+	for _, item := range expected {
+		matches := make([]int, 0, 1)
+		for index, file := range release.URLs {
+			if file.Filename == item.Asset.Filename {
+				matches = append(matches, index)
+			}
+		}
+		if len(matches) == 0 {
+			return fmt.Errorf("PyPI file %s is missing", item.Asset.Filename)
+		}
+		if len(matches) != 1 {
+			return fmt.Errorf("PyPI file %s appears %d times", item.Asset.Filename, len(matches))
+		}
+		file := release.URLs[matches[0]]
+		if file.PackageType != item.PackageType {
+			return fmt.Errorf("PyPI file %s type = %q, want %q", item.Asset.Filename, file.PackageType, item.PackageType)
+		}
+		if file.Digests.SHA256 != item.Asset.SHA256 {
+			return fmt.Errorf("PyPI file %s digest = %s, want %s", item.Asset.Filename, file.Digests.SHA256, item.Asset.SHA256)
+		}
+		if err := verifyPyPIProvenance(ctx, client, base, contract, item.Asset); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func verifyPyPIProvenance(
+	ctx context.Context,
+	client *http.Client,
+	base string,
+	contract releaseContract,
+	asset releaseAsset,
+) error {
+	provenanceIdentity := contract.ReleaseTarget.Provenance
+	endpoint := fmt.Sprintf("%s/integrity/%s/%s/%s/provenance", base, url.PathEscape(provenanceIdentity.PyPIProject), url.PathEscape(contract.ReleaseTarget.Version), url.PathEscape(asset.Filename))
+	var provenance pypiProvenance
+	label := "PyPI provenance for " + asset.Filename
+	if err := fetchJSON(ctx, client, label, endpoint, "", &provenance); err != nil {
+		return err
+	}
+	if provenance.Version != 1 || len(provenance.AttestationBundles) != 1 {
+		return fmt.Errorf("%s has version %d and %d bundles, want version 1 and one bundle", label, provenance.Version, len(provenance.AttestationBundles))
+	}
+	bundle := provenance.AttestationBundles[0]
+	wantPublisher := provenanceIdentity.Publisher
+	if bundle.Publisher.Kind != wantPublisher.Kind || bundle.Publisher.Repository != wantPublisher.Repository ||
+		bundle.Publisher.Workflow != wantPublisher.Workflow {
+		return fmt.Errorf("%s publisher = %s/%s/%s, want %s/%s/%s", label,
+			bundle.Publisher.Kind, bundle.Publisher.Repository, bundle.Publisher.Workflow,
+			wantPublisher.Kind, wantPublisher.Repository, wantPublisher.Workflow)
+	}
+	if len(bundle.Attestations) != 1 || bundle.Attestations[0].Version != 1 {
+		return fmt.Errorf("%s has %d attestations, want one version 1 attestation", label, len(bundle.Attestations))
+	}
+	statementBytes, err := base64.StdEncoding.DecodeString(bundle.Attestations[0].Envelope.Statement)
+	if err != nil {
+		return fmt.Errorf("%s statement is not valid base64", label)
+	}
+	var statement inTotoStatement
+	if err := json.Unmarshal(statementBytes, &statement); err != nil {
+		return fmt.Errorf("%s statement is not valid JSON", label)
+	}
+	if statement.Type != statementType || statement.PredicateType != publishPredicate {
+		return fmt.Errorf("%s statement type or predicate is not the PyPI publish contract", label)
+	}
+	if len(statement.Subject) != 1 || statement.Subject[0].Name != asset.Filename ||
+		statement.Subject[0].Digest["sha256"] != asset.SHA256 {
+		return fmt.Errorf("%s subject does not bind %s at %s", label, asset.Filename, asset.SHA256)
+	}
+	return nil
+}
+
+func fetchJSON(ctx context.Context, client *http.Client, label, location, token string, target any) error {
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, location, nil)
+	if err != nil {
+		return fmt.Errorf("%s request: %w", label, err)
+	}
+	request.Header.Set("Accept", "application/json")
+	request.Header.Set("User-Agent", "powercontext-go-release-contract-verify")
+	if token != "" {
+		request.Header.Set("Authorization", "Bearer "+token)
+		request.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	}
+	response, err := client.Do(request)
+	if err != nil {
+		return fmt.Errorf("%s request failed: %w", label, err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode != http.StatusOK {
+		return fmt.Errorf("%s returned HTTP %d", label, response.StatusCode)
+	}
+	contents, err := io.ReadAll(io.LimitReader(response.Body, maxJSONBytes+1))
+	if err != nil {
+		return fmt.Errorf("read %s response: %w", label, err)
+	}
+	if len(contents) > maxJSONBytes {
+		return fmt.Errorf("%s response exceeds %d bytes", label, maxJSONBytes)
+	}
+	if err := json.Unmarshal(contents, target); err != nil {
+		return fmt.Errorf("decode %s response: %w", label, err)
+	}
+	return nil
+}
+
+func validSHA256(value string) bool {
+	decoded, err := hex.DecodeString(value)
+	return err == nil && len(decoded) == sha256.Size && value == strings.ToLower(value)
+}

--- a/tools/release-contract-verify/main_test.go
+++ b/tools/release-contract-verify/main_test.go
@@ -1,0 +1,410 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json/v2"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const (
+	testReleaseCommit = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	testOtherCommit   = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	testWheelName     = "powercontext-0.1.0-py3-none-any.whl"
+	testSdistName     = "powercontext-0.1.0.tar.gz"
+	testWheelDigest   = "40c2e87b960db2bbd181cb6d8704bd60415c23cb3f2b619c56b87197b195aa13"
+	testSdistDigest   = "0c29bf6333bf7f09b7a85ea94ec22b5c6a35129933cb7c18c0539c305dc8d6bf"
+	testAPIBase       = "https://release.test"
+)
+
+type releaseFixtureOptions struct {
+	annotatedTag          bool
+	tagCommit             string
+	omitGitHubWheel       bool
+	duplicateGitHubWheel  bool
+	githubWheelDigest     string
+	wheelContents         string
+	duplicatePyPIWheel    bool
+	pypiWheelDigest       string
+	publisherWorkflow     string
+	provenanceWheelDigest string
+	provenanceStatus      int
+}
+
+func TestVerifyReleaseAcceptsOfficialIdentityAssetsAndProvenance(t *testing.T) {
+	err := verifyRelease(t.Context(), releaseVerifierConfig{
+		ContractPath:  writeTestContract(t),
+		GitHubAPIBase: testAPIBase,
+		PyPIBase:      testAPIBase,
+		HTTPClient:    newReleaseClient(defaultReleaseFixtureOptions()),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestVerifyReleaseAcceptsAnnotatedTagResolvingToContractCommit(t *testing.T) {
+	options := defaultReleaseFixtureOptions()
+	options.annotatedTag = true
+
+	err := verifyRelease(t.Context(), releaseVerifierConfig{
+		ContractPath:  writeTestContract(t),
+		GitHubAPIBase: testAPIBase,
+		PyPIBase:      testAPIBase,
+		HTTPClient:    newReleaseClient(options),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestVerifyReleaseRejectsIdentityAssetAndProvenanceDrift(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*releaseFixtureOptions)
+		want   string
+	}{
+		{
+			name: "tag commit",
+			mutate: func(options *releaseFixtureOptions) {
+				options.tagCommit = testOtherCommit
+			},
+			want: "release tag resolves to",
+		},
+		{
+			name: "missing GitHub asset",
+			mutate: func(options *releaseFixtureOptions) {
+				options.omitGitHubWheel = true
+			},
+			want: "GitHub release asset " + testWheelName + " is missing",
+		},
+		{
+			name: "duplicate GitHub asset",
+			mutate: func(options *releaseFixtureOptions) {
+				options.duplicateGitHubWheel = true
+			},
+			want: "GitHub release asset " + testWheelName + " appears 2 times",
+		},
+		{
+			name: "GitHub asset metadata digest",
+			mutate: func(options *releaseFixtureOptions) {
+				options.githubWheelDigest = strings.Repeat("c", 64)
+			},
+			want: "GitHub release asset " + testWheelName + " digest",
+		},
+		{
+			name: "downloaded asset bytes",
+			mutate: func(options *releaseFixtureOptions) {
+				options.wheelContents = "tampered-release-bytes"
+			},
+			want: "downloaded GitHub release asset " + testWheelName + " digest",
+		},
+		{
+			name: "duplicate PyPI file",
+			mutate: func(options *releaseFixtureOptions) {
+				options.duplicatePyPIWheel = true
+			},
+			want: "PyPI file " + testWheelName + " appears 2 times",
+		},
+		{
+			name: "PyPI file digest",
+			mutate: func(options *releaseFixtureOptions) {
+				options.pypiWheelDigest = strings.Repeat("d", 64)
+			},
+			want: "PyPI file " + testWheelName + " digest",
+		},
+		{
+			name: "provenance publisher",
+			mutate: func(options *releaseFixtureOptions) {
+				options.publisherWorkflow = "other.yml"
+			},
+			want: "publisher =",
+		},
+		{
+			name: "provenance subject",
+			mutate: func(options *releaseFixtureOptions) {
+				options.provenanceWheelDigest = strings.Repeat("e", 64)
+			},
+			want: "subject does not bind",
+		},
+		{
+			name: "provenance unavailable",
+			mutate: func(options *releaseFixtureOptions) {
+				options.provenanceStatus = http.StatusNotFound
+			},
+			want: "PyPI provenance for " + testWheelName + " returned HTTP 404",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			options := defaultReleaseFixtureOptions()
+			test.mutate(&options)
+
+			err := verifyRelease(t.Context(), releaseVerifierConfig{
+				ContractPath:  writeTestContract(t),
+				GitHubAPIBase: testAPIBase,
+				PyPIBase:      testAPIBase,
+				HTTPClient:    newReleaseClient(options),
+			})
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("verifyRelease error = %v, want text %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestVerifyReleaseDoesNotExposeHTTPBodiesOrTokens(t *testing.T) {
+	const secret = "remote-body-and-token-secret"
+	client := &http.Client{Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		return testResponse(request, http.StatusUnauthorized, "text/plain", []byte(secret)), nil
+	})}
+
+	err := verifyRelease(t.Context(), releaseVerifierConfig{
+		ContractPath:  writeTestContract(t),
+		GitHubAPIBase: testAPIBase,
+		PyPIBase:      testAPIBase,
+		GitHubToken:   secret,
+		HTTPClient:    client,
+	})
+	if err == nil || !strings.Contains(err.Error(), "GitHub tag reference returned HTTP 401") {
+		t.Fatalf("verifyRelease error = %v", err)
+	}
+	if strings.Contains(err.Error(), secret) {
+		t.Fatalf("verifyRelease error exposed remote body or token: %v", err)
+	}
+}
+
+func TestVerifyReleaseRejectsPlaintextAPIBaseBeforeSendingToken(t *testing.T) {
+	client := &http.Client{Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		return nil, errors.New("transport must not run")
+	})}
+	err := verifyRelease(t.Context(), releaseVerifierConfig{
+		ContractPath:  writeTestContract(t),
+		GitHubAPIBase: "http://release.test",
+		PyPIBase:      testAPIBase,
+		GitHubToken:   "credential-must-stay-local",
+		HTTPClient:    client,
+	})
+	if err == nil || !strings.Contains(err.Error(), "GitHub API base: must use HTTPS") {
+		t.Fatalf("verifyRelease error = %v", err)
+	}
+}
+
+func TestReadReleaseContractRejectsAmbiguousDocuments(t *testing.T) {
+	tests := []struct {
+		name     string
+		contents string
+	}{
+		{
+			name:     "duplicate member",
+			contents: `{"schema_version":3,"schema_version":3}`,
+		},
+		{
+			name:     "unknown member",
+			contents: `{"schema_version":3,"future_semantics":true}`,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "contract.json")
+			if err := os.WriteFile(path, []byte(test.contents), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := readReleaseContract(path); err == nil {
+				t.Fatal("accepted ambiguous release contract")
+			}
+		})
+	}
+}
+
+func defaultReleaseFixtureOptions() releaseFixtureOptions {
+	return releaseFixtureOptions{
+		tagCommit:             testReleaseCommit,
+		githubWheelDigest:     testWheelDigest,
+		wheelContents:         "wheel-release-bytes",
+		pypiWheelDigest:       testWheelDigest,
+		publisherWorkflow:     "release.yml",
+		provenanceWheelDigest: testWheelDigest,
+		provenanceStatus:      http.StatusOK,
+	}
+}
+
+func newReleaseClient(options releaseFixtureOptions) *http.Client {
+	return &http.Client{Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		var value any
+		switch request.URL.Path {
+		case "/repos/oceanbase/powercontext/git/ref/tags/powercontext-v0.1.0":
+			objectType, objectSHA := "commit", options.tagCommit
+			if options.annotatedTag {
+				objectType, objectSHA = "tag", "tag-object"
+			}
+			value = map[string]any{"object": map[string]any{"type": objectType, "sha": objectSHA}}
+		case "/repos/oceanbase/powercontext/git/tags/tag-object":
+			value = map[string]any{"object": map[string]any{"type": "commit", "sha": options.tagCommit}}
+		case "/repos/oceanbase/powercontext/releases/tags/powercontext-v0.1.0":
+			assets := []any{}
+			wheel := map[string]any{
+				"name": testWheelName, "digest": "sha256:" + options.githubWheelDigest,
+				"browser_download_url": testAPIBase + "/downloads/wheel",
+			}
+			if !options.omitGitHubWheel {
+				assets = append(assets, wheel)
+			}
+			if options.duplicateGitHubWheel {
+				assets = append(assets, wheel)
+			}
+			assets = append(assets, map[string]any{
+				"name": testSdistName, "digest": "sha256:" + testSdistDigest,
+				"browser_download_url": testAPIBase + "/downloads/sdist",
+			})
+			value = map[string]any{"tag_name": "powercontext-v0.1.0", "assets": assets}
+		case "/downloads/wheel":
+			return testResponse(request, http.StatusOK, "application/octet-stream", []byte(options.wheelContents)), nil
+		case "/downloads/sdist":
+			return testResponse(request, http.StatusOK, "application/octet-stream", []byte("sdist-release-bytes")), nil
+		case "/pypi/powercontext/0.1.0/json":
+			files := []any{
+				map[string]any{
+					"filename": testWheelName, "packagetype": "bdist_wheel",
+					"digests": map[string]any{"sha256": options.pypiWheelDigest},
+				},
+				map[string]any{
+					"filename": testSdistName, "packagetype": "sdist",
+					"digests": map[string]any{"sha256": testSdistDigest},
+				},
+			}
+			if options.duplicatePyPIWheel {
+				files = append(files, map[string]any{
+					"filename": testWheelName, "packagetype": "bdist_wheel",
+					"digests": map[string]any{"sha256": options.pypiWheelDigest},
+				})
+			}
+			value = map[string]any{
+				"info": map[string]any{"name": "powercontext", "version": "0.1.0"},
+				"urls": files,
+			}
+		default:
+			prefix := "/integrity/powercontext/0.1.0/"
+			if !strings.HasPrefix(request.URL.Path, prefix) || !strings.HasSuffix(request.URL.Path, "/provenance") {
+				return testResponse(request, http.StatusNotFound, "text/plain", nil), nil
+			}
+			if options.provenanceStatus != http.StatusOK {
+				return testResponse(request, options.provenanceStatus, "application/json", nil), nil
+			}
+			filename := strings.TrimSuffix(strings.TrimPrefix(request.URL.Path, prefix), "/provenance")
+			digest := testSdistDigest
+			if filename == testWheelName {
+				digest = options.provenanceWheelDigest
+			}
+			statement, err := json.Marshal(map[string]any{
+				"_type": "https://in-toto.io/Statement/v1",
+				"subject": []any{map[string]any{
+					"name": filename, "digest": map[string]any{"sha256": digest},
+				}},
+				"predicateType": "https://docs.pypi.org/attestations/publish/v1",
+				"predicate":     nil,
+			})
+			if err != nil {
+				panic(err)
+			}
+			value = map[string]any{
+				"version": 1,
+				"attestation_bundles": []any{map[string]any{
+					"publisher": map[string]any{
+						"kind": "GitHub", "repository": "oceanbase/powercontext", "workflow": options.publisherWorkflow,
+					},
+					"attestations": []any{map[string]any{
+						"version":  1,
+						"envelope": map[string]any{"statement": base64.StdEncoding.EncodeToString(statement), "signature": "test-signature"},
+					}},
+				}},
+			}
+		}
+		contents, err := json.Marshal(value)
+		if err != nil {
+			return nil, err
+		}
+		return testResponse(request, http.StatusOK, "application/json", contents), nil
+	})}
+}
+
+func writeTestContract(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "parity-contract.json")
+	contents := fmt.Sprintf(`{
+  "schema_version": 3,
+  "upstream": {
+    "repository": "oceanbase/powercontext",
+    "url": "https://github.com/oceanbase/powercontext",
+    "default_branch": "master"
+  },
+  "frozen_release_oracle": {
+    "commit": "ffffffffffffffffffffffffffffffffffffffff",
+    "baseline": "python-v0.0.2",
+    "evidence_directory": "test/conformance/testdata/python-v0.0.2"
+  },
+  "release_target": {
+    "tag": "powercontext-v0.1.0",
+    "version": "0.1.0",
+    "commit": %q,
+    "test_case_count": 812,
+    "test_file_count": 132,
+    "wheel": {"filename": %q, "sha256": %q},
+    "sdist": {"filename": %q, "sha256": %q},
+    "provenance": {
+      "pypi_project": "powercontext",
+      "publisher": {
+        "kind": "GitHub",
+        "repository": "oceanbase/powercontext",
+        "workflow": "release.yml"
+      }
+    }
+  },
+  "exact_target_sha": %q,
+  "target_test_case_count": 812,
+  "active_parity_target": %q
+}
+`, testReleaseCommit, testWheelName, testWheelDigest, testSdistName, testSdistDigest, testReleaseCommit, testReleaseCommit)
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (function roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return function(request)
+}
+
+func testResponse(request *http.Request, status int, contentType string, contents []byte) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Status:     fmt.Sprintf("%d %s", status, http.StatusText(status)),
+		Header:     http.Header{"Content-Type": []string{contentType}},
+		Body:       io.NopCloser(bytes.NewReader(contents)),
+		Request:    request,
+	}
+}


### PR DESCRIPTION
## Tracking

- Tracking issue: #3
- Relationship: Part of #3

## Problem and rationale

The WP1 parity workflow regenerated the exact upstream inventory, delta, traceability, and fixture manifests, but the release tag, GitHub assets, PyPI digests, and provenance were only checked-in strings. A moved tag, replaced asset, changed PyPI file, or different publisher could therefore remain green until someone manually re-audited the release.

This PR adds one dedicated verifier rather than embedding network behavior in the inventory generator or relying on shell substring checks.

## Changes

- Upgrade the parity contract to schema v3 and record the expected PyPI project and publisher identity.
- Add `tools/release-contract-verify` using only the Go standard library.
- Resolve lightweight or annotated GitHub tags to the contract commit.
- Verify GitHub Release asset names and metadata digests, then download and hash the real wheel and sdist bytes.
- Verify PyPI release metadata and Integrity provenance publisher plus DSSE subject filename/digest.
- Reject plaintext endpoint overrides before any credential-bearing request is constructed.
- Add `make release-contract-check` and invoke it from the existing frozen-Oracle job with `${{ github.token }}`.
- Keep existing workflow and required-job names unchanged.

## Behavior and compatibility

- User-visible behavior: the frozen-Oracle CI lane now fails when the official release identity, bytes, or provenance drift or cannot be verified.
- Public API or protocol impact: none.
- Breaking changes or migration requirements: none. Reliable local GitHub API verification requires `GITHUB_TOKEN`; CI supplies it automatically.
- Explicit non-goals: no Runtime, provider, embedding, persistence, OpenAPI, or host-adapter changes.

## Generated, dependency, and workflow impact

- [x] No generated output changed; the parity generator accepts schema v3 and its exact-upstream `-check` remains clean.
- [x] No dependency changed; the verifier uses the Go standard library and `go.mod`/`go.sum` remain unchanged.
- [x] The existing frozen-Oracle job name, permissions, timeout, and failure-evidence lifecycle remain stable; one authenticated verification step was added.
- [x] No credential, private Source/Memory content, remote response body, or unredacted production log is included.

## Validation

Exact submitted Head: `d6df3570621ef43534c4e17f92dfe46da69d4ad2`
Exact upstream release checkout: `7b736206a53a6de6f43d4b517893ee1a80e7183d`

```text
go test -count=1 ./tools/release-contract-verify ./tools/parity-inventory-generate
PASS

go test -count=1 -cover ./tools/release-contract-verify
PASS, 71.9% statements

focused parity contract/workflow file-set test
PASS

go vet ./tools/release-contract-verify ./tools/parity-inventory-generate
PASS

go mod tidy -diff
PASS

go mod verify
PASS

go run ./tools/parity-inventory-generate -upstream <exact-v0.1.0-checkout> -check
PASS

pinned actionlint
PASS

pinned golangci-lint fmt --diff and focused lint
PASS, 0 issues

make license-check
PASS, 1056 checked / 0 invalid

GITHUB_TOKEN=<authenticated session token> make release-contract-check
PASS against the official GitHub tag/release bytes, PyPI JSON, and both provenance records

git diff origin/main...HEAD --check
PASS
```

- [x] `git diff --check`
- [x] `git status --short` was inspected after validation; the submitted worktree is clean.
- [x] Formatter evidence is recorded above.
- [x] No generated consumer changed; exact generator regeneration/check evidence is recorded above.
- [x] No public Go API changed; the contract and workflow boundary tests are the relevant compatibility evidence.
- [x] Relevant online release, workflow, schema, security, lint, license, and module checks were run.
- [x] Full `go test ./...` is not represented as locally passing because the Windows host lacks `sqlite3.h`; exact-Head Linux CI is required for the full repository suite.

## AI usage

AI assistance was used to audit the existing drift coverage, compare the official GitHub and PyPI API contracts, implement the verifier and tests, and prepare this PR. The final diff was independently constrained to the release contract, verifier, generator reader, Make/workflow wiring, documentation, and the reusable HTTPS-before-token rule. Tests exercise complete network-boundary fixtures and the live official release.