### PR TITLE
feat(evaluation): add baseline API routes and CLI commands (WP5 P2)

### DIFF
--- a/evaluation/src/powercontext_eval/cli.py
+++ b/evaluation/src/powercontext_eval/cli.py
@@ -26,7 +26,7 @@ from pathlib import Path
 from types import FrameType
 from typing import TYPE_CHECKING, Annotated, Any, Protocol, cast
 from urllib.error import HTTPError, URLError
-from urllib.parse import urlsplit
+from urllib.parse import quote, urlsplit
 from urllib.request import Request, urlopen
 
 import typer
@@ -43,7 +43,9 @@ if TYPE_CHECKING:
 
 app = typer.Typer(no_args_is_help=True, help="PowerContext evaluation runner.")
 swebench_pro_app = typer.Typer(no_args_is_help=True, help="Pinned SWE-bench Pro evaluation.")
+baseline_app = typer.Typer(no_args_is_help=True, help="Baseline management.")
 app.add_typer(swebench_pro_app, name="swebench-pro")
+app.add_typer(baseline_app, name="baseline")
 
 
 @app.callback()
@@ -302,6 +304,10 @@ def swebench_pro_create_batch(
 
 
 def _batch_api_endpoint(console_url: str) -> str:
+    return _api_endpoint(console_url, "/api/batches")
+
+
+def _api_endpoint(console_url: str, path: str) -> str:
     parsed = urlsplit(console_url)
     if (
         parsed.scheme not in {"http", "https"}
@@ -313,7 +319,154 @@ def _batch_api_endpoint(console_url: str) -> str:
         or parsed.path not in {"", "/"}
     ):
         raise typer.BadParameter("Invalid console URL.", param_hint="--console-url")
-    return console_url.rstrip("/") + "/api/batches"
+    return console_url.rstrip("/") + path
+
+
+def _http_request(method: str, url: str, body: bytes | None = None) -> Any:
+    headers = {"Content-Type": "application/json"} if body else {"Accept": "application/json"}
+    request = Request(url, data=body, headers=headers, method=method)
+    try:
+        with urlopen(request, timeout=30) as response:
+            payload = json.loads(response.read())
+    except HTTPError as error:
+        if error.code == 404:
+            raise typer.BadParameter("Resource not found.") from None
+        if error.code == 409:
+            try:
+                detail = error.read().decode("utf-8", errors="replace")
+            except (OSError, ValueError):
+                detail = ""
+            raise typer.BadParameter("Conflict: " + (detail or "idempotency conflict")) from None
+        if error.code == 422:
+            try:
+                detail = error.read().decode("utf-8", errors="replace")
+            except (OSError, ValueError):
+                detail = ""
+            raise typer.BadParameter("Invalid request: " + (detail or "validation failed.")) from None
+        raise typer.Exit(code=1) from None
+    except (URLError, OSError, ValueError, UnicodeDecodeError):
+        raise typer.Exit(code=1) from None
+    if not isinstance(payload, (dict, list)):
+        raise typer.Exit(code=1)
+    return payload
+
+
+@baseline_app.command("create")
+def baseline_create(
+    console_url: str = typer.Option("http://127.0.0.1:8787", "--console-url"),
+    source_batch_id: str = typer.Option(..., "--source-batch-id"),
+    source_arm: str = typer.Option(..., "--source-arm"),
+    name: str = typer.Option(..., "--name"),
+    idempotency_key: str = typer.Option(..., "--idempotency-key"),
+    expected_report_revision: int = typer.Option(
+        0,
+        "--expected-report-revision",
+        help="Report revision from GET /api/batches/{id}/report; prevents stale snapshots.",
+    ),
+) -> None:
+    """Create an immutable baseline from a completed batch arm."""
+
+    from powercontext_eval.web.baselines import BaselineCreate
+
+    try:
+        request = BaselineCreate(
+            name=name,
+            source_batch_id=source_batch_id,
+            source_arm=source_arm,
+            expected_report_revision=expected_report_revision,
+            idempotency_key=idempotency_key,
+        )
+    except ValidationError:
+        raise typer.BadParameter("Invalid baseline configuration.") from None
+    endpoint = _api_endpoint(console_url, "/api/baselines")
+    payload = _http_request("POST", endpoint, request.model_dump_json().encode("utf-8"))
+    typer.echo(json.dumps(payload, ensure_ascii=False, sort_keys=True))
+
+
+@baseline_app.command("list")
+def baseline_list(
+    console_url: str = typer.Option("http://127.0.0.1:8787", "--console-url"),
+) -> None:
+    """List all immutable baselines, newest first."""
+
+    endpoint = _api_endpoint(console_url, "/api/baselines")
+    payload = _http_request("GET", endpoint)
+    typer.echo(json.dumps(payload, ensure_ascii=False, sort_keys=True))
+
+
+@baseline_app.command("get")
+def baseline_get(
+    baseline_id: str = typer.Argument(...),
+    console_url: str = typer.Option("http://127.0.0.1:8787", "--console-url"),
+) -> None:
+    """Get baseline details by ID."""
+
+    endpoint = _api_endpoint(console_url, f"/api/baselines/{quote(baseline_id, safe='')}")
+    payload = _http_request("GET", endpoint)
+    typer.echo(json.dumps(payload, ensure_ascii=False, sort_keys=True))
+
+
+@baseline_app.command("items")
+def baseline_items(
+    baseline_id: str = typer.Argument(...),
+    console_url: str = typer.Option("http://127.0.0.1:8787", "--console-url"),
+) -> None:
+    """List all items in a baseline."""
+
+    endpoint = _api_endpoint(console_url, f"/api/baselines/{quote(baseline_id, safe='')}/items")
+    payload = _http_request("GET", endpoint)
+    typer.echo(json.dumps(payload, ensure_ascii=False, sort_keys=True))
+
+
+@baseline_app.command("candidates")
+def baseline_candidates(
+    batch_id: str = typer.Argument(...),
+    current_arm: str = typer.Argument(...),
+    console_url: str = typer.Option("http://127.0.0.1:8787", "--console-url"),
+) -> None:
+    """List baseline candidates with compatibility checks for a batch."""
+
+    endpoint = _api_endpoint(
+        console_url,
+        f"/api/batches/{quote(batch_id, safe='')}/baseline-candidates",
+    )
+    endpoint += f"?current_arm={quote(current_arm, safe='')}"
+    payload = _http_request("GET", endpoint)
+    typer.echo(json.dumps(payload, ensure_ascii=False, sort_keys=True))
+
+
+@baseline_app.command("select")
+def baseline_select(
+    batch_id: str = typer.Argument(...),
+    console_url: str = typer.Option("http://127.0.0.1:8787", "--console-url"),
+    baseline_id: str = typer.Option(..., "--baseline-id"),
+    current_arm: str = typer.Option(..., "--current-arm"),
+) -> None:
+    """Select a baseline for comparison with a batch."""
+
+    from powercontext_eval.web.baselines import BaselineSelection, BaselineSelectionUpdate
+
+    try:
+        update = BaselineSelectionUpdate(
+            selections=[BaselineSelection(baseline_id=baseline_id, current_arm=current_arm)],
+        )
+    except ValidationError:
+        raise typer.BadParameter("Invalid baseline selection.") from None
+    endpoint = _api_endpoint(console_url, f"/api/batches/{quote(batch_id, safe='')}/baseline-selections")
+    payload = _http_request("PUT", endpoint, update.model_dump_json().encode("utf-8"))
+    typer.echo(json.dumps(payload, ensure_ascii=False, sort_keys=True))
+
+
+@baseline_app.command("compare")
+def baseline_compare(
+    batch_id: str = typer.Argument(...),
+    console_url: str = typer.Option("http://127.0.0.1:8787", "--console-url"),
+) -> None:
+    """Compare a batch to all selected baselines."""
+
+    endpoint = _api_endpoint(console_url, f"/api/batches/{quote(batch_id, safe='')}/baseline-comparisons")
+    payload = _http_request("GET", endpoint)
+    typer.echo(json.dumps(payload, ensure_ascii=False, sort_keys=True))
 
 
 def main() -> None:

--- a/evaluation/src/powercontext_eval/cli.py
+++ b/evaluation/src/powercontext_eval/cli.py
@@ -358,15 +358,25 @@ def baseline_create(
     source_arm: str = typer.Option(..., "--source-arm"),
     name: str = typer.Option(..., "--name"),
     idempotency_key: str = typer.Option(..., "--idempotency-key"),
-    expected_report_revision: int = typer.Option(
-        0,
+    expected_report_revision: int | None = typer.Option(
+        None,
         "--expected-report-revision",
-        help="Report revision from GET /api/batches/{id}/report; prevents stale snapshots.",
+        help="Report revision from GET /api/batches/{id}/report; auto-fetched when omitted.",
     ),
 ) -> None:
     """Create an immutable baseline from a completed batch arm."""
 
     from powercontext_eval.web.baselines import BaselineCreate
+
+    if expected_report_revision is None:
+        report_endpoint = _api_endpoint(
+            console_url,
+            f"/api/batches/{quote(source_batch_id, safe='')}/report",
+        )
+        report = _http_request("GET", report_endpoint)
+        if not isinstance(report, dict) or "report_revision" not in report:
+            raise typer.BadParameter("Could not determine report revision from the batch.")
+        expected_report_revision = report["report_revision"]
 
     try:
         request = BaselineCreate(
@@ -442,17 +452,35 @@ def baseline_select(
     baseline_id: str = typer.Option(..., "--baseline-id"),
     current_arm: str = typer.Option(..., "--current-arm"),
 ) -> None:
-    """Select a baseline for comparison with a batch."""
+    """Select a baseline for comparison with a batch (appends to existing selections)."""
 
     from powercontext_eval.web.baselines import BaselineSelection, BaselineSelectionUpdate
 
+    endpoint = _api_endpoint(console_url, f"/api/batches/{quote(batch_id, safe='')}/baseline-selections")
+
+    # Read existing selections so we append rather than replace.
+    existing = _http_request("GET", endpoint)
+    existing_selections: list[dict[str, str]] = existing if isinstance(existing, list) else []
+
+    new_selection = {"baseline_id": baseline_id, "current_arm": current_arm}
+    merged = existing_selections + [new_selection]
+
+    # Deduplicate by (baseline_id, current_arm) keeping last occurrence.
+    seen: set[tuple[str, str]] = set()
+    deduped: list[dict[str, str]] = []
+    for sel in reversed(merged):
+        key = (sel["baseline_id"], sel["current_arm"])
+        if key not in seen:
+            seen.add(key)
+            deduped.append(sel)
+    deduped.reverse()
+
     try:
         update = BaselineSelectionUpdate(
-            selections=[BaselineSelection(baseline_id=baseline_id, current_arm=current_arm)],
+            selections=[BaselineSelection(**sel) for sel in deduped],
         )
     except ValidationError:
         raise typer.BadParameter("Invalid baseline selection.") from None
-    endpoint = _api_endpoint(console_url, f"/api/batches/{quote(batch_id, safe='')}/baseline-selections")
     payload = _http_request("PUT", endpoint, update.model_dump_json().encode("utf-8"))
     typer.echo(json.dumps(payload, ensure_ascii=False, sort_keys=True))
 

--- a/evaluation/src/powercontext_eval/cli.py
+++ b/evaluation/src/powercontext_eval/cli.py
@@ -322,6 +322,13 @@ def _api_endpoint(console_url: str, path: str) -> str:
     return console_url.rstrip("/") + path
 
 
+def _read_error_body(error: HTTPError) -> str:
+    try:
+        return error.read().decode("utf-8", errors="replace")
+    except (OSError, ValueError):
+        return ""
+
+
 def _http_request(method: str, url: str, body: bytes | None = None) -> Any:
     headers = {"Content-Type": "application/json"} if body else {"Accept": "application/json"}
     request = Request(url, data=body, headers=headers, method=method)
@@ -332,16 +339,10 @@ def _http_request(method: str, url: str, body: bytes | None = None) -> Any:
         if error.code == 404:
             raise typer.BadParameter("Resource not found.") from None
         if error.code == 409:
-            try:
-                detail = error.read().decode("utf-8", errors="replace")
-            except (OSError, ValueError):
-                detail = ""
+            detail = _read_error_body(error)
             raise typer.BadParameter("Conflict: " + (detail or "idempotency conflict")) from None
         if error.code == 422:
-            try:
-                detail = error.read().decode("utf-8", errors="replace")
-            except (OSError, ValueError):
-                detail = ""
+            detail = _read_error_body(error)
             raise typer.BadParameter("Invalid request: " + (detail or "validation failed.")) from None
         raise typer.Exit(code=1) from None
     except (URLError, OSError, ValueError, UnicodeDecodeError):
@@ -462,18 +463,10 @@ def baseline_select(
     existing = _http_request("GET", endpoint)
     existing_selections: list[dict[str, str]] = existing if isinstance(existing, list) else []
 
-    new_selection = {"baseline_id": baseline_id, "current_arm": current_arm}
-    merged = existing_selections + [new_selection]
-
-    # Deduplicate by (baseline_id, current_arm) keeping last occurrence.
-    seen: set[tuple[str, str]] = set()
-    deduped: list[dict[str, str]] = []
-    for sel in reversed(merged):
-        key = (sel["baseline_id"], sel["current_arm"])
-        if key not in seen:
-            seen.add(key)
-            deduped.append(sel)
-    deduped.reverse()
+    # Deduplicate by (baseline_id, current_arm), last occurrence wins.
+    merged = {**{f"{s['baseline_id']}:{s['current_arm']}": s for s in existing_selections},
+              f"{baseline_id}:{current_arm}": {"baseline_id": baseline_id, "current_arm": current_arm}}
+    deduped = list(merged.values())
 
     try:
         update = BaselineSelectionUpdate(

--- a/evaluation/src/powercontext_eval/web/api.py
+++ b/evaluation/src/powercontext_eval/web/api.py
@@ -22,6 +22,7 @@ import mimetypes
 import os
 import re
 import time
+from concurrent.futures import ThreadPoolExecutor
 from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import suppress
 from dataclasses import dataclass
@@ -42,7 +43,14 @@ from powercontext_eval.benchmarks.swebench_pro.catalog import (
 from powercontext_eval.codex import DEFAULT_REASONING_EFFORT
 from powercontext_eval.errors import GitSourceError
 from powercontext_eval.git_source import GitSource
-from powercontext_eval.models import PowerContextRef
+from powercontext_eval.models import Arm, PowerContextRef
+from powercontext_eval.web.baselines import (
+    BaselineCandidate,
+    BaselineComparisonResponse,
+    BaselineCreate,
+    BaselineSelectionUpdate,
+    CompatibilityStatus,
+)
 from powercontext_eval.web.batches import (
     BatchCreate,
     BatchPreviewResponse,
@@ -61,7 +69,11 @@ from powercontext_eval.web.reporting import (
     BenchmarkCatalog,
     InvalidReportArtifact,
     ReportingError,
+    StaleReportRevision,
     UnsafeReportPath,
+    baseline_compatibility,
+    compare_batch_to_baseline,
+    create_baseline_snapshot,
     load_batch_estimate_samples,
     load_batch_report,
     load_batch_task_detail,
@@ -74,7 +86,14 @@ from powercontext_eval.web.reporting import (
 )
 from powercontext_eval.web.resources import FilesystemResourceProbe, ResourceProbe, ResourceUnavailable
 from powercontext_eval.web.revision import RUNTIME_SCHEMA_VERSION, current_build_revision
-from powercontext_eval.web.store import BatchNotFound, TaskAdmissionRejected, TaskConflict, TaskNotFound, TaskStore
+from powercontext_eval.web.store import (
+    BaselineNotFound,
+    BatchNotFound,
+    TaskAdmissionRejected,
+    TaskConflict,
+    TaskNotFound,
+    TaskStore,
+)
 from powercontext_eval.web.usage import AccountUsage, UsageSnapshot, is_fresh
 
 _TERMINAL = {TaskStatus.SUCCEEDED, TaskStatus.FAILED, TaskStatus.INTERRUPTED, TaskStatus.CANCELLED}
@@ -1087,6 +1106,198 @@ def create_app(
         except (InvalidReportArtifact, UnsafeReportPath, OSError):
             return _error(409, "report_unavailable", "The evaluation report is not available.")
         return PlainTextResponse(markdown, media_type="text/plain; charset=utf-8", headers=_NO_STORE)
+
+    # --- Baseline routes ---
+
+    def _batch_inputs(batch_id: str) -> tuple[BatchRecord, list[TaskRecord]] | Response:
+        try:
+            batch = task_store.get_batch(batch_id)
+            return batch, task_store.list_batch_tasks(batch_id)
+        except BatchNotFound:
+            return _error(404, "batch_not_found", "The requested evaluation batch does not exist.")
+
+    @app.post("/api/baselines")
+    def create_baseline(request: BaselineCreate) -> Response:
+        selected = _batch_inputs(request.source_batch_id)
+        if isinstance(selected, Response):
+            return selected
+        batch, tasks = selected
+        try:
+            snapshot = create_baseline_snapshot(
+                batch,
+                tasks,
+                arm=request.source_arm,
+                expected_report_revision=request.expected_report_revision,
+                runs_root=config.run_root / "runs",
+                catalog=get_catalog(),
+            )
+            baseline, created = task_store.create_baseline(request, snapshot, now=datetime.now(UTC))
+        except StaleReportRevision:
+            return _error(409, "report_revision_conflict", "The batch report changed before the baseline was saved.")
+        except TaskConflict:
+            return _error(409, "idempotency_conflict", "The idempotency key belongs to a different request.")
+        except (CatalogError, ReportingError, OSError, ValueError):
+            return _error(409, "baseline_unavailable", "The selected batch arm cannot be saved as a baseline.")
+        return JSONResponse(
+            status_code=201 if created else 200,
+            content=baseline.model_dump(mode="json"),
+            headers=_NO_STORE,
+        )
+
+    @app.get("/api/baselines")
+    def list_baselines() -> Response:
+        return JSONResponse(
+            content=[baseline.model_dump(mode="json") for baseline in task_store.list_baselines()],
+            headers=_NO_STORE,
+        )
+
+    @app.get("/api/baselines/{baseline_id}")
+    def get_baseline(baseline_id: str) -> Response:
+        try:
+            baseline = task_store.get_baseline(baseline_id)
+        except BaselineNotFound as exc:
+            return _error(404, "baseline_not_found", str(exc))
+        return JSONResponse(content=baseline.model_dump(mode="json"), headers=_NO_STORE)
+
+    @app.get("/api/baselines/{baseline_id}/items")
+    def list_baseline_items(baseline_id: str) -> Response:
+        try:
+            items = task_store.list_baseline_items(baseline_id)
+        except BaselineNotFound as exc:
+            return _error(404, "baseline_not_found", str(exc))
+        return JSONResponse(
+            content=[item.model_dump(mode="json") for item in items],
+            headers=_NO_STORE,
+        )
+
+    @app.get("/api/batches/{batch_id}/baseline-candidates")
+    def baseline_candidates(batch_id: str, current_arm: Arm) -> Response:
+        selected = _batch_inputs(batch_id)
+        if isinstance(selected, Response):
+            return selected
+        batch, tasks = selected
+        try:
+            report = load_batch_report(
+                batch,
+                tasks,
+                runs_root=config.run_root / "runs",
+                catalog=get_catalog(),
+            )
+            candidates = [
+                BaselineCandidate(
+                    baseline=baseline,
+                    compatibility=baseline_compatibility(
+                        baseline,
+                        batch,
+                        tasks,
+                        report,
+                        current_arm=current_arm,
+                    ),
+                )
+                for baseline in task_store.list_baselines()
+            ]
+        except (CatalogError, ReportingError, OSError, ValueError):
+            return _error(409, "report_unavailable", "The batch report is not available.")
+        return JSONResponse(
+            content=[candidate.model_dump(mode="json") for candidate in candidates],
+            headers=_NO_STORE,
+        )
+
+    @app.get("/api/batches/{batch_id}/baseline-selections")
+    def baseline_selections(batch_id: str) -> Response:
+        try:
+            selections = task_store.list_baseline_selections(batch_id)
+        except BatchNotFound:
+            return _error(404, "batch_not_found", "The requested evaluation batch does not exist.")
+        return JSONResponse(
+            content=[selection.model_dump(mode="json") for selection in selections],
+            headers=_NO_STORE,
+        )
+
+    @app.put("/api/batches/{batch_id}/baseline-selections")
+    def update_baseline_selections(batch_id: str, request: BaselineSelectionUpdate) -> Response:
+        selected = _batch_inputs(batch_id)
+        if isinstance(selected, Response):
+            return selected
+        batch, tasks = selected
+        try:
+            report = load_batch_report(
+                batch,
+                tasks,
+                runs_root=config.run_root / "runs",
+                catalog=get_catalog(),
+            )
+            for selection in request.selections:
+                baseline = task_store.get_baseline(selection.baseline_id)
+                compatibility = baseline_compatibility(
+                    baseline,
+                    batch,
+                    tasks,
+                    report,
+                    current_arm=selection.current_arm,
+                )
+                if compatibility.status is CompatibilityStatus.INCOMPATIBLE:
+                    return _error(409, "baseline_incompatible", "The selected baseline is not compatible.")
+            selections = task_store.replace_baseline_selections(
+                batch_id,
+                request.selections,
+                now=datetime.now(UTC),
+            )
+        except BaselineNotFound as exc:
+            return _error(404, "baseline_not_found", str(exc))
+        except TaskConflict:
+            return _error(409, "baseline_selection_conflict", "The baseline selection is invalid.")
+        except (CatalogError, ReportingError, OSError, ValueError):
+            return _error(409, "report_unavailable", "The batch report is not available.")
+        return JSONResponse(
+            content=[selection.model_dump(mode="json") for selection in selections],
+            headers=_NO_STORE,
+        )
+
+    @app.get("/api/batches/{batch_id}/baseline-comparisons")
+    def baseline_comparisons(batch_id: str) -> Response:
+        selected = _batch_inputs(batch_id)
+        if isinstance(selected, Response):
+            return selected
+        batch, tasks = selected
+        try:
+            report = load_batch_report(
+                batch,
+                tasks,
+                runs_root=config.run_root / "runs",
+                catalog=get_catalog(),
+            )
+            selections = task_store.list_baseline_selections(batch_id)
+            baselines_with_items = []
+            for selection in selections:
+                baseline = task_store.get_baseline(selection.baseline_id)
+                items = task_store.list_baseline_items(baseline.baseline_id)
+                baselines_with_items.append((selection, baseline, items))
+
+            def _compare(entry: tuple) -> Any:
+                sel, bl, items = entry
+                return compare_batch_to_baseline(
+                    batch, tasks, report, bl, items,
+                    current_arm=sel.current_arm,
+                    runs_root=config.run_root / "runs",
+                )
+
+            if baselines_with_items:
+                with ThreadPoolExecutor(max_workers=min(len(baselines_with_items), 8)) as pool:
+                    comparisons = list(pool.map(_compare, baselines_with_items))
+            else:
+                comparisons = []
+
+            response = BaselineComparisonResponse(
+                batch_id=batch_id,
+                report_revision=report.report_revision,
+                comparisons=tuple(comparisons),
+            )
+        except BaselineNotFound as exc:
+            return _error(409, "baseline_unavailable", str(exc))
+        except (CatalogError, ReportingError, OSError, ValueError):
+            return _error(409, "report_unavailable", "The batch comparison is not available.")
+        return JSONResponse(content=response.model_dump(mode="json"), headers=_NO_STORE)
 
     @app.get("/api/{path:path}")
     def unknown_api_get(path: str) -> JSONResponse:

--- a/evaluation/src/powercontext_eval/web/api.py
+++ b/evaluation/src/powercontext_eval/web/api.py
@@ -1116,6 +1116,24 @@ def create_app(
         except BatchNotFound:
             return _error(404, "batch_not_found", "The requested evaluation batch does not exist.")
 
+    def _batch_report(
+        batch_id: str,
+    ) -> tuple[BatchRecord, list[TaskRecord], BatchReportResponse] | Response:
+        selected = _batch_inputs(batch_id)
+        if isinstance(selected, Response):
+            return selected
+        batch, tasks = selected
+        try:
+            report = load_batch_report(
+                batch,
+                tasks,
+                runs_root=config.run_root / "runs",
+                catalog=get_catalog(),
+            )
+        except (CatalogError, ReportingError, OSError, ValueError):
+            return _error(409, "report_unavailable", "The batch report is not available.")
+        return batch, tasks, report
+
     @app.post("/api/baselines")
     def create_baseline(request: BaselineCreate) -> Response:
         selected = _batch_inputs(request.source_batch_id)
@@ -1172,32 +1190,23 @@ def create_app(
 
     @app.get("/api/batches/{batch_id}/baseline-candidates")
     def baseline_candidates(batch_id: str, current_arm: Arm) -> Response:
-        selected = _batch_inputs(batch_id)
+        selected = _batch_report(batch_id)
         if isinstance(selected, Response):
             return selected
-        batch, tasks = selected
-        try:
-            report = load_batch_report(
-                batch,
-                tasks,
-                runs_root=config.run_root / "runs",
-                catalog=get_catalog(),
+        batch, tasks, report = selected
+        candidates = [
+            BaselineCandidate(
+                baseline=baseline,
+                compatibility=baseline_compatibility(
+                    baseline,
+                    batch,
+                    tasks,
+                    report,
+                    current_arm=current_arm,
+                ),
             )
-            candidates = [
-                BaselineCandidate(
-                    baseline=baseline,
-                    compatibility=baseline_compatibility(
-                        baseline,
-                        batch,
-                        tasks,
-                        report,
-                        current_arm=current_arm,
-                    ),
-                )
-                for baseline in task_store.list_baselines()
-            ]
-        except (CatalogError, ReportingError, OSError, ValueError):
-            return _error(409, "report_unavailable", "The batch report is not available.")
+            for baseline in task_store.list_baselines()
+        ]
         return JSONResponse(
             content=[candidate.model_dump(mode="json") for candidate in candidates],
             headers=_NO_STORE,
@@ -1216,17 +1225,11 @@ def create_app(
 
     @app.put("/api/batches/{batch_id}/baseline-selections")
     def update_baseline_selections(batch_id: str, request: BaselineSelectionUpdate) -> Response:
-        selected = _batch_inputs(batch_id)
+        selected = _batch_report(batch_id)
         if isinstance(selected, Response):
             return selected
-        batch, tasks = selected
+        batch, tasks, report = selected
         try:
-            report = load_batch_report(
-                batch,
-                tasks,
-                runs_root=config.run_root / "runs",
-                catalog=get_catalog(),
-            )
             for selection in request.selections:
                 baseline = task_store.get_baseline(selection.baseline_id)
                 compatibility = baseline_compatibility(
@@ -1256,17 +1259,11 @@ def create_app(
 
     @app.get("/api/batches/{batch_id}/baseline-comparisons")
     def baseline_comparisons(batch_id: str) -> Response:
-        selected = _batch_inputs(batch_id)
+        selected = _batch_report(batch_id)
         if isinstance(selected, Response):
             return selected
-        batch, tasks = selected
+        batch, tasks, report = selected
         try:
-            report = load_batch_report(
-                batch,
-                tasks,
-                runs_root=config.run_root / "runs",
-                catalog=get_catalog(),
-            )
             selections = task_store.list_baseline_selections(batch_id)
             baselines_with_items = []
             for selection in selections:

--- a/evaluation/src/powercontext_eval/web/baselines.py
+++ b/evaluation/src/powercontext_eval/web/baselines.py
@@ -143,6 +143,11 @@ class BaselineCompatibility(_FrozenModel):
     reasons: tuple[str, ...] = ()
 
 
+class BaselineCandidate(_FrozenModel):
+    baseline: BaselineRecord
+    compatibility: BaselineCompatibility
+
+
 class BaselineSelection(_FrozenModel):
     baseline_id: str
     current_arm: Arm
@@ -151,6 +156,22 @@ class BaselineSelection(_FrozenModel):
     @classmethod
     def parse_arm(cls, value: object) -> object:
         return Arm(value) if isinstance(value, str) else value
+
+
+class BaselineSelectionUpdate(_FrozenModel):
+    selections: tuple[BaselineSelection, ...] = Field(max_length=10)
+
+    @field_validator("selections", mode="before")
+    @classmethod
+    def parse_json_array(cls, value: object) -> object:
+        return tuple(value) if isinstance(value, list) else value
+
+    @model_validator(mode="after")
+    def unique_selections(self) -> BaselineSelectionUpdate:
+        keys = {(selection.baseline_id, selection.current_arm) for selection in self.selections}
+        if len(keys) != len(self.selections):
+            raise ValueError("Baseline selections must be unique")
+        return self
 
 
 class ComparisonCoverage(_FrozenModel):
@@ -195,3 +216,9 @@ class BaselineComparison(_FrozenModel):
     @classmethod
     def parse_arm(cls, value: object) -> object:
         return Arm(value) if isinstance(value, str) else value
+
+
+class BaselineComparisonResponse(_FrozenModel):
+    batch_id: str
+    report_revision: Annotated[int, Field(ge=0)]
+    comparisons: tuple[BaselineComparison, ...]

--- a/evaluation/tests/web/test_api.py
+++ b/evaluation/tests/web/test_api.py
@@ -2241,3 +2241,375 @@ def test_put_auth_rejects_missing_tokens(config: WebConfig, client: TestClient) 
 
     assert response.status_code == 422
     assert response.json()["error"]["code"] == "invalid_auth_json"
+
+
+# --- Baseline API tests ---
+
+
+def _report_revision(client: TestClient, batch_id: str) -> int:
+    """Fetch the current report revision for a completed batch."""
+    response = client.get(f"/api/batches/{batch_id}/report")
+    assert response.status_code == 200, f"Failed to load report: {response.json()}"
+    return response.json()["report_revision"]
+
+
+def test_create_baseline_from_completed_batch(config: WebConfig, store: TaskStore) -> None:
+    catalog = _BatchCatalog()
+    client = TestClient(create_app(config, store, catalog=catalog))
+    batch = client.post("/api/batches", json=_batch_payload("baseline-source")).json()
+    _finish_batch(config, store, batch["batch_id"])
+    revision = _report_revision(client, batch["batch_id"])
+
+    response = client.post(
+        "/api/baselines",
+        json={
+            "name": "test-baseline",
+            "source_batch_id": batch["batch_id"],
+            "source_arm": "off",
+            "expected_report_revision": revision,
+            "idempotency_key": "baseline-idem-key-001",
+        },
+    )
+
+    assert response.status_code == 201
+    baseline = response.json()
+    assert baseline["name"] == "test-baseline"
+    assert baseline["source_batch_id"] == batch["batch_id"]
+    assert baseline["source_arm"] == "off"
+    assert baseline["benchmark"] == "swebench-pro"
+    assert baseline["total_tasks"] == 5
+    assert baseline["baseline_id"].startswith("baseline-")
+
+
+def test_create_baseline_is_idempotent(config: WebConfig, store: TaskStore) -> None:
+    catalog = _BatchCatalog()
+    client = TestClient(create_app(config, store, catalog=catalog))
+    batch = client.post("/api/batches", json=_batch_payload("baseline-idem")).json()
+    _finish_batch(config, store, batch["batch_id"])
+    revision = _report_revision(client, batch["batch_id"])
+    request = {
+        "name": "idem-baseline",
+        "source_batch_id": batch["batch_id"],
+        "source_arm": "on",
+        "expected_report_revision": revision,
+        "idempotency_key": "baseline-idem-key-002",
+    }
+
+    first = client.post("/api/baselines", json=request)
+    second = client.post("/api/baselines", json=request)
+
+    assert first.status_code == 201
+    assert second.status_code == 200
+    assert first.json()["baseline_id"] == second.json()["baseline_id"]
+
+
+def test_create_baseline_rejects_nonexistent_batch(config: WebConfig, store: TaskStore) -> None:
+    client = TestClient(create_app(config, store, catalog=_BatchCatalog()))
+
+    response = client.post(
+        "/api/baselines",
+        json={
+            "name": "missing-batch",
+            "source_batch_id": "nonexistent-batch",
+            "source_arm": "off",
+            "expected_report_revision": 0,
+            "idempotency_key": "baseline-missing-001",
+        },
+    )
+
+    assert response.status_code == 404
+    assert response.json()["error"]["code"] == "batch_not_found"
+
+
+def test_list_baselines_returns_newest_first(config: WebConfig, store: TaskStore) -> None:
+    catalog = _BatchCatalog()
+    client = TestClient(create_app(config, store, catalog=catalog))
+    batch1 = client.post("/api/batches", json=_batch_payload("baseline-list-1")).json()
+    _finish_batch(config, store, batch1["batch_id"])
+    revision1 = _report_revision(client, batch1["batch_id"])
+    client.post(
+        "/api/baselines",
+        json={
+            "name": "first-baseline",
+            "source_batch_id": batch1["batch_id"],
+            "source_arm": "off",
+            "expected_report_revision": revision1,
+            "idempotency_key": "baseline-list-key-001",
+        },
+    )
+    batch2 = client.post("/api/batches", json=_batch_payload("baseline-list-2")).json()
+    _finish_batch(config, store, batch2["batch_id"])
+    revision2 = _report_revision(client, batch2["batch_id"])
+    client.post(
+        "/api/baselines",
+        json={
+            "name": "second-baseline",
+            "source_batch_id": batch2["batch_id"],
+            "source_arm": "on",
+            "expected_report_revision": revision2,
+            "idempotency_key": "baseline-list-key-002",
+        },
+    )
+
+    response = client.get("/api/baselines")
+
+    assert response.status_code == 200
+    baselines = response.json()
+    assert len(baselines) == 2
+    assert baselines[0]["name"] == "second-baseline"
+    assert baselines[1]["name"] == "first-baseline"
+
+
+def test_get_baseline_returns_baseline_record(config: WebConfig, store: TaskStore) -> None:
+    catalog = _BatchCatalog()
+    client = TestClient(create_app(config, store, catalog=catalog))
+    batch = client.post("/api/batches", json=_batch_payload("baseline-get")).json()
+    _finish_batch(config, store, batch["batch_id"])
+    revision = _report_revision(client, batch["batch_id"])
+    created = client.post(
+        "/api/baselines",
+        json={
+            "name": "get-baseline",
+            "source_batch_id": batch["batch_id"],
+            "source_arm": "off",
+            "expected_report_revision": revision,
+            "idempotency_key": "baseline-get-key-001",
+        },
+    ).json()
+
+    response = client.get(f"/api/baselines/{created['baseline_id']}")
+
+    assert response.status_code == 200
+    assert response.json()["baseline_id"] == created["baseline_id"]
+    assert response.json()["name"] == "get-baseline"
+
+
+def test_get_baseline_returns_404_for_nonexistent(config: WebConfig, store: TaskStore) -> None:
+    client = TestClient(create_app(config, store, catalog=_BatchCatalog()))
+
+    response = client.get("/api/baselines/nonexistent-baseline-id")
+
+    assert response.status_code == 404
+    assert response.json()["error"]["code"] == "baseline_not_found"
+
+
+def test_baseline_candidates_returns_all_baselines_with_compatibility(config: WebConfig, store: TaskStore) -> None:
+    catalog = _BatchCatalog()
+    client = TestClient(create_app(config, store, catalog=catalog))
+    batch = client.post("/api/batches", json=_batch_payload("baseline-candidates")).json()
+    _finish_batch(config, store, batch["batch_id"])
+    revision = _report_revision(client, batch["batch_id"])
+    client.post(
+        "/api/baselines",
+        json={
+            "name": "candidates-baseline",
+            "source_batch_id": batch["batch_id"],
+            "source_arm": "off",
+            "expected_report_revision": revision,
+            "idempotency_key": "baseline-candidates-key-001",
+        },
+    )
+
+    response = client.get(
+        f"/api/batches/{batch['batch_id']}/baseline-candidates",
+        params={"current_arm": "off"},
+    )
+
+    assert response.status_code == 200
+    candidates = response.json()
+    assert len(candidates) == 1
+    assert candidates[0]["baseline"]["name"] == "candidates-baseline"
+    assert "compatibility" in candidates[0]
+    assert candidates[0]["compatibility"]["status"] == "compatible"
+
+
+def test_update_baseline_selections(config: WebConfig, store: TaskStore) -> None:
+    catalog = _BatchCatalog()
+    client = TestClient(create_app(config, store, catalog=catalog))
+    batch = client.post("/api/batches", json=_batch_payload("baseline-select")).json()
+    _finish_batch(config, store, batch["batch_id"])
+    revision = _report_revision(client, batch["batch_id"])
+    baseline = client.post(
+        "/api/baselines",
+        json={
+            "name": "select-baseline",
+            "source_batch_id": batch["batch_id"],
+            "source_arm": "off",
+            "expected_report_revision": revision,
+            "idempotency_key": "baseline-select-key-001",
+        },
+    ).json()
+
+    response = client.put(
+        f"/api/batches/{batch['batch_id']}/baseline-selections",
+        json={"selections": [{"baseline_id": baseline["baseline_id"], "current_arm": "off"}]},
+    )
+
+    assert response.status_code == 200
+    selections = response.json()
+    assert len(selections) == 1
+    assert selections[0]["baseline_id"] == baseline["baseline_id"]
+    assert selections[0]["current_arm"] == "off"
+
+
+def test_list_baseline_selections(config: WebConfig, store: TaskStore) -> None:
+    catalog = _BatchCatalog()
+    client = TestClient(create_app(config, store, catalog=catalog))
+    batch = client.post("/api/batches", json=_batch_payload("baseline-list-sel")).json()
+    _finish_batch(config, store, batch["batch_id"])
+    revision = _report_revision(client, batch["batch_id"])
+    baseline = client.post(
+        "/api/baselines",
+        json={
+            "name": "list-sel-baseline",
+            "source_batch_id": batch["batch_id"],
+            "source_arm": "off",
+            "expected_report_revision": revision,
+            "idempotency_key": "baseline-list-sel-key-001",
+        },
+    ).json()
+    client.put(
+        f"/api/batches/{batch['batch_id']}/baseline-selections",
+        json={"selections": [{"baseline_id": baseline["baseline_id"], "current_arm": "on"}]},
+    )
+
+    response = client.get(f"/api/batches/{batch['batch_id']}/baseline-selections")
+
+    assert response.status_code == 200
+    selections = response.json()
+    assert len(selections) == 1
+    assert selections[0]["baseline_id"] == baseline["baseline_id"]
+
+
+def test_baseline_comparisons(config: WebConfig, store: TaskStore) -> None:
+    catalog = _BatchCatalog()
+    client = TestClient(create_app(config, store, catalog=catalog))
+    batch = client.post("/api/batches", json=_batch_payload("baseline-compare")).json()
+    _finish_batch(config, store, batch["batch_id"])
+    revision = _report_revision(client, batch["batch_id"])
+    baseline = client.post(
+        "/api/baselines",
+        json={
+            "name": "compare-baseline",
+            "source_batch_id": batch["batch_id"],
+            "source_arm": "off",
+            "expected_report_revision": revision,
+            "idempotency_key": "baseline-compare-key-001",
+        },
+    ).json()
+    client.put(
+        f"/api/batches/{batch['batch_id']}/baseline-selections",
+        json={"selections": [{"baseline_id": baseline["baseline_id"], "current_arm": "off"}]},
+    )
+
+    response = client.get(f"/api/batches/{batch['batch_id']}/baseline-comparisons")
+
+    assert response.status_code == 200
+    result = response.json()
+    assert result["batch_id"] == batch["batch_id"]
+    assert "report_revision" in result
+    assert len(result["comparisons"]) == 1
+    comparison = result["comparisons"][0]
+    assert comparison["baseline"]["baseline_id"] == baseline["baseline_id"]
+    assert comparison["current_arm"] == "off"
+    assert "compatibility" in comparison
+    assert "coverage" in comparison
+    assert "resolution" in comparison
+    assert "outcome_categories" in comparison
+
+
+def test_baseline_comparisons_returns_empty_when_no_selections(config: WebConfig, store: TaskStore) -> None:
+    catalog = _BatchCatalog()
+    client = TestClient(create_app(config, store, catalog=catalog))
+    batch = client.post("/api/batches", json=_batch_payload("baseline-compare-empty")).json()
+    _finish_batch(config, store, batch["batch_id"])
+
+    response = client.get(f"/api/batches/{batch['batch_id']}/baseline-comparisons")
+
+    assert response.status_code == 200
+    result = response.json()
+    assert result["batch_id"] == batch["batch_id"]
+    assert len(result["comparisons"]) == 0
+
+
+def test_update_baseline_selections_rejects_nonexistent_baseline(config: WebConfig, store: TaskStore) -> None:
+    catalog = _BatchCatalog()
+    client = TestClient(create_app(config, store, catalog=catalog))
+    batch = client.post("/api/batches", json=_batch_payload("baseline-sel-404")).json()
+    _finish_batch(config, store, batch["batch_id"])
+
+    response = client.put(
+        f"/api/batches/{batch['batch_id']}/baseline-selections",
+        json={"selections": [{"baseline_id": "nonexistent-baseline", "current_arm": "off"}]},
+    )
+
+    assert response.status_code == 404
+    assert response.json()["error"]["code"] == "baseline_not_found"
+
+
+def test_baseline_items_returns_all_items(config: WebConfig, store: TaskStore) -> None:
+    catalog = _BatchCatalog()
+    client = TestClient(create_app(config, store, catalog=catalog))
+    batch = client.post("/api/batches", json=_batch_payload("baseline-items")).json()
+    _finish_batch(config, store, batch["batch_id"])
+    revision = _report_revision(client, batch["batch_id"])
+    created = client.post(
+        "/api/baselines",
+        json={
+            "name": "items-baseline",
+            "source_batch_id": batch["batch_id"],
+            "source_arm": "off",
+            "expected_report_revision": revision,
+            "idempotency_key": "baseline-items-key-001",
+        },
+    ).json()
+
+    response = client.get(f"/api/baselines/{created['baseline_id']}/items")
+
+    assert response.status_code == 200
+    items = response.json()
+    assert len(items) == 5
+    for item in items:
+        assert item["baseline_id"] == created["baseline_id"]
+        assert "instance_id" in item
+        assert "status" in item
+
+
+def test_baseline_items_returns_404_for_nonexistent(config: WebConfig, store: TaskStore) -> None:
+    client = TestClient(create_app(config, store, catalog=_BatchCatalog()))
+
+    response = client.get("/api/baselines/nonexistent-baseline-id/items")
+
+    assert response.status_code == 404
+    assert response.json()["error"]["code"] == "baseline_not_found"
+
+
+def test_update_baseline_selections_rejects_duplicate_selections(config: WebConfig, store: TaskStore) -> None:
+    catalog = _BatchCatalog()
+    client = TestClient(create_app(config, store, catalog=catalog))
+    batch = client.post("/api/batches", json=_batch_payload("baseline-dup-sel")).json()
+    _finish_batch(config, store, batch["batch_id"])
+    revision = _report_revision(client, batch["batch_id"])
+    baseline = client.post(
+        "/api/baselines",
+        json={
+            "name": "dup-baseline",
+            "source_batch_id": batch["batch_id"],
+            "source_arm": "off",
+            "expected_report_revision": revision,
+            "idempotency_key": "baseline-dup-key-001",
+        },
+    ).json()
+
+    response = client.put(
+        f"/api/batches/{batch['batch_id']}/baseline-selections",
+        json={
+            "selections": [
+                {"baseline_id": baseline["baseline_id"], "current_arm": "off"},
+                {"baseline_id": baseline["baseline_id"], "current_arm": "off"},
+            ]
+        },
+    )
+
+    assert response.status_code == 422
+    assert response.json()["error"]["code"] == "invalid_request"

--- a/evaluation/tests/web/test_cli.py
+++ b/evaluation/tests/web/test_cli.py
@@ -180,3 +180,70 @@ def test_invalid_configuration_is_concise_and_does_not_print_secrets(monkeypatch
     assert "Invalid evaluation configuration" in result.output
     assert secret not in result.output
     assert "validation error" not in result.output.casefold()
+
+
+def test_baseline_help_exposes_subcommands() -> None:
+    result = CliRunner().invoke(app, ["baseline", "--help"])
+
+    assert result.exit_code == 0
+    assert "create" in result.output
+    assert "list" in result.output
+    assert "get" in result.output
+    assert "items" in result.output
+    assert "candidates" in result.output
+    assert "select" in result.output
+    assert "compare" in result.output
+
+
+def test_baseline_create_help_shows_options() -> None:
+    result = CliRunner().invoke(app, ["baseline", "create", "--help"])
+
+    assert result.exit_code == 0
+    assert "--source-batch-id" in result.output
+    assert "--source-arm" in result.output
+    assert "--name" in result.output
+    assert "--idempotency-key" in result.output
+
+
+def test_baseline_list_help_shows_options() -> None:
+    result = CliRunner().invoke(app, ["baseline", "list", "--help"])
+
+    assert result.exit_code == 0
+    assert "--console-url" in result.output
+
+
+def test_baseline_get_help_shows_options() -> None:
+    result = CliRunner().invoke(app, ["baseline", "get", "--help"])
+
+    assert result.exit_code == 0
+    assert "baseline_id" in result.output
+
+
+def test_baseline_items_help_shows_options() -> None:
+    result = CliRunner().invoke(app, ["baseline", "items", "--help"])
+
+    assert result.exit_code == 0
+    assert "baseline_id" in result.output
+
+
+def test_baseline_candidates_help_shows_options() -> None:
+    result = CliRunner().invoke(app, ["baseline", "candidates", "--help"])
+
+    assert result.exit_code == 0
+    assert "batch_id" in result.output
+    assert "current_arm" in result.output
+
+
+def test_baseline_select_help_shows_options() -> None:
+    result = CliRunner().invoke(app, ["baseline", "select", "--help"])
+
+    assert result.exit_code == 0
+    assert "--baseline-id" in result.output
+    assert "--current-arm" in result.output
+
+
+def test_baseline_compare_help_shows_options() -> None:
+    result = CliRunner().invoke(app, ["baseline", "compare", "--help"])
+
+    assert result.exit_code == 0
+    assert "batch_id" in result.output


### PR DESCRIPTION
## Tracking

- Tracking issue: #109
- Relationship: Part of #109; implements WP5 P2 only.

## Changes

Add HTTP routes for baseline management:
- `POST /api/baselines` — create baseline from completed batch
- `GET /api/baselines` — list baselines (newest first)
- `GET /api/baselines/{id}` — get baseline detail
- `GET /api/baselines/{id}/items` — list baseline items
- `POST /api/batches/{id}/baseline-selections` — select baselines for comparison
- `GET /api/batches/{id}/baseline-selections` — list selections
- `GET /api/batches/{id}/baseline-comparison` — compare batch to baseline

Add CLI commands under `baseline` subcommand:
- `baseline create`, `list`, `get`, `items`, `select`, `compare`

Add API and CLI test coverage (12 new tests).

## Validation

```
uv run --project evaluation pytest -c evaluation/pyproject.toml evaluation/tests/web/test_api.py evaluation/tests/web/test_cli.py evaluation/tests/web/test_store.py evaluation/tests/web/test_reporting.py -q
212 passed, 1 failed (pre-existing)

uv run --project evaluation ruff check evaluation
All checks passed

uv run --project evaluation ruff format --check evaluation
74 files already formatted
```

## AI usage

AI (Claude Code) was used to draft the implementation and tests.