### PR TITLE
feat(cli): align provider-aware configuration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -380,4 +380,7 @@ source / artifact / trigger / inference
   display redaction from the explicit managed credential metadata rather than
   inferring names from a model prefix. Verify marked custom values never appear
   in `show`, unmarked operational values remain visible, and validation refuses
-  a required recorded credential before writing a runnable configuration.
+  a required recorded credential before writing a runnable configuration. When
+  generation and embedding share a marked variable, deduplicate the metadata
+  in first-presented order before strict validation and verify the generated
+  configuration remains runnable.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -376,3 +376,8 @@ source / artifact / trigger / inference
   fails, preserve the successful publication result and report only a bounded
   stale-discovery state. Verify scan and registry-read failures leave the
   published package intact, return success, and never expose discovery errors.
+- When a configuration generator records provider credentials, derive every
+  display redaction from the explicit managed credential metadata rather than
+  inferring names from a model prefix. Verify marked custom values never appear
+  in `show`, unmarked operational values remain visible, and validation refuses
+  a required recorded credential before writing a runnable configuration.

--- a/docs/superpowers/plans/2026-09-02-provider-aware-config-cli.md
+++ b/docs/superpowers/plans/2026-09-02-provider-aware-config-cli.md
@@ -1,0 +1,32 @@
+# Provider-Aware Config CLI Implementation Plan
+
+**Goal:** Align Go `config init`, `config show`, and `config validate` with the v0.1.0 provider-aware configuration contract without widening the Server's supported provider set or exposing credentials.
+
+**Scope:** The sixteen pending cases in `tests/test_config_cli.py` at the exact v0.1.0 target. This plan owns only `internal/cli` configuration collection, managed environment rendering/parsing, redaction, and provider constructibility checks. It does not add a provider adapter, change Server runtime configuration semantics, or add retained-agent behavior.
+
+## Decisions
+
+- Preserve the existing managed-block markers and atomic `0600` write behavior.
+- Replace the fixed OpenRouter-only values with a CLI-local configuration value containing a generation model, embedding model, provider environment assignments, and explicit credential names.
+- Treat provider prefixes as data first: known model-provider routes must pass the Go route/factory boundary; unknown provider/model identifiers fail before writing. Provider environment variable names remain extensible when syntactically valid.
+- Permit a configured HTTP base URL only when it contains no embedded user information. Provider error text, URLs, credentials, and values never appear in `show`, response output, or stable validation errors.
+- Keep an explicit credential-name list in the managed block. `show` redacts this list in addition to the existing suffix/container redaction policy.
+- `init` refuses to overwrite any existing file without `--force`; a force update preserves unrelated assignments and replaces only the managed values.
+- A successful `init` writes only after the complete configuration validates. Invalid dimensions, duplicate names, missing required credentials, invalid routes, and Server-invalid values leave no new output file.
+
+## Tasks
+
+1. Add RED tests for a provider-aware generated configuration: OpenAI defaults, arbitrary supported provider assignments, base URL credential rejection, duplicate assignments, numeric errors, credential metadata/redaction, and overwrite protection.
+2. Introduce CLI-local model/variable/configuration values and pure validation/rendering helpers. Keep them independent from terminal I/O.
+3. Refactor `config init` to collect defaults or terminal input into the configuration value, validate it, and render the managed environment block with metadata.
+4. Refactor `config show` and `config validate` to reconstruct configuration metadata, preserve redaction, and provide actionable usage errors without a traceback.
+5. Add exact case mappings, regenerate the v0.1.0 inventory, and run targeted CLI, model-provider, Server configuration, generator, lint, and module checks.
+6. Refresh the base, push an isolated PR, require exact-Head CI/review, verify the server merge and five post-main workflows, then update Issue #3 only from the merged main evidence.
+
+## Constraints
+
+- No provider request, credential logging, persistence write, or external process is needed to validate the configuration model.
+- Existing noninteractive invocation remains supported and produces a usable default configuration without credentials.
+- Do not make a custom connection inherit a provider credential merely because its model text happens to use a known prefix.
+- Do not introduce a broad provider allowlist distinct from `internal/modelprovider`; accept only the existing Server-provider route contract when constructibility is claimed.
+- All commits use the Lore message format and the OmX co-author trailer.

--- a/internal/cli/config_collection.go
+++ b/internal/cli/config_collection.go
@@ -74,7 +74,7 @@ func collectProviderAwareConfig(input io.Reader, output io.Writer) (providerAwar
 			return providerAwareConfig{}, collectErr
 		}
 		config.generation, config.embedding = generation, embedding
-		config.credentials = append(generationCredentials, embeddingCredentials...)
+		config.credentials = uniqueConfigCredentialNames(append(generationCredentials, embeddingCredentials...))
 	default:
 		return providerAwareConfig{}, errors.New("Generation API protocol is not supported")
 	}
@@ -88,6 +88,19 @@ func collectProviderAwareConfig(input io.Reader, output io.Writer) (providerAwar
 	}
 	config.embeddingProfileID = configProfileID(config.embedding.model, config.embeddingDimension)
 	return config, nil
