### PR TITLE
feat(evaluation): add baseline storage foundation

### DIFF
--- a/evaluation/src/powercontext_eval/web/baselines.py
+++ b/evaluation/src/powercontext_eval/web/baselines.py
@@ -1,0 +1,197 @@
+# Copyright (c) 2026 OceanBase.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Immutable single-arm baseline and historical-comparison contracts."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from enum import StrEnum
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from powercontext_eval.benchmarks.swebench_pro.catalog import TaskSet
+from powercontext_eval.models import Arm
+from powercontext_eval.web.models import TaskStatus
+
+
+class _FrozenModel(BaseModel):
+    model_config = ConfigDict(extra="forbid", strict=True, frozen=True)
+
+
+def _require_utc(value: datetime) -> datetime:
+    if value.tzinfo is None or value.utcoffset() != UTC.utcoffset(value):
+        raise ValueError("Timestamps must use UTC")
+    return value
+
+
+class BaselineCreate(_FrozenModel):
+    name: str = Field(min_length=1, max_length=120)
+    source_batch_id: str = Field(min_length=1, max_length=200)
+    source_arm: Arm
+    expected_report_revision: Annotated[int, Field(ge=0)]
+    idempotency_key: str = Field(min_length=8, max_length=128, pattern=r"^[A-Za-z0-9._-]+$")
+
+    @field_validator("name")
+    @classmethod
+    def normalize_name(cls, value: str) -> str:
+        normalized = " ".join(value.split())
+        if not normalized:
+            raise ValueError("Baseline name must not be blank")
+        return normalized
+
+    @field_validator("source_arm", mode="before")
+    @classmethod
+    def parse_arm(cls, value: object) -> object:
+        return Arm(value) if isinstance(value, str) else value
+
+
+class BaselineRecord(_FrozenModel):
+    baseline_id: str
+    name: str
+    source_batch_id: str
+    source_arm: Arm
+    source_report_revision: Annotated[int, Field(ge=0)]
+    benchmark: Literal["swebench-pro"]
+    task_set: TaskSet
+    instance_set_digest: str = Field(pattern=r"^[0-9a-f]{64}$")
+    total_tasks: Annotated[int, Field(ge=1)]
+    resolved_tasks: Annotated[int, Field(ge=0)]
+    execution_failures: Annotated[int, Field(ge=0)]
+    model: str
+    reasoning_effort: Literal["medium"]
+    dataset_revision: str
+    harness_revision: str
+    powercontext_sha: str | None = Field(default=None, pattern=r"^[0-9a-f]{40}$")
+    codex_version: str | None = None
+    created_at: datetime
+
+    _created_at_utc = field_validator("created_at")(_require_utc)
+
+    @field_validator("source_arm", mode="before")
+    @classmethod
+    def parse_arm(cls, value: object) -> object:
+        return Arm(value) if isinstance(value, str) else value
+
+
+class BaselineItemRecord(_FrozenModel):
+    baseline_id: str
+    instance_id: str
+    source_index: Annotated[int, Field(ge=0)]
+    source_task_id: str
+    source_attempt_id: str | None = None
+    status: TaskStatus
+    resolved: bool | None = None
+    input_tokens: Annotated[int, Field(ge=0)] | None = None
+    output_tokens: Annotated[int, Field(ge=0)] | None = None
+    total_tokens: Annotated[int, Field(ge=0)] | None = None
+
+    @model_validator(mode="after")
+    def validate_outcome(self) -> BaselineItemRecord:
+        if self.status is TaskStatus.SUCCEEDED:
+            if self.source_attempt_id is None or self.resolved is None:
+                raise ValueError("Successful baseline items require an exact attempt and result")
+        elif any(
+            value is not None for value in (self.resolved, self.input_tokens, self.output_tokens, self.total_tokens)
+        ):
+            raise ValueError("Unsuccessful baseline items cannot contain arm outcomes")
+        if (
+            self.input_tokens is not None
+            and self.output_tokens is not None
+            and self.total_tokens != self.input_tokens + self.output_tokens
+        ):
+            raise ValueError("Baseline token totals are inconsistent")
+        return self
+
+
+class BaselineSnapshot(_FrozenModel):
+    benchmark: Literal["swebench-pro"]
+    task_set: TaskSet
+    instance_set_digest: str = Field(pattern=r"^[0-9a-f]{64}$")
+    total_tasks: Annotated[int, Field(ge=1)]
+    resolved_tasks: Annotated[int, Field(ge=0)]
+    execution_failures: Annotated[int, Field(ge=0)]
+    model: str
+    reasoning_effort: Literal["medium"]
+    dataset_revision: str
+    harness_revision: str
+    powercontext_sha: str | None = Field(default=None, pattern=r"^[0-9a-f]{40}$")
+    codex_version: str | None = None
+    items: tuple[BaselineItemRecord, ...]
+
+
+class CompatibilityStatus(StrEnum):
+    COMPATIBLE = "compatible"
+    WARNING = "warning"
+    INCOMPATIBLE = "incompatible"
+
+
+class BaselineCompatibility(_FrozenModel):
+    status: CompatibilityStatus
+    reasons: tuple[str, ...] = ()
+
+
+class BaselineSelection(_FrozenModel):
+    baseline_id: str
+    current_arm: Arm
+
+    @field_validator("current_arm", mode="before")
+    @classmethod
+    def parse_arm(cls, value: object) -> object:
+        return Arm(value) if isinstance(value, str) else value
+
+
+class ComparisonCoverage(_FrozenModel):
+    matched_tasks: Annotated[int, Field(ge=0)]
+    comparable_tasks: Annotated[int, Field(ge=0)]
+    current_execution_failures: Annotated[int, Field(ge=0)]
+    baseline_execution_failures: Annotated[int, Field(ge=0)]
+
+
+class HistoricalResolutionComparison(_FrozenModel):
+    baseline_resolved: Annotated[int, Field(ge=0)]
+    current_resolved: Annotated[int, Field(ge=0)]
+    total: Annotated[int, Field(ge=0)]
+    baseline_rate_percent: Annotated[float, Field(ge=0, le=100, allow_inf_nan=False)]
+    current_rate_percent: Annotated[float, Field(ge=0, le=100, allow_inf_nan=False)]
+    delta_points: Annotated[float, Field(allow_inf_nan=False)]
+
+
+class HistoricalTokenComparison(_FrozenModel):
+    baseline: Annotated[int, Field(ge=0)]
+    current: Annotated[int, Field(ge=0)]
+    delta: int
+    baseline_measured_tasks: Annotated[int, Field(ge=0)]
+    current_measured_tasks: Annotated[int, Field(ge=0)]
+
+
+class BaselineComparison(_FrozenModel):
+    baseline: BaselineRecord
+    current_arm: Arm
+    compatibility: BaselineCompatibility
+    coverage: ComparisonCoverage
+    resolution: HistoricalResolutionComparison
+    outcome_categories: dict[
+        Literal["baseline_fail_current_pass", "baseline_pass_current_fail", "both_pass", "both_fail"],
+        Annotated[int, Field(ge=0)],
+    ]
+    input_tokens: HistoricalTokenComparison | None = None
+    output_tokens: HistoricalTokenComparison | None = None
+    total_tokens: HistoricalTokenComparison | None = None
+
+    @field_validator("current_arm", mode="before")
+    @classmethod
+    def parse_arm(cls, value: object) -> object:
+        return Arm(value) if isinstance(value, str) else value

