### PR TITLE
feat(cli): load Server settings from environment files

### DIFF
--- a/internal/cli/python_contract_test.go
+++ b/internal/cli/python_contract_test.go
@@ -217,6 +217,140 @@ func TestServerCommandLayersPartialCLIOverridesOverEnvironment(t *testing.T) {
 	}
 }
 
+func TestServerCommandEnvFileOverridesStaleEnvironmentAndRestores(t *testing.T) {
+	t.Setenv(server.PowerContextHomeEnv, t.TempDir())
+	t.Setenv("OPENAI_API_KEY", "shell-secret")
+	t.Setenv("POWERCONTEXT_SERVER_HTTP_HOST", "192.0.2.20")
+	t.Setenv("POWERCONTEXT_SERVER_ALLOW_UNAUTHENTICATED_NON_LOOPBACK", "true")
+	path := filepath.Join(t.TempDir(), "powercontext.env")
+	if err := os.WriteFile(path, []byte(strings.Join([]string{
+		"POWERCONTEXT_SERVER_HTTP_HOST=127.0.0.2",
+		"POWERCONTEXT_SERVER_HTTP_PORT=8125",
+		"OPENAI_API_KEY=file-secret",
+		"",
+	}, "\n")), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var received server.ProcessConfig
+	runner := func(_ context.Context, _ *commandState, config server.ProcessConfig) error {
+		received = config
+		if value := os.Getenv("OPENAI_API_KEY"); value != "file-secret" {
+			t.Fatalf("OPENAI_API_KEY during run = %q", value)
+		}
+		if _, present := os.LookupEnv("POWERCONTEXT_SERVER_ALLOW_UNAUTHENTICATED_NON_LOOPBACK"); present {
+			t.Fatal("stale Server opt-in remained during env-file run")
+		}
+		return nil
+	}
+	var stdout, stderr bytes.Buffer
+	command := newCommandWithDependencies(VersionInfo{Version: "test"}, &stdout, &stderr, nil, runner)
+	command.SetArgs([]string{"server", "run", "--env-file", path})
+	if err := command.ExecuteContext(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	if received.HTTP.Host != "127.0.0.2" || received.HTTP.Port != 8125 {
+		t.Fatalf("HTTP config = %s:%d, want 127.0.0.2:8125", received.HTTP.Host, received.HTTP.Port)
+	}
+	if value := os.Getenv("OPENAI_API_KEY"); value != "shell-secret" {
+		t.Fatalf("OPENAI_API_KEY after run = %q", value)
+	}
+	if value := os.Getenv("POWERCONTEXT_SERVER_HTTP_HOST"); value != "192.0.2.20" {
+		t.Fatalf("Server host after run = %q", value)
+	}
+}
+
+func TestServerCommandEnvFileClearsMissingServerValues(t *testing.T) {
+	t.Setenv(server.PowerContextHomeEnv, t.TempDir())
+	t.Setenv("POWERCONTEXT_SERVER_AUTH_ENABLED", "true")
+	t.Setenv("POWERCONTEXT_SERVER_AUTH_TOKEN", "")
+	path := filepath.Join(t.TempDir(), "powercontext.env")
+	if err := os.WriteFile(path, []byte("POWERCONTEXT_SERVER_HTTP_HOST=127.0.0.1\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var received server.ProcessConfig
+	runner := func(_ context.Context, _ *commandState, config server.ProcessConfig) error {
+		received = config
+		return nil
+	}
+	var stdout, stderr bytes.Buffer
+	command := newCommandWithDependencies(VersionInfo{Version: "test"}, &stdout, &stderr, nil, runner)
+	command.SetArgs([]string{"server", "run", "--env-file", path})
+	if err := command.ExecuteContext(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	if received.Auth.Enabled {
+		t.Fatal("stale authentication setting affected env-file run")
+	}
+	if value := os.Getenv("POWERCONTEXT_SERVER_AUTH_ENABLED"); value != "true" {
+		t.Fatalf("authentication setting after run = %q", value)
+	}
+}
+
+func TestServerCommandEnvFileFailurePreventsRunner(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		content []byte
+	}{
+		{name: "missing"},
+		{name: "invalid syntax", content: []byte("TOKEN=$(command)\n")},
+		{name: "invalid UTF-8", content: []byte("TOKEN=\xff\n")},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "powercontext.env")
+			if test.content != nil {
+				if err := os.WriteFile(path, test.content, 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			called := false
+			runner := func(context.Context, *commandState, server.ProcessConfig) error {
+				called = true
+				return nil
+			}
+			var stdout, stderr bytes.Buffer
+			command := newCommandWithDependencies(VersionInfo{Version: "test"}, &stdout, &stderr, nil, runner)
+			command.SetArgs([]string{"server", "run", "--env-file", path})
+			err := command.ExecuteContext(t.Context())
+			if err == nil || ExitCode(err) != 2 || !strings.Contains(err.Error(), "--env-file") {
+				t.Fatalf("server run error = %v, exit = %d", err, ExitCode(err))
+			}
+			if called {
+				t.Fatal("Server runner started for an invalid environment file")
+			}
+		})
+	}
+}
+
+func TestServerCommandEnvFileRetainsCLIHTTPOverridePrecedence(t *testing.T) {
+	t.Setenv(server.PowerContextHomeEnv, t.TempDir())
+	path := filepath.Join(t.TempDir(), "powercontext.env")
+	if err := os.WriteFile(path, []byte(strings.Join([]string{
+		"POWERCONTEXT_SERVER_HTTP_HOST=0.0.0.0",
+		"POWERCONTEXT_SERVER_AUTH_ENABLED=false",
+		"POWERCONTEXT_SERVER_ALLOW_UNAUTHENTICATED_NON_LOOPBACK=false",
+		"",
+	}, "\n")), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var received server.ProcessConfig
+	runner := func(_ context.Context, _ *commandState, config server.ProcessConfig) error {
+		received = config
+		return nil
+	}
+	var stdout, stderr bytes.Buffer
+	command := newCommandWithDependencies(VersionInfo{Version: "test"}, &stdout, &stderr, nil, runner)
+	command.SetArgs([]string{"server", "run", "--env-file", path, "--host", "127.0.0.1", "--port", "8126"})
+	if err := command.ExecuteContext(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	if received.HTTP.Host != "127.0.0.1" || received.HTTP.Port != 8126 {
+		t.Fatalf("HTTP config = %s:%d, want 127.0.0.1:8126", received.HTTP.Host, received.HTTP.Port)
+	}
+}
+
 func TestServerCommandRejectsUnauthenticatedNonLoopbackHostOverride(t *testing.T) {
 	called := false
 	runner := func(context.Context, *commandState, server.ProcessConfig) error {

--- a/internal/cli/server_command.go
+++ b/internal/cli/server_command.go
@@ -20,8 +20,10 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"os"
 	"os/signal"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -33,6 +35,13 @@ import (
 
 type serverCommandRunner func(context.Context, *commandState, server.ProcessConfig) error
 
+var serverEnvironmentScopeMu sync.Mutex
+
+type serverEnvironmentValue struct {
+	value   string
+	present bool
+}
+
 func newServerCommand(state *commandState) *cobra.Command {
 	command := &cobra.Command{Use: "server", Short: "Run a configured PowerContext service."}
 	command.AddCommand(newServerRunCommand(state))
@@ -40,45 +49,122 @@ func newServerCommand(state *commandState) *cobra.Command {
 }
 
 func newServerRunCommand(state *commandState) *cobra.Command {
+	var envFile string
 	var host string
 	var port int
 	command := &cobra.Command{
 		Use: "run", Short: "Run the HTTP and MCP service in the foreground.", Args: cobra.NoArgs,
 		RunE: func(command *cobra.Command, _ []string) error {
-			override := server.HTTPConfigOverride{}
-			if command.Flags().Changed("host") {
-				trimmedHost := strings.TrimSpace(host)
-				if trimmedHost == "" || host != trimmedHost {
-					return usageError(errors.New("server: --host must be a non-empty trimmed value"))
+			run := func() error {
+				override := server.HTTPConfigOverride{}
+				if command.Flags().Changed("host") {
+					trimmedHost := strings.TrimSpace(host)
+					if trimmedHost == "" || host != trimmedHost {
+						return usageError(errors.New("server: --host must be a non-empty trimmed value"))
+					}
+					override.Host = new(host)
 				}
-				override.Host = new(host)
+				if command.Flags().Changed("port") {
+					override.Port = new(port)
+				}
+				config, err := server.LoadConfigWithHTTPOverride(override)
+				if err != nil {
+					if _, ok := errors.AsType[*server.UnauthenticatedNonLoopbackBindError](err); ok {
+						return usageError(err)
+					}
+					if _, ok := errors.AsType[*server.AuthenticationTokenRequiredError](err); ok {
+						return usageError(fmt.Errorf(
+							"server: set POWERCONTEXT_SERVER_AUTH_TOKEN or POWERCONTEXT_SERVER_AUTH_ENABLED=false: %w",
+							err,
+						))
+					}
+					return err
+				}
+				runner := state.serverRun
+				if runner == nil {
+					runner = runServer
+				}
+				return runner(command.Context(), state, config)
 			}
-			if command.Flags().Changed("port") {
-				override.Port = new(port)
+			if !command.Flags().Changed("env-file") {
+				return run()
 			}
-			config, err := server.LoadConfigWithHTTPOverride(override)
+			values, err := loadServerEnvironmentFile(envFile)
 			if err != nil {
-				if _, ok := errors.AsType[*server.UnauthenticatedNonLoopbackBindError](err); ok {
-					return usageError(err)
-				}
-				if _, ok := errors.AsType[*server.AuthenticationTokenRequiredError](err); ok {
-					return usageError(fmt.Errorf(
-						"server: set POWERCONTEXT_SERVER_AUTH_TOKEN or POWERCONTEXT_SERVER_AUTH_ENABLED=false: %w",
-						err,
-					))
-				}
 				return err
 			}
-			runner := state.serverRun
-			if runner == nil {
-				runner = runServer
-			}
-			return runner(command.Context(), state, config)
+			return withServerEnvironment(values, run)
 		},
 	}
+	command.Flags().StringVar(&envFile, "env-file", "", "Load Server and provider settings from this environment file.")
 	command.Flags().StringVar(&host, "host", "", "Address to bind.")
 	command.Flags().IntVar(&port, "port", 0, "Port to bind.")
 	return command
+}
+
+func loadServerEnvironmentFile(path string) (map[string]string, error) {
+	content, exists, err := readConfigDocument(path)
+	if err != nil {
+		return nil, usageError(fmt.Errorf("server: invalid --env-file: %w", err))
+	}
+	if !exists {
+		return nil, usageError(errors.New("server: --env-file does not exist"))
+	}
+	values, err := parseConfigEnvironment(content)
+	if err != nil {
+		return nil, usageError(fmt.Errorf("server: invalid --env-file: %w", err))
+	}
+	return values, nil
+}
+
+func withServerEnvironment(values map[string]string, run func() error) (err error) {
+	serverEnvironmentScopeMu.Lock()
+	defer serverEnvironmentScopeMu.Unlock()
+
+	loadedBefore := make(map[string]serverEnvironmentValue, len(values))
+	for name := range values {
+		value, present := os.LookupEnv(name)
+		loadedBefore[name] = serverEnvironmentValue{value: value, present: present}
+	}
+	serverBefore := make(map[string]string)
+	for _, item := range os.Environ() {
+		name, value, found := strings.Cut(item, "=")
+		if found && strings.HasPrefix(name, "POWERCONTEXT_SERVER_") {
+			serverBefore[name] = value
+		}
+	}
+	defer func() {
+		err = errors.Join(err, restoreServerEnvironment(loadedBefore, serverBefore))
+	}()
+
+	for name := range serverBefore {
+		if unsetErr := os.Unsetenv(name); unsetErr != nil {
+			return fmt.Errorf("server: clear environment: %w", unsetErr)
+		}
+	}
+	for name, value := range values {
+		if setErr := os.Setenv(name, value); setErr != nil {
+			return fmt.Errorf("server: load environment: %w", setErr)
+		}
+	}
+	return run()
+}
+
+func restoreServerEnvironment(loadedBefore map[string]serverEnvironmentValue, serverBefore map[string]string) error {
+	var err error
+	for name, original := range loadedBefore {
+		if original.present {
+			err = errors.Join(err, os.Setenv(name, original.value))
+		} else {
+			err = errors.Join(err, os.Unsetenv(name))
+		}
+	}
+	for name, value := range serverBefore {
+		if _, loaded := loadedBefore[name]; !loaded {
+			err = errors.Join(err, os.Setenv(name, value))
+		}
+	}
+	return err
 }
 
 func runServer(parent context.Context, state *commandState, config server.ProcessConfig) error {

--- a/test/conformance/parity-inventory-rules.json
+++ b/test/conformance/parity-inventory-rules.json
@@ -496,6 +496,21 @@
       "mode": "go-port",
       "reason": "CLI server command transport overrides; the CLI is Go (internal/cli) and the behavior is part of the WP2 transport surface.",
       "cases": {
+        "test_server_command_uses_env_file_instead_of_stale_shell_environment": {
+          "evidence": [
+            "go:internal/cli/python_contract_test.go#TestServerCommandEnvFileOverridesStaleEnvironmentAndRestores"
+          ]
+        },
+        "test_server_command_clears_stale_server_values_missing_from_env_file": {
+          "evidence": [
+            "go:internal/cli/python_contract_test.go#TestServerCommandEnvFileClearsMissingServerValues"
+          ]
+        },
+        "test_server_command_reports_a_missing_env_file_without_starting": {
+          "evidence": [
+            "go:internal/cli/python_contract_test.go#TestServerCommandEnvFileFailurePreventsRunner"
+          ]
+        },
         "test_server_command_rejects_an_unauthenticated_non_loopback_host_override": {
           "evidence": [
             "go:internal/cli/python_contract_test.go#TestServerCommandRejectsUnauthenticatedNonLoopbackHostOverride"

--- a/test/conformance/parity-inventory.json
+++ b/test/conformance/parity-inventory.json
@@ -4,8 +4,8 @@
   "oracle_commit": "3a6cb0151670eaff7dc0293466edd673124e80da",
   "python_test_file_count": 132,
   "python_test_case_count": 812,
-  "mapped_case_count": 749,
-  "pending_case_count": 63,
+  "mapped_case_count": 752,
+  "pending_case_count": 60,
   "entries": [
     {
       "python": {
@@ -7919,8 +7919,15 @@
         "line": 232
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/python_contract_test.go",
+          "test": "TestServerCommandEnvFileOverridesStaleEnvironmentAndRestores"
+        }
+      ]
     },
     {
       "python": {
@@ -7929,8 +7936,15 @@
         "line": 269
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/python_contract_test.go",
+          "test": "TestServerCommandEnvFileClearsMissingServerValues"
+        }
+      ]
     },
     {
       "python": {
@@ -7939,8 +7953,15 @@
         "line": 293
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/python_contract_test.go",
+          "test": "TestServerCommandEnvFileFailurePreventsRunner"
+        }
+      ]
     },
     {
       "python": {


### PR DESCRIPTION
## Summary

- add optional `powercontext server run --env-file` support for v0.1.0 Server and provider settings
- isolate stale `POWERCONTEXT_SERVER_*` values for the service lifetime, load file values, preserve final `--host`/`--port` precedence, and restore the caller environment afterwards
- map the three corresponding release cases and regenerate inventory from 749 mapped / 63 pending to 752 mapped / 60 pending

## Scope and compatibility

When `--env-file` is absent, `server run` keeps its previous behavior. The scope is internal to the CLI; it does not change the Server public API, persistence, retained-host behavior, or default environment handling.

## Verification

- `go test -count=1 ./internal/cli -run '^TestServerCommand'` with the supported local SQLite header include
- `go vet ./internal/cli` with the supported local SQLite header include
- `go test -count=1 ./test/conformance -run '^TestParityInventoryMatchesContract$'` with the supported local SQLite header include
- exact v0.1.0/previous-target `parity-inventory-generate -check -check-delta`
- `gofmt` and `git diff --check`

`make lint` reached only the pre-existing staticcheck diagnostics in `internal/sqlstore/database.go:269` and `:272`; that file is unchanged from the PR base. The exact-Head pinned lint CI remains the merge gate.

Part of #3.