### PR TITLE
fix(sqlite): diagnose embedding projection dimension drift

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -367,3 +367,8 @@ source / artifact / trigger / inference
   packaged release-consumer test, prove the installed bundle bytes and manifest
   originate from the release archive rather than asserting a retired installer
   command.
+- When a pinned native extension imposes a fixed schema dimension limit,
+  validate the configured dimension against that exact versioned limit before
+  creating any projection DDL. Verify a fresh over-limit profile returns a
+  typed, redacted error that states both limits, creates no projection, and
+  leaves the extension's raw diagnostic unexposed.

--- a/docs/superpowers/plans/2026-09-01-sqlite-vector-projection-drift.md
+++ b/docs/superpowers/plans/2026-09-01-sqlite-vector-projection-drift.md
@@ -1,0 +1,467 @@
+# SQLite Vector Projection Drift Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Detect an existing sqlite-vec projection dimension/schema mismatch before probing, preserve safe typed and underlying errors, clean stale probe rows, and fail Server startup without rewriting authoritative Memory data.
+
+**Architecture:** `SQLiteMemoryVectorIndex.Initialize` inspects only the owned vec0 projection schema before creating or probing it. An internal wrapper presents a safe `memory.CapabilityNotSupportedError` while unwrapping root causes for matching. Projection mismatch remains an Application-construction failure; no degraded Application, automatic drop, migration, or rebuild is introduced.
+
+**Tech Stack:** Go 1.27, CGO SQLite with embedded sqlite-vec v0.1.9, `database/sql`, `errors.Join`/multi-unwrapping, Server application composition, parity inventory generator.
+
+**Spec:** `docs/superpowers/specs/2026-09-01-embedding-dimension-readiness-design.md`
+
+## Global Constraints
+
+- Start from current `origin/main`; any changed Base or Head invalidates previous diff, test, review, and CI evidence.
+- Load complete Modern Go guidance before every Go edit.
+- Use TDD: every new behavior starts with a focused RED execution, then a minimal GREEN repair.
+- The vec0 table is a rebuildable projection, but this plan never automatically drops, truncates, rebuilds, or migrates it.
+- Do not modify authoritative Memory revisions, manifests, content, SQL scope identities, provider behavior, OpenAPI, CLI settings, or environment settings.
+- Existing vec0 schema dimension mismatch prevents `OpenApplication` from returning an Application; do not construct a degraded Server solely for `/health/ready`.
+- Public mismatch details may contain only existing/configured numeric dimensions and fixed rebuild guidance.
+- Do not expose raw DDL, SQL, bind values, database paths/URLs, Memory content, vectors, scope IDs, or root-cause text in stable errors.
+- Underlying root causes must remain matchable with `errors.Is`; safe public capability classification must remain matchable with `errors.As`.
+- `rowid = -1` remains the probe identity. Remove stale `-1` before probing and attempt cleanup after every query outcome.
+- SQLite raw bytes are not a fixture assertion target; tests compare schema and row semantics.
+- OceanBase and seekDB remain final P4 work and must not change in this PR.
+- Windows missing `sqlite3.h` is a validation gap, never authorization to disable CGO or replace real sqlite-vec tests with mocks. Linux exact-Head CI is required for real index and Server proof.
+- Update generated parity inventory only through `tools/parity-inventory-generate`; never hand-edit its counts.
+- All commits use the repository Lore format and `Co-authored-by: OmX <omx@oh-my-codex.dev>`.
+
+---
+
+### Task 1: Define owned vec0 schema parsing and safe multi-cause failures
+
+**Files:**
+- Modify: `internal/sqlstore/sqlite_memory_vector.go`
+- Modify: `internal/sqlstore/sqlite_memory_vector_test.go`
+- Create: `internal/sqlstore/sqlite_memory_vector_schema_test.go`
+
+**Interfaces:**
+- Produces: `parseSQLiteVecProjectionDimension(string) (int, bool)` as an unexported parser for the exact owned vec0 DDL shape.
+- Produces: `sqliteVecCapabilityFailure` with `Error() string` and `Unwrap() []error`.
+- Produces: `newSQLiteVecCapabilityFailure(detail string, causes ...error) error`.
+- Preserves: `errors.As(err, *memory.CapabilityNotSupportedError)` and existing `Capability == "vector"` classification.
+
+- [ ] **Step 1: Write failing exact-schema parser tests**
+
+Create `sqlite_memory_vector_schema_test.go` with hand-derived DDL literals:
+
+```go
+func TestParseSQLiteVecProjectionDimensionAcceptsOwnedSchema(t *testing.T) {
+    dimension, ok := parseSQLiteVecProjectionDimension(
+        "CREATE VIRTUAL TABLE pc_memory_entry_vec USING vec0(embedding float[1536])",
+    )
+    if !ok || dimension != 1536 {
+        t.Fatalf("dimension, ok = %d, %t", dimension, ok)
+    }
+}
+
+func TestParseSQLiteVecProjectionDimensionRejectsForeignSchema(t *testing.T) {
+    for _, schema := range []string{
+        "CREATE TABLE pc_memory_entry_vec (embedding BLOB)",
+        "CREATE VIRTUAL TABLE pc_memory_entry_vec USING vec0(other float[3])",
+        "CREATE VIRTUAL TABLE pc_memory_entry_vec USING vec0(embedding float[0])",
+        "CREATE VIRTUAL TABLE another_vec USING vec0(embedding float[3])",
+        "untrusted DDL with /private/path and embedding float[3]",
+    } {
+        if dimension, ok := parseSQLiteVecProjectionDimension(schema); ok || dimension != 0 {
+            t.Fatalf("accepted schema %q as %d", schema, dimension)
+        }
+    }
+}
+```
+
+Use exact complete string matching or a regex anchored to the complete owned DDL; never extract `float[N]` from arbitrary DDL text.
+
+- [ ] **Step 2: Run parser tests and verify RED**
+
+Run:
+
+```text
+go test -count=1 ./internal/sqlstore -run '^TestParseSQLiteVecProjectionDimension'
+```
+
+Expected: FAIL because the parser is not defined.
+
+- [ ] **Step 3: Write failing multi-cause safe-error tests**
+
+Add tests with independent sentinel causes:
+
+```go
+func TestSQLiteVecCapabilityFailureMatchesSafeCapabilityAndRootCauses(t *testing.T) {
+    queryCause := errors.New("query cause /private/db API_KEY=secret")
+    cleanupCause := errors.New("cleanup cause Memory private text")
+    err := newSQLiteVecCapabilityFailure("sqlite-vec probe failed", queryCause, cleanupCause)
+
+    var capability *memory.CapabilityNotSupportedError
+    if !errors.As(err, &capability) || capability.Capability != "vector" {
+        t.Fatalf("capability = %#v, err = %v", capability, err)
+    }
+    if !errors.Is(err, queryCause) || !errors.Is(err, cleanupCause) {
+        t.Fatalf("root causes are not matchable: %v", err)
+    }
+    for _, secret := range []string{"/private/db", "API_KEY=secret", "Memory private text"} {
+        if strings.Contains(err.Error(), secret) {
+            t.Fatalf("safe error leaked %q: %v", secret, err)
+        }
+    }
+}
+```
+
+Add a direct mismatch-detail test requiring:
+
+```text
+sqlite-vec projection dimension 1536 does not match configured dimension 768; rebuild the projection
+```
+
+and rejecting raw DDL/path/vector sentinel text.
+
+- [ ] **Step 4: Run safe-error tests and verify RED**
+
+Run:
+
+```text
+go test -count=1 ./internal/sqlstore -run '^TestSQLiteVecCapabilityFailure|^TestSQLiteVecProjectionDimensionMismatchDetail'
+```
+
+Expected: FAIL because the internal wrapper and safe mismatch constructor are absent.
+
+- [ ] **Step 5: Implement parser and internal wrapper**
+
+Use a package-level anchored regex or an exact parser that accepts only:
+
+```text
+CREATE VIRTUAL TABLE pc_memory_entry_vec USING vec0(embedding float[N])
+```
+
+where `N` is a positive decimal integer with no signs, whitespace variants, or
+additional columns.
+
+Implement:
+
+```go
+type sqliteVecCapabilityFailure struct {
+    public *memory.CapabilityNotSupportedError
+    causes []error
+}
+
+func (e *sqliteVecCapabilityFailure) Error() string { return e.public.Error() }
+
+func (e *sqliteVecCapabilityFailure) Unwrap() []error {
+    values := make([]error, 0, 1+len(e.causes))
+    values = append(values, e.public)
+    values = append(values, e.causes...)
+    return values
+}
+```
+
+Filter nil causes. Return the bare public capability error only when no root
+cause exists; return the wrapper otherwise. The public error type and fields
+remain unchanged.
+
+Add helpers that construct only the two fixed safe schema messages:
+
+```go
+func sqliteVecDimensionMismatchError(existing, configured int, causes ...error) error
+func sqliteVecIncompatibleSchemaError(causes ...error) error
+```
+
+- [ ] **Step 6: Run Task 1 tests and verify GREEN**
+
+Run:
+
+```text
+go test -count=1 ./internal/sqlstore -run 'TestParseSQLiteVecProjectionDimension|TestSQLiteVecCapabilityFailure|TestSQLiteVecProjectionDimensionMismatchDetail'
+go vet ./internal/sqlstore
+```
+
+Expected: PASS on a supported CGO SQLite host. If Windows cannot compile the
+package because `sqlite3.h` is missing, run parser/wrapper tests using the
+repository-supported temporary matching header include and record the command;
+the exact Linux CI remains the full proof.
+
+- [ ] **Step 7: Commit schema/error primitives**
+
+```text
+git add internal/sqlstore/sqlite_memory_vector.go internal/sqlstore/sqlite_memory_vector_test.go internal/sqlstore/sqlite_memory_vector_schema_test.go
+git commit \
+  -m "Diagnose sqlite vector projection schema drift" \
+  -m "Owned vec0 schema parsing now distinguishes an incompatible or dimension-mismatched projection from a generic probe failure, while safe capability classification and root-cause matching are both preserved." \
+  -m "Constraint: Stable errors expose only dimensions and rebuild guidance; raw DDL and root-cause text remain private" \
+  -m "Tested: exact schema parser and safe multi-cause error tests" \
+  -m "Not-tested: real vec0 initialization lifecycle is delivered by the next task" \
+  -m "Co-authored-by: OmX <omx@oh-my-codex.dev>"
+```
+
+### Task 2: Initialize vec0 safely, detect dimension drift, and clean probe rows
+
+**Files:**
+- Modify: `internal/sqlstore/sqlite_memory_vector.go`
+- Modify: `internal/sqlstore/sqlite_memory_vector_test.go`
+
+**Interfaces:**
+- Consumes: `parseSQLiteVecProjectionDimension`, `sqliteVecDimensionMismatchError`, `sqliteVecIncompatibleSchemaError`, and safe multi-cause wrapper from Task 1.
+- Produces: `SQLiteMemoryVectorIndex.Initialize` that validates existing projection dimension before probe and cleans stale probe rows.
+- Preserves: exact sqlite-vec version v0.1.9, `rowid = -1`, current projection metadata table, and vector search behavior.
+
+- [ ] **Step 1: Add failing real SQLite dimension mismatch tests**
+
+Use `OpenSQLite` with a temporary file-backed database so initialization can
+run twice across independent transactions. Create profile dimension `3`, call
+`Initialize`, then create profile dimension `4` and call `Initialize` again.
+
+Require:
+
+```go
+var capability *memory.CapabilityNotSupportedError
+if !errors.As(err, &capability) || capability.Capability != "vector" {
+    t.Fatalf("err = %v", err)
+}
+if got := err.Error(); !strings.Contains(got, "dimension 3 does not match configured dimension 4; rebuild the projection") {
+    t.Fatalf("err = %q", got)
+}
+```
+
+Assert the error omits the database path, `CREATE VIRTUAL TABLE`, a Memory
+sentinel, and an embedding/vector sentinel. Assert existing schema remains
+`float[3]`; do not expect a new `float[4]` table.
+
+- [ ] **Step 2: Add failing incompatible-schema and stale-probe tests**
+
+Create a same-name ordinary table:
+
+```sql
+CREATE TABLE pc_memory_entry_vec (embedding BLOB)
+```
+
+Require the fixed incompatible-schema/rebuild message and no raw SQL text.
+
+For stale probe cleanup, initialize a valid index, insert `rowid = -1` with a
+valid packed vector, then call `Initialize` again and assert exactly zero
+`rowid = -1` rows remain after successful probing.
+
+- [ ] **Step 3: Add failing query/cleanup cause-preservation tests**
+
+Introduce a narrow `DBTX` wrapper in the test file that delegates to the real
+database except for the probe query and/or delete statement. The probe must use
+`QueryContext`, rather than `QueryRowContext`: `DBTX.QueryRowContext` returns
+the concrete `*sql.Row` type and cannot expose an injected sentinel from a
+test wrapper. Return two sentinel errors only for these exact query strings:
+
+```go
+const probeQuery = "SELECT rowid FROM pc_memory_entry_vec WHERE embedding MATCH ? AND k = 1"
+const probeDelete = "DELETE FROM pc_memory_entry_vec WHERE rowid = ?"
+```
+
+Require `errors.Is(err, queryCause)` and `errors.Is(err, cleanupCause)`, plus
+safe public `CapabilityNotSupportedError` matching and no sentinel text in
+`err.Error()`.
+
+- [ ] **Step 4: Run lifecycle tests and verify RED**
+
+Run:
+
+```text
+go test -count=1 ./internal/sqlstore -run 'TestSQLiteVec.*(DimensionMismatch|IncompatibleSchema|StaleProbe|Probe.*Cause)'
+```
+
+Expected: current initialization either returns generic `sqlite-vec probe
+failed`, leaves stale probe behavior unproven, or loses one of the root causes.
+
+- [ ] **Step 5: Refactor Initialize into schema and probe phases**
+
+Keep version validation first. Keep creating `pc_memory_vector_entries` with
+`CREATE TABLE IF NOT EXISTS`. Replace unconditional vec0 `CREATE ... IF NOT
+EXISTS` with:
+
+1. query `sqlite_master` for `type` and `sql` where name is
+   `pc_memory_entry_vec`;
+2. if absent, create the exact owned vec0 schema using the configured
+   dimension, then query `sqlite_master` again;
+3. if type is not `table` or the DDL parser rejects the SQL, return
+   `sqliteVecIncompatibleSchemaError` with the underlying database cause only;
+4. if parsed dimension differs, return `sqliteVecDimensionMismatchError`;
+5. delete stale `rowid = -1` before packing/inserting the new probe;
+6. insert the probe, query it with `QueryContext` and scan exactly one row,
+   close the resulting rows, always attempt delete, then join any query,
+   rows-close, and delete root causes through the Task 1 wrapper;
+7. preserve `rowID == -1` validation after both operations succeed.
+
+Do not log the DDL, error causes, or database location. Do not call `DROP`,
+`DELETE` against rows other than `rowid = -1`, or rebuild any projection.
+
+- [ ] **Step 6: Run real lifecycle tests and verify GREEN**
+
+Run the Step 4 command, then:
+
+```text
+go test -count=1 ./internal/sqlstore -run '^TestSQLiteVecEmbeddedExtensionAndVec0Schema$'
+go test -count=1 ./internal/sqlstore -run '^TestSQLiteVec0ReplaceHydrateAndSearch$'
+```
+
+Expected: PASS. Existing normal vec0 schema/search behavior remains intact.
+
+- [ ] **Step 7: Add a high-repetition probe cleanup check**
+
+Run the stale-probe test under:
+
+```text
+go test -count=25 ./internal/sqlstore -run '^TestSQLiteVecInitializeClearsStaleProbeRow$'
+```
+
+Expected: PASS. This proves initialization repeatedly leaves no probe row.
+
+- [ ] **Step 8: Commit initialization lifecycle**
+
+```text
+git add internal/sqlstore/sqlite_memory_vector.go internal/sqlstore/sqlite_memory_vector_test.go
+git commit \
+  -m "Fail startup on sqlite vector dimension drift" \
+  -m "SQLite vec0 initialization now inspects the owned projection before probing, fails safely on schema/dimension drift, clears stale probe rows, and preserves query and cleanup root causes." \
+  -m "Constraint: Never drop or rebuild the projection automatically and never expose DDL, paths, vectors, or root-cause text" \
+  -m "Tested: real SQLite mismatch, incompatible-schema, stale-probe, and multi-cause lifecycle tests" \
+  -m "Not-tested: public Server startup proof is delivered by the next task" \
+  -m "Co-authored-by: OmX <omx@oh-my-codex.dev>"
+```
+
+### Task 3: Prove Application startup failure, map four SQLite cases, and deliver PR2
+
+**Files:**
+- Modify: `server/application_test.go`
+- Modify: `test/conformance/parity-inventory-rules.json`
+- Regenerate: `test/conformance/parity-inventory.json`
+- Modify: `AGENTS.md` only if implementation reveals a new reusable rule not already represented.
+
+**Interfaces:**
+- Consumes: SQLite index safe mismatch error and initialization lifecycle from Tasks 1-2.
+- Produces: public `OpenApplication` startup-failure proof and four case-specific release mappings.
+
+- [ ] **Step 1: Add a failing public Application startup test**
+
+Create a file-backed SQLite database and initialize it with embedding profile
+dimension `3`. Build a normal `ProcessConfig` with a configured embedding
+model/profile dimension `4` and dependencies that provide an embedding model
+with profile dimension `4`. Call:
+
+```go
+application, err := OpenApplication(t.Context(), config, dependencies)
+if application != nil {
+    t.Fatal("OpenApplication returned an Application despite projection mismatch")
+}
+```
+
+Require `errors.As(err, *memory.CapabilityNotSupportedError)`, the safe
+dimension/rebuild detail, and absence of DB path/DDL/Memory/vector sentinel
+text. After failure, query the original database and prove its owned vec0
+schema remains `float[3]` and an authoritative artifact/entry sentinel row
+remains present.
+
+- [ ] **Step 2: Run startup test and verify RED**
+
+Run:
+
+```text
+go test -count=1 -tags sqlite_fts5 ./server -run '^TestOpenApplicationRejectsSQLiteVectorProjectionDimensionMismatch$'
+```
+
+Expected: current code returns a generic probe failure or otherwise fails to
+provide the stable mismatch contract.
+
+- [ ] **Step 3: Run startup test and verify GREEN**
+
+After Task 2 implementation, run the same command. Expected: PASS on a
+supported CGO SQLite host. The test must not start an HTTP Server or assert a
+manufactured degraded `/health/ready` response.
+
+- [ ] **Step 4: Add four exact parity mappings**
+
+Add case-specific rules for:
+
+```text
+tests/builtin/persistence/test_sqlite_memory_vector_index.py
+  test_vector_index_probe_clears_a_leftover_probe_row
+  test_vector_index_probe_reports_a_table_dimension_mismatch
+  test_vector_index_probe_surfaces_the_underlying_cause
+  test_vector_index_probe_reports_the_provider_limit_for_a_fresh_oversized_dimension
+```
+
+Map the first three to the exact real SQLite test declarations added in Tasks
+1-2. Map the startup/mismatch consumer behavior to the public Server test when
+it is the closest exact evidence. Do not map a case to a generic file-level
+reason or an injected error that does not exercise the described boundary.
+
+- [ ] **Step 5: Regenerate and inspect parity inventory**
+
+Run:
+
+```text
+go run ./tools/parity-inventory-generate -upstream <exact-v0.1.0-checkout>
+go run ./tools/parity-inventory-generate -upstream <exact-v0.1.0-checkout> -check
+```
+
+Inspect the diff. Exactly the four named SQLite cases move from pending to
+mapped. Counts change only through the generator. The provider/readiness six
+cases remain mapped.
+
+- [ ] **Step 6: Run final changed-surface validation**
+
+Run:
+
+```text
+go test -count=1 ./internal/sqlstore -run SQLiteVec
+go test -race -count=1 ./internal/sqlstore -run SQLiteVec
+go test -count=1 -tags sqlite_fts5 ./server -run 'SQLiteVector|ProjectionDimension|Embedding'
+make test-sqlite
+make lint
+go mod tidy -diff
+go mod verify
+git diff --check
+```
+
+If Windows cannot compile the real CGO tests, document the exact `sqlite3.h`
+gap and run parser/wrapper tests using only the repository-supported matching
+header include. Do not treat local parser-only success as full index proof.
+Linux exact-Head `Standard` and `Main/tests` jobs are required merge evidence.
+
+- [ ] **Step 7: Perform test-guard review**
+
+Confirm real SQLite is used for schema and row behavior; fake DBTX is limited
+to injecting exact probe query/delete failures while every other operation
+delegates to a real database. Ensure no raw SQLite bytes, mock call count, or
+source-text assertion substitutes for projection semantics.
+
+- [ ] **Step 8: Refresh Base and create PR2**
+
+Before push:
+
+```text
+git fetch --no-prune origin main
+git rev-list --left-right --count origin/main...HEAD
+git merge-base --is-ancestor origin/main HEAD
+```
+
+If Base drifted, rebase and rerun every validation above. Push only after a
+fresh Head check. Create:
+
+```text
+fix(sqlite): diagnose embedding projection dimension drift
+```
+
+PR body must state Part of #3, the startup-failure lifecycle, no automatic
+drop/rebuild, safe public versus root-cause matching, exactly four SQLite cases
+mapped, and Windows CGO gaps. Reconcile `changedFiles`, REST filenames, and
+local Base...Head filenames before using any CI evidence.
+
+- [ ] **Step 9: Wait for exact-Head CI and merge only after all gates**
+
+Require exact Head 37/37 success, zero unresolved review threads, and current
+Base `CLEAN` merge state. Verify merge server-side through REST `merged: true`,
+then wait for exact-main Main, E2E, CodeQL, License, and Windows workflows.
+
+- [ ] **Step 10: Update Issue only from exact-main evidence**
+
+After post-main success, read main's generated inventory. Update Issue #3
+mapping counts and check the combined embedding release-delta item only when
+all provider/readiness and SQLite requirements are proven. Keep the wider
+all-case mapping item unchecked until all remaining cases resolve.

