### PR TITLE
test(conformance): map environment file release cases

### DIFF
--- a/internal/cli/config_command_test.go
+++ b/internal/cli/config_command_test.go
@@ -345,6 +345,43 @@ func TestParseConfigEnvironmentSupportsShellLiteralSyntax(t *testing.T) {
 	}
 }
 
+func TestParseConfigEnvironmentMatchesV010EnvironmentFileContract(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		key     string
+		want    string
+		wantErr bool
+	}{
+		{name: "URL fragment", content: "URL=https://example.com/page#section\n", key: "URL", want: "https://example.com/page#section"},
+		{name: "export hash", content: "export BEARER=token#a1\n", key: "BEARER", want: "token#a1"},
+		{name: "full line comments", content: "# leading comment\n\nTOKEN=value # explanation\n", key: "TOKEN", want: "value"},
+		{name: "even backslash before space", content: "TOKEN=abc\\\\ #comment\n", key: "TOKEN", want: "abc\\"},
+		{name: "escaped quote", content: "TOKEN=abc\\\" #comment\n", key: "TOKEN", want: "abc\""},
+		{name: "escaped tab", content: "TOKEN=abc\\\t#123\n", key: "TOKEN", want: "abc\t#123"},
+		{name: "trailing escaped space", content: "TOKEN=abc\\ \n", key: "TOKEN", want: "abc "},
+		{name: "trailing escaped tab", content: "TOKEN=abc\\\t\n", key: "TOKEN", want: "abc\t"},
+		{name: "unterminated quote", content: "TOKEN=\"unterminated\n", wantErr: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			values, err := parseConfigEnvironment(test.content)
+			if test.wantErr {
+				if err == nil {
+					t.Fatal("parseConfigEnvironment accepted an unterminated quote")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(values) != 1 || values[test.key] != test.want {
+				t.Fatalf("parsed values = %#v, want %s=%q", values, test.key, test.want)
+			}
+		})
+	}
+}
+
 func TestParseConfigEnvironmentRejectsExpansionAndControlInput(t *testing.T) {
 	for _, value := range []string{"$ROOT/data", "${ROOT}/data", "$(command)", "`command`", "~/data", "value\x00tail"} {
 		t.Run(value, func(t *testing.T) {

--- a/test/conformance/parity-inventory-rules.json
+++ b/test/conformance/parity-inventory-rules.json
@@ -300,6 +300,46 @@
             "go:internal/cli/config_command_test.go#TestParseConfigEnvironmentSupportsShellLiteralSyntax"
           ]
         },
+        "test_url_fragment_assignment_survives": {
+          "evidence": [
+            "go:internal/cli/config_command_test.go#TestParseConfigEnvironmentMatchesV010EnvironmentFileContract"
+          ]
+        },
+        "test_export_prefix_keeps_hash_values": {
+          "evidence": [
+            "go:internal/cli/config_command_test.go#TestParseConfigEnvironmentMatchesV010EnvironmentFileContract"
+          ]
+        },
+        "test_full_line_comments_are_ignored": {
+          "evidence": [
+            "go:internal/cli/config_command_test.go#TestParseConfigEnvironmentMatchesV010EnvironmentFileContract"
+          ]
+        },
+        "test_even_backslash_before_space_starts_a_comment_like_shell": {
+          "evidence": [
+            "go:internal/cli/config_command_test.go#TestParseConfigEnvironmentMatchesV010EnvironmentFileContract"
+          ]
+        },
+        "test_backslash_escaped_quote_outside_quotes_is_literal": {
+          "evidence": [
+            "go:internal/cli/config_command_test.go#TestParseConfigEnvironmentMatchesV010EnvironmentFileContract"
+          ]
+        },
+        "test_backslash_escaped_tab_preserves_hash_value": {
+          "evidence": [
+            "go:internal/cli/config_command_test.go#TestParseConfigEnvironmentMatchesV010EnvironmentFileContract"
+          ]
+        },
+        "test_trailing_escaped_whitespace_is_preserved": {
+          "evidence": [
+            "go:internal/cli/config_command_test.go#TestParseConfigEnvironmentMatchesV010EnvironmentFileContract"
+          ]
+        },
+        "test_unterminated_quote_is_rejected": {
+          "evidence": [
+            "go:internal/cli/config_command_test.go#TestParseConfigEnvironmentMatchesV010EnvironmentFileContract"
+          ]
+        },
         "test_unescaped_tab_starts_a_comment_boundary": {
           "evidence": [
             "go:internal/cli/config_command_test.go#TestParseConfigEnvironmentSupportsShellLiteralSyntax"

--- a/test/conformance/parity-inventory.json
+++ b/test/conformance/parity-inventory.json
@@ -4,8 +4,8 @@
   "oracle_commit": "3a6cb0151670eaff7dc0293466edd673124e80da",
   "python_test_file_count": 132,
   "python_test_case_count": 812,
-  "mapped_case_count": 741,
-  "pending_case_count": 71,
+  "mapped_case_count": 749,
+  "pending_case_count": 63,
   "entries": [
     {
       "python": {
@@ -9531,8 +9531,15 @@
         "line": 42
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/config_command_test.go",
+          "test": "TestParseConfigEnvironmentMatchesV010EnvironmentFileContract"
+        }
+      ]
     },
     {
       "python": {
@@ -9541,8 +9548,15 @@
         "line": 46
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/config_command_test.go",
+          "test": "TestParseConfigEnvironmentMatchesV010EnvironmentFileContract"
+        }
+      ]
     },
     {
       "python": {
@@ -9551,8 +9565,15 @@
         "line": 50
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/config_command_test.go",
+          "test": "TestParseConfigEnvironmentMatchesV010EnvironmentFileContract"
+        }
+      ]
     },
     {
       "python": {
@@ -9595,8 +9616,15 @@
         "line": 63
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/config_command_test.go",
+          "test": "TestParseConfigEnvironmentMatchesV010EnvironmentFileContract"
+        }
+      ]
     },
     {
       "python": {
@@ -9605,8 +9633,15 @@
         "line": 67
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/config_command_test.go",
+          "test": "TestParseConfigEnvironmentMatchesV010EnvironmentFileContract"
+        }
+      ]
     },
     {
       "python": {
@@ -9615,8 +9650,15 @@
         "line": 71
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/config_command_test.go",
+          "test": "TestParseConfigEnvironmentMatchesV010EnvironmentFileContract"
+        }
+      ]
     },
     {
       "python": {
@@ -9642,8 +9684,15 @@
         "line": 80
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/config_command_test.go",
+          "test": "TestParseConfigEnvironmentMatchesV010EnvironmentFileContract"
+        }
+      ]
     },
     {
       "python": {
@@ -9737,8 +9786,15 @@
         "line": 126
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/config_command_test.go",
+          "test": "TestParseConfigEnvironmentMatchesV010EnvironmentFileContract"
+        }
+      ]
     },
     {
       "python": {


### PR DESCRIPTION
## Summary

- add direct Go contract coverage for the eight remaining v0.1.0 `tests/test_env_file.py` shell parsing cases
- bind those cases to the new focused evidence and regenerate the 812-case inventory
- advance the active release mapping from 741 mapped / 71 pending to 749 mapped / 63 pending

## Scope and compatibility

This is traceability and regression coverage only. It does not change the configuration parser, CLI behavior, public API, persistence, generated API code, or retained-host scope.

## Verification

- `go test -count=1 ./internal/cli -run '^TestParseConfigEnvironmentMatchesV010EnvironmentFileContract$'` with the supported local SQLite header include
- `go vet ./internal/cli` with the supported local SQLite header include
- `go test -count=1 ./test/conformance -run '^TestParityInventoryMatchesContract$'` with the supported local SQLite header include
- `go run ./tools/parity-inventory-generate -upstream <v0.1.0 exact checkout> -check -check-delta -previous-upstream <f2ec1f75 exact checkout> -release-upstream <v0.1.0 exact checkout>`
- `gofmt -d internal/cli/config_command_test.go` and `git diff --check`

Part of #3.