+}
+
+func uniqueConfigCredentialNames(names []string) []string {
+	seen := make(map[string]struct{}, len(names))
+	unique := make([]string, 0, len(names))
+	for _, name := range names {
+		if _, exists := seen[name]; exists {
+			continue
+		}
+		seen[name] = struct{}{}
+		unique = append(unique, name)
+	}
+	return unique
 }
 
 func collectCustomConfigConnection(

--- a/internal/cli/config_collection.go
+++ b/internal/cli/config_collection.go
@@ -1,0 +1,183 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+
+	"golang.org/x/term"
+)
+
+func collectProviderAwareConfig(input io.Reader, output io.Writer) (providerAwareConfig, error) {
+	config := defaultProviderAwareConfig()
+	var err error
+	if config.scopeID, err = configPrompt(input, output, "Scope ID", config.scopeID, false); err != nil {
+		return providerAwareConfig{}, err
+	}
+	if config.displayName, err = configPrompt(input, output, "Dashboard display name", config.displayName, false); err != nil {
+		return providerAwareConfig{}, err
+	}
+	protocol, err := configPrompt(input, output, "Generation API protocol", "openai-chat", false)
+	if err != nil {
+		return providerAwareConfig{}, err
+	}
+	switch protocol {
+	case "openai-chat", "openai-responses":
+		config.generation.model, err = configPrompt(input, output, "Generation model", "gpt-4.1-mini", false)
+		if err != nil {
+			return providerAwareConfig{}, err
+		}
+		config.generation.model = protocol + ":" + config.generation.model
+		baseURL, promptErr := configPrompt(input, output, "Generation API Base URL", "https://api.openai.com/v1", false)
+		if promptErr != nil {
+			return providerAwareConfig{}, promptErr
+		}
+		credential, promptErr := configPrompt(input, output, "Generation API key", "", true)
+		if promptErr != nil {
+			return providerAwareConfig{}, promptErr
+		}
+		config.generation.environment = []configProviderVariable{
+			{name: "OPENAI_BASE_URL", value: baseURL},
+			{name: "OPENAI_API_KEY", value: credential},
+		}
+		config.embedding.model, err = configPrompt(input, output, "Embedding model", "text-embedding-3-small", false)
+		if err != nil {
+			return providerAwareConfig{}, err
+		}
+		config.embedding.model = "openai:" + config.embedding.model
+		config.embedding.environment = append([]configProviderVariable(nil), config.generation.environment...)
+		config.credentials = []string{"OPENAI_API_KEY"}
+	case "custom":
+		generation, generationCredentials, collectErr := collectCustomConfigConnection(input, output, "generation")
+		if collectErr != nil {
+			return providerAwareConfig{}, collectErr
+		}
+		embedding, embeddingCredentials, collectErr := collectCustomConfigConnection(input, output, "embedding")
+		if collectErr != nil {
+			return providerAwareConfig{}, collectErr
+		}
+		config.generation, config.embedding = generation, embedding
+		config.credentials = append(generationCredentials, embeddingCredentials...)
+	default:
+		return providerAwareConfig{}, errors.New("Generation API protocol is not supported")
+	}
+	dimension, err := configPrompt(input, output, "Embedding dimension", strconv.Itoa(config.embeddingDimension), false)
+	if err != nil {
+		return providerAwareConfig{}, err
+	}
+	config.embeddingDimension, err = strconv.Atoi(dimension)
+	if err != nil {
+		return providerAwareConfig{}, errors.New("Embedding dimension must be an integer")
+	}
+	config.embeddingProfileID = configProfileID(config.embedding.model, config.embeddingDimension)
+	return config, nil
+}
+
+func collectCustomConfigConnection(
+	input io.Reader,
+	output io.Writer,
+	role string,
+) (configModelSelection, []string, error) {
+	model, err := configPrompt(input, output, role+" model identifier", "openai-chat:model-name", false)
+	if err != nil {
+		return configModelSelection{}, nil, err
+	}
+	variables := make([]configProviderVariable, 0)
+	credentials := make([]string, 0)
+	for {
+		name, promptErr := configPrompt(input, output, "Additional "+role+" provider environment variable name", "", false)
+		if promptErr != nil {
+			return configModelSelection{}, nil, promptErr
+		}
+		if name == "" {
+			break
+		}
+		if !configEnvironmentName.MatchString(name) {
+			return configModelSelection{}, nil, errors.New("invalid provider environment variable")
+		}
+		credentialMarker, promptErr := configPrompt(input, output, "Treat "+name+" as a credential", "false", false)
+		if promptErr != nil {
+			return configModelSelection{}, nil, promptErr
+		}
+		isCredential, parseErr := strconv.ParseBool(credentialMarker)
+		if parseErr != nil {
+			return configModelSelection{}, nil, errors.New("credential marker must be true or false")
+		}
+		value, promptErr := configPrompt(input, output, name, "", isCredential)
+		if promptErr != nil {
+			return configModelSelection{}, nil, promptErr
+		}
+		variables = append(variables, configProviderVariable{name: name, value: value})
+		if isCredential {
+			credentials = append(credentials, name)
+		}
+	}
+	return configModelSelection{model: model, environment: variables}, credentials, nil
+}
+
+func configPrompt(input io.Reader, output io.Writer, label, fallback string, secret bool) (string, error) {
+	if output == nil {
+		output = io.Discard
+	}
+	if _, err := fmt.Fprintf(output, "%s [%s]: ", label, fallback); err != nil {
+		return "", err
+	}
+	if secret {
+		if file, ok := input.(*os.File); ok && term.IsTerminal(int(file.Fd())) {
+			value, err := term.ReadPassword(int(file.Fd()))
+			if _, writeErr := fmt.Fprintln(output); err == nil && writeErr != nil {
+				err = writeErr
+			}
+			if err != nil {
+				return "", errors.New("cannot read credential input")
+			}
+			return strings.TrimSpace(string(value)), nil
+		}
+	}
+	line, err := readConfigPromptLine(input)
+	if err != nil {
+		return "", err
+	}
+	value := strings.TrimSpace(line)
+	if value == "" {
+		return fallback, nil
+	}
+	return value, nil
+}
+
+func readConfigPromptLine(input io.Reader) (string, error) {
+	line := make([]byte, 0, 64)
+	buffer := []byte{0}
+	for {
+		count, err := input.Read(buffer)
+		if count > 0 && buffer[0] != '\n' {
+			line = append(line, buffer[0])
+		}
+		if count > 0 && buffer[0] == '\n' {
+			return string(line), nil
+		}
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return string(line), nil
+			}
+			return "", err
+		}
+	}
+}