--- a/docs/superpowers/plans/2026-09-01-sqlite-vector-projection-drift.md
+++ b/docs/superpowers/plans/2026-09-01-sqlite-vector-projection-drift.md
@@ -2,7 +2,7 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Detect an existing sqlite-vec projection dimension/schema mismatch before probing, preserve safe typed and underlying errors, clean stale probe rows, and fail Server startup without rewriting authoritative Memory data.
+**Goal:** Detect an existing sqlite-vec projection dimension/schema mismatch before probing, reject fresh profiles above the embedded sqlite-vec limit, preserve safe typed and underlying errors, clean stale probe rows, and fail Server startup without rewriting authoritative Memory data.
 
 **Architecture:** `SQLiteMemoryVectorIndex.Initialize` inspects only the owned vec0 projection schema before creating or probing it. An internal wrapper presents a safe `memory.CapabilityNotSupportedError` while unwrapping root causes for matching. Projection mismatch remains an Application-construction failure; no degraded Application, automatic drop, migration, or rebuild is introduced.
 
@@ -18,6 +18,7 @@
 - The vec0 table is a rebuildable projection, but this plan never automatically drops, truncates, rebuilds, or migrates it.
 - Do not modify authoritative Memory revisions, manifests, content, SQL scope identities, provider behavior, OpenAPI, CLI settings, or environment settings.
 - Existing vec0 schema dimension mismatch prevents `OpenApplication` from returning an Application; do not construct a degraded Server solely for `/health/ready`.
