### PR TITLE
ci: define Go-primary monorepo boundary

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -25,6 +25,13 @@
 Dockerfile text eol=lf
 Makefile text eol=lf
 
+# Maintained auxiliary monorepo assets. They remain tested and licensed, but
+# are not implementation languages of the PowerContext Go primary product.
+evaluation/** -linguist-detectable
+integrations/** -linguist-detectable
+test/conformance/*.py -linguist-detectable
+test/differential/*.py -linguist-detectable
+
 *.db binary
 *.db-shm binary
 *.db-wal binary

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -19,7 +19,7 @@ Four Go-specific workflows extend, rather than replace, that Python topology:
 
 | Go workflow | Purpose |
 | --- | --- |
-| `migration-gates.yml` | Reusable PR assurance called by `master.yml`: explicit owned-module integrity, fresh generated-consumer builds, public API compatibility, online verification of the recorded upstream tag, release bytes, and PyPI provenance, frozen Python Oracle and exact v0.1.0 release-fixture regeneration, Python↔Go interoperability, HTTP differential, race/fuzz, live OceanBase, host adapters, evaluation, four-platform standard/Full builds, CGO-disabled portable SDK cross-builds, and the isolated downstream public-consumer workflow. |
+| `migration-gates.yml` | Reusable PR assurance called by `master.yml`: explicit owned-module integrity, fresh generated-consumer builds, public API compatibility, online verification of the recorded upstream tag, release bytes, and PyPI provenance, frozen Python Oracle and exact v0.1.0 release-fixture regeneration, Python↔Go interoperability, HTTP differential, race/fuzz, live OceanBase, split host-adapter evidence, Codex/SQLite evaluation, four-platform standard/Full builds, CGO-disabled portable SDK cross-builds, and the isolated downstream public-consumer workflow. |
 | `codeql.yml` | Go CodeQL analysis on pull requests, pushes to `main`, a weekly schedule, and manual dispatch. Pull request runs check out the exact submitted head commit before the explicit Go build. |
 | `provider-smoke.yml` | Explicitly dispatched, credentialed, bounded real-provider verification; never required on an ordinary pull request. |
 | `windows-contract.yml` | Windows checkout-only contract guard: verifies LF attributes, both versioned fixture SHA-256 inventories, and generated-contract cleanliness without claiming Windows binary support. |
@@ -29,6 +29,19 @@ The committed `test/conformance/testdata/python-v0.0.2` baseline remains immutab
 it does not silently replace the historical Oracle. Pull requests regenerate both directories from their pinned
 sources, while Python-to-Go interoperability and HTTP differential checks continue to state exactly which Oracle
 they exercise.
+
+Within `migration-gates.yml`, host and evaluation evidence has three explicit
+contracts:
+
+| Job ID and display name | Scope | Acceptance role |
+| --- | --- | --- |
+| `host-adapters` / `Pre-WP6 host adapters` | Codex and WorkBuddy | Stable required pre-WP6 host gate; it must run for every pull request. |
+| `retained-host-adapters` / `Post-WP6 retained host adapters` | Bub, Claude Code, DSH, Hermes, LangGraph, OpenClaw, OpenCode, and Pi | Executable P3 evidence. It remains failing when its real tests fail, but branch protection must not count it as a pre-WP6 required check. |
+| `evaluation` / `Codex/SQLite evaluation control plane` | Python control plane and frontend for Codex/SQLite evaluation | WP5 evidence; it is not proof of every retained host adapter. |
+
+After the new checks first run on `main`, repository administrators must retain
+the stable `Pre-WP6 host adapters` required check and explicitly review branch
+protection so the retained P3 job is not added to the pre-WP6 required set.
 
 All third-party GitHub Actions are pinned to reviewed 40-character commit SHAs. The adjacent version comments retain
 the human-readable update intent while preventing a mutable tag from changing executable CI code.

--- a/.github/workflows/migration-gates.yml
+++ b/.github/workflows/migration-gates.yml
@@ -528,11 +528,16 @@ jobs:
           version: "0.10.12"
           enable-cache: true
 
-      - name: Test pre-WP6 host adapters
-        id: python_adapters
+      - name: Test Codex host adapter
+        id: codex_adapter
         run: |
           uv run --project integrations/codex/plugins/powercontext --locked --with pytest \
             pytest integrations/codex/tests
+
+      - name: Test WorkBuddy host adapter
+        id: workbuddy_adapter
+        if: success() || failure()
+        run: |
           uv run --with pytest pytest integrations/workbuddy/tests
 
       - name: Write bounded pre-WP6 host adapter diagnostics
@@ -540,13 +545,15 @@ jobs:
         if: always()
         shell: bash
         env:
-          PYTHON_ADAPTERS_OUTCOME: ${{ steps.python_adapters.outcome }}
+          CODEX_ADAPTER_OUTCOME: ${{ steps.codex_adapter.outcome }}
+          WORKBUDDY_ADAPTER_OUTCOME: ${{ steps.workbuddy_adapter.outcome }}
         run: |
           diagnostics="$RUNNER_TEMP/powercontext-pre-wp6-host-adapter-diagnostics"
           mkdir -p "$diagnostics"
           {
             printf 'commit=%s\n' "$GITHUB_SHA"
-            printf 'python_adapters_outcome=%s\n' "$PYTHON_ADAPTERS_OUTCOME"
+            printf 'codex_adapter_outcome=%s\n' "$CODEX_ADAPTER_OUTCOME"
+            printf 'workbuddy_adapter_outcome=%s\n' "$WORKBUDDY_ADAPTER_OUTCOME"
             sha256sum \
               integrations/codex/plugins/powercontext/uv.lock \
               integrations/workbuddy/plugins/powercontext/powercontext.json.example \

--- a/.github/workflows/migration-gates.yml
+++ b/.github/workflows/migration-gates.yml
@@ -510,7 +510,61 @@ jobs:
           make smoke-full VERSION=ci COMMIT=${{ github.sha }} BUILD_DATE=1970-01-01T00:00:00Z
 
   host-adapters:
-    name: Host adapters
+    name: Pre-WP6 host adapters
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - name: Check out
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          version: "0.10.12"
+          enable-cache: true
+
+      - name: Test pre-WP6 host adapters
+        id: python_adapters
+        run: |
+          uv run --project integrations/codex/plugins/powercontext --locked --with pytest \
+            pytest integrations/codex/tests
+          uv run --with pytest pytest integrations/workbuddy/tests
+
+      - name: Write bounded pre-WP6 host adapter diagnostics
+        id: pre_wp6_adapter_diagnostics
+        if: always()
+        shell: bash
+        env:
+          PYTHON_ADAPTERS_OUTCOME: ${{ steps.python_adapters.outcome }}
+        run: |
+          diagnostics="$RUNNER_TEMP/powercontext-pre-wp6-host-adapter-diagnostics"
+          mkdir -p "$diagnostics"
+          {
+            printf 'commit=%s\n' "$GITHUB_SHA"
+            printf 'python_adapters_outcome=%s\n' "$PYTHON_ADAPTERS_OUTCOME"
+            sha256sum \
+              integrations/codex/plugins/powercontext/uv.lock \
+              integrations/workbuddy/plugins/powercontext/powercontext.json.example \
+              integrations/workbuddy/plugins/powercontext/hooks/workbuddy_powercontext_hook.py
+          } > "$diagnostics/summary.txt"
+
+      - name: Upload pre-WP6 host adapter diagnostics
+        id: pre_wp6_adapter_upload
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: pre-wp6-host-adapter-diagnostics-${{ github.sha }}
+          path: ${{ runner.temp }}/powercontext-pre-wp6-host-adapter-diagnostics/summary.txt
+          if-no-files-found: error
+          retention-days: 14
+
+  retained-host-adapters:
+    name: Post-WP6 retained host adapters
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
@@ -531,16 +585,13 @@ jobs:
           version: "0.10.12"
           enable-cache: true
 
-      - name: Test Python host adapters
+      - name: Test retained Python host adapters
         id: python_adapters
         run: |
-          uv run --project integrations/codex/plugins/powercontext --locked --with pytest \
-            pytest integrations/codex/tests
           uv run --project integrations/bub --locked --with pytest pytest integrations/bub/tests
           uv run --with pytest pytest integrations/claude-code/tests
           uv run --with pytest --with pydantic --with httpx pytest integrations/hermes/tests
           uv run --project integrations/langgraph --locked --with pytest pytest integrations/langgraph/tests
-          uv run --with pytest pytest integrations/workbuddy/tests
 
       - name: Set up pnpm
         uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
@@ -603,7 +654,8 @@ jobs:
           pnpm build
           git diff --exit-code -- dist
 
-      - name: Write bounded host adapter diagnostics
+      - name: Write bounded retained host adapter diagnostics
+        id: retained_adapter_diagnostics
         if: always()
         shell: bash
         env:
@@ -614,7 +666,7 @@ jobs:
           OPENCODE_ADAPTER_OUTCOME: ${{ steps.opencode_adapter.outcome }}
           OPENCLAW_ADAPTER_OUTCOME: ${{ steps.openclaw_adapter.outcome }}
         run: |
-          diagnostics="$RUNNER_TEMP/powercontext-host-adapter-diagnostics"
+          diagnostics="$RUNNER_TEMP/powercontext-retained-host-adapter-diagnostics"
           mkdir -p "$diagnostics"
           {
             printf 'commit=%s\n' "$GITHUB_SHA"
@@ -636,17 +688,18 @@ jobs:
             done
           } > "$diagnostics/summary.txt"
 
-      - name: Upload host adapter diagnostics
+      - name: Upload retained host adapter diagnostics
+        id: retained_adapter_upload
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: host-adapter-diagnostics-${{ github.sha }}
-          path: ${{ runner.temp }}/powercontext-host-adapter-diagnostics/summary.txt
+          name: retained-host-adapter-diagnostics-${{ github.sha }}
+          path: ${{ runner.temp }}/powercontext-retained-host-adapter-diagnostics/summary.txt
           if-no-files-found: error
           retention-days: 14
 
   evaluation:
-    name: Evaluation control plane and console
+    name: Codex/SQLite evaluation control plane
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:

--- a/README.md
+++ b/README.md
@@ -102,8 +102,8 @@ Run `powercontext config init --non-interactive` to create a managed local
 environment file. Inspect it without disclosing credential values with
 `powercontext config show --env-file .env`, and validate syntax, persistent
 storage paths, and Server settings with `powercontext config validate --env-file .env`.
-The same installation guide documents the optional native seekDB profile;
-SQLite remains the zero-dependency default.
+SQLite remains the zero-dependency default. seekDB and OceanBase installation
+and release guidance remain deferred to the final P4 backend-alignment scope.
 
 Plain HTTP is trusted only on loopback (`localhost`, `::1`, or any address in
 `127.0.0.0/8`). The Server refuses an unauthenticated non-loopback bind by

--- a/README.md
+++ b/README.md
@@ -1,19 +1,23 @@
 # PowerContext Go
 
-PowerContext Go requires Go 1.27.0 or newer. It preserves the frozen Python
-`v0.0.2` observable contract while using Go-native domain
-types, lifecycle ownership, concurrency, persistence, transports, and release
-packaging.
+PowerContext Go requires Go 1.27.0 or newer. Its current alignment target is
+the formal PowerContext v0.1.0 release at
+`7b736206a53a6de6f43d4b517893ee1a80e7183d`; the frozen Python v0.0.2
+snapshot remains a historical regression fixture, not the current acceptance
+target. The implementation uses Go-native domain types, lifecycle ownership,
+concurrency, persistence, transports, and release packaging.
 
 ```text
 module github.com/ob-labs/powercontext-go
-oracle 3a6cb0151670eaff7dc0293466edd673124e80da
+parity target powercontext-v0.1.0 7b736206a53a6de6f43d4b517893ee1a80e7183d
+historical fixture python-v0.0.2 3a6cb0151670eaff7dc0293466edd673124e80da
 ```
 
 The HTTP source of truth is [`openapi/powercontext.yaml`](openapi/powercontext.yaml).
 Generated code under `api/v1` and generated operation tables are never edited
-by hand. Compatibility evidence lives under `test/conformance`: all 622 frozen
-Python test cases are inventoried with resolvable Go or retained-host evidence.
+by hand. Compatibility evidence lives under `test/conformance`: the v0.1.0
+release inventory contains 812 Python test cases in 132 files, alongside the
+immutable historical v0.0.2 fixture.
 
 ## Repository shape
 
@@ -31,9 +35,13 @@ Python test cases are inventoried with resolvable Go or retained-host evidence.
   observability. Native seekDB and sqlite-vec ownership lives below
   `internal/sqlstore`.
 
-- `integrations` contains host-native adapters for Codex, Claude Code, Bub,
-  DeepSeek Harness, Hermes, LangGraph, OpenClaw, OpenCode, and Pi. They
-  communicate only with the Go Server.
+- `integrations` contains maintained host-native adapters. They communicate
+  only with the Go Server and are auxiliary monorepo assets rather than Go
+  binary implementation languages. Before WP6 acceptance, the primary host
+  scope is Codex and WorkBuddy only; all other retained hosts are P3 work.
+- `evaluation` contains the deployment-neutral Codex/SQLite evaluation control
+  plane. It is maintained and tested in this repository, but is neither
+  embedded in the Go binary nor a Go release-runtime requirement.
 - `test` contains conformance, differential, and process-level suites; `tools`
   contains generators and release tooling.
 - `benchmark/locomo` contains operator-facing LoCoMo configuration and result
@@ -50,6 +58,13 @@ stability before the first release.
 There is intentionally no `common`, `utils`, generic repository layer, or DI
 container. Shared infrastructure exists only where it has one clear owner—for
 example, privacy-safe `log/slog` setup under `internal/observability/logging`.
+
+This is a Go-primary monorepo: Python and TypeScript host assets and the
+evaluation control plane remain tracked, licensed, and tested, but GitHub
+language statistics deliberately exclude them from the primary Go product
+classification. The pre-WP6 acceptance matrix is Codex, WorkBuddy, and
+SQLite. Retained host adapters expand after WP6; seekDB and OceanBase remain
+the final backend-alignment scope.
 
 See [`docs/architecture/README.md`](docs/architecture/README.md) for the full
 directory map and dependency rules.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -20,7 +20,7 @@ powercontext-go/
 ├── client/                    typed client for all OpenAPI operations
 ├── cmd/powercontext/          single executable entrypoint
 ├── docs/                      architecture, ADRs, RFCs, release guidance
-├── evaluation/                independent long-horizon evaluation harness
+├── evaluation/                deployment-neutral Codex/SQLite evaluation control plane
 ├── inference/                 provider-neutral generation and embeddings
 ├── integrations/
 │   ├── bub/                   retained Python host adapter
@@ -31,7 +31,8 @@ powercontext-go/
 │   ├── langgraph/             retained Python LangGraph package
 │   ├── openclaw/              retained TypeScript OpenClaw memory plugin
 │   ├── opencode/              retained TypeScript OpenCode plugin
-│   └── pi/                    retained TypeScript Pi extension
+│   ├── pi/                    retained TypeScript Pi extension
+│   └── workbuddy/             retained Python WorkBuddy plugin
 ├── internal/
 │   ├── benchmark/             bounded benchmark adapters and fixtures
 │   ├── cli/                   Cobra command implementation
@@ -69,6 +70,20 @@ Top-level packages are public only when users or integrations need their types.
 Concrete technology choices stay under `internal`; process startup stays in
 `server` and `cmd`. This avoids both a Python-shaped `src` tree and a large
 catch-all infrastructure package.
+
+## Go-primary monorepo boundary
+
+The Go Server, SDK, CLI, OpenAPI contract, and SQLite path are this
+repository's primary product surface. `evaluation/` and `integrations/` remain
+maintained, licensed, and tested auxiliary monorepo assets: the former is a
+deployment-neutral Codex/SQLite evaluation control plane, while the latter
+contains host-native assets that call the Go Server over HTTP or MCP. They are
+not Go binary runtime dependencies or primary implementation languages.
+
+Before WP6 acceptance, Codex, WorkBuddy, and SQLite are the only host/database
+scope. The other retained adapters remain P3 assets with their own executable
+CI job; they are not removed or treated as WP6 evidence. seekDB and OceanBase
+remain the final P4 backend-alignment scope.
 
 ## Dependency direction
 

--- a/docs/release/INSTALL.md
+++ b/docs/release/INSTALL.md
@@ -1,9 +1,9 @@
 # Install a PowerContext binary release
 
 Every archive is self-describing and contains the CLI/Server binary, the
-authoritative OpenAPI document, `.env.example`, all nine host adapters, embedded
-sqlite-vec, dependency licenses, build metadata, an SPDX JSON SBOM, and an
-internal `SHA256SUMS` file.
+authoritative OpenAPI document, `.env.example`, retained host-adapter assets,
+embedded sqlite-vec, dependency licenses, build metadata, an SPDX JSON SBOM,
+and an internal `SHA256SUMS` file.
 
 Release verification checks the packaged `.env.example` before starting the
 binary. Its security-sensitive defaults keep the Server and Client on
@@ -31,29 +31,18 @@ host SQLite package is required. The Full archive also contains ONNX Runtime und
 `lib/onnxruntime/`; set `POWERCONTEXT_ONNXRUNTIME_LIBRARY_DIR` to that
 directory before selecting a `sentence-transformers:*` embedding model.
 
-SQLite is the self-contained default. Embedded seekDB is optional on Linux and
-macOS and requires a native `libseekdb` package from the official
-[`oceanbase/seekdb-bindings`](https://github.com/oceanbase/seekdb-bindings)
-release. Keep the `seekdb` executable beside `libseekdb.so` (or
-`libseekdb.dylib`). Either place that library beside the PowerContext binary or
-set its explicit path, then select the profile:
+SQLite is the self-contained default and the only database in the pre-WP6
+installation and acceptance scope. seekDB and OceanBase remain the final P4
+backend-alignment work; their migration, packaging, license/SBOM, and release
+reconciliation instructions are intentionally deferred until that scope is
+accepted.
 
-```sh
-export POWERCONTEXT_SERVER_DATABASE_KIND=seekdb
-export POWERCONTEXT_SERVER_DATABASE_LIBRARY_PATH=/opt/seekdb/lib/libseekdb.so
-# Optional; defaults to $POWERCONTEXT_HOME/seekdb.
-export POWERCONTEXT_SERVER_DATABASE_PATH=/var/lib/powercontext/seekdb
-./bin/powercontext server run
-```
-
-The server fails closed if the native library is missing, incompatible, or
-does not return a valid local connection profile; it never silently falls back
-to a different database.
-
-The binary itself does not require a Python runtime. Codex, Claude Code, Bub,
-Hermes, and LangGraph retain host-native Python adapters; DSH, OpenClaw,
-OpenCode, and Pi retain TypeScript adapters. Each adapter is isolated from the
-Go implementation and calls the Go Server over HTTP or MCP.
+The binary itself does not require a Python runtime. This monorepo tracks
+Python and TypeScript assets for host-native integrations and the evaluation
+control plane, but they are not Go binary runtime requirements. Before WP6,
+the supported acceptance matrix is Codex, WorkBuddy, and SQLite. Other
+retained host adapters are isolated from the Go implementation, call the Go
+Server over HTTP or MCP, and remain in the post-WP6 P3 work plan.
 
 The container images bind `0.0.0.0:8000` and declare the explicit
 controlled-network opt-in required for a published port. That opt-in does not

--- a/docs/superpowers/plans/2026-09-01-go-primary-monorepo-boundary.md
+++ b/docs/superpowers/plans/2026-09-01-go-primary-monorepo-boundary.md
@@ -1,0 +1,317 @@
+# Go-primary Monorepo Boundary Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Keep all assets in `powercontext-go` while making Go the documented and GitHub-classified primary product, and limiting pre-WP6 acceptance to Codex, WorkBuddy, and SQLite.
+
+**Architecture:** The repository remains a monorepo. `.gitattributes` excludes maintained auxiliary sources from GitHub language statistics without calling them vendored or generated; a Go contract test prevents classification drift. The existing `host-adapters` job keeps its stable required identity but runs Codex and WorkBuddy only, while a separate retained-agent job preserves executable P3 evidence. Documentation and Issue #3 state the same boundary.
+
+**Tech Stack:** Go 1.27.0, Go test, GitHub Actions YAML, actionlint, GitHub CLI, Zensical documentation build, Git attributes.
+
+**Spec:** `docs/superpowers/specs/2026-09-01-go-primary-monorepo-boundary-design.md`
+
+## Global Constraints
+
+- Work in the isolated `codex/monorepo-boundary` worktree created from current `origin/main`; do not edit the stale root checkout or its `.omx/` and `.workbuddy/` directories.
+- Preserve every tracked adapter, evaluation asset, fixture, lock file, and completed Issue #3 checkbox.
+- Keep `host-adapters` as the stable pre-WP6 required job identifier; never use a path filter that can make it disappear.
+- Use `-linguist-detectable` only. Do not add `linguist-vendored` or `linguist-generated` to any maintained project path.
+- Do not modify Go runtime behavior, public APIs, database formats, OpenAPI, generated contracts, or seekDB/OceanBase scope.
+- Follow Go 1.27 guidelines for any changed Go test file; run the Modern Go Guidelines `list` command for that file before editing it.
+- Every external GitHub state claim must be reread after mutation; GitHub language statistics may be asynchronous and must be verified after the merge reaches default branch.
+
+---
+
+### Task 1: Pin the GitHub language-classification boundary
+
+**Files:**
+- Modify: `.gitattributes`
+- Modify: `tools/release/workflow_test.go`
+- Test: `tools/release/workflow_test.go`
+
+**Interfaces:**
+- Consumes: tracked monorepo roots `evaluation/`, `integrations/`, `test/conformance/*.py`, and `test/differential/*.py`.
+- Produces: exact Git attribute rules that GitHub Linguist applies after commit; a Go regression test that rejects missing, widened, or misleading rules.
+
+- [ ] **Step 1: Add the failing Go contract test before changing `.gitattributes`**
+
+  Add `TestGoPrimaryMonorepoLinguistPolicy` to `tools/release/workflow_test.go`. It must read `.gitattributes` from the repository root and require these full lines:
+
+  ```go
+  required := []string{
+      "evaluation/** -linguist-detectable",
+      "integrations/** -linguist-detectable",
+      "test/conformance/*.py -linguist-detectable",
+      "test/differential/*.py -linguist-detectable",
+  }
+  forbidden := []string{
+      "linguist-vendored",
+      "linguist-generated",
+  }
+  ```
+
+  The test must fail with the missing exact rule or forbidden attribute. It must not accept an arbitrary `*.py` global rule because that could hide Go-adjacent Python fixtures outside the reviewed roots.
+
+- [ ] **Step 2: Run the new test and record the expected failure**
+
+  Run:
+
+  ```powershell
+  go test ./tools/release -run TestGoPrimaryMonorepoLinguistPolicy -count=1
+  ```
+
+  Expected: FAIL because no `linguist-detectable` rules exist yet.
+
+- [ ] **Step 3: Add only the four reviewed Linguist rules**
+
+  Append this explanatory block to `.gitattributes`, keeping the existing LF and binary entries unchanged:
+
+  ```gitattributes
+  # Maintained auxiliary monorepo assets. They remain tested and licensed, but
+  # are not implementation languages of the PowerContext Go primary product.
+  evaluation/** -linguist-detectable
+  integrations/** -linguist-detectable
+  test/conformance/*.py -linguist-detectable
+  test/differential/*.py -linguist-detectable
+  ```
+
+- [ ] **Step 4: Prove the checked-out attribute semantics and the regression test**
+
+  Run:
+
+  ```powershell
+  git check-attr linguist-detectable -- evaluation/src/powercontext_eval/runner.py integrations/codex/plugins/powercontext/hooks/recall.py test/conformance/python_oracle_fixture.py test/differential/compare_servers.py
+  go test ./tools/release -run TestGoPrimaryMonorepoLinguistPolicy -count=1
+  git diff --check
+  ```
+
+  Expected: each listed path reports `linguist-detectable: unset`; the Go contract passes; whitespace validation passes.
+
+- [ ] **Step 5: Commit the isolated language-policy slice**
+
+  ```powershell
+  git add .gitattributes tools/release/workflow_test.go
+  git commit -m "build: mark auxiliary monorepo sources non-detectable"
+  ```
+
+### Task 2: Split pre-WP6 and retained-adapter CI contracts
+
+**Files:**
+- Modify: `.github/workflows/migration-gates.yml`
+- Modify: `tools/release/workflow_test.go`
+- Test: `tools/release/workflow_test.go`
+
+**Interfaces:**
+- Consumes: the existing `host-adapters` job and all current adapter commands.
+- Produces: stable `host-adapters` job ID for pre-WP6 required coverage, new `retained-host-adapters` job ID for P3 evidence, and independently sanitized failure diagnostics for each job.
+
+- [ ] **Step 1: Write workflow-contract tests that fail against the mixed job**
+
+  Replace the single mixed-job assertions in `TestHostAdapterFailureDiagnosticsAreBoundedAndSanitized` with two focused checks, or add two new tests named `TestPreWP6HostAdapterWorkflowContract` and `TestRetainedHostAdapterWorkflowContract`.
+
+  The pre-WP6 test must require:
+
+  ```go
+  preWP6, ok := workflow.Jobs["host-adapters"]
+  if !ok {
+      t.Fatal("migration-gates.yml has no host-adapters job")
+  }
+  if preWP6.Name != "Pre-WP6 host adapters" {
+      t.Fatalf("host-adapters name = %q", preWP6.Name)
+  }
+  ```
+
+  It must assert that the Python command contains the Codex and WorkBuddy test paths and does not contain `bub`, `claude-code`, `hermes`, or `langgraph`; it must require diagnostics with the Codex `uv.lock` plus WorkBuddy `powercontext.json.example` and `workbuddy_powercontext_hook.py` identities.
+
+  The retained test must require `workflow.Jobs["retained-host-adapters"]`, display name `Post-WP6 retained host adapters`, all former non-Codex/WorkBuddy Python and Node commands, `if: failure()` upload behavior, and no secret-revealing commands in its diagnostics.
+
+- [ ] **Step 2: Run the focused contract tests and record their failure**
+
+  Run:
+
+  ```powershell
+  go test ./tools/release -run 'Test(PreWP6|Retained)HostAdapterWorkflowContract' -count=1
+  ```
+
+  Expected: FAIL because the existing workflow has only the mixed `host-adapters` job.
+
+- [ ] **Step 3: Split `.github/workflows/migration-gates.yml` without weakening real commands**
+
+  Keep `host-adapters:` and set `name: Pre-WP6 host adapters`. Its setup must retain Python 3.12 and uv, then execute exactly:
+
+  ```bash
+  uv run --project integrations/codex/plugins/powercontext --locked --with pytest \
+    pytest integrations/codex/tests
+  uv run --with pytest pytest integrations/workbuddy/tests
+  ```
+
+  Add `retained-host-adapters:` with `name: Post-WP6 retained host adapters`. Move, unchanged, the Bub, Claude Code, Hermes, LangGraph, DSH, Pi, OpenCode, and OpenClaw setup/build/test/generated-diff commands into that job. Give it its own bounded summary directory, `if: always()` summary step, and `if: failure()` artifact upload; do not use `continue-on-error`.
+
+  In the pre-WP6 summary, hash:
+
+  ```bash
+  sha256sum \
+    integrations/codex/plugins/powercontext/uv.lock \
+    integrations/workbuddy/plugins/powercontext/powercontext.json.example \
+    integrations/workbuddy/plugins/powercontext/hooks/workbuddy_powercontext_hook.py
+  ```
+
+- [ ] **Step 4: Update workflow-contract expectations and validate static workflow behavior**
+
+  Update `TestContinuousIntegrationPreservesPythonTopologyAndGoAssurance` so `migration-gates.yml` requires both visible job names. Run:
+
+  ```powershell
+  go test ./tools/release -run 'Test(PreWP6|Retained|HostAdapter|ContinuousIntegration)' -count=1
+  make actionlint
+  git diff --check
+  ```
+
+  Expected: all selected tests pass; actionlint reports no invalid job, cache, expression, shell, or action configuration; diff check passes.
+
+- [ ] **Step 5: Commit the CI-scope slice**
+
+  ```powershell
+  git add .github/workflows/migration-gates.yml tools/release/workflow_test.go
+  git commit -m "ci: split pre-WP6 and retained adapter gates"
+  ```
+
+### Task 3: Align the repository documentation and issue work plan
+
+**Files:**
+- Modify: `README.md`
+- Modify: `docs/architecture/README.md`
+- Modify: `docs/release/INSTALL.md`
+- Modify: `.github/workflows/README.md`
+- Modify: GitHub Issue `ob-labs/powercontext-go#3`
+- Test: documentation build and Issue readback
+
+**Interfaces:**
+- Consumes: the committed classification rules and CI job names from Tasks 1–2.
+- Produces: one consistent user-facing description of the Go-primary monorepo and an Issue #3 checklist that does not widen WP6 acceptance.
+
+- [ ] **Step 1: Update the root and architecture descriptions**
+
+  In `README.md`, replace the undifferentiated integrations bullet with language that identifies `integrations/` and `evaluation/` as maintained auxiliary monorepo assets, says they communicate with or evaluate the Go Server, and limits the pre-WP6 primary acceptance matrix to Codex, WorkBuddy, and SQLite.
+
+  In `docs/architecture/README.md`, keep every existing directory in the tree but annotate `evaluation/` as a deployment-neutral Codex/SQLite evaluation control plane and `integrations/` as host-native assets. Add a short ownership paragraph stating that retained adapters other than Codex/WorkBuddy are P3 assets, not WP6 acceptance evidence.
+
+- [ ] **Step 2: Update installation and workflow documentation**
+
+  In `docs/release/INSTALL.md`, retain the statement that the Go binary has no Python runtime dependency. Follow it with this exact distinction in prose: Python and TypeScript assets are tracked in the monorepo for host-native integrations and evaluation; they are not Go binary runtime requirements; only Codex, WorkBuddy, and SQLite form the pre-WP6 support matrix.
+
+  In `.github/workflows/README.md`, replace the one-row description of mixed host adapters/evaluation with three entries: `Pre-WP6 host adapters`, `Post-WP6 retained host adapters`, and `Codex/SQLite evaluation control plane`. State that required-check branch protection applies to the first and not the retained P3 job; administrators must make that branch-protection adjustment after the job appears on the merged default branch.
+
+- [ ] **Step 3: Add the Issue #3 monorepo-boundary work package without reopening completed work**
+
+  Download the current Issue body immediately before editing:
+
+  ```powershell
+  $issueBodyPath = Join-Path $env:TEMP 'powercontext-go-issue3-monorepo-boundary.md'
+  gh issue view 3 --repo ob-labs/powercontext-go --json body,updatedAt | ConvertFrom-Json
+  ```
+
+  Insert a `P0 — Go-primary monorepo boundary` subsection before the WP5/WP6 acceptance priority. Its unchecked work items must cover: exact `.gitattributes` classifications; required Codex/WorkBuddy workflow; separate retained-host workflow; documentation consistency; post-merge language API verification; and branch-protection review. Its prose must state that all source remains in one repository, retained adapters remain P3, and seekDB/OceanBase remain final P4.
+
+  Submit only after comparing checked-item counts before and after:
+
+  ```powershell
+  gh issue edit 3 --repo ob-labs/powercontext-go --body-file $issueBodyPath
+  gh issue view 3 --repo ob-labs/powercontext-go --json body,updatedAt
+  ```
+
+  Use a temporary file outside the repository or delete it with `apply_patch` after submission. Do not include secrets, local paths, or stale check counts.
+
+- [ ] **Step 4: Validate documentation and review the exact Issue result**
+
+  Run:
+
+  ```powershell
+  make docs-test
+  git diff --check
+  gh issue view 3 --repo ob-labs/powercontext-go --json body,updatedAt,url
+  ```
+
+  Expected: documentation build succeeds; no whitespace errors; Issue readback contains the monorepo P0 items, Codex/WorkBuddy/SQLite pre-WP6 scope, P3 retained agents, and final P4 seekDB/OceanBase boundary.
+
+- [ ] **Step 5: Commit the repository-documentation slice**
+
+  ```powershell
+  git add README.md docs/architecture/README.md docs/release/INSTALL.md .github/workflows/README.md
+  git commit -m "docs: define Go-primary monorepo scope"
+  ```
+
+### Task 4: Prove the branch and default-branch result
+
+**Files:**
+- Verify: `.gitattributes`
+- Verify: `.github/workflows/migration-gates.yml`
+- Verify: `tools/release/workflow_test.go`
+- Verify: documentation files and GitHub Issue #3
+
+**Interfaces:**
+- Consumes: all three implementation commits and the live GitHub repository.
+- Produces: exact-Head verification evidence, a reviewable pull request, merged default-branch confirmation, and post-Linguist language-API evidence.
+
+- [ ] **Step 1: Run the focused local acceptance set on the final branch Head**
+
+  Run:
+
+  ```powershell
+  go test ./tools/release -count=1
+  make actionlint
+  make docs-test
+  git diff --check
+  git status --short
+  ```
+
+  Expected: every command succeeds and `git status --short` is empty.
+
+- [ ] **Step 2: Push the branch and open a focused pull request**
+
+  Run:
+
+  ```powershell
+  $prBodyPath = Join-Path $env:TEMP 'powercontext-go-monorepo-boundary-pr.md'
+  git push -u origin codex/monorepo-boundary
+  gh pr create --repo ob-labs/powercontext-go --base main --head codex/monorepo-boundary --title "ci: define Go-primary monorepo boundary" --body-file $prBodyPath
+  ```
+
+  The PR description must link Issue #3, name the four Linguist paths, explain that no maintained code is labeled vendored/generated, list the pre-WP6 versus P3 job identities, state that no adapter/evaluation source is deleted, and record the exact validation commands.
+
+- [ ] **Step 3: Recheck exact Head and CI before merge**
+
+  Read the PR base/head SHA, files, review state, and check conclusions after the last push. Do not reuse evidence if the head changes. Resolve any failing gate without weakening the contract tests or making retained adapters silently pass.
+
+- [ ] **Step 4: Merge only after live approval and then verify default branch**
+
+  After the repository's normal review approval, merge through the configured GitHub policy. Verify server-side merge metadata, fetch `origin/main`, and confirm the merged commit and Issue state. A zero exit code from a merge command is not sufficient proof.
+
+- [ ] **Step 5: Verify Linguist after default-branch recalculation**
+
+  Poll no more often than once per hour until GitHub reflects the committed `.gitattributes`:
+
+  ```powershell
+  gh api repos/ob-labs/powercontext-go/languages
+  ```
+
+  Expected: the classified `evaluation/`, `integrations/`, and Python fixture paths are absent from the language-byte total and Go is the leading reported language. Record the full API response and the merge SHA in Issue #3 or the PR evidence; do not claim the percentage changed before this API confirms it.
+
+## Plan self-review
+
+### Spec coverage
+
+- Single-repository preservation and no adapter deletion: Tasks 1–3.
+- Honest Linguist classification and GitHub API verification: Tasks 1 and 4.
+- Codex/WorkBuddy/SQLite-only pre-WP6 CI: Task 2.
+- Executable P3 retained-adapter evidence: Task 2.
+- Evaluation's Codex/SQLite role and documentation: Task 3.
+- Issue #3 P3/P4 sequencing: Task 3.
+- Exact-Head, merge, and default-branch proof: Task 4.
+
+### Completeness scan
+
+The plan names exact files, commands, expected outcomes, and commit boundaries for every task. It has no deferred-action markers or generic test instructions.
+
+### Type and contract consistency
+
+The workflow retains the stable `host-adapters` job ID for branch protection. The separate P3 job is consistently named `retained-host-adapters`. Documentation and Issue text use the same pre-WP6 boundary: Codex, WorkBuddy, and SQLite; retained agents are P3; seekDB/OceanBase are P4.

--- a/docs/superpowers/specs/2026-09-01-go-primary-monorepo-boundary-design.md
+++ b/docs/superpowers/specs/2026-09-01-go-primary-monorepo-boundary-design.md
@@ -1,0 +1,171 @@
+# Go-primary monorepo boundary design
+
+## Status
+
+Approved design direction: retain one `powercontext-go` repository while
+making the Go Server, SDK, CLI, OpenAPI contract, and SQLite path its primary
+product surface. This document defines the boundary before the corresponding
+Issue, documentation, CI, and GitHub language-statistics changes are made.
+
+## Problem
+
+GitHub currently reports Python as 27.37% of this repository. The number is
+accurate for tracked source bytes: the `evaluation/` Python control plane is
+about 1.52 MB, host-native Python adapters are about 0.41 MB, and Python
+conformance/differential fixtures are about 0.07 MB. The repository therefore
+looks like a broad Python/TypeScript monorepo even though its principal
+deliverable is the Go Server, Go SDK, and Go CLI.
+
+The existing CI also treats every retained adapter as one `Host adapters` job.
+That contradicts the accepted delivery order: before WP6, only Codex and
+WorkBuddy are in the host-agent acceptance scope, and SQLite is the only
+database in scope. OpenCode, DSH, LangChain, Pydantic AI, Hermes, and other
+retained adapters belong to the post-WP6 expansion; seekDB and OceanBase are
+the final backend scope.
+
+## Goals
+
+1. Keep all current source, test evidence, and adapter history in this single
+   repository.
+2. Make the root documentation and Issue #3 describe a Go-primary monorepo
+   rather than a repository whose every language is a release-equivalent
+   product surface.
+3. Make GitHub language statistics identify the Go primary product without
+   misclassifying self-maintained sources as vendored or generated.
+4. Make pre-WP6 CI acceptance explicitly cover only Codex, WorkBuddy, and
+   SQLite, while retaining executable post-WP6 adapter evidence in an
+   independently named, non-pre-WP6 gate.
+5. Preserve the Python-to-Go conformance and differential fixtures needed to
+   prove the pinned PowerContext v0.1.0 contract.
+
+## Non-goals
+
+- Do not delete or move `evaluation/`, `integrations/`, or Python fixtures to
+  another repository.
+- Do not rewrite host adapters into Go.
+- Do not label maintained code with `linguist-vendored` or
+  `linguist-generated`.
+- Do not make a post-WP6 adapter failure invisible by weakening assertions,
+  silently skipping it, or treating a non-run job as a successful gate.
+- Do not move seekDB or OceanBase into the pre-WP6 database acceptance scope.
+
+## Repository ownership model
+
+| Area | Ownership and release role | Pre-WP6 acceptance role |
+| --- | --- | --- |
+| Go domain packages, `internal/`, `client/`, `server/`, `cmd/`, `openapi/`, `api/v1/` | Primary PowerContext Go implementation and release surface | Required |
+| SQLite runtime and SQLite tests | Default self-contained persistence implementation | Required |
+| `integrations/codex/`, `integrations/workbuddy/` | Maintained host-native assets consumed by the Go product | Required host adapters |
+| `evaluation/` | Maintained, deployment-neutral Codex/SQLite evaluation control plane; not embedded in the Go binary or release archive | WP5 evaluation evidence only |
+| Other `integrations/**` directories | Maintained retained-host assets and historical evidence | Post-WP6 only |
+| `test/conformance/*.py`, `test/differential/*.py` | Python execution fixtures used to prove Python-to-Go compatibility | Required parity evidence, not product implementation |
+| seekDB and OceanBase code/tests | Optional/final storage-backend work | Final P4 only |
+
+The root repository remains a monorepo. "Primary" describes the release and
+acceptance boundary; it does not claim the excluded directories are unowned.
+
+## GitHub language-statistics policy
+
+The root `.gitattributes` must retain its existing LF and binary rules and add
+these explicit Linguist classifications:
+
+```gitattributes
+# Tracked, maintained auxiliary assets; not implementation languages of the
+# PowerContext Go primary product.
+evaluation/** -linguist-detectable
+integrations/** -linguist-detectable
+test/conformance/*.py -linguist-detectable
+test/differential/*.py -linguist-detectable
+```
+
+`-linguist-detectable` changes only GitHub language classification. It must
+not change checkout attributes, syntax highlighting intent, test execution,
+license scanning, release contents, generated-file checks, or CI paths.
+GitHub recalculates language statistics from a committed `.gitattributes`;
+the change is accepted only after the default-branch language API confirms the
+expected Go-primary result.
+
+## CI topology
+
+The current single `host-adapters` job mixes pre-WP6 and deferred products.
+It must be split without path-filter disappearance or test weakening.
+
+1. The existing required job identity stays stable as `host-adapters`, with
+   display name `Pre-WP6 host adapters`. It executes only Codex and WorkBuddy
+   installation, packaging, surface, service-chain, redaction, and transport
+   tests. Its diagnostics contain only those two adapter outcomes plus one
+   stable dependency or source identity per adapter: the Codex `uv.lock` hash
+   and hashes of the WorkBuddy configuration template and hook entrypoint.
+2. A separately named `retained-host-adapters` job runs the currently retained
+   non-pre-WP6 adapters with their real Python/Node install, generation,
+   type-check, unit, build, and call-through commands. It remains a failing,
+   evidence-producing job when run; branch-protection configuration must not
+   count it as a pre-WP6 required check.
+3. The evaluation job is renamed to `Codex/SQLite evaluation control plane`.
+   It keeps its current Python, frontend, and deterministic evaluation tests,
+   but its documentation and diagnostics identify it as WP5 Codex/SQLite
+   evidence rather than proof of every host adapter.
+4. Workflow documentation describes the three distinct contracts above and
+   names their required/non-required lifecycle. The job graph must continue to
+   produce one stable conclusion for every pull request; no path filter may
+   omit a required pre-WP6 job.
+
+## Documentation and Issue contract
+
+Issue #3 gains a monorepo-boundary work package before WP6 acceptance. It
+records the exact directory classifications, the GitHub-statistics policy, the
+CI split, and the validation requirements. Its existing completed checkboxes
+remain completed. The WorkBuddy/Codex plus SQLite limit remains the sole
+pre-WP6 acceptance scope. All retained hosts stay in P3, and seekDB/OceanBase
+stay in final P4.
+
+The README, architecture overview, release installation guide, and workflow
+README must state all of the following consistently:
+
+- The Go binary does not need Python at runtime.
+- The repository deliberately tracks host-native adapters and a Python
+  evaluation control plane, but they are auxiliary monorepo assets rather than
+  Go core implementation languages.
+- Before WP6 acceptance, only Codex, WorkBuddy, and SQLite are supported by
+  the primary acceptance matrix.
+- Other retained adapters are not removed; they have an explicit post-WP6
+  ownership and CI path.
+
+## Migration sequence and rollback
+
+1. Add the Issue #3 work package and this documented boundary.
+2. Add `.gitattributes` classifications and a repository test that asserts the
+   exact classification lines, preserving existing LF rules.
+3. Split the host-adapter workflow and update its diagnostics and workflow
+   documentation.
+4. Update root/release/architecture documentation and test its executable
+   commands/links.
+5. Push the branch, wait for exact-Head CI, merge, then query the default
+   branch's GitHub language API after Linguist recalculates.
+
+Rollback is a normal revert of this focused boundary change. It does not
+delete adapters, evaluation data, test fixtures, lock files, or release
+artifacts. If a required Codex/WorkBuddy test is missing from the split, the
+split is repaired before merge; it is never bypassed by expanding the job back
+to every retained adapter.
+
+## Acceptance criteria
+
+1. The committed `.gitattributes` contains the four exact
+   `-linguist-detectable` path rules and no `linguist-vendored` or
+   `linguist-generated` rule for maintained project paths.
+2. GitHub's default-branch language API no longer counts the classified
+   auxiliary paths and reports Go as the primary language.
+3. The required `host-adapters` job runs real Codex and WorkBuddy tests only;
+   its failure diagnostics include both outcomes, the Codex lock identity, and
+   the WorkBuddy template and hook identities.
+4. The separate retained-adapter job remains executable and failing when its
+   own real test or generated-diff command fails, but is documented as
+   post-WP6 evidence rather than a pre-WP6 completion condition.
+5. The evaluation job continues to run the Python control-plane and frontend
+   tests and is documented as Codex/SQLite WP5 evidence.
+6. README, architecture, release, workflow documentation, and Issue #3 agree
+   on the same repository and phase boundaries.
+7. `make docs-test`, workflow/YAML contract tests, and the relevant adapter
+   test commands succeed on the exact branch Head without leaving worktree
+   changes.

--- a/tools/release/workflow_test.go
+++ b/tools/release/workflow_test.go
@@ -29,6 +29,30 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+func TestGoPrimaryMonorepoLinguistPolicy(t *testing.T) {
+	repository := filepath.Clean(filepath.Join("..", ".."))
+	payload, err := os.ReadFile(filepath.Join(repository, ".gitattributes"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	attributes := string(payload)
+	for _, required := range []string{
+		"evaluation/** -linguist-detectable",
+		"integrations/** -linguist-detectable",
+		"test/conformance/*.py -linguist-detectable",
+		"test/differential/*.py -linguist-detectable",
+	} {
+		if !strings.Contains(attributes, required) {
+			t.Errorf(".gitattributes is missing %q", required)
+		}
+	}
+	for _, forbidden := range []string{"linguist-vendored", "linguist-generated"} {
+		if strings.Contains(attributes, forbidden) {
+			t.Errorf(".gitattributes must not classify maintained sources as %q", forbidden)
+		}
+	}
+}
+
 func TestContinuousIntegrationPreservesPythonTopologyAndGoAssurance(t *testing.T) {
 	repository := filepath.Clean(filepath.Join("..", ".."))
 	workflows := filepath.Join(repository, ".github", "workflows")

--- a/tools/release/workflow_test.go
+++ b/tools/release/workflow_test.go
@@ -35,20 +35,34 @@ func TestGoPrimaryMonorepoLinguistPolicy(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	attributes := string(payload)
-	for _, required := range []string{
-		"evaluation/** -linguist-detectable",
-		"integrations/** -linguist-detectable",
-		"test/conformance/*.py -linguist-detectable",
-		"test/differential/*.py -linguist-detectable",
-	} {
-		if !strings.Contains(attributes, required) {
-			t.Errorf(".gitattributes is missing %q", required)
+	wantDetectable := map[string]bool{
+		"evaluation/**":          false,
+		"integrations/**":        false,
+		"test/conformance/*.py":  false,
+		"test/differential/*.py": false,
+	}
+	for _, line := range strings.Split(string(payload), "\n") {
+		fields := strings.Fields(strings.SplitN(line, "#", 2)[0])
+		if len(fields) < 2 {
+			continue
+		}
+		path := fields[0]
+		for _, attribute := range fields[1:] {
+			switch attribute {
+			case "-linguist-detectable":
+				if _, ok := wantDetectable[path]; !ok {
+					t.Errorf(".gitattributes has broad or unowned linguist classification %q", line)
+					continue
+				}
+				wantDetectable[path] = true
+			case "linguist-vendored", "linguist-generated":
+				t.Errorf(".gitattributes must not classify maintained sources as %q", attribute)
+			}
 		}
 	}
-	for _, forbidden := range []string{"linguist-vendored", "linguist-generated"} {
-		if strings.Contains(attributes, forbidden) {
-			t.Errorf(".gitattributes must not classify maintained sources as %q", forbidden)
+	for path, found := range wantDetectable {
+		if !found {
+			t.Errorf(".gitattributes is missing %q", path+" -linguist-detectable")
 		}
 	}
 }
@@ -996,18 +1010,24 @@ func TestPreWP6HostAdapterWorkflowContract(t *testing.T) {
 			}{step.Name, step.If, step.Uses, step.With, step.Env, step.Run}
 		}
 	}
-	python, ok := steps["python_adapters"]
+	codex, ok := steps["codex_adapter"]
 	if !ok {
-		t.Fatal("host-adapters has no python_adapters step")
+		t.Fatal("host-adapters has no codex_adapter step")
 	}
-	for _, required := range []string{"integrations/codex/tests", "integrations/workbuddy/tests"} {
-		if !strings.Contains(python.Run, required) {
-			t.Errorf("pre-WP6 adapter command is missing %q: %s", required, python.Run)
-		}
+	if !strings.Contains(codex.Run, "integrations/codex/tests") || strings.Contains(codex.Run, "integrations/workbuddy") {
+		t.Errorf("Codex adapter command = %q", codex.Run)
+	}
+	workBuddy, ok := steps["workbuddy_adapter"]
+	if !ok {
+		t.Fatal("host-adapters has no workbuddy_adapter step")
+	}
+	if workBuddy.If != "success() || failure()" || !strings.Contains(workBuddy.Run, "integrations/workbuddy/tests") ||
+		strings.Contains(workBuddy.Run, "integrations/codex") {
+		t.Errorf("WorkBuddy adapter contract = %#v", workBuddy)
 	}
 	for _, deferred := range []string{"integrations/bub", "integrations/claude-code", "integrations/hermes", "integrations/langgraph"} {
-		if strings.Contains(python.Run, deferred) {
-			t.Errorf("pre-WP6 adapter command must not include %q: %s", deferred, python.Run)
+		if strings.Contains(codex.Run, deferred) || strings.Contains(workBuddy.Run, deferred) {
+			t.Errorf("pre-WP6 adapter commands must not include %q", deferred)
 		}
 	}
 	for _, deferredID := range []string{"dsh_server", "dsh_adapter", "pi_adapter", "opencode_adapter", "openclaw_adapter"} {
@@ -1019,7 +1039,9 @@ func TestPreWP6HostAdapterWorkflowContract(t *testing.T) {
 	if !ok {
 		t.Fatal("host-adapters has no pre_wp6_adapter_diagnostics step")
 	}
-	if summary.If != "always()" || summary.Env["PYTHON_ADAPTERS_OUTCOME"] != "${{ steps.python_adapters.outcome }}" {
+	if summary.If != "always()" ||
+		summary.Env["CODEX_ADAPTER_OUTCOME"] != "${{ steps.codex_adapter.outcome }}" ||
+		summary.Env["WORKBUDDY_ADAPTER_OUTCOME"] != "${{ steps.workbuddy_adapter.outcome }}" {
 		t.Errorf("pre-WP6 diagnostics contract = %#v", summary)
 	}
 	for _, required := range []string{

--- a/tools/release/workflow_test.go
+++ b/tools/release/workflow_test.go
@@ -104,7 +104,7 @@ func TestContinuousIntegrationPreservesPythonTopologyAndGoAssurance(t *testing.T
 			"FuzzRestrictedPickleJobDecoder", "Frozen Python Oracle and differential fixtures",
 			"Run Python to Go to Python compatibility tests", "Run the frozen Python versus Go HTTP differential",
 			"OceanBase live compatibility", "Standard (", "Full build tags (",
-			"Host adapters", "Evaluation control plane and console",
+			"Pre-WP6 host adapters", "Post-WP6 retained host adapters", "Codex/SQLite evaluation control plane",
 		},
 		"codeql.yml": {
 			"name: CodeQL", "pull_request:", "push:", "branches: [main]", "schedule:", "workflow_dispatch:",
@@ -946,7 +946,7 @@ func TestFrozenOracleFailureDiagnosticsAreBoundedAndSanitized(t *testing.T) {
 	}
 }
 
-func TestHostAdapterFailureDiagnosticsAreBoundedAndSanitized(t *testing.T) {
+func TestPreWP6HostAdapterWorkflowContract(t *testing.T) {
 	repository := filepath.Clean(filepath.Join("..", ".."))
 	payload, err := os.ReadFile(filepath.Join(repository, ".github", "workflows", "migration-gates.yml"))
 	if err != nil {
@@ -954,6 +954,7 @@ func TestHostAdapterFailureDiagnosticsAreBoundedAndSanitized(t *testing.T) {
 	}
 	var workflow struct {
 		Jobs map[string]struct {
+			Name  string `yaml:"name"`
 			Steps []struct {
 				ID   string            `yaml:"id"`
 				Name string            `yaml:"name"`
@@ -968,70 +969,163 @@ func TestHostAdapterFailureDiagnosticsAreBoundedAndSanitized(t *testing.T) {
 	if err := yaml.Unmarshal(payload, &workflow); err != nil {
 		t.Fatal(err)
 	}
-	hostAdapters, ok := workflow.Jobs["host-adapters"]
+	job, ok := workflow.Jobs["host-adapters"]
 	if !ok {
 		t.Fatal("migration-gates.yml has no host-adapters job")
 	}
-	adapterStepIDs := map[string]bool{}
-	var summary, upload *struct {
-		ID   string
+	if job.Name != "Pre-WP6 host adapters" {
+		t.Fatalf("host-adapters name = %q, want Pre-WP6 host adapters", job.Name)
+	}
+	steps := map[string]struct {
 		Name string
 		If   string
 		Uses string
 		With map[string]string
 		Env  map[string]string
 		Run  string
-	}
-	for index := range hostAdapters.Steps {
-		step := hostAdapters.Steps[index]
+	}{}
+	for _, step := range job.Steps {
 		if step.ID != "" {
-			adapterStepIDs[step.ID] = true
-		}
-		if step.Name == "Write bounded host adapter diagnostics" {
-			summary = &struct {
-				ID   string
+			steps[step.ID] = struct {
 				Name string
 				If   string
 				Uses string
 				With map[string]string
 				Env  map[string]string
 				Run  string
-			}{step.ID, step.Name, step.If, step.Uses, step.With, step.Env, step.Run}
+			}{step.Name, step.If, step.Uses, step.With, step.Env, step.Run}
 		}
-		if step.Name == "Upload host adapter diagnostics" {
-			upload = &struct {
-				ID   string
+	}
+	python, ok := steps["python_adapters"]
+	if !ok {
+		t.Fatal("host-adapters has no python_adapters step")
+	}
+	for _, required := range []string{"integrations/codex/tests", "integrations/workbuddy/tests"} {
+		if !strings.Contains(python.Run, required) {
+			t.Errorf("pre-WP6 adapter command is missing %q: %s", required, python.Run)
+		}
+	}
+	for _, deferred := range []string{"integrations/bub", "integrations/claude-code", "integrations/hermes", "integrations/langgraph"} {
+		if strings.Contains(python.Run, deferred) {
+			t.Errorf("pre-WP6 adapter command must not include %q: %s", deferred, python.Run)
+		}
+	}
+	for _, deferredID := range []string{"dsh_server", "dsh_adapter", "pi_adapter", "opencode_adapter", "openclaw_adapter"} {
+		if _, found := steps[deferredID]; found {
+			t.Errorf("pre-WP6 host-adapters must not include deferred step %q", deferredID)
+		}
+	}
+	summary, ok := steps["pre_wp6_adapter_diagnostics"]
+	if !ok {
+		t.Fatal("host-adapters has no pre_wp6_adapter_diagnostics step")
+	}
+	if summary.If != "always()" || summary.Env["PYTHON_ADAPTERS_OUTCOME"] != "${{ steps.python_adapters.outcome }}" {
+		t.Errorf("pre-WP6 diagnostics contract = %#v", summary)
+	}
+	for _, required := range []string{
+		"powercontext-pre-wp6-host-adapter-diagnostics",
+		"integrations/codex/plugins/powercontext/uv.lock",
+		"integrations/workbuddy/plugins/powercontext/powercontext.json.example",
+		"integrations/workbuddy/plugins/powercontext/hooks/workbuddy_powercontext_hook.py",
+	} {
+		if !strings.Contains(summary.Run, required) {
+			t.Errorf("pre-WP6 diagnostics are missing %q: %s", required, summary.Run)
+		}
+	}
+	upload, ok := steps["pre_wp6_adapter_upload"]
+	if !ok {
+		t.Fatal("host-adapters has no pre_wp6_adapter_upload step")
+	}
+	if upload.If != "failure()" || upload.Uses != "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a" ||
+		upload.With["path"] != "${{ runner.temp }}/powercontext-pre-wp6-host-adapter-diagnostics/summary.txt" {
+		t.Errorf("pre-WP6 upload contract = %#v", upload)
+	}
+}
+
+func TestRetainedHostAdapterWorkflowContract(t *testing.T) {
+	repository := filepath.Clean(filepath.Join("..", ".."))
+	payload, err := os.ReadFile(filepath.Join(repository, ".github", "workflows", "migration-gates.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var workflow struct {
+		Jobs map[string]struct {
+			Name  string `yaml:"name"`
+			Steps []struct {
+				ID   string            `yaml:"id"`
+				Name string            `yaml:"name"`
+				If   string            `yaml:"if"`
+				Uses string            `yaml:"uses"`
+				With map[string]string `yaml:"with"`
+				Env  map[string]string `yaml:"env"`
+				Run  string            `yaml:"run"`
+			} `yaml:"steps"`
+		} `yaml:"jobs"`
+	}
+	if err := yaml.Unmarshal(payload, &workflow); err != nil {
+		t.Fatal(err)
+	}
+	job, ok := workflow.Jobs["retained-host-adapters"]
+	if !ok {
+		t.Fatal("migration-gates.yml has no retained-host-adapters job")
+	}
+	if job.Name != "Post-WP6 retained host adapters" {
+		t.Fatalf("retained-host-adapters name = %q, want Post-WP6 retained host adapters", job.Name)
+	}
+	steps := map[string]struct {
+		Name string
+		If   string
+		Uses string
+		With map[string]string
+		Env  map[string]string
+		Run  string
+	}{}
+	for _, step := range job.Steps {
+		if step.ID != "" {
+			steps[step.ID] = struct {
 				Name string
 				If   string
 				Uses string
 				With map[string]string
 				Env  map[string]string
 				Run  string
-			}{step.ID, step.Name, step.If, step.Uses, step.With, step.Env, step.Run}
+			}{step.Name, step.If, step.Uses, step.With, step.Env, step.Run}
 		}
 	}
-	for _, id := range []string{"python_adapters", "dsh_server", "dsh_adapter", "pi_adapter", "opencode_adapter", "openclaw_adapter"} {
-		if !adapterStepIDs[id] {
-			t.Fatalf("host adapter step id %q is missing", id)
+	python, ok := steps["python_adapters"]
+	if !ok {
+		t.Fatal("retained-host-adapters has no python_adapters step")
+	}
+	for _, required := range []string{"integrations/bub", "integrations/claude-code", "integrations/hermes", "integrations/langgraph"} {
+		if !strings.Contains(python.Run, required) {
+			t.Errorf("retained adapter command is missing %q: %s", required, python.Run)
 		}
 	}
-	if summary == nil || summary.If != "always()" || !strings.Contains(summary.Run, "powercontext-host-adapter-diagnostics") ||
-		summary.Env["PYTHON_ADAPTERS_OUTCOME"] != "${{ steps.python_adapters.outcome }}" ||
+	for _, requiredID := range []string{"dsh_server", "dsh_adapter", "pi_adapter", "opencode_adapter", "openclaw_adapter"} {
+		if _, found := steps[requiredID]; !found {
+			t.Errorf("retained-host-adapters is missing step %q", requiredID)
+		}
+	}
+	summary, ok := steps["retained_adapter_diagnostics"]
+	if !ok {
+		t.Fatal("retained-host-adapters has no retained_adapter_diagnostics step")
+	}
+	if summary.If != "always()" || summary.Env["PYTHON_ADAPTERS_OUTCOME"] != "${{ steps.python_adapters.outcome }}" ||
 		summary.Env["DSH_SERVER_OUTCOME"] != "${{ steps.dsh_server.outcome }}" ||
 		summary.Env["DSH_ADAPTER_OUTCOME"] != "${{ steps.dsh_adapter.outcome }}" ||
 		summary.Env["PI_ADAPTER_OUTCOME"] != "${{ steps.pi_adapter.outcome }}" ||
 		summary.Env["OPENCODE_ADAPTER_OUTCOME"] != "${{ steps.opencode_adapter.outcome }}" ||
-		summary.Env["OPENCLAW_ADAPTER_OUTCOME"] != "${{ steps.openclaw_adapter.outcome }}" {
-		t.Fatalf("host adapter summary step = %#v", summary)
+		summary.Env["OPENCLAW_ADAPTER_OUTCOME"] != "${{ steps.openclaw_adapter.outcome }}" ||
+		!strings.Contains(summary.Run, "powercontext-retained-host-adapter-diagnostics") {
+		t.Errorf("retained diagnostics contract = %#v", summary)
 	}
 	for _, forbidden := range []string{"cat ", "find ", "GITHUB_TOKEN", "POWERCONTEXT_GO_BINARY", "git diff"} {
 		if strings.Contains(summary.Run, forbidden) {
-			t.Fatalf("host adapter summary exposes %q: %s", forbidden, summary.Run)
+			t.Errorf("retained diagnostics expose %q: %s", forbidden, summary.Run)
 		}
 	}
 	for _, lockfile := range []string{
 		"integrations/bub/uv.lock",
-		"integrations/codex/plugins/powercontext/uv.lock",
 		"integrations/langgraph/uv.lock",
 		"integrations/dsh/plugins/powercontext/pnpm-lock.yaml",
 		"integrations/pi/plugins/powercontext/pnpm-lock.yaml",
@@ -1039,15 +1133,17 @@ func TestHostAdapterFailureDiagnosticsAreBoundedAndSanitized(t *testing.T) {
 		"integrations/openclaw/plugins/memory-powercontext/pnpm-lock.yaml",
 	} {
 		if !strings.Contains(summary.Run, lockfile) {
-			t.Fatalf("host adapter summary omits lockfile %q: %s", lockfile, summary.Run)
+			t.Errorf("retained diagnostics omit lockfile %q: %s", lockfile, summary.Run)
 		}
 	}
-	if upload == nil || upload.If != "failure()" || upload.Uses != "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a" {
-		t.Fatalf("host adapter upload step = %#v", upload)
+	upload, ok := steps["retained_adapter_upload"]
+	if !ok {
+		t.Fatal("retained-host-adapters has no retained_adapter_upload step")
 	}
-	if upload.With["path"] != "${{ runner.temp }}/powercontext-host-adapter-diagnostics/summary.txt" ||
+	if upload.If != "failure()" || upload.Uses != "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a" ||
+		upload.With["path"] != "${{ runner.temp }}/powercontext-retained-host-adapter-diagnostics/summary.txt" ||
 		upload.With["if-no-files-found"] != "error" || upload.With["retention-days"] != "14" {
-		t.Fatalf("host adapter upload contract = %#v", upload.With)
+		t.Errorf("retained upload contract = %#v", upload)
 	}
 }
 


### PR DESCRIPTION
## Summary

Implements the approved Go-primary monorepo boundary for #3 without deleting or moving any maintained adapter, evaluation, or conformance asset.

- Marks `evaluation/**`, `integrations/**`, `test/conformance/*.py`, and `test/differential/*.py` as `-linguist-detectable`, with a Go regression test that rejects broad, vendored, or generated classifications.
- Keeps the stable `host-adapters` job ID, renamed `Pre-WP6 host adapters`, and limits it to real Codex and WorkBuddy tests plus bounded identity diagnostics.
- Adds `retained-host-adapters` for actual P3 adapter execution: Bub, Claude Code, DSH, Hermes, LangGraph, OpenClaw, OpenCode, and Pi retain their install, generation, type-check, test, build, and failure-evidence paths.
- Names evaluation `Codex/SQLite evaluation control plane`; aligns README, architecture, installation, workflow documentation, and Issue #3 with the single-repository, pre-WP6 Codex/WorkBuddy/SQLite, P3 retained-adapter, and P4 seekDB/OceanBase boundaries.

## Validation

- `go test ./tools/release -run 'Test(GoPrimaryMonorepoLinguistPolicy|PreWP6HostAdapterWorkflowContract|RetainedHostAdapterWorkflowContract|ContinuousIntegrationPreservesPythonTopologyAndGoAssurance)' -count=1`
- Repository-pinned `.tools/bin/actionlint.exe .github/workflows/migration-gates.yml`
- `make governance-check`
- `make docs-test`
- `git diff --check origin/main...HEAD`

The full `go test ./tools/release -count=1` is not green on Windows because the pre-existing `TestReleaseArchiveKeepsStableExecutablePathAndMode` observes `0644` after Windows drops the POSIX executable bit. The same focused test fails on unmodified current `origin/main`; this PR does not change release archive code or that test. Linux exact-Head CI remains the required cross-platform signal.

## Non-goals

- No maintained path is classified as `linguist-vendored` or `linguist-generated`.
- No host adapter, evaluation control-plane asset, lock file, or Python compatibility fixture is deleted.
- No Go runtime, public API, OpenAPI, SQLite format, seekDB, or OceanBase behavior changes.
