### PR TITLE
fix(webui): tolerate unavailable skill registry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,6 +136,10 @@ source / artifact / trigger / inference
 - Merge with an existing rule when the lesson is already covered. Keep the
   stronger wording and remove duplication so this file remains a practical
   engineering contract rather than an append-only incident log.
+- When authoritative state changes successfully before best-effort discovery or
+  bookkeeping runs, preserve the successful response if that follow-up fails.
+  Emit one bounded warning per degraded call, and verify the public response
+  reflects authoritative state without logging raw errors, identifiers, or paths.
 - When a generator rewrites generated code to call project-specific support,
   emit that support as a declared generated artifact and verify a fresh
   temporary module can tidy, verify, and test the complete output.

--- a/internal/webui/handler.go
+++ b/internal/webui/handler.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"html/template"
 	"io/fs"
+	"log/slog"
 	"net/http"
 	"strconv"
 
@@ -50,6 +51,7 @@ type Options struct {
 	AuthenticationRequired bool
 	AgentSkillTargets      []skill.AgentSkillTarget
 	SkillProjections       SkillProjectionOperations
+	Logger                 *slog.Logger
 }
 
 type SkillProjectionOperations interface {
@@ -69,6 +71,7 @@ type pages struct {
 	static            http.Handler
 	projectionTargets []skill.AgentSkillTarget
 	projections       SkillProjectionOperations
+	logger            *slog.Logger
 }
 
 type pageData struct {
@@ -131,6 +134,7 @@ func Mount(mux *http.ServeMux, options Options) error {
 		scopes:    append([]Scope{}, options.Scopes...),
 		options:   options,
 		static:    http.StripPrefix("/static/", http.FileServer(http.FS(staticFS))),
+		logger:    options.Logger,
 	}
 	owner.projections = options.SkillProjections
 	for _, target := range options.AgentSkillTargets {

--- a/internal/webui/skill_projection.go
+++ b/internal/webui/skill_projection.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"slices"
 	"unicode/utf8"
@@ -26,6 +27,7 @@ import (
 	"github.com/ob-labs/powercontext-go/artifact"
 	"github.com/ob-labs/powercontext-go/artifact/skill"
 	"github.com/ob-labs/powercontext-go/internal/endpoint"
+	serverlogging "github.com/ob-labs/powercontext-go/internal/observability/logging"
 	"github.com/ob-labs/powercontext-go/internal/review"
 )
 
@@ -157,8 +159,15 @@ func (p *pages) skillProjectionPublish(writer http.ResponseWriter, request *http
 		return
 	}
 	if _, err := p.projections.ScanExternalSkills(request.Context(), selection.ScopeID); err != nil {
-		p.writeOperationError(writer, err)
-		return
+		serverlogging.LogSafely(
+			request.Context(), p.logger, slog.LevelWarn,
+			"PowerContext external Skill scan failed after publication",
+			slog.String("event", "skill_projection.registry_scan.degraded"),
+			slog.String("operation", "scan_external_skills"),
+			slog.String("outcome", "degraded"),
+			slog.String("unit", "application"),
+			slog.String("error_code", "external_skill_scan_failed"),
+		)
 	}
 	response, err := p.projectionResponse(request, selection.ScopeID, value)
 	if err != nil {
@@ -220,7 +229,16 @@ func (p *pages) projectionResponse(
 		}
 		registrations, err = p.projections.ListExternalSkills(request.Context(), scopeID, true)
 		if err != nil {
-			return projectionResponse{}, err
+			serverlogging.LogSafely(
+				request.Context(), p.logger, slog.LevelWarn,
+				"PowerContext external Skill registry discovery failed",
+				slog.String("event", "skill_projection.registry_discovery.degraded"),
+				slog.String("operation", "list_external_skills"),
+				slog.String("outcome", "degraded"),
+				slog.String("unit", "application"),
+				slog.String("error_code", "external_skill_discovery_failed"),
+			)
+			registrations = nil
 		}
 	}
 	result := projectionResponse{

--- a/internal/webui/skill_projection_test.go
+++ b/internal/webui/skill_projection_test.go
@@ -18,6 +18,9 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -26,6 +29,7 @@ import (
 
 	"github.com/ob-labs/powercontext-go/artifact"
 	"github.com/ob-labs/powercontext-go/artifact/skill"
+	serverlogging "github.com/ob-labs/powercontext-go/internal/observability/logging"
 	"github.com/ob-labs/powercontext-go/internal/review"
 	"github.com/ob-labs/powercontext-go/source"
 )
@@ -86,6 +90,103 @@ func TestDashboardSkillProjectionStatusAndPublish(t *testing.T) {
 	conflict := requestJSON(t, mux, "/dashboard/skill-projections/publish", selection)
 	if conflict.Code != http.StatusConflict || !bytes.Contains(conflict.Body.Bytes(), []byte(`"code":"skill_projection_conflict"`)) {
 		t.Fatalf("drift publish = %d %s", conflict.Code, conflict.Body.String())
+	}
+}
+
+func TestDashboardSkillProjectionPublishToleratesUnavailableRegistry(t *testing.T) {
+	t.Parallel()
+	root := filepath.Join(t.TempDir(), ".agents", "skills")
+	target, err := skill.NewAgentSkillTarget("codex-project", skill.CodexAgent, skill.ProjectScope, root, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	provider, err := skill.NewAgentSkillProvider("workstation-1", []skill.AgentSkillTarget{target})
+	if err != nil {
+		t.Fatal(err)
+	}
+	operations := projectionOperationsFixture(t, provider)
+	operations.scanErr = errors.New("scan failed for project:example at /private/registry")
+	operations.listErr = errors.New("list failed for project:example at /private/registry")
+	var logs bytes.Buffer
+	logger, err := serverlogging.New(serverlogging.Config{
+		Level: slog.LevelDebug, Format: serverlogging.JSON, Writer: &logs,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	mux := http.NewServeMux()
+	if err := Mount(mux, Options{
+		DashboardEnabled:  true,
+		Scopes:            []Scope{{ScopeID: "project:example", DisplayName: "Example"}},
+		AgentSkillTargets: []skill.AgentSkillTarget{target},
+		SkillProjections:  operations,
+		Logger:            logger,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	selection := map[string]any{
+		"scope_id": "project:example", "candidate_id": operations.candidate.ID(), "target_id": "codex-project",
+		"artifact": map[string]any{
+			"family": operations.managed.Ref().Family(), "artifact_id": operations.managed.Ref().ID(),
+			"revision": operations.managed.Ref().Revision(),
+		},
+	}
+
+	response := requestJSON(t, mux, "/dashboard/skill-projections/publish", selection)
+	if response.Code != http.StatusOK {
+		t.Fatalf("publish = %d %s", response.Code, response.Body.String())
+	}
+	assertProjectionResponse(t, response, "current", "unavailable")
+	if _, err := os.Stat(filepath.Join(root, operations.managed.Content().Name(), "powercontext.json")); err != nil {
+		t.Fatalf("published projection is absent: %v", err)
+	}
+	if operations.scanCalls != 1 || operations.listCalls != 1 {
+		t.Fatalf("registry calls = scan %d, list %d; want 1 each", operations.scanCalls, operations.listCalls)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(logs.Bytes()))
+	var records []map[string]any
+	for {
+		var record map[string]any
+		if err := decoder.Decode(&record); errors.Is(err, io.EOF) {
+			break
+		} else if err != nil {
+			t.Fatalf("decode logs: %v", err)
+		}
+		records = append(records, record)
+	}
+	wantLogs := map[string]map[string]string{
+		"PowerContext external Skill scan failed after publication": {
+			"event": "skill_projection.registry_scan.degraded", "operation": "scan_external_skills",
+			"error_code": "external_skill_scan_failed",
+		},
+		"PowerContext external Skill registry discovery failed": {
+			"event": "skill_projection.registry_discovery.degraded", "operation": "list_external_skills",
+			"error_code": "external_skill_discovery_failed",
+		},
+	}
+	if len(records) != len(wantLogs) {
+		t.Fatalf("WARNING records = %d, want %d; logs = %s", len(records), len(wantLogs), logs.String())
+	}
+	for _, record := range records {
+		message, ok := record["message"].(string)
+		want, expected := wantLogs[message]
+		if !ok || !expected || record["level"] != "WARN" || record["outcome"] != "degraded" || record["unit"] != "application" {
+			t.Fatalf("unexpected degraded log = %#v", record)
+		}
+		for key, value := range want {
+			if record[key] != value {
+				t.Fatalf("log %q field %q = %#v, want %q", message, key, record[key], value)
+			}
+		}
+		delete(wantLogs, message)
+	}
+	if len(wantLogs) != 0 {
+		t.Fatalf("missing degraded logs = %#v", wantLogs)
+	}
+	for _, secret := range [][]byte{[]byte("project:example"), []byte("/private/registry")} {
+		if bytes.Contains(logs.Bytes(), secret) {
+			t.Fatalf("logs contain sensitive diagnostic %q: %s", secret, logs.String())
+		}
 	}
 }
 
@@ -158,6 +259,9 @@ type projectionOperations struct {
 	provider  *skill.AgentSkillProvider
 	listed    []skill.Resolution
 	scanCalls int
+	listCalls int
+	scanErr   error
+	listErr   error
 }
 
 func projectionOperationsFixture(t *testing.T, provider *skill.AgentSkillProvider) *projectionOperations {
@@ -201,11 +305,18 @@ func (o *projectionOperations) GetSkill(context.Context, string, artifact.Ref) (
 }
 
 func (o *projectionOperations) ListExternalSkills(context.Context, string, bool) ([]skill.Resolution, error) {
+	o.listCalls++
+	if o.listErr != nil {
+		return nil, o.listErr
+	}
 	return append([]skill.Resolution(nil), o.listed...), nil
 }
 
 func (o *projectionOperations) ScanExternalSkills(ctx context.Context, _ string) (skill.ProviderScan, error) {
 	o.scanCalls++
+	if o.scanErr != nil {
+		return skill.ProviderScan{}, o.scanErr
+	}
 	scan, err := o.provider.Scan(ctx)
 	if err != nil {
 		return skill.ProviderScan{}, err

--- a/server/application.go
+++ b/server/application.go
@@ -129,6 +129,7 @@ func (a *Application) HTTPHandler() (http.Handler, error) {
 			AuthenticationRequired: a.config.Auth.Enabled,
 			AgentSkillTargets:      append([]skill.AgentSkillTarget(nil), a.agentSkillTargets...),
 			SkillProjections:       webSkillProjectionOperations{review: a.review, external: a.externalSkills},
+			Logger:                 namedLogger(a.logger, "powercontext.server.webui"),
 		}
 	}
 	return NewHTTPHandler(a.endpoint, HTTPOptions{


### PR DESCRIPTION
## Tracking

- Tracking issue: #160
- Relationship: Closes #160

## Problem and rationale

An Agent-target Skill publication writes the authoritative projection to disk
before refreshing the external Skill Registry.

When the subsequent registry scan or discovery failed, the Dashboard returned
an error even though publication had already succeeded. This change treats
those registry operations as best-effort and reports the on-disk state.

## Changes

- Keep a successful Skill publication successful when the post-publication
  registry scan fails.
- Fall back to the on-disk projection state when registry discovery fails.
- Emit one bounded WARNING for each degraded registry call without logging raw
  errors, scope IDs, content, or local paths.
- Pass the existing Server logger into the Web UI.
- Add regression coverage for simultaneous scan and discovery failures.
- Add a bug-prevention rule for best-effort work after authoritative writes.

## Behavior and compatibility

- User-visible behavior: a published Skill returns HTTP 200 with
  `state: current` and `discovery: unavailable` when the registry is unavailable.
- Public API or protocol impact: none.
- Breaking changes or migration requirements: none.
- Explicit non-goals: no changes to the external Skill scan endpoint, publish
  conflict semantics, response shape, discovery vocabulary, or generated
  contracts.

## Generated, dependency, and workflow impact

- [x] No generated contract changed.
- [x] No dependency changed.
- [x] No CI or release contract changed.
- [x] No credential, private Source/Memory content, or unredacted production
  log is included.

## Validation

gofmt -w internal/webui/handler.go internal/webui/skill_projection.go \
  internal/webui/skill_projection_test.go server/application.go
git diff --check

Not run yet:
go test ./internal/webui/

- [x] `git diff --check`
- [x] `git status --short` was inspected after validation.
- [x] Formatter evidence is recorded above.
- [x] Generated-consumer evidence is not applicable because generated outputs
  did not change.
- [x] Compatibility evidence is not applicable because no public Go or wire
  contract changed.
- [ ] Targeted tests are pending.

## AI usage

AI assistance was used to inspect the existing failure handling, implement the
bounded fallback behavior, and prepare regression coverage. The final diff and
logging boundaries were reviewed locally. Targeted tests have not yet been run.