--- a/evaluation/src/powercontext_eval/web/reporting.py
+++ b/evaluation/src/powercontext_eval/web/reporting.py
@@ -16,11 +16,12 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import stat
 from collections import Counter
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Literal, Protocol
@@ -29,10 +30,23 @@ from pydantic import ValidationError
 
 from powercontext_eval.artifacts import ArmState
 from powercontext_eval.benchmarks.swebench_pro.adapter import DATASET_REVISION, HARNESS_COMMIT, SweBenchProInstance
+from powercontext_eval.models import Arm
 from powercontext_eval.report import ArmReport, ReportBundle, TestGroupReport
+from powercontext_eval.web.baselines import (
+    BaselineComparison,
+    BaselineCompatibility,
+    BaselineItemRecord,
+    BaselineRecord,
+    BaselineSnapshot,
+    ComparisonCoverage,
+    CompatibilityStatus,
+    HistoricalResolutionComparison,
+    HistoricalTokenComparison,
+)
 from powercontext_eval.web.batches import (
     BatchRecord,
     BatchReportResponse,
+    BatchStatus,
     BatchTaskDetailResponse,
     BatchTaskItem,
     BatchTaskPage,
@@ -115,6 +129,10 @@ class InvalidReportArtifact(ReportingError):
 
     def __init__(self) -> None:
         super().__init__("Evaluation report artifacts are invalid")
+
+
+class StaleReportRevision(ReportingError):
+    """The report changed after the operator chose to save it."""
 
 
 def _directory_flags() -> int:
@@ -622,6 +640,226 @@ def load_batch_report(
         ),
         revisions=revisions,
         configuration=configuration,
+    )
+
+
+def instance_set_digest(tasks: Sequence[TaskRecord]) -> str:
+    """Return a stable identity for the exact ordered benchmark instance set."""
+
+    instance_ids = [task.instance_id for task in tasks]
+    if any(instance_id is None for instance_id in instance_ids):
+        raise InvalidReportArtifact
+    payload = json.dumps(instance_ids, ensure_ascii=True, separators=(",", ":")).encode()
+    return hashlib.sha256(payload).hexdigest()
+
+
+def create_baseline_snapshot(
+    batch: BatchRecord,
+    tasks: Sequence[TaskRecord],
+    *,
+    arm: Arm,
+    expected_report_revision: int,
+    runs_root: Path,
+    catalog: BenchmarkCatalog,
+) -> BaselineSnapshot:
+    """Materialize immutable comparison facts for one exact completed batch arm."""
+
+    if batch.status is not BatchStatus.COMPLETED:
+        raise ValueError("Only completed batches can be saved as baselines")
+    report = load_batch_report(batch, tasks, runs_root=runs_root, catalog=catalog)
+    if report.report_revision != expected_report_revision:
+        raise StaleReportRevision
+    items: list[BaselineItemRecord] = []
+    resolved_tasks = 0
+    for task in tasks:
+        resolved: bool | None = None
+        input_tokens: int | None = None
+        output_tokens: int | None = None
+        total_tokens: int | None = None
+        if task.status is TaskStatus.SUCCEEDED:
+            bundle = _bundle_for_task(task, runs_root)
+            arm_report = bundle.off if arm is Arm.OFF else bundle.on
+            resolved = arm_report.resolved
+            input_tokens = arm_report.metrics.input_tokens
+            output_tokens = arm_report.metrics.output_tokens
+            total_tokens = _arm_total(arm_report)
+            resolved_tasks += int(resolved)
+        if task.instance_id is None or task.source_index is None:
+            raise InvalidReportArtifact
+        items.append(
+            BaselineItemRecord(
+                baseline_id="",
+                instance_id=task.instance_id,
+                source_index=task.source_index,
+                source_task_id=task.task_id,
+                source_attempt_id=task.attempt_id,
+                status=task.status,
+                resolved=resolved,
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                total_tokens=total_tokens,
+            )
+        )
+    dataset_revision = report.revisions.get("dataset")
+    harness_revision = report.revisions.get("harness")
+    if not dataset_revision or not harness_revision:
+        raise InvalidReportArtifact
+    return BaselineSnapshot(
+        benchmark=batch.request.benchmark,
+        task_set=batch.request.task_set,
+        instance_set_digest=instance_set_digest(tasks),
+        total_tasks=batch.total_tasks,
+        resolved_tasks=resolved_tasks,
+        execution_failures=report.execution_failures,
+        model=batch.request.model,
+        reasoning_effort=batch.request.reasoning_effort,
+        dataset_revision=dataset_revision,
+        harness_revision=harness_revision,
+        powercontext_sha=report.revisions.get("powercontext"),
+        codex_version=report.configuration.get("codex"),
+        items=tuple(items),
+    )
+
+
+def baseline_compatibility(
+    baseline: BaselineRecord,
+    batch: BatchRecord,
+    tasks: Sequence[TaskRecord],
+    report: BatchReportResponse,
+    *,
+    current_arm: Arm,
+) -> BaselineCompatibility:
+    """Classify comparison safety without treating the PowerContext revision as a gate."""
+
+    checks = (
+        (baseline.benchmark, batch.request.benchmark, "benchmark differs"),
+        (baseline.task_set, batch.request.task_set, "task set differs"),
+        (baseline.instance_set_digest, instance_set_digest(tasks), "instance set differs"),
+        (baseline.total_tasks, batch.total_tasks, "task count differs"),
+        (baseline.model, batch.request.model, "model differs"),
+        (baseline.reasoning_effort, batch.request.reasoning_effort, "reasoning effort differs"),
+        (baseline.dataset_revision, report.revisions.get("dataset"), "dataset revision differs"),
+        (baseline.harness_revision, report.revisions.get("harness"), "harness revision differs"),
+    )
+    hard_reasons = [reason for baseline_value, current_value, reason in checks if baseline_value != current_value]
+    if baseline.codex_version is not None and baseline.codex_version != report.configuration.get("codex"):
+        hard_reasons.append("Codex version differs")
+    if hard_reasons:
+        return BaselineCompatibility(status=CompatibilityStatus.INCOMPATIBLE, reasons=tuple(hard_reasons))
+    if baseline.source_arm is not current_arm:
+        return BaselineCompatibility(status=CompatibilityStatus.WARNING, reasons=("cross-arm comparison",))
+    return BaselineCompatibility(status=CompatibilityStatus.COMPATIBLE)
+
+
+def _historical_tokens(
+    baseline_items: Sequence[BaselineItemRecord],
+    current_values: Mapping[str, int | None],
+    field: Literal["input_tokens", "output_tokens", "total_tokens"],
+) -> HistoricalTokenComparison | None:
+    baseline_values = [getattr(item, field) for item in baseline_items if getattr(item, field) is not None]
+    measured_current = [value for value in current_values.values() if value is not None]
+    if not baseline_values or not measured_current:
+        return None
+    baseline_total = sum(baseline_values)
+    current_total = sum(measured_current)
+    return HistoricalTokenComparison(
+        baseline=baseline_total,
+        current=current_total,
+        delta=current_total - baseline_total,
+        baseline_measured_tasks=len(baseline_values),
+        current_measured_tasks=len(measured_current),
+    )
+
+
+def compare_batch_to_baseline(
+    batch: BatchRecord,
+    tasks: Sequence[TaskRecord],
+    report: BatchReportResponse,
+    baseline: BaselineRecord,
+    baseline_items: Sequence[BaselineItemRecord],
+    *,
+    current_arm: Arm,
+    runs_root: Path,
+) -> BaselineComparison:
+    """Compare frozen per-instance facts without invoking the evaluation runner."""
+
+    compatibility = baseline_compatibility(baseline, batch, tasks, report, current_arm=current_arm)
+    baseline_by_instance = {item.instance_id: item for item in baseline_items}
+    current_by_instance = {task.instance_id: task for task in tasks if task.instance_id is not None}
+    matched_ids = sorted(set(baseline_by_instance) & set(current_by_instance))
+    categories: dict[
+        Literal["baseline_fail_current_pass", "baseline_pass_current_fail", "both_pass", "both_fail"], int
+    ] = {
+        "baseline_fail_current_pass": 0,
+        "baseline_pass_current_fail": 0,
+        "both_pass": 0,
+        "both_fail": 0,
+    }
+    current_resolved = 0
+    comparable = 0
+    current_failures = 0
+    baseline_failures = 0
+    current_tokens: dict[str, dict[str, int | None]] = {
+        "input_tokens": {},
+        "output_tokens": {},
+        "total_tokens": {},
+    }
+    matched_baseline_items: list[BaselineItemRecord] = []
+    for instance_id in matched_ids:
+        baseline_item = baseline_by_instance[instance_id]
+        task = current_by_instance[instance_id]
+        matched_baseline_items.append(baseline_item)
+        baseline_failures += int(baseline_item.status in _EXECUTION_FAILURE_STATES)
+        current_failures += int(task.status in _EXECUTION_FAILURE_STATES)
+        current_result: bool | None = None
+        values = {"input_tokens": None, "output_tokens": None, "total_tokens": None}
+        if task.status is TaskStatus.SUCCEEDED:
+            bundle = _bundle_for_task(task, runs_root)
+            arm_report = bundle.off if current_arm is Arm.OFF else bundle.on
+            current_result = arm_report.resolved
+            current_resolved += int(current_result)
+            values = {
+                "input_tokens": arm_report.metrics.input_tokens,
+                "output_tokens": arm_report.metrics.output_tokens,
+                "total_tokens": _arm_total(arm_report),
+            }
+        for field, value in values.items():
+            current_tokens[field][instance_id] = value
+        if baseline_item.resolved is not None and current_result is not None:
+            comparable += 1
+            if baseline_item.resolved and current_result:
+                categories["both_pass"] += 1
+            elif baseline_item.resolved:
+                categories["baseline_pass_current_fail"] += 1
+            elif current_result:
+                categories["baseline_fail_current_pass"] += 1
+            else:
+                categories["both_fail"] += 1
+    total = len(matched_ids)
+    baseline_rate = baseline.resolved_tasks / total * 100 if total else 0.0
+    current_rate = current_resolved / total * 100 if total else 0.0
+    return BaselineComparison(
+        baseline=baseline,
+        current_arm=current_arm,
+        compatibility=compatibility,
+        coverage=ComparisonCoverage(
+            matched_tasks=total,
+            comparable_tasks=comparable,
+            current_execution_failures=current_failures,
+            baseline_execution_failures=baseline_failures,
+        ),
+        resolution=HistoricalResolutionComparison(
+            baseline_resolved=baseline.resolved_tasks,
+            current_resolved=current_resolved,
+            total=total,
+            baseline_rate_percent=baseline_rate,
+            current_rate_percent=current_rate,
+            delta_points=current_rate - baseline_rate,
+        ),
+        outcome_categories=categories,
+        input_tokens=_historical_tokens(matched_baseline_items, current_tokens["input_tokens"], "input_tokens"),
+        output_tokens=_historical_tokens(matched_baseline_items, current_tokens["output_tokens"], "output_tokens"),
+        total_tokens=_historical_tokens(matched_baseline_items, current_tokens["total_tokens"], "total_tokens"),
     )
 
 

