### PR TITLE
docs: define pre-WP6 v0.1.0 operation contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Generated code under `api/v1` and generated operation tables are never edited
 by hand. Compatibility evidence lives under `test/conformance`: the v0.1.0
 release inventory contains 812 Python test cases in 132 files, alongside the
 immutable historical v0.0.2 fixture. At this commit, the generated inventory
-maps 741 release-target cases to case-specific evidence and records 71 as
+maps 749 release-target cases to case-specific evidence and records 63 as
 pending; the pending set is not a compatibility claim.
 
 ## Alignment and support matrix
@@ -29,7 +29,7 @@ binary release.
 
 | Surface | Current evidence | Pre-WP6 acceptance boundary |
 | --- | --- | --- |
-| Upstream release identity | `powercontext-v0.1.0` at `7b736206a53a6de6f43d4b517893ee1a80e7183d`; the generated inventory covers 812 cases in 132 files, with 741 mapped and 71 pending. | The exact target, distribution digests, fixtures, and traceability rules are checked by the release-contract workflow. |
+| Upstream release identity | `powercontext-v0.1.0` at `7b736206a53a6de6f43d4b517893ee1a80e7183d`; the generated inventory covers 812 cases in 132 files, with 749 mapped and 63 pending. | The exact target, distribution digests, fixtures, and traceability rules are checked by the release-contract workflow. |
 | Go Server, SDK, CLI, and OpenAPI | Go-native implementation with `openapi/powercontext.yaml` as the authoritative HTTP contract. | SQLite is the only database accepted before WP6. |
 | Codex and WorkBuddy | Installed integrations call the running Go Server through HTTP or MCP; their service-chain evidence is a required `Pre-WP6 host adapters` check. | These are the only host integrations counted toward WP6 acceptance. |
 | Evaluation | The Codex/SQLite evaluation control plane is executable and independently checked. | It is WP5 evidence, not evidence for every retained host adapter. |