+- The embedded sqlite-vec v0.1.9 maximum is 8192 float dimensions; reject a fresh larger configured profile before creating a projection and do not parse extension error text.
 - Public mismatch details may contain only existing/configured numeric dimensions and fixed rebuild guidance.
 - Do not expose raw DDL, SQL, bind values, database paths/URLs, Memory content, vectors, scope IDs, or root-cause text in stable errors.
 - Underlying root causes must remain matchable with `errors.Is`; safe public capability classification must remain matchable with `errors.As`.
@@ -43,7 +44,7 @@
 - Produces: `newSQLiteVecCapabilityFailure(detail string, causes ...error) error`.
 - Preserves: `errors.As(err, *memory.CapabilityNotSupportedError)` and existing `Capability == "vector"` classification.
 
-- [ ] **Step 1: Write failing exact-schema parser tests**
+- [x] **Step 1: Write failing exact-schema parser tests**
 
 Create `sqlite_memory_vector_schema_test.go` with hand-derived DDL literals:
 
@@ -74,7 +75,7 @@ func TestParseSQLiteVecProjectionDimensionRejectsForeignSchema(t *testing.T) {
 
 Use exact complete string matching or a regex anchored to the complete owned DDL; never extract `float[N]` from arbitrary DDL text.
 
-- [ ] **Step 2: Run parser tests and verify RED**
+- [x] **Step 2: Run parser tests and verify RED**
 
 Run:
 
@@ -84,7 +85,7 @@ go test -count=1 ./internal/sqlstore -run '^TestParseSQLiteVecProjectionDimensio
 
 Expected: FAIL because the parser is not defined.
 
-- [ ] **Step 3: Write failing multi-cause safe-error tests**
+- [x] **Step 3: Write failing multi-cause safe-error tests**
 
 Add tests with independent sentinel causes:
 
@@ -117,7 +118,7 @@ sqlite-vec projection dimension 1536 does not match configured dimension 768; re
 
 and rejecting raw DDL/path/vector sentinel text.
 
-- [ ] **Step 4: Run safe-error tests and verify RED**
+- [x] **Step 4: Run safe-error tests and verify RED**
 
 Run:
 
@@ -127,7 +128,7 @@ go test -count=1 ./internal/sqlstore -run '^TestSQLiteVecCapabilityFailure|^Test
 
 Expected: FAIL because the internal wrapper and safe mismatch constructor are absent.
 
-- [ ] **Step 5: Implement parser and internal wrapper**
+- [x] **Step 5: Implement parser and internal wrapper**
 
 Use a package-level anchored regex or an exact parser that accepts only:
 
@@ -167,7 +168,7 @@ func sqliteVecDimensionMismatchError(existing, configured int, causes ...error) 
 func sqliteVecIncompatibleSchemaError(causes ...error) error
 ```
 
-- [ ] **Step 6: Run Task 1 tests and verify GREEN**
+- [x] **Step 6: Run Task 1 tests and verify GREEN**
 
 Run:
 
@@ -181,7 +182,7 @@ package because `sqlite3.h` is missing, run parser/wrapper tests using the
 repository-supported temporary matching header include and record the command;
 the exact Linux CI remains the full proof.
 
-- [ ] **Step 7: Commit schema/error primitives**
+- [x] **Step 7: Commit schema/error primitives**
 
 ```text
 git add internal/sqlstore/sqlite_memory_vector.go internal/sqlstore/sqlite_memory_vector_test.go internal/sqlstore/sqlite_memory_vector_schema_test.go
@@ -202,10 +203,10 @@ git commit \
 
 **Interfaces:**
 - Consumes: `parseSQLiteVecProjectionDimension`, `sqliteVecDimensionMismatchError`, `sqliteVecIncompatibleSchemaError`, and safe multi-cause wrapper from Task 1.
-- Produces: `SQLiteMemoryVectorIndex.Initialize` that validates existing projection dimension before probe and cleans stale probe rows.
+- Produces: `SQLiteMemoryVectorIndex.Initialize` that validates existing projection dimension before probe, rejects a fresh oversized profile, and cleans stale probe rows.
 - Preserves: exact sqlite-vec version v0.1.9, `rowid = -1`, current projection metadata table, and vector search behavior.
 
-- [ ] **Step 1: Add failing real SQLite dimension mismatch tests**
+- [x] **Step 1: Add failing real SQLite dimension mismatch tests**
 
 Use `OpenSQLite` with a temporary file-backed database so initialization can
 run twice across independent transactions. Create profile dimension `3`, call
@@ -227,7 +228,7 @@ Assert the error omits the database path, `CREATE VIRTUAL TABLE`, a Memory
 sentinel, and an embedding/vector sentinel. Assert existing schema remains
 `float[3]`; do not expect a new `float[4]` table.
 
-- [ ] **Step 2: Add failing incompatible-schema and stale-probe tests**
+- [x] **Step 2: Add failing incompatible-schema, fresh-oversized, and stale-probe tests**
 
 Create a same-name ordinary table:
 
@@ -241,7 +242,12 @@ For stale probe cleanup, initialize a valid index, insert `rowid = -1` with a
 valid packed vector, then call `Initialize` again and assert exactly zero
 `rowid = -1` rows remain after successful probing.
 
-- [ ] **Step 3: Add failing query/cleanup cause-preservation tests**
+For a fresh profile dimension `65536`, require the fixed safe detail
+`sqlite-vec supports at most 8192 dimensions; configured dimension 65536 is unsupported`,
+assert that no vec0 projection exists, and reject raw extension text or the
+word `migrate` in the public error.
+
+- [x] **Step 3: Add failing query/cleanup cause-preservation tests**
 
 Introduce a narrow `DBTX` wrapper in the test file that delegates to the real
 database except for the probe query and/or delete statement. The probe must use
@@ -258,7 +264,7 @@ Require `errors.Is(err, queryCause)` and `errors.Is(err, cleanupCause)`, plus
 safe public `CapabilityNotSupportedError` matching and no sentinel text in
 `err.Error()`.
 
-- [ ] **Step 4: Run lifecycle tests and verify RED**
+- [x] **Step 4: Run lifecycle tests and verify RED**
 
 Run:
 
@@ -269,7 +275,7 @@ go test -count=1 ./internal/sqlstore -run 'TestSQLiteVec.*(DimensionMismatch|Inc
 Expected: current initialization either returns generic `sqlite-vec probe
 failed`, leaves stale probe behavior unproven, or loses one of the root causes.
 
-- [ ] **Step 5: Refactor Initialize into schema and probe phases**
+- [x] **Step 5: Refactor Initialize into schema and probe phases**
 
 Keep version validation first. Keep creating `pc_memory_vector_entries` with
 `CREATE TABLE IF NOT EXISTS`. Replace unconditional vec0 `CREATE ... IF NOT
@@ -282,16 +288,19 @@ EXISTS` with:
 3. if type is not `table` or the DDL parser rejects the SQL, return
    `sqliteVecIncompatibleSchemaError` with the underlying database cause only;
 4. if parsed dimension differs, return `sqliteVecDimensionMismatchError`;
-5. delete stale `rowid = -1` before packing/inserting the new probe;
-6. insert the probe, query it with `QueryContext` and scan exactly one row,
+5. after confirming the pinned sqlite-vec version but before any projection DDL,
+   reject a fresh configured dimension above the embedded v0.1.9 limit using a
+   fixed safe capability detail;
+6. delete stale `rowid = -1` before packing/inserting the new probe;
+7. insert the probe, query it with `QueryContext` and scan exactly one row,
    close the resulting rows, always attempt delete, then join any query,
    rows-close, and delete root causes through the Task 1 wrapper;
-7. preserve `rowID == -1` validation after both operations succeed.
+8. preserve `rowID == -1` validation after both operations succeed.
 
 Do not log the DDL, error causes, or database location. Do not call `DROP`,
 `DELETE` against rows other than `rowid = -1`, or rebuild any projection.
 
-- [ ] **Step 6: Run real lifecycle tests and verify GREEN**
+- [x] **Step 6: Run real lifecycle tests and verify GREEN**
 
 Run the Step 4 command, then:
 
@@ -302,7 +311,7 @@ go test -count=1 ./internal/sqlstore -run '^TestSQLiteVec0ReplaceHydrateAndSearc
 
 Expected: PASS. Existing normal vec0 schema/search behavior remains intact.
 
-- [ ] **Step 7: Add a high-repetition probe cleanup check**
+- [x] **Step 7: Add a high-repetition probe cleanup check**
 
 Run the stale-probe test under:
 
@@ -312,7 +321,7 @@ go test -count=25 ./internal/sqlstore -run '^TestSQLiteVecInitializeClearsStaleP
 
 Expected: PASS. This proves initialization repeatedly leaves no probe row.
 
-- [ ] **Step 8: Commit initialization lifecycle**
+- [x] **Step 8: Commit initialization lifecycle**
 
 ```text
 git add internal/sqlstore/sqlite_memory_vector.go internal/sqlstore/sqlite_memory_vector_test.go
@@ -337,7 +346,7 @@ git commit \
 - Consumes: SQLite index safe mismatch error and initialization lifecycle from Tasks 1-2.
 - Produces: public `OpenApplication` startup-failure proof and four case-specific release mappings.
 
-- [ ] **Step 1: Add a failing public Application startup test**
+- [x] **Step 1: Add a failing public Application startup test**
 
 Create a file-backed SQLite database and initialize it with embedding profile
 dimension `3`. Build a normal `ProcessConfig` with a configured embedding
@@ -357,7 +366,7 @@ text. After failure, query the original database and prove its owned vec0
 schema remains `float[3]` and an authoritative artifact/entry sentinel row
 remains present.
 
-- [ ] **Step 2: Run startup test and verify RED**
+- [x] **Step 2: Run startup test and verify RED**
 
 Run:
 
@@ -368,13 +377,13 @@ go test -count=1 -tags sqlite_fts5 ./server -run '^TestOpenApplicationRejectsSQL
 Expected: current code returns a generic probe failure or otherwise fails to
 provide the stable mismatch contract.
 
-- [ ] **Step 3: Run startup test and verify GREEN**
+- [x] **Step 3: Run startup test and verify GREEN**
 
 After Task 2 implementation, run the same command. Expected: PASS on a
 supported CGO SQLite host. The test must not start an HTTP Server or assert a
 manufactured degraded `/health/ready` response.
 
-- [ ] **Step 4: Add four exact parity mappings**
+- [x] **Step 4: Add four exact parity mappings**
 
 Add case-specific rules for:
 
@@ -386,12 +395,13 @@ tests/builtin/persistence/test_sqlite_memory_vector_index.py
   test_vector_index_probe_reports_the_provider_limit_for_a_fresh_oversized_dimension
 ```
 
-Map the first three to the exact real SQLite test declarations added in Tasks
-1-2. Map the startup/mismatch consumer behavior to the public Server test when
-it is the closest exact evidence. Do not map a case to a generic file-level
-reason or an injected error that does not exercise the described boundary.
+Map all four to the exact real SQLite test declarations added in Tasks 1-2.
+The public Server test remains cross-layer evidence for startup failure, but
+does not substitute for the fresh-oversized SQLite case. Do not map a case to
+a generic file-level reason or an injected error that does not exercise the
+described boundary.
 
-- [ ] **Step 5: Regenerate and inspect parity inventory**
+- [x] **Step 5: Regenerate and inspect parity inventory**
 
 Run:
 
@@ -404,7 +414,7 @@ Inspect the diff. Exactly the four named SQLite cases move from pending to
 mapped. Counts change only through the generator. The provider/readiness six
 cases remain mapped.
 
-- [ ] **Step 6: Run final changed-surface validation**
+- [x] **Step 6: Run final changed-surface validation**
 
 Run:
 
@@ -424,7 +434,7 @@ gap and run parser/wrapper tests using only the repository-supported matching
 header include. Do not treat local parser-only success as full index proof.
 Linux exact-Head `Standard` and `Main/tests` jobs are required merge evidence.
 
-- [ ] **Step 7: Perform test-guard review**
+- [x] **Step 7: Perform test-guard review**
 
 Confirm real SQLite is used for schema and row behavior; fake DBTX is limited
 to injecting exact probe query/delete failures while every other operation

--- a/internal/sqlstore/sqlite_memory_vector.go
+++ b/internal/sqlstore/sqlite_memory_vector.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"regexp"
 	"strconv"
 
 	"github.com/ob-labs/powercontext-go/artifact"
@@ -29,6 +30,10 @@ import (
 )
 
 const requiredSQLiteVecVersion = "v0.1.9"
+
+var sqliteVecProjectionSchema = regexp.MustCompile(
+	`^CREATE VIRTUAL TABLE pc_memory_entry_vec USING vec0\(embedding float\[([1-9][0-9]*)\]\)$`,
+)
 
 // SQLiteMemoryVectorIndex maintains the Python-compatible sqlite-vec vec0
 // active-head projection for one exact embedding profile. OpenSQLite embeds
@@ -513,6 +518,59 @@ func sqliteVectorDistance(value any) (float64, error) {
 
 func sqliteVecCapabilityError(detail string) *memory.CapabilityNotSupportedError {
 	return &memory.CapabilityNotSupportedError{Capability: "vector", Detail: detail}
+}
+
+type sqliteVecCapabilityFailure struct {
+	public *memory.CapabilityNotSupportedError
+	causes []error
+}
+
+func (e *sqliteVecCapabilityFailure) Error() string { return e.public.Error() }
+
+func (e *sqliteVecCapabilityFailure) Unwrap() []error {
+	errors := make([]error, 0, 1+len(e.causes))
+	errors = append(errors, e.public)
+	errors = append(errors, e.causes...)
+	return errors
+}
+
+func newSQLiteVecCapabilityFailure(detail string, causes ...error) error {
+	filtered := make([]error, 0, len(causes))
+	for _, cause := range causes {
+		if cause != nil {
+			filtered = append(filtered, cause)
+		}
+	}
+	if len(filtered) == 0 {
+		return sqliteVecCapabilityError(detail)
+	}
+	return &sqliteVecCapabilityFailure{public: sqliteVecCapabilityError(detail), causes: filtered}
+}
+
+func sqliteVecDimensionMismatchError(existing, configured int, causes ...error) error {
+	return newSQLiteVecCapabilityFailure(
+		fmt.Sprintf(
+			"sqlite-vec projection dimension %d does not match configured dimension %d; rebuild the projection",
+			existing, configured,
+		),
+		causes...,
+	)
+}
+
+func sqliteVecIncompatibleSchemaError(causes ...error) error {
+	return newSQLiteVecCapabilityFailure("sqlite-vec projection schema is incompatible; rebuild the projection", causes...)
+}
+
+func parseSQLiteVecProjectionDimension(schema string) (int, bool) {
+	matches := sqliteVecProjectionSchema.FindStringSubmatch(schema)
+	if matches == nil {
+		return 0, false
+	}
+	dimension, err := strconv.Atoi(matches[1])
+	if err != nil || dimension < 1 {
+		return 0, false
+	}
+	return dimension, true
 }
 
 var _ MemoryIndex = (*SQLiteMemoryVectorIndex)(nil)

--- a/internal/sqlstore/sqlite_memory_vector.go
+++ b/internal/sqlstore/sqlite_memory_vector.go
@@ -31,6 +31,14 @@ import (
 
 const requiredSQLiteVecVersion = "v0.1.9"
 
+const (
+	sqliteVecProjectionName         = "pc_memory_entry_vec"
+	sqliteVecProjectionSchemaLookup = "SELECT type, sql FROM sqlite_master WHERE name = ?"
+	sqliteVecProbeInsert            = "INSERT INTO pc_memory_entry_vec (rowid, embedding) VALUES (?, ?)"
+	sqliteVecProbeQuery             = "SELECT rowid FROM pc_memory_entry_vec WHERE embedding MATCH ? AND k = 1"
+	sqliteVecProbeDelete            = "DELETE FROM pc_memory_entry_vec WHERE rowid = ?"
+)
+
 var sqliteVecProjectionSchema = regexp.MustCompile(
 	`^CREATE VIRTUAL TABLE pc_memory_entry_vec USING vec0\(embedding float\[([1-9][0-9]*)\]\)$`,
 )
@@ -60,13 +68,12 @@ func (i *SQLiteMemoryVectorIndex) Capabilities() memory.Capabilities {
 func (i *SQLiteMemoryVectorIndex) Initialize(ctx context.Context, db DBTX) error {
 	var version any
 	if err := db.QueryRowContext(ctx, "SELECT vec_version()").Scan(&version); err != nil {
-		return sqliteVecCapabilityError("sqlite-vec probe failed")
+		return newSQLiteVecCapabilityFailure("sqlite-vec probe failed", err)
 	}
 	if err := validateSQLiteVecVersion(version); err != nil {
 		return err
 	}
-	for _, statement := range []string{
-		`CREATE TABLE IF NOT EXISTS pc_memory_vector_entries (
+	if _, err := db.ExecContext(ctx, `CREATE TABLE IF NOT EXISTS pc_memory_vector_entries (
             vector_id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
             scope_id VARCHAR(256) NOT NULL,
             memory_artifact_id VARCHAR(128) NOT NULL,
@@ -84,36 +91,90 @@ func (i *SQLiteMemoryVectorIndex) Initialize(ctx context.Context, db DBTX) error
                 scope_id, memory_artifact_id, entry_id
             ) ON DELETE CASCADE,
             CONSTRAINT ck_pc_memory_vector_entries_revision_positive CHECK (head_revision > 0)
-        )`,
-		fmt.Sprintf(`CREATE VIRTUAL TABLE IF NOT EXISTS pc_memory_entry_vec USING vec0(embedding float[%d])`, i.profile.Dimension),
-	} {
-		if _, err := db.ExecContext(ctx, statement); err != nil {
-			return sqliteVecCapabilityError("sqlite-vec probe failed")
-		}
+		)`); err != nil {
+		return newSQLiteVecCapabilityFailure("sqlite-vec probe failed", err)
+	}
+	if err := i.ensureSQLiteVecProjection(ctx, db); err != nil {
+		return err
 	}
 
 	probe := make([]float64, i.profile.Dimension)
 	packed, err := packSQLiteVector(probe)
 	if err != nil {
-		return sqliteVecCapabilityError("sqlite-vec probe failed")
+		return newSQLiteVecCapabilityFailure("sqlite-vec probe failed", err)
+	}
+	if _, err := db.ExecContext(ctx, sqliteVecProbeDelete, -1); err != nil {
+		return newSQLiteVecCapabilityFailure("sqlite-vec probe failed", err)
 	}
 	if _, err := db.ExecContext(ctx,
-		"INSERT INTO pc_memory_entry_vec (rowid, embedding) VALUES (?, ?)", -1, packed,
+		sqliteVecProbeInsert, -1, packed,
 	); err != nil {
-		return sqliteVecCapabilityError("sqlite-vec probe failed")
+		return newSQLiteVecCapabilityFailure("sqlite-vec probe failed", err)
 	}
-	var rowID int64
-	queryErr := db.QueryRowContext(ctx,
-		"SELECT rowid FROM pc_memory_entry_vec WHERE embedding MATCH ? AND k = 1", packed,
-	).Scan(&rowID)
-	_, deleteErr := db.ExecContext(ctx, "DELETE FROM pc_memory_entry_vec WHERE rowid = ?", -1)
-	if queryErr != nil || deleteErr != nil {
-		return sqliteVecCapabilityError("sqlite-vec probe failed")
+	rowID, queryErr, closeErr := sqliteVecProbeRowID(ctx, db, packed)
+	_, deleteErr := db.ExecContext(ctx, sqliteVecProbeDelete, -1)
+	if queryErr != nil || closeErr != nil || deleteErr != nil {
+		return newSQLiteVecCapabilityFailure("sqlite-vec probe failed", queryErr, closeErr, deleteErr)
 	}
 	if rowID != -1 {
 		return sqliteVecCapabilityError("sqlite-vec probe returned an invalid row")
 	}
 	return nil
+}
+
+func (i *SQLiteMemoryVectorIndex) ensureSQLiteVecProjection(ctx context.Context, db DBTX) error {
+	tableType, schema, err := sqliteVecProjectionDefinition(ctx, db)
+	if errors.Is(err, sql.ErrNoRows) {
+		statement := fmt.Sprintf(
+			"CREATE VIRTUAL TABLE %s USING vec0(embedding float[%d])",
+			sqliteVecProjectionName, i.profile.Dimension,
+		)
+		if _, err := db.ExecContext(ctx, statement); err != nil {
+			return newSQLiteVecCapabilityFailure("sqlite-vec probe failed", err)
+		}
+		tableType, schema, err = sqliteVecProjectionDefinition(ctx, db)
+	}
+	if err != nil {
+		return newSQLiteVecCapabilityFailure("sqlite-vec probe failed", err)
+	}
+	if tableType != "table" {
+		return sqliteVecIncompatibleSchemaError()
+	}
+	dimension, ok := parseSQLiteVecProjectionDimension(schema)
+	if !ok {
+		return sqliteVecIncompatibleSchemaError()
+	}
+	if dimension != i.profile.Dimension {
+		return sqliteVecDimensionMismatchError(dimension, i.profile.Dimension)
+	}
+	return nil
+}
+
+func sqliteVecProjectionDefinition(ctx context.Context, db DBTX) (string, string, error) {
+	var tableType, schema string
+	err := db.QueryRowContext(ctx, sqliteVecProjectionSchemaLookup, sqliteVecProjectionName).Scan(&tableType, &schema)
+	return tableType, schema, err
+}
+
+func sqliteVecProbeRowID(ctx context.Context, db DBTX, packed []byte) (int64, error, error) {
+	rows, err := db.QueryContext(ctx, sqliteVecProbeQuery, packed)
+	if err != nil {
+		return 0, err, nil
+	}
+	var rowID int64
+	var queryErr error
+	if rows.Next() {
+		queryErr = rows.Scan(&rowID)
+	} else {
+		queryErr = rows.Err()
+		if queryErr == nil {
+			queryErr = sql.ErrNoRows
+		}
+	}
+	if queryErr == nil {
+		queryErr = rows.Err()
+	}
+	return rowID, queryErr, rows.Close()
 }
 
 func (i *SQLiteMemoryVectorIndex) Replace(

--- a/internal/sqlstore/sqlite_memory_vector.go
+++ b/internal/sqlstore/sqlite_memory_vector.go
@@ -29,7 +29,10 @@ import (
 	"github.com/ob-labs/powercontext-go/artifact/memory"
 )
 
-const requiredSQLiteVecVersion = "v0.1.9"
+const (
+	requiredSQLiteVecVersion  = "v0.1.9"
+	sqliteVecMaximumDimension = 8192 // SQLITE_VEC_VEC0_MAX_DIMENSIONS in the embedded v0.1.9 source.
+)
 
 const (
 	sqliteVecProjectionName         = "pc_memory_entry_vec"
@@ -72,6 +75,9 @@ func (i *SQLiteMemoryVectorIndex) Initialize(ctx context.Context, db DBTX) error
 	}
 	if err := validateSQLiteVecVersion(version); err != nil {
 		return err
+	}
+	if i.profile.Dimension > sqliteVecMaximumDimension {
+		return sqliteVecDimensionLimitError(i.profile.Dimension)
 	}
 	if _, err := db.ExecContext(ctx, `CREATE TABLE IF NOT EXISTS pc_memory_vector_entries (
             vector_id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
@@ -129,8 +135,8 @@ func (i *SQLiteMemoryVectorIndex) ensureSQLiteVecProjection(ctx context.Context,
 			"CREATE VIRTUAL TABLE %s USING vec0(embedding float[%d])",
 			sqliteVecProjectionName, i.profile.Dimension,
 		)
-		if _, err := db.ExecContext(ctx, statement); err != nil {
-			return newSQLiteVecCapabilityFailure("sqlite-vec probe failed", err)
+		if _, createErr := db.ExecContext(ctx, statement); createErr != nil {
+			return newSQLiteVecCapabilityFailure("sqlite-vec probe failed", createErr)
 		}
 		tableType, schema, err = sqliteVecProjectionDefinition(ctx, db)
 	}
@@ -613,6 +619,16 @@ func sqliteVecDimensionMismatchError(existing, configured int, causes ...error) 
 		fmt.Sprintf(
 			"sqlite-vec projection dimension %d does not match configured dimension %d; rebuild the projection",
 			existing, configured,
+		),
+		causes...,
+	)
+}
+
+func sqliteVecDimensionLimitError(configured int, causes ...error) error {
+	return newSQLiteVecCapabilityFailure(
+		fmt.Sprintf(
+			"sqlite-vec supports at most %d dimensions; configured dimension %d is unsupported",
+			sqliteVecMaximumDimension, configured,
 		),
 		causes...,
 	)

--- a/internal/sqlstore/sqlite_memory_vector_schema_test.go
+++ b/internal/sqlstore/sqlite_memory_vector_schema_test.go
@@ -1,0 +1,76 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sqlstore
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/ob-labs/powercontext-go/artifact/memory"
+)
+
+func TestParseSQLiteVecProjectionDimensionAcceptsOwnedSchema(t *testing.T) {
+	t.Parallel()
+	dimension, ok := parseSQLiteVecProjectionDimension(
+		"CREATE VIRTUAL TABLE pc_memory_entry_vec USING vec0(embedding float[1536])",
+	)
+	if !ok || dimension != 1536 {
+		t.Fatalf("dimension, ok = %d, %t", dimension, ok)
+	}
+}
+
+func TestParseSQLiteVecProjectionDimensionRejectsForeignSchema(t *testing.T) {
+	t.Parallel()
+	for _, schema := range []string{
+		"CREATE TABLE pc_memory_entry_vec (embedding BLOB)",
+		"CREATE VIRTUAL TABLE pc_memory_entry_vec USING vec0(other float[3])",
+		"CREATE VIRTUAL TABLE pc_memory_entry_vec USING vec0(embedding float[0])",
+		"CREATE VIRTUAL TABLE another_vec USING vec0(embedding float[3])",
+		"untrusted DDL with /private/path and embedding float[3]",
+	} {
+		if dimension, ok := parseSQLiteVecProjectionDimension(schema); ok || dimension != 0 {
+			t.Fatalf("accepted schema %q as %d", schema, dimension)
+		}
+	}
+}
+
+func TestSQLiteVecCapabilityFailureMatchesSafeCapabilityAndRootCauses(t *testing.T) {
+	t.Parallel()
+	queryCause := errors.New("query cause /private/db API_KEY=secret")
+	cleanupCause := errors.New("cleanup cause Memory private text")
+	err := newSQLiteVecCapabilityFailure("sqlite-vec probe failed", queryCause, cleanupCause)
+
+	capability, ok := errors.AsType[*memory.CapabilityNotSupportedError](err)
+	if !ok || capability.Capability != "vector" {
+		t.Fatalf("capability = %#v, err = %v", capability, err)
+	}
+	if !errors.Is(err, queryCause) || !errors.Is(err, cleanupCause) {
+		t.Fatalf("root causes are not matchable: %v", err)
+	}
+	for _, secret := range []string{"/private/db", "API_KEY=secret", "Memory private text"} {
+		if strings.Contains(err.Error(), secret) {
+			t.Fatalf("safe error leaked %q: %v", secret, err)
+		}
+	}
+}
+
+func TestSQLiteVecProjectionDimensionMismatchDetail(t *testing.T) {
+	t.Parallel()
+	err := sqliteVecDimensionMismatchError(1536, 768)
+	if got, want := err.Error(), "memory capability is not supported: vector (sqlite-vec projection dimension 1536 does not match configured dimension 768; rebuild the projection)"; got != want {
+		t.Fatalf("error = %q, want %q", got, want)
+	}
+}

--- a/internal/sqlstore/sqlite_memory_vector_test.go
+++ b/internal/sqlstore/sqlite_memory_vector_test.go
@@ -311,6 +311,35 @@ func TestSQLiteVecInitializeRejectsIncompatibleProjectionSchema(t *testing.T) {
 	assertSQLiteVecErrorDoesNotLeak(t, err, "CREATE TABLE", "pc_memory_entry_vec (embedding BLOB)")
 }
 
+func TestSQLiteVecInitializeRejectsFreshOversizedDimension(t *testing.T) {
+	database := openSQLiteVecTestDatabase(t)
+	err := database.Transaction(t.Context(), func(tx DBTX) error {
+		return newSQLiteVecTestIndex(t, 65536).Initialize(t.Context(), tx)
+	})
+	capability, ok := errors.AsType[*memory.CapabilityNotSupportedError](err)
+	if !ok || capability.Capability != "vector" {
+		t.Fatalf("capability = %#v, err = %v", capability, err)
+	}
+	if got, want := err.Error(), "memory capability is not supported: vector (sqlite-vec supports at most 8192 dimensions; configured dimension 65536 is unsupported)"; got != want {
+		t.Fatalf("error = %q, want %q", got, want)
+	}
+	assertSQLiteVecErrorDoesNotLeak(t, err, "projection.db", "migrate", "CREATE VIRTUAL TABLE", "[0 0 0]")
+	if err := database.Transaction(t.Context(), func(tx DBTX) error {
+		var count int
+		if err := tx.QueryRowContext(t.Context(),
+			"SELECT COUNT(*) FROM sqlite_master WHERE name = 'pc_memory_entry_vec'",
+		).Scan(&count); err != nil {
+			return err
+		}
+		if count != 0 {
+			t.Fatalf("fresh oversized profile created %d vec0 tables", count)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestSQLiteVecInitializeClearsStaleProbeRow(t *testing.T) {
 	database := openSQLiteVecTestDatabase(t)
 	initializeSQLiteVecTestIndex(t, database, 3)

--- a/internal/sqlstore/sqlite_memory_vector_test.go
+++ b/internal/sqlstore/sqlite_memory_vector_test.go
@@ -16,9 +16,11 @@ package sqlstore
 
 import (
 	"context"
+	"database/sql"
 	"encoding/hex"
 	"errors"
 	"math"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -267,4 +269,181 @@ func TestSQLiteVec0ReplaceHydrateAndSearch(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func TestSQLiteVecInitializeRejectsProjectionDimensionMismatch(t *testing.T) {
+	database := openSQLiteVecTestDatabase(t)
+	initializeSQLiteVecTestIndex(t, database, 3)
+
+	err := database.Transaction(t.Context(), func(tx DBTX) error {
+		return newSQLiteVecTestIndex(t, 4).Initialize(t.Context(), tx)
+	})
+	capability, ok := errors.AsType[*memory.CapabilityNotSupportedError](err)
+	if !ok || capability.Capability != "vector" {
+		t.Fatalf("capability = %#v, err = %v", capability, err)
+	}
+	if got, want := err.Error(), "memory capability is not supported: vector (sqlite-vec projection dimension 3 does not match configured dimension 4; rebuild the projection)"; got != want {
+		t.Fatalf("error = %q, want %q", got, want)
+	}
+	assertSQLiteVecErrorDoesNotLeak(t, err, "projection.db", "CREATE VIRTUAL TABLE", "Memory private text", "[0 0 0]")
+	assertSQLiteVecSchema(t, database, "CREATE VIRTUAL TABLE pc_memory_entry_vec USING vec0(embedding float[3])")
+}
+
+func TestSQLiteVecInitializeRejectsIncompatibleProjectionSchema(t *testing.T) {
+	database := openSQLiteVecTestDatabase(t)
+	if err := database.Transaction(t.Context(), func(tx DBTX) error {
+		_, err := tx.ExecContext(t.Context(), "CREATE TABLE pc_memory_entry_vec (embedding BLOB)")
+		return err
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	err := database.Transaction(t.Context(), func(tx DBTX) error {
+		return newSQLiteVecTestIndex(t, 3).Initialize(t.Context(), tx)
+	})
+	capability, ok := errors.AsType[*memory.CapabilityNotSupportedError](err)
+	if !ok || capability.Capability != "vector" {
+		t.Fatalf("capability = %#v, err = %v", capability, err)
+	}
+	if got, want := err.Error(), "memory capability is not supported: vector (sqlite-vec projection schema is incompatible; rebuild the projection)"; got != want {
+		t.Fatalf("error = %q, want %q", got, want)
+	}
+	assertSQLiteVecErrorDoesNotLeak(t, err, "CREATE TABLE", "pc_memory_entry_vec (embedding BLOB)")
+}
+
+func TestSQLiteVecInitializeClearsStaleProbeRow(t *testing.T) {
+	database := openSQLiteVecTestDatabase(t)
+	initializeSQLiteVecTestIndex(t, database, 3)
+	packed, err := packSQLiteVector([]float64{0, 0, 0})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := database.Transaction(t.Context(), func(tx DBTX) error {
+		_, err := tx.ExecContext(t.Context(),
+			"INSERT INTO pc_memory_entry_vec (rowid, embedding) VALUES (?, ?)", -1, packed,
+		)
+		return err
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	initializeSQLiteVecTestIndex(t, database, 3)
+	if err := database.Transaction(t.Context(), func(tx DBTX) error {
+		var count int
+		if err := tx.QueryRowContext(t.Context(),
+			"SELECT COUNT(*) FROM pc_memory_entry_vec WHERE rowid = ?", -1,
+		).Scan(&count); err != nil {
+			return err
+		}
+		if count != 0 {
+			t.Fatalf("stale probe rows = %d", count)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSQLiteVecInitializePreservesProbeQueryAndCleanupCauses(t *testing.T) {
+	database := openSQLiteVecTestDatabase(t)
+	queryCause := errors.New("query failure /private/db API_KEY=secret")
+	cleanupCause := errors.New("cleanup failure Memory private text")
+	failed := &sqliteVecProbeFailureDB{DBTX: database.SQLDB(), queryCause: queryCause, cleanupCause: cleanupCause}
+
+	err := newSQLiteVecTestIndex(t, 3).Initialize(t.Context(), failed)
+	capability, ok := errors.AsType[*memory.CapabilityNotSupportedError](err)
+	if !ok || capability.Capability != "vector" {
+		t.Fatalf("capability = %#v, err = %v", capability, err)
+	}
+	if !errors.Is(err, queryCause) || !errors.Is(err, cleanupCause) {
+		t.Fatalf("root causes are not matchable: %v", err)
+	}
+	assertSQLiteVecErrorDoesNotLeak(t, err, "/private/db", "API_KEY=secret", "Memory private text")
+}
+
+func openSQLiteVecTestDatabase(t *testing.T) *Database {
+	t.Helper()
+	database, err := OpenSQLite(t.Context(), DefaultSQLiteConfig(filepath.Join(t.TempDir(), "projection.db")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if closeErr := database.Close(context.Background()); closeErr != nil {
+			t.Error(closeErr)
+		}
+	})
+	return database
+}
+
+func newSQLiteVecTestIndex(t *testing.T, dimension int) *SQLiteMemoryVectorIndex {
+	t.Helper()
+	profile, err := memory.NewEmbeddingProfile("profile", "model", dimension, "unit")
+	if err != nil {
+		t.Fatal(err)
+	}
+	index, err := NewSQLiteMemoryVectorIndex(profile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return index
+}
+
+func initializeSQLiteVecTestIndex(t *testing.T, database *Database, dimension int) {
+	t.Helper()
+	if err := database.Transaction(t.Context(), func(tx DBTX) error {
+		return newSQLiteVecTestIndex(t, dimension).Initialize(t.Context(), tx)
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func assertSQLiteVecSchema(t *testing.T, database *Database, want string) {
+	t.Helper()
+	if err := database.Transaction(t.Context(), func(tx DBTX) error {
+		var schema string
+		if err := tx.QueryRowContext(t.Context(),
+			"SELECT sql FROM sqlite_master WHERE name = 'pc_memory_entry_vec'",
+		).Scan(&schema); err != nil {
+			return err
+		}
+		if schema != want {
+			t.Fatalf("schema = %q, want %q", schema, want)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func assertSQLiteVecErrorDoesNotLeak(t *testing.T, err error, forbidden ...string) {
+	t.Helper()
+	for _, value := range forbidden {
+		if strings.Contains(err.Error(), value) {
+			t.Fatalf("error leaked %q: %v", value, err)
+		}
+	}
+}
+
+type sqliteVecProbeFailureDB struct {
+	DBTX
+	queryCause   error
+	cleanupCause error
+	deleteCalls  int
+}
+
+func (d *sqliteVecProbeFailureDB) ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error) {
+	if query == "DELETE FROM pc_memory_entry_vec WHERE rowid = ?" {
+		d.deleteCalls++
+		if d.deleteCalls == 2 {
+			return nil, d.cleanupCause
+		}
+	}
+	return d.DBTX.ExecContext(ctx, query, args...)
+}
+
+func (d *sqliteVecProbeFailureDB) QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error) {
+	if query == "SELECT rowid FROM pc_memory_entry_vec WHERE embedding MATCH ? AND k = 1" {
+		return nil, d.queryCause
+	}
+	return d.DBTX.QueryContext(ctx, query, args...)
 }

--- a/server/application_test.go
+++ b/server/application_test.go
@@ -106,6 +106,76 @@ func TestOpenApplicationProvidesRunnableSQLiteVerticalSlice(t *testing.T) {
 	}
 }
 
+func TestOpenApplicationRejectsSQLiteVectorProjectionDimensionMismatch(t *testing.T) {
+	config := applicationTestConfig(t)
+	path, err := SQLiteDSN(config.Database.SQLite.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	configureSQLiteProjectionEmbedding(&config, 3)
+	application, err := OpenApplication(t.Context(), config, Dependencies{
+		EmbeddingModel: sqliteProjectionEmbedding{dimension: 3},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := application.Close(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+
+	database, err := sql.Open("sqlite3", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+	if _, err := database.ExecContext(t.Context(),
+		"INSERT INTO pc_artifacts (scope_id, family, artifact_id, revision, content) VALUES (?, ?, ?, ?, ?)",
+		"scope", memory.Family, "projection-sentinel", 1, []byte(`{"text":"Memory private text"}`),
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	configureSQLiteProjectionEmbedding(&config, 4)
+	application, err = OpenApplication(t.Context(), config, Dependencies{
+		EmbeddingModel: sqliteProjectionEmbedding{dimension: 4},
+	})
+	if application != nil {
+		t.Fatal("OpenApplication returned an Application despite projection mismatch")
+	}
+	capability, ok := errors.AsType[*memory.CapabilityNotSupportedError](err)
+	if !ok || capability.Capability != "vector" {
+		t.Fatalf("capability = %#v, err = %v", capability, err)
+	}
+	if got, want := err.Error(), "server: initialize search projections: memory capability is not supported: vector (sqlite-vec projection dimension 3 does not match configured dimension 4; rebuild the projection)"; got != want {
+		t.Fatalf("error = %q, want %q", got, want)
+	}
+	for _, forbidden := range []string{path, "CREATE VIRTUAL TABLE", "Memory private text", "[0 0 0]"} {
+		if strings.Contains(err.Error(), forbidden) {
+			t.Fatalf("startup error leaked %q: %v", forbidden, err)
+		}
+	}
+
+	var schema string
+	if err := database.QueryRowContext(t.Context(),
+		"SELECT sql FROM sqlite_master WHERE name = 'pc_memory_entry_vec'",
+	).Scan(&schema); err != nil {
+		t.Fatal(err)
+	}
+	if schema != "CREATE VIRTUAL TABLE pc_memory_entry_vec USING vec0(embedding float[3])" {
+		t.Fatalf("schema = %q", schema)
+	}
+	var artifactCount int
+	if err := database.QueryRowContext(t.Context(),
+		"SELECT COUNT(*) FROM pc_artifacts WHERE scope_id = ? AND family = ? AND artifact_id = ?",
+		"scope", memory.Family, "projection-sentinel",
+	).Scan(&artifactCount); err != nil {
+		t.Fatal(err)
+	}
+	if artifactCount != 1 {
+		t.Fatalf("authoritative artifact count = %d", artifactCount)
+	}
+}
+
 func TestApplicationCloseWaitsForInFlightHTTPMemoryFlush(t *testing.T) {
 	config := applicationTestConfig(t)
 	pipeline := &blockingApplicationMemoryPipeline{started: make(chan struct{}), release: make(chan struct{})}
@@ -1153,6 +1223,13 @@ func applicationTestConfig(t *testing.T) ProcessConfig {
 	return config
 }
 
+func configureSQLiteProjectionEmbedding(config *ProcessConfig, dimension int) {
+	config.Inference.EmbeddingModel = "test:embedding"
+	config.Inference.EmbeddingProfileID = "projection-test"
+	config.Inference.EmbeddingDimension = dimension
+	config.Inference.EmbeddingNormalization = "unit"
+}
+
 func postApplicationJSON(t *testing.T, handler http.Handler, path string, value any) *httptest.ResponseRecorder {
 	t.Helper()
 	body, err := json.Marshal(value)
@@ -1252,6 +1329,27 @@ type failingReadinessEmbedding struct {
 	calls *atomic.Int64
 	err   error
 }
+
+type sqliteProjectionEmbedding struct{ dimension int }
+
+func (m sqliteProjectionEmbedding) Profile() inference.EmbeddingProfile {
+	return sqliteProjectionEmbeddingProfile{dimension: m.dimension}
+}
+
+func (m sqliteProjectionEmbedding) Embed(_ context.Context, texts []string) (inference.EmbeddingResult, error) {
+	vectors := make([][]float64, len(texts))
+	for index := range vectors {
+		vectors[index] = make([]float64, m.dimension)
+	}
+	return inference.EmbeddingResult{Vectors: vectors}, nil
+}
+
+type sqliteProjectionEmbeddingProfile struct{ dimension int }
+
+func (p sqliteProjectionEmbeddingProfile) ID() string                { return "projection-test" }
+func (p sqliteProjectionEmbeddingProfile) ModelName() string         { return "test:embedding" }
+func (p sqliteProjectionEmbeddingProfile) DimensionCount() int       { return p.dimension }
+func (p sqliteProjectionEmbeddingProfile) NormalizationMode() string { return "unit" }
 
 func (m failingReadinessEmbedding) Profile() inference.EmbeddingProfile {
 	return readinessEmbeddingProfile{}

--- a/test/conformance/parity-inventory-rules.json
+++ b/test/conformance/parity-inventory-rules.json
@@ -15,7 +15,30 @@
     },
     "tests/builtin/persistence/test_sqlite_memory_vector_index.py": {
       "mode": "go-port",
-      "reason": "SQLite vector-index dimension and probe behavior maps to the Go SQLite persistence implementation."
+      "reason": "SQLite vector-index dimension and probe behavior maps to the Go SQLite persistence implementation.",
+      "cases": {
+        "test_vector_index_probe_clears_a_leftover_probe_row": {
+          "evidence": [
+            "go:internal/sqlstore/sqlite_memory_vector_test.go#TestSQLiteVecInitializeClearsStaleProbeRow"
+          ]
+        },
+        "test_vector_index_probe_reports_a_table_dimension_mismatch": {
+          "evidence": [
+            "go:internal/sqlstore/sqlite_memory_vector_test.go#TestSQLiteVecInitializeRejectsProjectionDimensionMismatch",
+            "go:server/application_test.go#TestOpenApplicationRejectsSQLiteVectorProjectionDimensionMismatch"
+          ]
+        },
+        "test_vector_index_probe_surfaces_the_underlying_cause": {
+          "evidence": [
+            "go:internal/sqlstore/sqlite_memory_vector_test.go#TestSQLiteVecInitializePreservesProbeQueryAndCleanupCauses"
+          ]
+        },
+        "test_vector_index_probe_reports_the_provider_limit_for_a_fresh_oversized_dimension": {
+          "evidence": [
+            "go:internal/sqlstore/sqlite_memory_vector_test.go#TestSQLiteVecInitializeRejectsFreshOversizedDimension"
+          ]
+        }
+      }
     },
     "tests/builtin/runtime/test_composition_embedding.py": {
       "mode": "go-port",

--- a/test/conformance/parity-inventory.json
+++ b/test/conformance/parity-inventory.json
@@ -4,8 +4,8 @@
   "oracle_commit": "3a6cb0151670eaff7dc0293466edd673124e80da",
   "python_test_file_count": 132,
   "python_test_case_count": 812,
-  "mapped_case_count": 719,
-  "pending_case_count": 93,
+  "mapped_case_count": 723,
+  "pending_case_count": 89,
   "entries": [
     {
       "python": {
@@ -2427,8 +2427,15 @@
         "line": 41
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/sqlstore/sqlite_memory_vector_test.go",
+          "test": "TestSQLiteVecInitializeClearsStaleProbeRow"
+        }
+      ]
     },
     {
       "python": {
@@ -2437,8 +2444,20 @@
         "line": 65
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/sqlstore/sqlite_memory_vector_test.go",
+          "test": "TestSQLiteVecInitializeRejectsProjectionDimensionMismatch"
+        },
+        {
+          "kind": "go",
+          "file": "server/application_test.go",
+          "test": "TestOpenApplicationRejectsSQLiteVectorProjectionDimensionMismatch"
+        }
+      ]
     },
     {
       "python": {
@@ -2447,8 +2466,15 @@
         "line": 88
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/sqlstore/sqlite_memory_vector_test.go",
+          "test": "TestSQLiteVecInitializePreservesProbeQueryAndCleanupCauses"
+        }
+      ]
     },
     {
       "python": {
@@ -2457,8 +2483,15 @@
         "line": 112
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/sqlstore/sqlite_memory_vector_test.go",
+          "test": "TestSQLiteVecInitializeRejectsFreshOversizedDimension"
+        }
+      ]
     },
     {
       "python": {


### PR DESCRIPTION
Part of #3.\n\nThis completes the SQLite half of the configured embedding-dimension release delta. SQLiteMemoryVectorIndex.Initialize now reads the owned vec0 schema before probing, rejects an existing dimension or DDL mismatch with a stable redacted capability error, and clears stale probe rows while retaining query and cleanup root causes for errors.Is matching.\n\nA fresh profile larger than the embedded sqlite-vec v0.1.9 8192-dimension limit is refused before projection DDL. No path, DDL, bind value, vector, Memory content, or native error text is exposed. The change never drops, truncates, migrates, or rebuilds the projection automatically. An existing mismatch makes OpenApplication return nil rather than create a degraded Application.\n\nParity: maps exactly four v0.1.0 SQLite vector cases; generated inventory is 723 mapped / 89 pending.\n\nValidation: focused and race SQLiteVec tests, tagged Server embedding/projection tests, exact-target parity generation check, go mod tidy -diff, go mod verify, and git diff --check all passed using the matching temporary SQLite header on Windows. make test-sqlite is blocked by existing Windows symlink-privilege tests in artifact/skill. make lint retains two pre-existing SA4023 diagnostics in internal/sqlstore/database.go, outside this PR. Linux exact-Head CI remains the full gate.