--- a/evaluation/src/powercontext_eval/web/store.py
+++ b/evaluation/src/powercontext_eval/web/store.py
@@ -26,10 +26,17 @@ from datetime import UTC, datetime, timedelta
 from enum import StrEnum
 from pathlib import Path
 from re import fullmatch
-from typing import Any, Literal, TypedDict
+from typing import Any, Literal, TypedDict, cast
 
 from powercontext_eval.codex import DEFAULT_CODEX_MODEL, DEFAULT_REASONING_EFFORT
 from powercontext_eval.paths import EvaluationPaths
+from powercontext_eval.web.baselines import (
+    BaselineCreate,
+    BaselineItemRecord,
+    BaselineRecord,
+    BaselineSelection,
+    BaselineSnapshot,
+)
 from powercontext_eval.web.batches import (
     BatchControlEvent,
     BatchControlEventType,
@@ -80,6 +87,10 @@ class TaskNotFound(TaskStoreError):
 
 class BatchNotFound(TaskStoreError):
     """The requested batch does not exist."""
+
+
+class BaselineNotFound(TaskStoreError):
+    """The requested baseline does not exist."""
 
 
 class TaskConflict(TaskStoreError):
@@ -388,6 +399,52 @@ class TaskStore:
                     lease_expires_at TEXT,
                     UNIQUE(attempt_id, arm)
                 );