--- a/internal/cli/config_command.go
+++ b/internal/cli/config_command.go
@@ -17,7 +17,6 @@ package cli
 import (
 	"errors"
 	"fmt"
-	"io"
 	"maps"
 	"os"
 	"path/filepath"
@@ -28,7 +27,6 @@ import (
 	"unicode/utf8"
 
 	"github.com/spf13/cobra"
-	"golang.org/x/term"
 
 	"github.com/ob-labs/powercontext-go/server"
 )
@@ -68,21 +66,25 @@ func newConfigInitCommand(state *commandState) *cobra.Command {
 			if exists && !force {
 				return usageError(errors.New("configuration file already exists; use --force to replace the managed block"))
 			}
-			values, err := defaultConfigEnvironment(nonInteractive)
-			if err != nil {
-				return err
+			config := defaultProviderAwareConfig()
+			if !nonInteractive {
+				config, err = collectProviderAwareConfig(command.InOrStdin(), state.stderr)
+				if err != nil {
+					return usageError(err)
+				}
 			}
-			credential, err := promptConfigCredential(command.InOrStdin(), state.stderr, nonInteractive)
-			if err != nil {
-				return err
+			if validationErr := validateProviderAwareConfig(config, !nonInteractive); validationErr != nil {
+				return usageError(validationErr)
 			}
-			if credential != "" {
-				values["OPENROUTER_API_KEY"] = credential
+			documentBlock, renderErr := renderProviderAwareConfigBlock(config)
+			if renderErr != nil {
+				return usageError(renderErr)
 			}
-			document, err := updateConfigDocument(content, values)
-			if err != nil {
-				return usageError(err)
+			document, documentErr := updateConfigDocument(content, providerAwareManagedEnvironment(config))
+			if documentErr != nil {
+				return usageError(documentErr)
 			}
+			document = replaceConfigManagedBlock(document, documentBlock)
 			if writeErr := writeFileAtomically(path, []byte(document), 0o600); writeErr != nil {
 				return errors.New("cannot write configuration file")
 			}
@@ -158,6 +160,15 @@ func newConfigValidateCommand(state *commandState) *cobra.Command {
 			if persistenceErr := validateConfigPersistence(values); persistenceErr != nil {
 				return usageError(persistenceErr)
 			}
+			config, configErr := providerAwareConfigFromDocument(content, values)
+			if configErr != nil {
+				return usageError(configErr)
+			}
+			if config != nil {
+				if providerErr := validateProviderAwareConfig(*config, true); providerErr != nil {
+					return usageError(providerErr)
+				}
+			}
 			if serverValidationErr := validateServerEnvironment(values); serverValidationErr != nil {
 				return usageError(serverValidationErr)
 			}
@@ -177,48 +188,6 @@ func configOutputPath(value string) (string, error) {
 		return "", errors.New("configuration output path must not be blank")
 	}
 	return filepath.Abs(value)
-}
-
-func defaultConfigEnvironment(_ bool) (map[string]string, error) {
-	defaults, err := server.DefaultConfig()
-	if err != nil {
-		return nil, err
-	}
-	return map[string]string{
-		"POWERCONTEXT_SERVER_HTTP_HOST":                   defaults.HTTP.Host,
-		"POWERCONTEXT_SERVER_HTTP_PORT":                   strconv.Itoa(defaults.HTTP.Port),
-		"POWERCONTEXT_SERVER_MCP_ENABLED":                 strconv.FormatBool(defaults.MCP.Enabled),
-		"POWERCONTEXT_SERVER_MCP_PATH":                    defaults.MCP.Path,
-		"POWERCONTEXT_SERVER_AUTH_ENABLED":                strconv.FormatBool(defaults.Auth.Enabled),
-		"POWERCONTEXT_SERVER_DATABASE_KIND":               "sqlite",
-		"POWERCONTEXT_SERVER_DATABASE_URL":                defaults.Database.SQLite.URL,
-		"POWERCONTEXT_SERVER_RUNTIME_SOURCE_WINDOW_LIMIT": strconv.FormatInt(defaults.Runtime.SourceWindowLimit, 10),
-		"OPENROUTER_API_KEY":                              "",
-	}, nil
-}
-
-func promptConfigCredential(input io.Reader, output io.Writer, nonInteractive bool) (string, error) {
-	if nonInteractive {
-		return "", nil
-	}
-	file, ok := input.(*os.File)
-	if !ok || !term.IsTerminal(int(file.Fd())) {
-		return "", nil
-	}
-	if output == nil {
-		output = os.Stderr
-	}
-	if _, err := fmt.Fprint(output, "OPENROUTER_API_KEY: "); err != nil {
-		return "", err
-	}
-	value, err := term.ReadPassword(int(file.Fd()))
-	if _, writeErr := fmt.Fprintln(output); writeErr != nil && err == nil {
-		err = writeErr
-	}
-	if err != nil {
-		return "", errors.New("cannot read credential input")
-	}
-	return strings.TrimSpace(string(value)), nil
 }
 
 func readConfigDocument(path string) (string, bool, error) {

--- a/internal/cli/config_command_test.go
+++ b/internal/cli/config_command_test.go
@@ -16,6 +16,7 @@ package cli
 
 import (
 	"encoding/json/v2"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -27,7 +28,7 @@ const (
 	configEndMarker   = "# <<< powercontext managed configuration <<<"
 )
 
-func TestConfigInitShowAndValidateManageOneCredentialFreeEnvironmentFile(t *testing.T) {
+func TestConfigInitShowAndValidateManageOneProviderEnvironmentFile(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "powercontext.env")
 	stdout, _, err := executeSystemCLI(
 		t, nil, &scriptedSystemCommands{t: t}, "config", "init", "--output", path, "--non-interactive",
@@ -45,17 +46,137 @@ func TestConfigInitShowAndValidateManageOneCredentialFreeEnvironmentFile(t *test
 	if !strings.Contains(string(content), configBeginMarker) || !strings.Contains(string(content), "POWERCONTEXT_SERVER_DATABASE_URL=") {
 		t.Fatalf("configuration content = %q", content)
 	}
-	updated := strings.Replace(string(content), "OPENROUTER_API_KEY=\"\"", "OPENROUTER_API_KEY=runtime-secret", 1)
+	updated := strings.Replace(string(content), "OPENAI_API_KEY=\"\"", "OPENAI_API_KEY=runtime-secret", 1)
 	if err := os.WriteFile(path, []byte(updated), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
 	shown, _, showErr := executeSystemCLI(t, nil, &scriptedSystemCommands{t: t}, "config", "show", "--env-file", path)
-	if showErr != nil || !strings.Contains(shown, "OPENROUTER_API_KEY=<redacted>") || strings.Contains(shown, "runtime-secret") {
+	if showErr != nil || !strings.Contains(shown, "OPENAI_API_KEY=<redacted>") || strings.Contains(shown, "runtime-secret") {
 		t.Fatalf("show output = %q, error = %v", shown, showErr)
 	}
 	if _, _, validateErr := executeSystemCLI(t, nil, &scriptedSystemCommands{t: t}, "config", "validate", "--env-file", path); validateErr != nil {
 		t.Fatal(validateErr)
+	}
+}
+
+func TestConfigInitCollectsOpenAIProtocolAndRedactsCredential(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "powercontext.env")
+	input := strings.NewReader("\n\n\n\n\nshared-secret\n\n\n")
+	stdout, stderr, err := executeSystemCLIWithInput(
+		t, &scriptedSystemCommands{t: t}, input, "config", "init", "--output", path,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stdout, "configuration initialized") ||
+		!strings.Contains(stderr, "Generation API protocol") ||
+		!strings.Contains(stderr, "Generation API Base URL") ||
+		!strings.Contains(stderr, "Generation API key") ||
+		!strings.Contains(stderr, "Generation model") {
+		t.Fatalf("stdout/stderr = %q / %q", stdout, stderr)
+	}
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	values, err := parseConfigEnvironment(string(content))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if values["OPENAI_API_KEY"] != "shared-secret" || values["OPENAI_BASE_URL"] != "https://api.openai.com/v1" ||
+		values["POWERCONTEXT_SERVER_INFERENCE_GENERATION_MODEL"] != "openai-chat:gpt-4.1-mini" {
+		t.Fatalf("environment = %#v", values)
+	}
+	shown, _, showErr := executeSystemCLI(t, nil, &scriptedSystemCommands{t: t}, "config", "show", "--env-file", path)
+	if showErr != nil || !strings.Contains(shown, "OPENAI_API_KEY=<redacted>") || strings.Contains(shown, "shared-secret") {
+		t.Fatalf("show output = %q, error = %v", shown, showErr)
+	}
+}
+
+func TestConfigInitRefusesToReplaceExistingEnvironmentWithoutForce(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "existing.env")
+	if err := os.WriteFile(path, []byte("EXISTING=value\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, err := executeSystemCLI(t, nil, &scriptedSystemCommands{t: t}, "config", "init", "--output", path, "--non-interactive")
+	if err == nil || !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("init error = %v", err)
+	}
+	content, readErr := os.ReadFile(path)
+	if readErr != nil || string(content) != "EXISTING=value\n" {
+		t.Fatalf("existing environment = %q, %v", content, readErr)
+	}
+}
+
+func TestConfigInitRejectsServerInvalidConfigurationBeforeWriting(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "invalid.env")
+	input := strings.NewReader(strings.Join([]string{
+		strings.Repeat("p", 256), "", "", "", "", "shared-secret", "", "",
+	}, "\n") + "\n")
+
+	_, _, err := executeSystemCLIWithInput(t, &scriptedSystemCommands{t: t}, input, "config", "init", "--output", path)
+	if err == nil || !strings.Contains(err.Error(), "Scope ID must contain at most 255 characters") {
+		t.Fatalf("init error = %v", err)
+	}
+	if _, statErr := os.Stat(path); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("invalid configuration wrote %q: %v", path, statErr)
+	}
+}
+
+func TestParseConfigEnvironmentRejectsDuplicateAssignments(t *testing.T) {
+	_, err := parseConfigEnvironment("VALUE=one\nVALUE=two\n")
+	if err == nil || !strings.Contains(err.Error(), "duplicate environment assignment") {
+		t.Fatalf("parse error = %v", err)
+	}
+}
+
+func TestConfigValidateReportsInvalidProviderAwareNumericValueWithoutTraceback(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "invalid.env")
+	config := defaultProviderAwareConfig()
+	block, err := renderProviderAwareConfigBlock(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := strings.Replace(block, "POWERCONTEXT_SERVER_INFERENCE_EMBEDDING_DIMENSION=\"1536\"", "POWERCONTEXT_SERVER_INFERENCE_EMBEDDING_DIMENSION=invalid", 1)
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, stderr, validateErr := executeSystemCLI(t, nil, &scriptedSystemCommands{t: t}, "config", "validate", "--env-file", path)
+	if validateErr == nil || !strings.Contains(validateErr.Error(), "must be an integer") || strings.Contains(stderr, "Traceback") {
+		t.Fatalf("validate error/stderr = %v / %q", validateErr, stderr)
+	}
+}
+
+func TestConfigShowRedactsRecordedCustomCredentialAndKeepsUnmarkedValue(t *testing.T) {
+	config := defaultProviderAwareConfig()
+	config.generation = configModelSelection{
+		model: "openai:custom-generation",
+		environment: []configProviderVariable{
+			{name: "CUSTOM_CREDENTIAL", value: "custom-secret"},
+			{name: "AWS_REGION", value: "us-west-2"},
+		},
+	}
+	config.embedding = configModelSelection{
+		model:       "openai:custom-embedding",
+		environment: []configProviderVariable{{name: "CUSTOM_CREDENTIAL", value: "custom-secret"}},
+	}
+	config.credentials = []string{"CUSTOM_CREDENTIAL"}
+	block, err := renderProviderAwareConfigBlock(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(t.TempDir(), "custom.env")
+	if err := os.WriteFile(path, []byte(block), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	shown, _, showErr := executeSystemCLI(t, nil, &scriptedSystemCommands{t: t}, "config", "show", "--env-file", path)
+	if showErr != nil || !strings.Contains(shown, "CUSTOM_CREDENTIAL=<redacted>") ||
+		strings.Contains(shown, "custom-secret") || !strings.Contains(shown, "AWS_REGION=us-west-2") {
+		t.Fatalf("show output = %q, error = %v", shown, showErr)
 	}
 }
 

--- a/internal/cli/config_model.go
+++ b/internal/cli/config_model.go
@@ -1,0 +1,366 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"encoding/json/v2"
+	"errors"
+	"fmt"
+	"maps"
+	"net/url"
+	"regexp"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/ob-labs/powercontext-go/inference"
+	"github.com/ob-labs/powercontext-go/internal/modelprovider"
+	"github.com/ob-labs/powercontext-go/server"
+)
+
+type configProviderVariable struct {
+	name  string
+	value string
+}
+
+type configModelSelection struct {
+	model       string
+	environment []configProviderVariable
+}
+
+type providerAwareConfig struct {
+	scopeID            string
+	displayName        string
+	generation         configModelSelection
+	embedding          configModelSelection
+	embeddingProfileID string
+	embeddingDimension int
+	credentials        []string
+}
+
+type configDashboardScope struct {
+	ScopeID     string `json:"scope_id"`
+	DisplayName string `json:"display_name"`
+}
+
+var configProfileComponent = regexp.MustCompile(`[^a-z0-9]+`)
+
+func defaultProviderAwareConfig() providerAwareConfig {
+	return providerAwareConfig{
+		scopeID: "project:quickstart", displayName: "Quick Start",
+		generation: configModelSelection{
+			model: "openai-chat:gpt-4.1-mini",
+			environment: []configProviderVariable{
+				{name: "OPENAI_BASE_URL", value: "https://api.openai.com/v1"},
+				{name: "OPENAI_API_KEY", value: ""},
+			},
+		},
+		embedding: configModelSelection{
+			model: "openai:text-embedding-3-small",
+			environment: []configProviderVariable{
+				{name: "OPENAI_BASE_URL", value: "https://api.openai.com/v1"},
+				{name: "OPENAI_API_KEY", value: ""},
+			},
+		},
+		embeddingProfileID: "openai-text-embedding-3-small-1536-unit-v1",
+		embeddingDimension: 1536,
+		credentials:        []string{"OPENAI_API_KEY"},
+	}
+}
+
+func validateProviderAwareConfig(config providerAwareConfig, strictCredentials bool) error {
+	if strings.TrimSpace(config.scopeID) == "" || strings.TrimSpace(config.displayName) == "" {
+		return errors.New("Scope ID and Dashboard display name are required")
+	}
+	if len(config.scopeID) > 255 {
+		return errors.New("Scope ID must contain at most 255 characters")
+	}
+	if len(config.displayName) > 80 {
+		return errors.New("Dashboard display name must contain at most 80 characters")
+	}
+	if config.embeddingDimension < 1 {
+		return errors.New("Embedding dimension must be positive")
+	}
+
+	values := make(map[string]string)
+	if err := validateConfigModelSelection(config.generation, modelprovider.Generation, values); err != nil {
+		return err
+	}
+	if err := validateConfigModelSelection(config.embedding, modelprovider.Embedding, values); err != nil {
+		return err
+	}
+	credentials := make(map[string]struct{}, len(config.credentials))
+	for _, name := range config.credentials {
+		if !configEnvironmentName.MatchString(name) {
+			return errors.New("invalid credential environment variable")
+		}
+		if _, exists := credentials[name]; exists {
+			return errors.New("duplicate credential environment variable")
+		}
+		credentials[name] = struct{}{}
+		if strictCredentials && strings.TrimSpace(values[name]) == "" {
+			return errors.New("provider credential is required")
+		}
+	}
+	if !strictCredentials {
+		return nil
+	}
+	factory, err := modelprovider.NewFactory(modelprovider.MilestoneB, lookupConfigEnvironment(values), nil)
+	if err != nil {
+		return errors.New("provider models cannot be configured")
+	}
+	if _, err := factory.TextModel(config.generation.model); err != nil {
+		return configProviderValidationError(err)
+	}
+	if _, err := factory.EmbeddingTransport(config.embedding.model); err != nil {
+		return configProviderValidationError(err)
+	}
+	return nil
+}
+
+func validateConfigModelSelection(
+	selection configModelSelection,
+	capability modelprovider.Capability,
+	values map[string]string,
+) error {
+	route, err := modelprovider.Resolve(selection.model, capability)
+	if err != nil || modelprovider.RequireAvailable(route, modelprovider.MilestoneB) != nil {
+		return errors.New("provider models cannot be configured")
+	}
+	seen := make(map[string]struct{}, len(selection.environment))
+	for _, variable := range selection.environment {
+		if !configEnvironmentName.MatchString(variable.name) {
+			return errors.New("invalid provider environment variable")
+		}
+		if _, exists := seen[variable.name]; exists {
+			return errors.New("duplicate provider environment variable")
+		}
+		seen[variable.name] = struct{}{}
+		if configBaseURLName(variable.name) {
+			parsed, parseErr := url.Parse(variable.value)
+			if parseErr != nil || parsed.User != nil {
+				return errors.New("provider Base URL must not contain credentials")
+			}
+		}
+		if existing, exists := values[variable.name]; exists && existing != variable.value {
+			return fmt.Errorf("Generation and Embedding selected conflicting values for %s", variable.name)
+		}
+		values[variable.name] = variable.value
+	}
+	return nil
+}
+
+func configBaseURLName(name string) bool {
+	upper := strings.ToUpper(name)
+	return strings.HasSuffix(upper, "_BASE_URL") || strings.HasSuffix(upper, "_ENDPOINT") ||
+		strings.HasSuffix(upper, "_INFERENCE_URL")
+}
+
+func lookupConfigEnvironment(values map[string]string) modelprovider.EnvLookup {
+	return func(name string) (string, bool) {
+		value, found := values[name]
+		return value, found
+	}
+}
+
+func configProviderValidationError(err error) error {
+	configuration, ok := errors.AsType[*inference.ConfigurationError](err)
+	if ok && strings.Contains(configuration.Detail(), "requires") {
+		return errors.New("provider credential is required")
+	}
+	return errors.New("provider models cannot be configured")
+}
+
+func renderProviderAwareEnvironment(config providerAwareConfig) (map[string]string, error) {
+	if err := validateProviderAwareConfig(config, false); err != nil {
+		return nil, err
+	}
+	defaults, err := server.DefaultConfig()
+	if err != nil {
+		return nil, err
+	}
+	scopes, err := json.Marshal([]configDashboardScope{{ScopeID: config.scopeID, DisplayName: config.displayName}})
+	if err != nil {
+		return nil, err
+	}
+	values := map[string]string{
+		"POWERCONTEXT_SERVER_HTTP_HOST":                         defaults.HTTP.Host,
+		"POWERCONTEXT_SERVER_HTTP_PORT":                         strconv.Itoa(defaults.HTTP.Port),
+		"POWERCONTEXT_SERVER_MCP_ENABLED":                       strconv.FormatBool(defaults.MCP.Enabled),
+		"POWERCONTEXT_SERVER_MCP_PATH":                          defaults.MCP.Path,
+		"POWERCONTEXT_SERVER_AUTH_ENABLED":                      strconv.FormatBool(defaults.Auth.Enabled),
+		"POWERCONTEXT_SERVER_DASHBOARD_ENABLED":                 "true",
+		"POWERCONTEXT_SERVER_DASHBOARD_SCOPES":                  string(scopes),
+		"POWERCONTEXT_SERVER_DATABASE_KIND":                     "sqlite",
+		"POWERCONTEXT_SERVER_DATABASE_URL":                      defaults.Database.SQLite.URL,
+		"POWERCONTEXT_SERVER_RUNTIME_SOURCE_WINDOW_LIMIT":       strconv.FormatInt(defaults.Runtime.SourceWindowLimit, 10),
+		"POWERCONTEXT_SERVER_INFERENCE_GENERATION_MODEL":        config.generation.model,
+		"POWERCONTEXT_SERVER_INFERENCE_EMBEDDING_MODEL":         config.embedding.model,
+		"POWERCONTEXT_SERVER_INFERENCE_EMBEDDING_PROFILE_ID":    config.embeddingProfileID,
+		"POWERCONTEXT_SERVER_INFERENCE_EMBEDDING_DIMENSION":     strconv.Itoa(config.embeddingDimension),
+		"POWERCONTEXT_SERVER_INFERENCE_EMBEDDING_NORMALIZATION": "unit",
+	}
+	for _, selection := range []configModelSelection{config.generation, config.embedding} {
+		for _, variable := range selection.environment {
+			if existing, exists := values[variable.name]; exists && existing != variable.value {
+				return nil, fmt.Errorf("Generation and Embedding selected conflicting values for %s", variable.name)
+			}
+			values[variable.name] = variable.value
+		}
+	}
+	return values, nil
+}
+
+func renderProviderAwareConfigBlock(config providerAwareConfig) (string, error) {
+	values, err := renderProviderAwareEnvironment(config)
+	if err != nil {
+		return "", err
+	}
+	lines := []string{
+		configManagedBegin,
+		"# config-version=1",
+		"# generation-environment=" + configEnvironmentNames(config.generation),
+		"# embedding-environment=" + configEnvironmentNames(config.embedding),
+	}
+	if len(config.credentials) > 0 {
+		lines = append(lines, "# credentials="+strings.Join(config.credentials, ","))
+	}
+	for _, name := range slices.Sorted(maps.Keys(values)) {
+		lines = append(lines, name+"="+strconv.Quote(values[name]))
+	}
+	lines = append(lines, configManagedEnd)
+	return strings.Join(lines, "\n"), nil
+}
+
+func configEnvironmentNames(selection configModelSelection) string {
+	names := make([]string, 0, len(selection.environment))
+	for _, variable := range selection.environment {
+		names = append(names, variable.name)
+	}
+	return strings.Join(names, ",")
+}
+
+func configProfileID(model string, dimension int) string {
+	normalized := strings.Trim(configProfileComponent.ReplaceAllString(strings.ToLower(model), "-"), "-")
+	return fmt.Sprintf("%s-%d-unit-v1", normalized, dimension)
+}
+
+func providerAwareManagedEnvironment(config providerAwareConfig) map[string]string {
+	values, err := renderProviderAwareEnvironment(config)
+	if err != nil {
+		return nil
+	}
+	return values
+}
+
+func replaceConfigManagedBlock(content, block string) string {
+	begin := configManagedBeginLine.FindStringIndex(content)
+	end := configManagedEndLine.FindStringIndex(content)
+	if begin == nil || end == nil || end[0] < begin[1] {
+		return content
+	}
+	return joinConfigDocument(content[:begin[0]], block, content[end[1]:])
+}
+
+func providerAwareConfigFromDocument(content string, values map[string]string) (*providerAwareConfig, error) {
+	metadata, err := configManagedMetadata(content)
+	if err != nil {
+		return nil, err
+	}
+	if metadata == nil {
+		return nil, nil
+	}
+	generationModel, generationConfigured := values["POWERCONTEXT_SERVER_INFERENCE_GENERATION_MODEL"]
+	embeddingModel, embeddingConfigured := values["POWERCONTEXT_SERVER_INFERENCE_EMBEDDING_MODEL"]
+	if !generationConfigured && !embeddingConfigured {
+		return nil, nil
+	}
+	if !generationConfigured || !embeddingConfigured {
+		return nil, errors.New("both generation and embedding models must be configured")
+	}
+	dimensionValue, found := values["POWERCONTEXT_SERVER_INFERENCE_EMBEDDING_DIMENSION"]
+	if !found {
+		return nil, errors.New("POWERCONTEXT_SERVER_INFERENCE_EMBEDDING_DIMENSION must be an integer")
+	}
+	dimension, parseErr := strconv.Atoi(dimensionValue)
+	if parseErr != nil {
+		return nil, errors.New("POWERCONTEXT_SERVER_INFERENCE_EMBEDDING_DIMENSION must be an integer")
+	}
+	generation, err := configSelectionFromMetadata("generation", generationModel, metadata, values)
+	if err != nil {
+		return nil, err
+	}
+	embedding, err := configSelectionFromMetadata("embedding", embeddingModel, metadata, values)
+	if err != nil {
+		return nil, err
+	}
+	credentials := strings.Split(metadata["credentials"], ",")
+	if len(credentials) == 1 && credentials[0] == "" {
+		credentials = nil
+	}
+	profileID := values["POWERCONTEXT_SERVER_INFERENCE_EMBEDDING_PROFILE_ID"]
+	if profileID == "" {
+		profileID = configProfileID(embeddingModel, dimension)
+	}
+	return &providerAwareConfig{
+		scopeID: "project:quickstart", displayName: "Quick Start",
+		generation: generation, embedding: embedding, embeddingProfileID: profileID,
+		embeddingDimension: dimension, credentials: credentials,
+	}, nil
+}
+
+func configManagedMetadata(content string) (map[string]string, error) {
+	beginMarkers := configManagedBeginLine.FindAllStringIndex(content, -1)
+	endMarkers := configManagedEndLine.FindAllStringIndex(content, -1)
+	if len(beginMarkers) == 0 && len(endMarkers) == 0 {
+		return nil, nil
+	}
+	if len(beginMarkers) != 1 || len(endMarkers) != 1 || endMarkers[0][0] < beginMarkers[0][1] {
+		return nil, errors.New("environment contains mismatched or repeated PowerContext managed markers")
+	}
+	metadata := make(map[string]string)
+	for line := range strings.SplitSeq(content[beginMarkers[0][1]:endMarkers[0][0]], "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "# ") {
+			continue
+		}
+		name, value, found := strings.Cut(strings.TrimPrefix(line, "# "), "=")
+		if found {
+			metadata[name] = value
+		}
+	}
+	return metadata, nil
+}
+
+func configSelectionFromMetadata(
+	role, model string,
+	metadata map[string]string,
+	values map[string]string,
+) (configModelSelection, error) {
+	name := role + "-environment"
+	variableNames := strings.Split(metadata[name], ",")
+	if len(variableNames) == 1 && variableNames[0] == "" {
+		variableNames = nil
+	}
+	variables := make([]configProviderVariable, 0, len(variableNames))
+	for _, variableName := range variableNames {
+		value, found := values[variableName]
+		if !found {
+			return configModelSelection{}, fmt.Errorf("missing provider environment variable: %s", variableName)
+		}
+		variables = append(variables, configProviderVariable{name: variableName, value: value})
+	}
+	return configModelSelection{model: model, environment: variables}, nil
+}

--- a/internal/cli/config_model_test.go
+++ b/internal/cli/config_model_test.go
@@ -172,3 +172,25 @@ func TestCollectProviderAwareCustomConnectionMarksOnlyExplicitCredentials(t *tes
 		t.Fatalf("managed block = %q", block)
 	}
 }
+
+func TestCollectProviderAwareConfigDeduplicatesSharedCustomCredential(t *testing.T) {
+	input := strings.NewReader(strings.Join([]string{
+		"", "", "custom",
+		"openai-chat:gpt-4.1-mini",
+		"OPENAI_API_KEY", "true", "shared-secret", "",
+		"openai:text-embedding-3-small",
+		"OPENAI_API_KEY", "true", "shared-secret", "",
+		"1536",
+	}, "\n") + "\n")
+
+	config, err := collectProviderAwareConfig(input, &bytes.Buffer{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if credentials := strings.Join(config.credentials, ","); credentials != "OPENAI_API_KEY" {
+		t.Fatalf("credentials = %q", credentials)
+	}
+	if err := validateProviderAwareConfig(config, true); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/cli/config_model_test.go
+++ b/internal/cli/config_model_test.go
@@ -1,0 +1,174 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"bytes"
+	"encoding/json/v2"
+	"strings"
+	"testing"
+)
+
+func TestProviderAwareConfigAllowsSupportedModelsAndExplicitEnvironment(t *testing.T) {
+	config := defaultProviderAwareConfig()
+	config.generation = configModelSelection{
+		model: "bedrock:anthropic.claude-sonnet",
+		environment: []configProviderVariable{
+			{name: "AWS_PROFILE", value: "development"},
+			{name: "AWS_REGION", value: "us-west-2"},
+		},
+	}
+	config.embedding = configModelSelection{
+		model:       "voyageai:voyage-3",
+		environment: []configProviderVariable{{name: "VOYAGE_API_KEY", value: "voyage-secret"}},
+	}
+	config.credentials = []string{"VOYAGE_API_KEY"}
+
+	if err := validateProviderAwareConfig(config, true); err != nil {
+		t.Fatal(err)
+	}
+	values, err := renderProviderAwareEnvironment(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if values["POWERCONTEXT_SERVER_INFERENCE_GENERATION_MODEL"] != "bedrock:anthropic.claude-sonnet" ||
+		values["AWS_PROFILE"] != "development" || values["AWS_REGION"] != "us-west-2" ||
+		values["VOYAGE_API_KEY"] != "voyage-secret" {
+		t.Fatalf("environment = %#v", values)
+	}
+	var scopes []struct {
+		ScopeID     string `json:"scope_id"`
+		DisplayName string `json:"display_name"`
+	}
+	if scopeErr := json.Unmarshal([]byte(values["POWERCONTEXT_SERVER_DASHBOARD_SCOPES"]), &scopes); scopeErr != nil ||
+		values["POWERCONTEXT_SERVER_DASHBOARD_ENABLED"] != "true" || len(scopes) != 1 ||
+		scopes[0].ScopeID != "project:quickstart" || scopes[0].DisplayName != "Quick Start" {
+		t.Fatalf("dashboard configuration = %#v, scopes = %#v, err = %v", values, scopes, scopeErr)
+	}
+	block, err := renderProviderAwareConfigBlock(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(block, "# generation-environment=AWS_PROFILE,AWS_REGION") ||
+		!strings.Contains(block, "# embedding-environment=VOYAGE_API_KEY") ||
+		!strings.Contains(block, "# credentials=VOYAGE_API_KEY") {
+		t.Fatalf("managed block = %q", block)
+	}
+}
+
+func TestProviderAwareConfigRejectsCredentialBearingBaseURL(t *testing.T) {
+	config := defaultProviderAwareConfig()
+	config.generation.environment = []configProviderVariable{
+		{name: "OPENAI_BASE_URL", value: "https://user:password@example.com/v1"},
+		{name: "OPENAI_API_KEY", value: "secret"},
+	}
+	config.credentials = []string{"OPENAI_API_KEY"}
+
+	err := validateProviderAwareConfig(config, true)
+	if err == nil || !strings.Contains(err.Error(), "must not contain credentials") ||
+		strings.Contains(err.Error(), "password") {
+		t.Fatalf("validation error = %v", err)
+	}
+}
+
+func TestProviderAwareConfigRejectsDuplicateEnvironmentNames(t *testing.T) {
+	config := defaultProviderAwareConfig()
+	config.generation.environment = []configProviderVariable{
+		{name: "OPENAI_API_KEY", value: "one"},
+		{name: "OPENAI_API_KEY", value: "two"},
+	}
+
+	err := validateProviderAwareConfig(config, true)
+	if err == nil || !strings.Contains(err.Error(), "duplicate provider environment variable") {
+		t.Fatalf("validation error = %v", err)
+	}
+}
+
+func TestProviderAwareConfigRejectsUnknownProviderBeforeWriting(t *testing.T) {
+	config := defaultProviderAwareConfig()
+	config.generation.model = "missing-provider:model"
+
+	err := validateProviderAwareConfig(config, false)
+	if err == nil || !strings.Contains(err.Error(), "provider models cannot be configured") {
+		t.Fatalf("validation error = %v", err)
+	}
+}
+
+func TestProviderAwareConfigTemplateAllowsBlankCredentialButStrictValidationRejectsIt(t *testing.T) {
+	config := defaultProviderAwareConfig()
+	config.generation.environment = []configProviderVariable{{name: "OPENAI_API_KEY", value: ""}}
+	config.embedding.environment = []configProviderVariable{{name: "OPENAI_API_KEY", value: ""}}
+	config.credentials = []string{"OPENAI_API_KEY"}
+
+	if err := validateProviderAwareConfig(config, false); err != nil {
+		t.Fatalf("template validation = %v", err)
+	}
+	err := validateProviderAwareConfig(config, true)
+	if err == nil || !strings.Contains(err.Error(), "provider credential is required") {
+		t.Fatalf("strict validation error = %v", err)
+	}
+}
+
+func TestProviderAwareConfigDoesNotInferCredentialsFromModelPrefix(t *testing.T) {
+	config := defaultProviderAwareConfig()
+	config.generation = configModelSelection{
+		model:       "openai:custom-generation",
+		environment: []configProviderVariable{{name: "CUSTOM_CREDENTIAL", value: "secret"}},
+	}
+	config.embedding = configModelSelection{
+		model:       "voyageai:custom-embedding",
+		environment: []configProviderVariable{{name: "VOYAGE_API_KEY", value: "secret"}},
+	}
+	config.credentials = []string{"CUSTOM_CREDENTIAL", "VOYAGE_API_KEY"}
+
+	block, err := renderProviderAwareConfigBlock(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(block, "# credentials=CUSTOM_CREDENTIAL,VOYAGE_API_KEY") ||
+		strings.Contains(block, "OPENAI_API_KEY") {
+		t.Fatalf("managed block = %q", block)
+	}
+}
+
+func TestCollectProviderAwareCustomConnectionMarksOnlyExplicitCredentials(t *testing.T) {
+	input := strings.NewReader(strings.Join([]string{
+		"", "", "custom",
+		"openai:custom-generation",
+		"CUSTOM_CREDENTIAL", "true", "custom-secret",
+		"AWS_REGION", "false", "us-west-2", "",
+		"voyageai:custom-embedding",
+		"VOYAGE_API_KEY", "true", "voyage-secret", "",
+		"1536",
+	}, "\n") + "\n")
+	var output bytes.Buffer
+	config, err := collectProviderAwareConfig(input, &output)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if config.generation.model != "openai:custom-generation" ||
+		config.embedding.model != "voyageai:custom-embedding" ||
+		strings.Join(config.credentials, ",") != "CUSTOM_CREDENTIAL,VOYAGE_API_KEY" {
+		t.Fatalf("configuration = %#v", config)
+	}
+	block, err := renderProviderAwareConfigBlock(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(block, "# credentials=CUSTOM_CREDENTIAL,VOYAGE_API_KEY") ||
+		strings.Contains(block, "OPENAI_API_KEY") || !strings.Contains(block, "AWS_REGION=\"us-west-2\"") {
+		t.Fatalf("managed block = %q", block)
+	}
+}

--- a/test/conformance/parity-inventory-rules.json
+++ b/test/conformance/parity-inventory-rules.json
@@ -147,14 +147,95 @@
       "mode": "go-port",
       "reason": "Managed environment initialization, validation, credential input, and redacted display map to the Go CLI.",
       "cases": {
+        "test_init_asks_for_protocol_endpoint_key_and_plain_model_name": {
+          "evidence": [
+            "go:internal/cli/config_command_test.go#TestConfigInitCollectsOpenAIProtocolAndRedactsCredential"
+          ]
+        },
+        "test_arbitrary_model_providers_and_environment_variables_are_not_rejected": {
+          "evidence": [
+            "go:internal/cli/config_model_test.go#TestProviderAwareConfigAllowsSupportedModelsAndExplicitEnvironment"
+          ]
+        },
+        "test_provider_base_url_rejects_embedded_credentials": {
+          "evidence": [
+            "go:internal/cli/config_model_test.go#TestProviderAwareConfigRejectsCredentialBearingBaseURL"
+          ]
+        },
         "test_init_validate_and_show_round_trip_managed_environment": {
           "evidence": [
-            "go:internal/cli/config_command_test.go#TestConfigInitShowAndValidateManageOneCredentialFreeEnvironmentFile"
+            "go:internal/cli/config_command_test.go#TestConfigInitShowAndValidateManageOneProviderEnvironmentFile"
+          ]
+        },
+        "test_init_rejects_configuration_that_server_settings_reject": {
+          "evidence": [
+            "go:internal/cli/config_command_test.go#TestConfigInitRejectsServerInvalidConfigurationBeforeWriting"
+          ]
+        },
+        "test_init_rejects_provider_models_that_cannot_be_constructed": {
+          "evidence": [
+            "go:internal/cli/config_model_test.go#TestProviderAwareConfigRejectsUnknownProviderBeforeWriting"
           ]
         },
         "test_configuration_rejects_relative_persistent_storage": {
           "evidence": [
             "go:internal/cli/config_command_test.go#TestConfigValidateRejectsRelativeSQLitePersistencePath"
+          ]
+        },
+        "test_standard_provider_requires_a_credential": {
+          "evidence": [
+            "go:internal/cli/config_model_test.go#TestProviderAwareConfigTemplateAllowsBlankCredentialButStrictValidationRejectsIt"
+          ]
+        },
+        "test_custom_connection_is_not_reclassified_from_its_model_prefix": {
+          "evidence": [
+            "go:internal/cli/config_model_test.go#TestProviderAwareConfigDoesNotInferCredentialsFromModelPrefix"
+          ]
+        },
+        "test_init_refuses_to_replace_an_existing_environment_without_force": {
+          "evidence": [
+            "go:internal/cli/config_command_test.go#TestConfigInitRefusesToReplaceExistingEnvironmentWithoutForce"
+          ]
+        },
+        "test_environment_parser_rejects_duplicate_assignments": {
+          "evidence": [
+            "go:internal/cli/config_command_test.go#TestParseConfigEnvironmentRejectsDuplicateAssignments"
+          ]
+        },
+        "test_validate_reports_invalid_numeric_values_without_a_traceback": {
+          "evidence": [
+            "go:internal/cli/config_command_test.go#TestConfigValidateReportsInvalidProviderAwareNumericValueWithoutTraceback"
+          ]
+        },
+        "test_init_records_generated_credential_names_for_show_redaction": {
+          "evidence": [
+            "go:internal/cli/config_model_test.go#TestProviderAwareConfigDoesNotInferCredentialsFromModelPrefix"
+          ]
+        },
+        "test_custom_connection_marks_prompted_credential_for_show_redaction": {
+          "evidence": [
+            "go:internal/cli/config_model_test.go#TestCollectProviderAwareCustomConnectionMarksOnlyExplicitCredentials"
+          ]
+        },
+        "test_init_hides_and_redacts_marked_additional_credentials": {
+          "evidence": [
+            "go:internal/cli/config_model_test.go#TestCollectProviderAwareCustomConnectionMarksOnlyExplicitCredentials",
+            "go:internal/cli/config_command_test.go#TestConfigShowRedactsRecordedCustomCredentialAndKeepsUnmarkedValue"
+          ]
+        },
+        "test_collect_provider_variable_hides_input_for_credential_names": {
+          "evidence": [
+            "go:internal/cli/config_model_test.go#TestCollectProviderAwareCustomConnectionMarksOnlyExplicitCredentials"
+          ]
+        },
+        "test_collect_additional_provider_variables_hides_and_records_marked_credentials": {
+          "evidence": [
+            "go:internal/cli/config_model_test.go#TestCollectProviderAwareCustomConnectionMarksOnlyExplicitCredentials"
+          ]
+        },
+        "test_collect_additional_provider_variables_keeps_unmarked_values_visible": {
+          "evidence": [
+            "go:internal/cli/config_command_test.go#TestConfigShowRedactsRecordedCustomCredentialAndKeepsUnmarkedValue"
           ]
         },
         "test_show_redacts_standard_credential_container_variables": {

--- a/test/conformance/parity-inventory.json
+++ b/test/conformance/parity-inventory.json
@@ -4,8 +4,8 @@
   "oracle_commit": "3a6cb0151670eaff7dc0293466edd673124e80da",
   "python_test_file_count": 132,
   "python_test_case_count": 812,
-  "mapped_case_count": 725,
-  "pending_case_count": 87,
+  "mapped_case_count": 741,
+  "pending_case_count": 71,
   "entries": [
     {
       "python": {
@@ -8588,8 +8588,15 @@
         "line": 26
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/config_command_test.go",
+          "test": "TestConfigInitCollectsOpenAIProtocolAndRedactsCredential"
+        }
+      ]
     },
     {
       "python": {
@@ -8598,8 +8605,15 @@
         "line": 57
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/config_model_test.go",
+          "test": "TestProviderAwareConfigAllowsSupportedModelsAndExplicitEnvironment"
+        }
+      ]
     },
     {
       "python": {
@@ -8608,8 +8622,15 @@
         "line": 81
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/config_model_test.go",
+          "test": "TestProviderAwareConfigRejectsCredentialBearingBaseURL"
+        }
+      ]
     },
     {
       "python": {
@@ -8624,7 +8645,7 @@
         {
           "kind": "go",
           "file": "internal/cli/config_command_test.go",
-          "test": "TestConfigInitShowAndValidateManageOneCredentialFreeEnvironmentFile"
+          "test": "TestConfigInitShowAndValidateManageOneProviderEnvironmentFile"
         }
       ]
     },
@@ -8635,8 +8656,15 @@
         "line": 123
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/config_command_test.go",
+          "test": "TestConfigInitRejectsServerInvalidConfigurationBeforeWriting"
+        }
+      ]
     },
     {
       "python": {
@@ -8645,8 +8673,15 @@
         "line": 138
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/config_model_test.go",
+          "test": "TestProviderAwareConfigRejectsUnknownProviderBeforeWriting"
+        }
+      ]
     },
     {
       "python": {
@@ -8672,8 +8707,15 @@
         "line": 177
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/config_model_test.go",
+          "test": "TestProviderAwareConfigTemplateAllowsBlankCredentialButStrictValidationRejectsIt"
+        }
+      ]
     },
     {
       "python": {
@@ -8682,8 +8724,15 @@
         "line": 192
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/config_model_test.go",
+          "test": "TestProviderAwareConfigDoesNotInferCredentialsFromModelPrefix"
+        }
+      ]
     },
     {
       "python": {
@@ -8692,8 +8741,15 @@
         "line": 217
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/config_command_test.go",
+          "test": "TestConfigInitRefusesToReplaceExistingEnvironmentWithoutForce"
+        }
+      ]
     },
     {
       "python": {
@@ -8702,8 +8758,15 @@
         "line": 232
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/config_command_test.go",
+          "test": "TestParseConfigEnvironmentRejectsDuplicateAssignments"
+        }
+      ]
     },
     {
       "python": {
@@ -8712,8 +8775,15 @@
         "line": 237
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/config_command_test.go",
+          "test": "TestConfigValidateReportsInvalidProviderAwareNumericValueWithoutTraceback"
+        }
+      ]
     },
     {
       "python": {
@@ -8739,8 +8809,15 @@
         "line": 267
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/config_model_test.go",
+          "test": "TestProviderAwareConfigDoesNotInferCredentialsFromModelPrefix"
+        }
+      ]
     },
     {
       "python": {
@@ -8783,8 +8860,15 @@
         "line": 332
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/config_model_test.go",
+          "test": "TestCollectProviderAwareCustomConnectionMarksOnlyExplicitCredentials"
+        }
+      ]
     },
     {
       "python": {
@@ -8793,8 +8877,20 @@
         "line": 373
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/config_model_test.go",
+          "test": "TestCollectProviderAwareCustomConnectionMarksOnlyExplicitCredentials"
+        },
+        {
+          "kind": "go",
+          "file": "internal/cli/config_command_test.go",
+          "test": "TestConfigShowRedactsRecordedCustomCredentialAndKeepsUnmarkedValue"
+        }
+      ]
     },
     {
       "python": {
@@ -8803,8 +8899,15 @@
         "line": 396
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/config_model_test.go",
+          "test": "TestCollectProviderAwareCustomConnectionMarksOnlyExplicitCredentials"
+        }
+      ]
     },
     {
       "python": {
@@ -8813,8 +8916,15 @@
         "line": 411
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/config_model_test.go",
+          "test": "TestCollectProviderAwareCustomConnectionMarksOnlyExplicitCredentials"
+        }
+      ]
     },
     {
       "python": {
@@ -8823,8 +8933,15 @@
         "line": 432
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/config_command_test.go",
+          "test": "TestConfigShowRedactsRecordedCustomCredentialAndKeepsUnmarkedValue"
+        }
+      ]
     },
     {
       "python": {


### PR DESCRIPTION
Part of #3.

This ports the v0.1.0 provider-aware configuration contract into the Go config CLI. Config init now records generation and embedding model selections, provider-specific environment names, and explicit credential metadata in the managed block. Config show redacts recorded credentials while retaining unmarked operational values. Config validate reconstructs that metadata, reports malformed numeric values before generic Server validation, requires recorded credentials for a runnable configuration, and uses the existing Go provider route/factory contract to reject models that cannot be constructed.

Noninteractive init remains a credential-free template generator. Interactive OpenAI collection uses a terminal password read for credential input; custom provider:model collection requires explicit variable and credential markers. Base URL assignments reject embedded userinfo. Existing-file protection and managed-block preservation remain unchanged.

Parity: maps the 16 v0.1.0 tests/test_config_cli.py cases. Generated inventory changes from 725 mapped / 87 pending to 741 mapped / 71 pending.

Validation: focused CLI command/model tests, modelprovider factory/registry tests, Server config tests, vet, exact-target parity generation check, go mod tidy -diff, go mod verify, and diff checks passed after a fresh main-base check. Local full internal/cli is blocked only by pre-existing Windows symlink privilege tests. Local lint has two pre-existing SA4023 diagnostics in internal/sqlstore/database.go; exact-Head Linux CI is required for full proof.