--- a/README.md
+++ b/README.md
@@ -17,7 +17,27 @@ The HTTP source of truth is [`openapi/powercontext.yaml`](openapi/powercontext.y
 Generated code under `api/v1` and generated operation tables are never edited
 by hand. Compatibility evidence lives under `test/conformance`: the v0.1.0
 release inventory contains 812 Python test cases in 132 files, alongside the
-immutable historical v0.0.2 fixture.
+immutable historical v0.0.2 fixture. At this commit, the generated inventory
+maps 741 release-target cases to case-specific evidence and records 71 as
+pending; the pending set is not a compatibility claim.
+
+## Alignment and support matrix
+
+This table describes the currently implemented and evidenced boundary. The
+upstream Python release is the alignment target; it is not a PowerContext Go
+binary release.
+
+| Surface | Current evidence | Pre-WP6 acceptance boundary |
+| --- | --- | --- |
+| Upstream release identity | `powercontext-v0.1.0` at `7b736206a53a6de6f43d4b517893ee1a80e7183d`; the generated inventory covers 812 cases in 132 files, with 741 mapped and 71 pending. | The exact target, distribution digests, fixtures, and traceability rules are checked by the release-contract workflow. |
+| Go Server, SDK, CLI, and OpenAPI | Go-native implementation with `openapi/powercontext.yaml` as the authoritative HTTP contract. | SQLite is the only database accepted before WP6. |
+| Codex and WorkBuddy | Installed integrations call the running Go Server through HTTP or MCP; their service-chain evidence is a required `Pre-WP6 host adapters` check. | These are the only host integrations counted toward WP6 acceptance. |
+| Evaluation | The Codex/SQLite evaluation control plane is executable and independently checked. | It is WP5 evidence, not evidence for every retained host adapter. |
+| Retained adapters | Other maintained adapters retain their own executable `Post-WP6 retained host adapters` CI evidence. | Bub, Claude Code, DSH, Hermes, LangGraph, OpenClaw, OpenCode, and Pi are P3 work and are not WP6 acceptance evidence. |
+| seekDB and OceanBase | Existing code and jobs remain useful backend-plan evidence. | Feature parity, migrations, packaging, license/SBOM work, and release reconciliation are final P4 work. |
+
+See [`docs/release/INSTALL.md`](docs/release/INSTALL.md) for the exact release
+identity, configuration, upgrade, transport, and host-operation contract.
 
 ## Repository shape
 

--- a/docs/release/INSTALL.md
+++ b/docs/release/INSTALL.md
@@ -109,7 +109,7 @@ the separately secured transport with `TrustTransportSecurity`.
 
 Before WP6, Codex and WorkBuddy are the supported host-operation scope. Both
 integrations call a running Server; neither embeds SQLite or starts the Server.
-Use the [Codex integration guide](../../integrations/codex/plugins/powercontext/README.md)
+Use the [Codex integration guide](https://github.com/ob-labs/powercontext-go/blob/main/integrations/codex/plugins/powercontext/README.md)
 for MCP, hook, scope, and credential-backed header configuration. Install
 WorkBuddy with `./bin/powercontext setup workbuddy`, then run
 `./bin/powercontext doctor workbuddy` to check its Hook, MCP registration,

--- a/docs/release/INSTALL.md
+++ b/docs/release/INSTALL.md
@@ -1,5 +1,25 @@
 # Install a PowerContext binary release
 
+## Upstream v0.1.0 alignment contract
+
+The current PowerContext Go alignment target is the upstream PowerContext
+v0.1.0 release, not a published PowerContext Go binary. PowerContext Go has no
+published release archive or image yet, so do not treat the upstream Python
+wheel or source distribution as a Go installation input. They are the
+independently verifiable provenance for the behavior being aligned.
+
+| Provenance | Exact value | Verification use |
+| --- | --- | --- |
+| Upstream release | [`powercontext-v0.1.0`](https://github.com/oceanbase/powercontext/releases/tag/powercontext-v0.1.0) at `7b736206a53a6de6f43d4b517893ee1a80e7183d` | Current parity identity; do not substitute a moving upstream branch. |
+| Wheel | `powercontext-0.1.0-py3-none-any.whl` | SHA-256 `94f8fef36d4afcee09dd5231fbe5edfe47e42e41994596b775e2f203ef6fac72`. |
+| Source distribution | `powercontext-0.1.0.tar.gz` | SHA-256 `18d47a335340b0870216e2cc0fb1fd8e4d865880155daeea3b01187c950fd746`. |
+| Python distribution provenance | [PyPI `powercontext` 0.1.0](https://pypi.org/project/powercontext/0.1.0/) | Cross-check the pinned release asset before changing parity fixtures or assertions. |
+
+When the first PowerContext Go release is published, obtain its archive and
+container digests from that Go release only. The release-verification workflow
+will then verify its release-level checksums, SBOM, archive contents, version
+metadata, and bounded CLI, Server, MCP, Memory, restart, and shutdown smokes.
+
 Every archive is self-describing and contains the CLI/Server binary, the
 authoritative OpenAPI document, `.env.example`, retained host-adapter assets,
 embedded sqlite-vec, dependency licenses, build metadata, an SPDX JSON SBOM,
@@ -26,6 +46,24 @@ sha256sum --check SHA256SUMS
 
 On macOS, use `shasum -a 256 -c SHA256SUMS` in place of `sha256sum`.
 
+## Configure the SQLite pre-WP6 installation
+
+SQLite is the zero-dependency default and the only database in the pre-WP6
+installation and acceptance scope. Create, inspect, and validate the managed
+environment file before starting the Server:
+
+```sh
+./bin/powercontext config init --non-interactive
+./bin/powercontext config show --env-file .env
+./bin/powercontext config validate --env-file .env
+./bin/powercontext server run
+```
+
+`config show` redacts credentials. `config validate` checks configuration
+syntax, persistent storage paths, and constructible Server settings before the
+Server owns the SQLite database. Keep the environment file and the SQLite data
+under the operator's backup policy; do not commit either file or credentials.
+
 sqlite-vec 0.1.9 is statically embedded in every binary; no extension path or
 host SQLite package is required. The Full archive also contains ONNX Runtime under
 `lib/onnxruntime/`; set `POWERCONTEXT_ONNXRUNTIME_LIBRARY_DIR` to that
@@ -36,6 +74,48 @@ installation and acceptance scope. seekDB and OceanBase remain the final P4
 backend-alignment work; their migration, packaging, license/SBOM, and release
 reconciliation instructions are intentionally deferred until that scope is
 accepted.
+
+## Upgrade and projection safety
+
+Before replacing a binary or changing an embedding dimension, stop the Server,
+retain a recoverable copy of the SQLite database and its configuration, then
+validate the candidate configuration and start the new binary. Immutable
+Artifact revisions, Memory manifests and entry versions, and Source journal
+state are authoritative. FTS and vector indexes are rebuildable projections
+derived from that authority state.
+
+If startup reports either `sqlite-vec projection dimension ... does not match
+configured dimension ...; rebuild the projection` or `sqlite-vec projection
+schema is incompatible; rebuild the projection`, preserve the database and the
+reported dimensions. Do not manually drop, truncate, edit, or migrate the
+projection tables, and do not repeatedly restart the Server against the same
+mismatch. The pre-WP6 product has no supported automatic or operator-facing
+vector-projection rebuild command. Recover with the previously working
+configuration or backup, then use an explicitly documented future maintenance
+procedure; that procedure must rebuild only projections and must not rewrite
+the authoritative revisions or manifests.
+
+## Transport and host operation
+
+Plain HTTP is trusted only on `localhost`, `::1`, and the full `127.0.0.0/8`
+range. The Server rejects an unauthenticated non-loopback bind by default. For
+remote access, enable bearer authentication, use a strong secret outside the
+environment file, and terminate TLS before the Server. A controlled network or
+upstream TLS deployment may set
+`POWERCONTEXT_SERVER_ALLOW_UNAUTHENTICATED_NON_LOOPBACK=true`, but that opt-in
+does not add authentication or encryption. The Go Client also refuses remote
+plaintext unless its caller supplies an HTTP client and explicitly vouches for
+the separately secured transport with `TrustTransportSecurity`.
+
+Before WP6, Codex and WorkBuddy are the supported host-operation scope. Both
+integrations call a running Server; neither embeds SQLite or starts the Server.
+Use the [Codex integration guide](../../integrations/codex/plugins/powercontext/README.md)
+for MCP, hook, scope, and credential-backed header configuration. Install
+WorkBuddy with `./bin/powercontext setup workbuddy`, then run
+`./bin/powercontext doctor workbuddy` to check its Hook, MCP registration,
+managed Skill, and Server health without exposing credentials or prompt data.
+OpenCode, DSH, LangChain, Pydantic AI, Hermes, and other retained adapters
+remain post-WP6 work and are not covered by this installation contract.
 
 The binary itself does not require a Python runtime. This monorepo tracks
 Python and TypeScript assets for host-native integrations and the evaluation


### PR DESCRIPTION
## Tracking

- Tracking issue: #3
- Relationship: Part of #3; advances the first three WP6 documentation items only.

## Changes

- Add a README matrix that distinguishes the pinned v0.1.0 target from a PowerContext Go release, records the generated `812 / 749 / 63` traceability state, and preserves Codex/WorkBuddy/SQLite pre-WP6 boundaries.
- Document the verified upstream release tag, commit, wheel/sdist digests, and PyPI provenance without presenting those Python artifacts as Go installation inputs.
- Document the SQLite configuration and upgrade contract, including non-destructive vector projection drift handling, transport trust, authenticated remote operation, and Codex/WorkBuddy scope.

## Validation

- `git diff --check`
- Repository-relative Markdown target checks for the new README and Codex-guide links
- Structured comparison of the documentation against `test/conformance/parity-contract.json` and `parity-inventory.json`: `powercontext-v0.1.0`, `7b736206a53a6de6f43d4b517893ee1a80e7183d`, both asset SHA-256 values, and `812 / 749 / 63`

## Validation gaps

- `make docs-test` was stopped locally after its `uv --frozen` initialization produced no output for several minutes; exact-Head Linux `check-docs` is the complete build signal.
- `go test ./internal/cli -run '^TestParseDocumentedServerRunRejectsCommentedCommand$' -count=1` cannot build on this Windows host because CGO cannot find `sqlite3.h`; no assertions were changed.

## Non-goals

- No Go runtime, OpenAPI, persistence, projection-rebuild implementation, host adapter, backend, or release artifact changes.
- No claim that the 63 pending release-target cases, first Go release verification, OCI image verification, or the remaining WP5 work are complete.