+                CREATE TABLE IF NOT EXISTS baselines (
+                    baseline_seq INTEGER PRIMARY KEY AUTOINCREMENT,
+                    baseline_id TEXT NOT NULL UNIQUE,
+                    idempotency_key TEXT NOT NULL UNIQUE,
+                    request_json TEXT NOT NULL,
+                    name TEXT NOT NULL,
+                    source_batch_id TEXT NOT NULL REFERENCES batches(batch_id),
+                    source_arm TEXT NOT NULL CHECK (source_arm IN ('off', 'on')),
+                    source_report_revision INTEGER NOT NULL CHECK (source_report_revision >= 0),
+                    benchmark TEXT NOT NULL CHECK (benchmark = 'swebench-pro'),
+                    task_set TEXT NOT NULL,
+                    instance_set_digest TEXT NOT NULL,
+                    total_tasks INTEGER NOT NULL CHECK (total_tasks > 0),
+                    resolved_tasks INTEGER NOT NULL CHECK (resolved_tasks >= 0),
+                    execution_failures INTEGER NOT NULL CHECK (execution_failures >= 0),
+                    model TEXT NOT NULL,
+                    reasoning_effort TEXT NOT NULL,
+                    dataset_revision TEXT NOT NULL,
+                    harness_revision TEXT NOT NULL,
+                    powercontext_sha TEXT,
+                    codex_version TEXT,
+                    created_at TEXT NOT NULL
+                );
+                CREATE TABLE IF NOT EXISTS baseline_items (
+                    baseline_id TEXT NOT NULL REFERENCES baselines(baseline_id),
+                    instance_id TEXT NOT NULL,
+                    source_index INTEGER NOT NULL CHECK (source_index >= 0),
+                    source_task_id TEXT NOT NULL,
+                    source_attempt_id TEXT,
+                    status TEXT NOT NULL,
+                    resolved INTEGER CHECK (resolved IN (0, 1)),
+                    input_tokens INTEGER CHECK (input_tokens >= 0),
+                    output_tokens INTEGER CHECK (output_tokens >= 0),
+                    total_tokens INTEGER CHECK (total_tokens >= 0),
+                    PRIMARY KEY (baseline_id, instance_id),
+                    UNIQUE (baseline_id, source_index)
+                );
+                CREATE TABLE IF NOT EXISTS batch_baseline_selections (
+                    batch_id TEXT NOT NULL REFERENCES batches(batch_id),
+                    baseline_id TEXT NOT NULL REFERENCES baselines(baseline_id),
+                    current_arm TEXT NOT NULL CHECK (current_arm IN ('off', 'on')),
+                    sort_order INTEGER NOT NULL CHECK (sort_order >= 0),
+                    created_at TEXT NOT NULL,
+                    PRIMARY KEY (batch_id, baseline_id, current_arm),
+                    UNIQUE (batch_id, sort_order)
+                );
                 """,
             )
             task_columns = {str(row["name"]) for row in connection.execute("PRAGMA table_info(tasks)").fetchall()}
@@ -540,6 +597,12 @@ class TaskStore:
                     ON tokensflow_finalizations(lease_expires_at);
                 CREATE INDEX IF NOT EXISTS tokensflow_finalizations_attempt
                     ON tokensflow_finalizations(attempt_id, arm);
+                CREATE INDEX IF NOT EXISTS baselines_created_desc
+                    ON baselines(created_at DESC, baseline_seq DESC);
+                CREATE INDEX IF NOT EXISTS baseline_items_source
+                    ON baseline_items(baseline_id, source_index);
+                CREATE INDEX IF NOT EXISTS batch_baseline_selections_order
+                    ON batch_baseline_selections(batch_id, sort_order);
                 """,
             )
 
