### PR TITLE
fix(webui): preserve skill publication through discovery failures

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -372,3 +372,7 @@ source / artifact / trigger / inference
   creating any projection DDL. Verify a fresh over-limit profile returns a
   typed, redacted error that states both limits, creates no projection, and
   leaves the extension's raw diagnostic unexposed.
+- When a durable publication succeeds but its post-publication discovery refresh
+  fails, preserve the successful publication result and report only a bounded
+  stale-discovery state. Verify scan and registry-read failures leave the
+  published package intact, return success, and never expose discovery errors.

--- a/internal/webui/skill_projection.go
+++ b/internal/webui/skill_projection.go
@@ -156,11 +156,7 @@ func (p *pages) skillProjectionPublish(writer http.ResponseWriter, request *http
 		writeWebError(writer, http.StatusServiceUnavailable, "runtime_not_ready", "The Runtime is not ready.", nil)
 		return
 	}
-	if _, err := p.projections.ScanExternalSkills(request.Context(), selection.ScopeID); err != nil {
-		p.writeOperationError(writer, err)
-		return
-	}
-	response, err := p.projectionResponse(request, selection.ScopeID, value)
+	response, err := p.publishedProjectionResponse(request, selection.ScopeID, value)
 	if err != nil {
 		p.writeOperationError(writer, err)
 		return
@@ -212,17 +208,41 @@ func (p *pages) projectionResponse(
 	scopeID string,
 	value skill.Skill,
 ) (projectionResponse, error) {
-	var registrations []skill.Resolution
-	var err error
 	if len(p.projectionTargets) > 0 {
 		if p.projections == nil {
 			return projectionResponse{}, &endpoint.RuntimeNotReadyError{}
 		}
-		registrations, err = p.projections.ListExternalSkills(request.Context(), scopeID, true)
+		registrations, err := p.projections.ListExternalSkills(request.Context(), scopeID, true)
 		if err != nil {
 			return projectionResponse{}, err
 		}
+		return p.projectionResponseWithRegistrations(value, registrations), nil
 	}
+	return p.projectionResponseWithRegistrations(value, nil), nil
+}
+
+func (p *pages) publishedProjectionResponse(
+	request *http.Request,
+	scopeID string,
+	value skill.Skill,
+) (projectionResponse, error) {
+	if p.projections == nil {
+		return projectionResponse{}, &endpoint.RuntimeNotReadyError{}
+	}
+	if _, err := p.projections.ScanExternalSkills(request.Context(), scopeID); err != nil {
+		return p.projectionResponseWithRegistrations(value, nil), nil
+	}
+	registrations, err := p.projections.ListExternalSkills(request.Context(), scopeID, true)
+	if err != nil {
+		return p.projectionResponseWithRegistrations(value, nil), nil
+	}
+	return p.projectionResponseWithRegistrations(value, registrations), nil
+}
+
+func (p *pages) projectionResponseWithRegistrations(
+	value skill.Skill,
+	registrations []skill.Resolution,
+) projectionResponse {
 	result := projectionResponse{
 		Artifact: wireProjectionArtifact(value.Ref()), Name: value.Content().Name(),
 		Targets: make([]projectionTargetResponse, 0, len(p.projectionTargets)),
@@ -268,7 +288,7 @@ func (p *pages) projectionResponse(
 			Discovery: discovery, ExternalSkillID: externalSkillID,
 		})
 	}
-	return result, nil
+	return result
 }
 
 func (p *pages) hasScope(scopeID string) bool {

--- a/internal/webui/skill_projection_test.go
+++ b/internal/webui/skill_projection_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -86,6 +87,42 @@ func TestDashboardSkillProjectionStatusAndPublish(t *testing.T) {
 	conflict := requestJSON(t, mux, "/dashboard/skill-projections/publish", selection)
 	if conflict.Code != http.StatusConflict || !bytes.Contains(conflict.Body.Bytes(), []byte(`"code":"skill_projection_conflict"`)) {
 		t.Fatalf("drift publish = %d %s", conflict.Code, conflict.Body.String())
+	}
+}
+
+func TestDashboardSkillProjectionPublishKeepsPublishedSkillWhenScanFails(t *testing.T) {
+	mux, operations, selection := projectionPublishFixture(t)
+	operations.scanErr = errors.New("scan failure /private/registry API_KEY=secret")
+
+	published := requestJSON(t, mux, "/dashboard/skill-projections/publish", selection)
+	assertPublishedProjectionRemainsCurrent(t, published, operations)
+}
+
+func TestDashboardSkillProjectionPublishKeepsPublishedSkillWhenDiscoveryListFails(t *testing.T) {
+	mux, operations, selection := projectionPublishFixture(t)
+	operations.listErr = errors.New("discovery failure /private/registry API_KEY=secret")
+
+	published := requestJSON(t, mux, "/dashboard/skill-projections/publish", selection)
+	assertPublishedProjectionRemainsCurrent(t, published, operations)
+}
+
+func assertPublishedProjectionRemainsCurrent(
+	t *testing.T,
+	published *httptest.ResponseRecorder,
+	operations *projectionOperations,
+) {
+	t.Helper()
+	if published.Code != http.StatusOK {
+		t.Fatalf("publish = %d %s", published.Code, published.Body.String())
+	}
+	assertProjectionResponse(t, published, "current", "unavailable")
+	if _, err := os.Stat(filepath.Join(operations.root, operations.managed.Content().Name(), "SKILL.md")); err != nil {
+		t.Fatalf("published projection is absent: %v", err)
+	}
+	for _, secret := range []string{"/private/registry", "API_KEY=secret"} {
+		if bytes.Contains(published.Body.Bytes(), []byte(secret)) {
+			t.Fatalf("publish response leaked %q: %s", secret, published.Body.String())
+		}
 	}
 }
 
@@ -158,6 +195,9 @@ type projectionOperations struct {
 	provider  *skill.AgentSkillProvider
 	listed    []skill.Resolution
 	scanCalls int
+	root      string
+	scanErr   error
+	listErr   error
 }
 
 func projectionOperationsFixture(t *testing.T, provider *skill.AgentSkillProvider) *projectionOperations {
@@ -201,11 +241,17 @@ func (o *projectionOperations) GetSkill(context.Context, string, artifact.Ref) (
 }
 
 func (o *projectionOperations) ListExternalSkills(context.Context, string, bool) ([]skill.Resolution, error) {
+	if o.listErr != nil {
+		return nil, o.listErr
+	}
 	return append([]skill.Resolution(nil), o.listed...), nil
 }
 
 func (o *projectionOperations) ScanExternalSkills(ctx context.Context, _ string) (skill.ProviderScan, error) {
 	o.scanCalls++
+	if o.scanErr != nil {
+		return skill.ProviderScan{}, o.scanErr
+	}
 	scan, err := o.provider.Scan(ctx)
 	if err != nil {
 		return skill.ProviderScan{}, err
@@ -219,6 +265,37 @@ func (o *projectionOperations) ScanExternalSkills(ctx context.Context, _ string)
 		o.listed = append(o.listed, resolved)
 	}
 	return scan, nil
+}
+
+func projectionPublishFixture(t *testing.T) (*http.ServeMux, *projectionOperations, map[string]any) {
+	t.Helper()
+	root := filepath.Join(t.TempDir(), ".agents", "skills")
+	target, err := skill.NewAgentSkillTarget("codex-project", skill.CodexAgent, skill.ProjectScope, root, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	provider, err := skill.NewAgentSkillProvider("workstation-1", []skill.AgentSkillTarget{target})
+	if err != nil {
+		t.Fatal(err)
+	}
+	operations := projectionOperationsFixture(t, provider)
+	operations.root = root
+	mux := http.NewServeMux()
+	if err := Mount(mux, Options{
+		DashboardEnabled:  true,
+		Scopes:            []Scope{{ScopeID: "project:example", DisplayName: "Example"}},
+		AgentSkillTargets: []skill.AgentSkillTarget{target},
+		SkillProjections:  operations,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return mux, operations, map[string]any{
+		"scope_id": "project:example", "candidate_id": operations.candidate.ID(), "target_id": target.ID(),
+		"artifact": map[string]any{
+			"family": operations.managed.Ref().Family(), "artifact_id": operations.managed.Ref().ID(),
+			"revision": operations.managed.Ref().Revision(),
+		},
+	}
 }
 
 func requestJSON(t *testing.T, handler http.Handler, target string, value any) *httptest.ResponseRecorder {

--- a/test/conformance/parity-inventory-rules.json
+++ b/test/conformance/parity-inventory-rules.json
@@ -176,7 +176,19 @@
     },
     "tests/test_dashboard.py": {
       "mode": "go-port",
-      "reason": "Skill publication and stale registry discovery behavior map to the Go endpoint and dashboard-facing API."
+      "reason": "Skill publication and stale registry discovery behavior map to the Go endpoint and dashboard-facing API.",
+      "cases": {
+        "test_publish_reports_success_when_post_publish_scan_fails": {
+          "evidence": [
+            "go:internal/webui/skill_projection_test.go#TestDashboardSkillProjectionPublishKeepsPublishedSkillWhenScanFails"
+          ]
+        },
+        "test_publish_reports_stale_discovery_when_registry_database_is_unavailable": {
+          "evidence": [
+            "go:internal/webui/skill_projection_test.go#TestDashboardSkillProjectionPublishKeepsPublishedSkillWhenDiscoveryListFails"
+          ]
+        }
+      }
     },
     "tests/test_env_file.py": {
       "mode": "go-port",

--- a/test/conformance/parity-inventory.json
+++ b/test/conformance/parity-inventory.json
@@ -4,8 +4,8 @@
   "oracle_commit": "3a6cb0151670eaff7dc0293466edd673124e80da",
   "python_test_file_count": 132,
   "python_test_case_count": 812,
-  "mapped_case_count": 723,
-  "pending_case_count": 89,
+  "mapped_case_count": 725,
+  "pending_case_count": 87,
   "entries": [
     {
       "python": {
@@ -8933,8 +8933,15 @@
         "line": 412
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/webui/skill_projection_test.go",
+          "test": "TestDashboardSkillProjectionPublishKeepsPublishedSkillWhenScanFails"
+        }
+      ]
     },
     {
       "python": {
@@ -8943,8 +8950,15 @@
         "line": 517
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/webui/skill_projection_test.go",
+          "test": "TestDashboardSkillProjectionPublishKeepsPublishedSkillWhenDiscoveryListFails"
+        }
+      ]
     },
     {
       "python": {


### PR DESCRIPTION
Part of #3.

A managed Agent Skill projection is a durable filesystem write. After that write succeeds, an external Registry scan or Registry discovery read may fail independently. This PR preserves the successful publication result and returns the on-disk projection as current with discovery unavailable, rather than returning HTTP 500.

The ordinary projection-status endpoint retains its existing Registry-error behavior. Projection conflicts and publication failures remain failures. No Registry error text, path, credential, or response body is exposed.

Parity: maps exactly two v0.1.0 dashboard cases. Generated inventory changes from 723 mapped / 89 pending to 725 mapped / 87 pending.

Validation: full internal/webui tests, vet, exact-target parity generator check, go mod tidy -diff, go mod verify, and diff check passed after rebase to current main. Full Server/native SQLite evidence is supplied by exact-Head CI.