@@ -675,6 +738,176 @@ class TaskStore:
 
         with self._connection() as connection:
             return self._batch_record(connection, self._select_batch(connection, batch_id))
+
+    def create_baseline(
+        self,
+        request: BaselineCreate,
+        snapshot: BaselineSnapshot,
+        *,
+        now: datetime,
+    ) -> tuple[BaselineRecord, bool]:
+        """Freeze one completed batch arm without copying mutable run artifacts."""
+
+        if len(snapshot.items) != snapshot.total_tasks:
+            raise ValueError("Baseline snapshot item count does not match its task count")
+        if [item.source_index for item in snapshot.items] != list(range(snapshot.total_tasks)):
+            raise ValueError("Baseline snapshot items must retain contiguous source order")
+        request_json = request.model_dump_json()
+        created_at = _timestamp(now)
+        with self._write() as connection:
+            self._select_batch(connection, request.source_batch_id)
+            existing = connection.execute(
+                "SELECT * FROM baselines WHERE idempotency_key = ?",
+                (request.idempotency_key,),
+            ).fetchone()
+            if existing is not None:
+                self._require_idempotent_request(existing["request_json"], request_json)
+                return self._baseline_record(existing), False
+            placeholder = f"pending-baseline-{uuid.uuid4().hex}"
+            cursor = connection.execute(
+                """
+                INSERT INTO baselines(
+                    baseline_id, idempotency_key, request_json, name, source_batch_id,
+                    source_arm, source_report_revision, benchmark, task_set,
+                    instance_set_digest, total_tasks, resolved_tasks, execution_failures,
+                    model, reasoning_effort, dataset_revision, harness_revision,
+                    powercontext_sha, codex_version, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    placeholder,
+                    request.idempotency_key,
+                    request_json,
+                    request.name,
+                    request.source_batch_id,
+                    request.source_arm.value,
+                    request.expected_report_revision,
+                    snapshot.benchmark,
+                    snapshot.task_set,
+                    snapshot.instance_set_digest,
+                    snapshot.total_tasks,
+                    snapshot.resolved_tasks,
+                    snapshot.execution_failures,
+                    snapshot.model,
+                    snapshot.reasoning_effort,
+                    snapshot.dataset_revision,
+                    snapshot.harness_revision,
+                    snapshot.powercontext_sha,
+                    snapshot.codex_version,
+                    created_at,
+                ),
+            )
+            sequence = cursor.lastrowid
+            if sequence is None:  # pragma: no cover - guaranteed by SQLite
+                raise TaskStoreError("SQLite did not assign a baseline sequence")
+            baseline_id = _baseline_id(now, sequence)
+            connection.execute(
+                "UPDATE baselines SET baseline_id = ? WHERE baseline_seq = ?",
+                (baseline_id, sequence),
+            )
+            connection.executemany(
+                """
+                INSERT INTO baseline_items(
+                    baseline_id, instance_id, source_index, source_task_id,
+                    source_attempt_id, status, resolved, input_tokens,
+                    output_tokens, total_tokens
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                [
+                    (
+                        baseline_id,
+                        item.instance_id,
+                        item.source_index,
+                        item.source_task_id,
+                        item.source_attempt_id,
+                        item.status.value,
+                        None if item.resolved is None else int(item.resolved),
+                        item.input_tokens,
+                        item.output_tokens,
+                        item.total_tokens,
+                    )
+                    for item in snapshot.items
+                ],
+            )
+            row = connection.execute("SELECT * FROM baselines WHERE baseline_id = ?", (baseline_id,)).fetchone()
+            assert row is not None
+            return self._baseline_record(row), True
+
+    def get_baseline(self, baseline_id: str) -> BaselineRecord:
+        with self._connection() as connection:
+            row = connection.execute("SELECT * FROM baselines WHERE baseline_id = ?", (baseline_id,)).fetchone()
+        if row is None:
+            raise BaselineNotFound(f"Baseline not found: {baseline_id}")
+        return self._baseline_record(row)
+
+    def list_baselines(self) -> list[BaselineRecord]:
+        """List newest immutable baselines first, with a stable sequence tie-breaker."""
+
+        with self._connection() as connection:
+            rows = connection.execute("SELECT * FROM baselines ORDER BY created_at DESC, baseline_seq DESC").fetchall()
+        return [self._baseline_record(row) for row in rows]
+
+    def list_baseline_items(self, baseline_id: str) -> list[BaselineItemRecord]:
+        with self._connection() as connection:
+            if connection.execute("SELECT 1 FROM baselines WHERE baseline_id = ?", (baseline_id,)).fetchone() is None:
+                raise BaselineNotFound(f"Baseline not found: {baseline_id}")
+            rows = connection.execute(
+                "SELECT * FROM baseline_items WHERE baseline_id = ? ORDER BY source_index ASC",
+                (baseline_id,),
+            ).fetchall()
+        return [self._baseline_item(row) for row in rows]
+
+    def replace_baseline_selections(
+        self,
+        batch_id: str,
+        selections: Sequence[BaselineSelection],
+        *,
+        now: datetime,
+    ) -> tuple[BaselineSelection, ...]:
+        """Replace only stored comparison state; no task is queued or rerun."""
+
+        now_text = _timestamp(now)
+        if len(selections) > 10:
+            raise ValueError("At most ten baseline comparisons may be selected")
+        with self._write() as connection:
+            self._select_batch(connection, batch_id)
+            for selection in selections:
+                if (
+                    connection.execute(
+                        "SELECT 1 FROM baselines WHERE baseline_id = ?", (selection.baseline_id,)
+                    ).fetchone()
+                    is None
+                ):
+                    raise BaselineNotFound(f"Baseline not found: {selection.baseline_id}")
+            connection.execute("DELETE FROM batch_baseline_selections WHERE batch_id = ?", (batch_id,))
+            connection.executemany(
+                """
+                INSERT INTO batch_baseline_selections(
+                    batch_id, baseline_id, current_arm, sort_order, created_at
+                ) VALUES (?, ?, ?, ?, ?)
+                """,
+                [
+                    (batch_id, selection.baseline_id, selection.current_arm.value, index, now_text)
+                    for index, selection in enumerate(selections)
+                ],
+            )
+        return tuple(selections)
+
+    def list_baseline_selections(self, batch_id: str) -> tuple[BaselineSelection, ...]:
+        with self._connection() as connection:
+            self._select_batch(connection, batch_id)
+            rows = connection.execute(
+                """
+                SELECT baseline_id, current_arm
+                FROM batch_baseline_selections
+                WHERE batch_id = ?
+                ORDER BY sort_order ASC
+                """,
+                (batch_id,),
+            ).fetchall()
+        return tuple(
+            BaselineSelection(baseline_id=str(row["baseline_id"]), current_arm=str(row["current_arm"])) for row in rows
+        )
 
     def save_usage_snapshot(self, snapshot: UsageSnapshot) -> UsageSnapshot:
         """Append one normalized account-wide usage observation."""
@@ -2515,6 +2748,61 @@ class TaskStore:
             strict=True,
         )
 
+    @staticmethod
+    def _baseline_record(row: sqlite3.Row) -> BaselineRecord:
+        return BaselineRecord(
+            baseline_id=str(row["baseline_id"]),
+            name=str(row["name"]),
+            source_batch_id=str(row["source_batch_id"]),
+            source_arm=str(row["source_arm"]),
+            source_report_revision=_stored_int(row["source_report_revision"], name="baseline report revision"),
+            benchmark=cast(Literal["swebench-pro"], str(row["benchmark"])),
+            task_set=cast(
+                Literal["swebench-pro-public-v2", "swebench-pro-stability-v1"],
+                str(row["task_set"]),
+            ),
+            instance_set_digest=str(row["instance_set_digest"]),
+            total_tasks=_stored_int(row["total_tasks"], name="baseline task count"),
+            resolved_tasks=_stored_int(row["resolved_tasks"], name="baseline resolved count"),
+            execution_failures=_stored_int(row["execution_failures"], name="baseline failure count"),
+            model=str(row["model"]),
+            reasoning_effort=cast(Literal["medium"], str(row["reasoning_effort"])),
+            dataset_revision=str(row["dataset_revision"]),
+            harness_revision=str(row["harness_revision"]),
+            powercontext_sha=str(row["powercontext_sha"]) if row["powercontext_sha"] is not None else None,
+            codex_version=str(row["codex_version"]) if row["codex_version"] is not None else None,
+            created_at=_parse_timestamp(row["created_at"]),
+        )
+
+    @staticmethod
+    def _baseline_item(row: sqlite3.Row) -> BaselineItemRecord:
+        return BaselineItemRecord(
+            baseline_id=str(row["baseline_id"]),
+            instance_id=str(row["instance_id"]),
+            source_index=_stored_int(row["source_index"], name="baseline source index"),
+            source_task_id=str(row["source_task_id"]),
+            source_attempt_id=str(row["source_attempt_id"]) if row["source_attempt_id"] is not None else None,
+            status=TaskStatus(str(row["status"])),
+            resolved=(
+                bool(_stored_int(row["resolved"], name="baseline resolution")) if row["resolved"] is not None else None
+            ),
+            input_tokens=(
+                _stored_int(row["input_tokens"], name="baseline input tokens")
+                if row["input_tokens"] is not None
+                else None
+            ),
+            output_tokens=(
+                _stored_int(row["output_tokens"], name="baseline output tokens")
+                if row["output_tokens"] is not None
+                else None
+            ),
+            total_tokens=(
+                _stored_int(row["total_tokens"], name="baseline total tokens")
+                if row["total_tokens"] is not None
+                else None
+            ),
+        )
+
     def _batch_record(self, connection: sqlite3.Connection, row: sqlite3.Row) -> BatchRecord:
         batch_id = row["batch_id"]
         if not isinstance(batch_id, str):
@@ -2933,6 +3221,11 @@ def _batch_id(now: datetime, sequence: int) -> str:
     batch_id = f"batch-{now.astimezone(UTC):%Y%m%d-%H%M%S-%f}-{sequence:010d}-{uuid.uuid4().hex[:8]}"
     EvaluationPaths(Path("."), batch_id)
     return batch_id
+
+
+def _baseline_id(now: datetime, sequence: int) -> str:
+    _timestamp(now)
+    return f"baseline-{now.astimezone(UTC):%Y%m%d-%H%M%S-%f}-{sequence:010d}-{uuid.uuid4().hex[:8]}"
 
 
 def _batch_task_id(now: datetime, batch_sequence: int, source_index: int) -> str:

--- a/evaluation/tests/web/test_store.py
+++ b/evaluation/tests/web/test_store.py
@@ -21,9 +21,28 @@ from typing import Any, Literal, cast
 
 import pytest
 
+from powercontext_eval.models import Arm
 from powercontext_eval.paths import EvaluationPaths
-from powercontext_eval.web.batches import BatchControlEventType, BatchCreate, BatchStatus
+from powercontext_eval.web.baselines import (
+    BaselineCreate,
+    BaselineItemRecord,
+    BaselineRecord,
+    BaselineSelection,
+    BaselineSnapshot,
+    CompatibilityStatus,
+)
+from powercontext_eval.web.batches import (
+    BatchControlEventType,
+    BatchCreate,
+    BatchReportResponse,
+    BatchStatus,
+    PairCategory,
+    ResolutionAggregate,
+    TokenAggregate,
+    TokenMetricAggregate,
+)
 from powercontext_eval.web.controls import BatchControlIntent, BatchPauseReason
+from powercontext_eval.web.estimation import BatchEstimate
 from powercontext_eval.web.models import (
     FailureCategory,
     FailureCode,
@@ -34,6 +53,7 @@ from powercontext_eval.web.models import (
     TaskResult,
     TaskStatus,
 )
+from powercontext_eval.web.reporting import baseline_compatibility, instance_set_digest
 from powercontext_eval.web.store import (
     FinalizationState,
     TaskAdmissionRejected,
@@ -69,6 +89,37 @@ def batch_request(key: str, *, model: str = "gpt-5.6-sol") -> BatchCreate:
         reasoning_effort="medium",
         treatment_mode="off_on",
         idempotency_key=key,
+    )
+
+
+def baseline_snapshot(*, resolved: bool) -> BaselineSnapshot:
+    return BaselineSnapshot(
+        benchmark="swebench-pro",
+        task_set="swebench-pro-public-v2",
+        instance_set_digest="d" * 64,
+        total_tasks=1,
+        resolved_tasks=int(resolved),
+        execution_failures=0,
+        model="gpt-5.6-sol",
+        reasoning_effort="medium",
+        dataset_revision="dataset-v1",
+        harness_revision="harness-v1",
+        powercontext_sha="a" * 40,
+        codex_version="0.145.0",
+        items=(
+            BaselineItemRecord(
+                baseline_id="",
+                instance_id="instance-one",
+                source_index=0,
+                source_task_id="source-task",
+                source_attempt_id="source-task.attempt-0001",
+                status=TaskStatus.SUCCEEDED,
+                resolved=resolved,
+                input_tokens=10,
+                output_tokens=5,
+                total_tokens=15,
+            ),
+        ),
     )
 
 
@@ -2021,3 +2072,123 @@ def test_batch_record_round_trips_container_env(store: TaskStore) -> None:
         "OPENROUTER_API_KEY": "sk-test",
         "POWERCONTEXT_SERVER_HTTP_PORT": "8000",
     }
+
+
+def test_baseline_snapshot_is_immutable_idempotent_and_survives_restart(database: Path) -> None:
+    store = TaskStore(database, lease_duration=timedelta(seconds=60))
+    store.initialize()
+    source, _ = store.create_batch(batch_request("baseline-source"), ("instance_a",), now=NOW)
+    request = BaselineCreate(
+        name="  release   candidate ",
+        source_batch_id=source.batch_id,
+        source_arm=Arm.ON,
+        expected_report_revision=101,
+        idempotency_key="baseline-release-candidate",
+    )
+
+    baseline, created = store.create_baseline(request, baseline_snapshot(resolved=True), now=NOW)
+    replay, replay_created = store.create_baseline(request, baseline_snapshot(resolved=True), now=NOW)
+
+    reloaded = TaskStore(database, lease_duration=timedelta(seconds=60))
+    reloaded.initialize()
+    assert created is True
+    assert replay_created is False
+    assert replay == baseline
+    assert reloaded.get_baseline(baseline.baseline_id).name == "release candidate"
+    assert reloaded.list_baseline_items(baseline.baseline_id)[0].total_tokens == 15
+
+
+def test_baseline_selections_replace_only_comparison_state(store: TaskStore) -> None:
+    batch, _ = store.create_batch(batch_request("baseline-selection"), ("instance_a",), now=NOW)
+    first, _ = store.create_baseline(
+        BaselineCreate(
+            name="First",
+            source_batch_id=batch.batch_id,
+            source_arm=Arm.ON,
+            expected_report_revision=1,
+            idempotency_key="baseline-selection-first",
+        ),
+        baseline_snapshot(resolved=True),
+        now=NOW,
+    )
+    second, _ = store.create_baseline(
+        BaselineCreate(
+            name="Second",
+            source_batch_id=batch.batch_id,
+            source_arm=Arm.OFF,
+            expected_report_revision=1,
+            idempotency_key="baseline-selection-second",
+        ),
+        baseline_snapshot(resolved=False),
+        now=NOW + timedelta(seconds=1),
+    )
+
+    selections = store.replace_baseline_selections(
+        batch.batch_id,
+        (
+            BaselineSelection(baseline_id=first.baseline_id, current_arm=Arm.ON),
+            BaselineSelection(baseline_id=second.baseline_id, current_arm=Arm.ON),
+        ),
+        now=NOW + timedelta(seconds=2),
+    )
+
+    assert selections == store.list_baseline_selections(batch.batch_id)
+    assert all(task.status is TaskStatus.QUEUED for task in store.list_batch_tasks(batch.batch_id))
+
+
+def test_baseline_compatibility_rejects_contract_drift_and_warns_cross_arm(store: TaskStore) -> None:
+    batch, _ = store.create_batch(batch_request("baseline-compatibility"), ("instance_a",), now=NOW)
+    tasks = store.list_batch_tasks(batch.batch_id)
+    metric = TokenMetricAggregate(off=0, on=0, delta=0, off_measured_tasks=0, on_measured_tasks=0)
+    report = BatchReportResponse(
+        batch_id=batch.batch_id,
+        report_revision=1,
+        total_tasks=batch.total_tasks,
+        terminal_tasks=0,
+        comparable_pairs=0,
+        execution_failures=0,
+        cancelled_tasks=0,
+        off=ResolutionAggregate(resolved=0, total=0, rate_percent=0),
+        on=ResolutionAggregate(resolved=0, total=0, rate_percent=0),
+        resolution_rate_delta_points=0,
+        pair_categories={category: 0 for category in PairCategory},
+        task_statuses={status: 0 for status in TaskStatus},
+        tokens=TokenAggregate(input=metric, output=metric, total=metric),
+        control=batch.control,
+        latest_usage=None,
+        estimate=BatchEstimate.unavailable(remaining_tasks=batch.total_tasks),
+        revisions={"dataset": "dataset-v1", "harness": "harness-v1"},
+        configuration={"codex": "0.145.0"},
+    )
+    baseline = BaselineRecord(
+        baseline_id="baseline-test",
+        name="Release candidate",
+        source_batch_id=batch.batch_id,
+        source_arm=Arm.ON,
+        source_report_revision=1,
+        benchmark="swebench-pro",
+        task_set=batch.request.task_set,
+        instance_set_digest=instance_set_digest(tasks),
+        total_tasks=batch.total_tasks,
+        resolved_tasks=0,
+        execution_failures=0,
+        model=batch.request.model,
+        reasoning_effort=batch.request.reasoning_effort,
+        dataset_revision="dataset-v1",
+        harness_revision="harness-v1",
+        codex_version="0.145.0",
+        created_at=NOW,
+    )
+
+    assert (
+        baseline_compatibility(baseline, batch, tasks, report, current_arm=Arm.ON).status
+        is CompatibilityStatus.COMPATIBLE
+    )
+    assert (
+        baseline_compatibility(baseline, batch, tasks, report, current_arm=Arm.OFF).status
+        is CompatibilityStatus.WARNING
+    )
+    drifted = baseline.model_copy(update={"harness_revision": "harness-v2"})
+    incompatible = baseline_compatibility(drifted, batch, tasks, report, current_arm=Arm.ON)
+    assert incompatible.status is CompatibilityStatus.INCOMPATIBLE
+    assert incompatible.reasons == ("harness revision differs",)


### PR DESCRIPTION
## Tracking

- Tracking issue: #109
- Relationship: Part of #109; implements WP5 P1 only.

## Problem and rationale

The v0.1.0 release includes immutable single-arm Baseline contracts, but the Go-primary repository''s evaluation control plane only retains paired OFF/ON reports. This PR establishes the narrow storage and comparison foundation without exposing a partial operator workflow.

## Changes

- Add immutable Baseline records, snapshots, item records, compatibility states, selections, and comparison result contracts.
- Add transactional SQLite schema, persistence, idempotent creation, restart-safe reads, newest-first listing, and replacement-only comparison selections.
- Add internal snapshot, compatibility, and current-versus-Baseline comparison calculations for completed paired batches.
- Add real SQLite regression coverage for immutable persistence, idempotency, restart recovery, non-mutating selections, cross-arm warnings, and incompatibility on contract drift.

## Behavior and compatibility

- User-visible behavior: none; HTTP routes, CLI commands, worker scheduling, and React views remain unchanged.
- Public API or protocol impact: none.
- Breaking changes or migration requirements: additive SQLite tables and indexes only; existing task/batch schema and behavior are unchanged.
- Explicit non-goals: Baseline HTTP routes and reporting exposure, CLI/worker support, single-arm submission, and the Baseline Library UI are sequential P2/P3 work.

## Generated, dependency, and workflow impact

- [x] No generated contract changed.
- [x] No dependency changed.
- [x] No CI or release contract changed.
- [x] No credential, private Source/Memory content, or unredacted production log is included.

## Validation

Run against exact Head `e55fc69acdb2ff93b4f2f331f7fda14e0ed389ad` in WSL with `POWERCONTEXT_EVAL_BUILD_REVISION` set to that Head:

```text
uv run --offline --project evaluation pytest -c evaluation/pyproject.toml evaluation/tests/web/test_store.py evaluation/tests/web/test_reporting.py -q
116 passed

uv run --offline --project evaluation ruff check evaluation
All checks passed

uv run --offline --project evaluation ruff format --check evaluation
74 files already formatted

uv run --offline --directory evaluation ty check src
All checks passed

git diff --check origin/main...HEAD
passed
```

- [x] `git diff --check`
- [x] `git status --short` inspected after validation.
- [x] Formatter evidence recorded.
- [x] Generated-consumer check is not applicable because no generator output changed.
- [x] Compatibility evidence is the focused Baseline contract and real SQLite persistence suite.
- [x] Relevant evaluation storage/reporting checks were run.
- [x] Full `evaluation/tests/web` was also run: 527 passed and five worker cleanup/requeue tests failed in WSL. The exact same five failures reproduce on the unmodified baseline; each defers attempt cleanup with `RuntimeError`, so this PR does not represent the full suite as passing.

## AI usage

AI assistance implemented the scoped port from the exact upstream v0.1.0 behavior. The submitted diff was independently checked against the upstream contract, reviewed for real SQLite/Pydantic test boundaries, rebased onto current main, and verified with the commands above.
