### PR TITLE
fix(tracing): isolate child spans after root failures

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -389,3 +389,7 @@ source / artifact / trigger / inference
   after an earlier adapter failure, and record every individual step outcome
   in bounded diagnostics. Verify a workflow contract test rejects a merged
   step, a missing failure-continuation guard, or a missing adapter outcome.
+- When a background tracing root cannot start, preserve cancellation and value
+  context while explicitly clearing the ambient trace parent before later
+  stages begin. Verify an injected root-start failure leaves child spans
+  unparented and on a different trace ID from the ambient operation.

--- a/server/runtime_tracing.go
+++ b/server/runtime_tracing.go
@@ -45,7 +45,14 @@ func (t runtimeStageTracing) StartBackground(
 	ctx context.Context,
 	name string,
 	attributes map[string]pcruntime.TraceAttribute,
-) (context.Context, pcruntime.StageSpan) {
+) (backgroundContext context.Context, stage pcruntime.StageSpan) {
+	backgroundContext = ctx
+	defer func() {
+		if recover() != nil {
+			backgroundContext = trace.ContextWithSpanContext(ctx, trace.SpanContext{})
+			stage = nil
+		}
+	}()
 	spanContext, operation := requesttrace.StartBackgroundOperation(ctx, t.provider, name, name)
 	operation.SetAttributes(attributes)
 	return spanContext, operation

--- a/server/runtime_tracing_test.go
+++ b/server/runtime_tracing_test.go
@@ -22,6 +22,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
 
 	pcruntime "github.com/ob-labs/powercontext-go/internal/runtime"
 )
@@ -118,6 +119,67 @@ func TestRuntimeBackgroundOperationStartsIndependentRootWithoutRawScope(t *testi
 			}
 		})
 	}
+}
+
+func TestRuntimeBackgroundRootFailureStartsUnparentedChildSpans(t *testing.T) {
+	t.Parallel()
+	recorder := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(
+		sdktrace.WithSampler(sdktrace.AlwaysSample()),
+		sdktrace.WithSpanProcessor(recorder),
+	)
+	t.Cleanup(func() { _ = provider.Shutdown(context.Background()) })
+	operation := pcruntime.ProcessSourceWindowOperation
+	runtime, err := pcruntime.NewConfigured(pcruntime.RuntimeOptions{
+		Tracing: newRuntimeStageTracing(failNamedTracerProvider{TracerProvider: provider, name: operation}),
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, ambient := provider.Tracer("test").Start(t.Context(), "HTTP flush_memory")
+	err = runtime.BackgroundOperation(ctx, operation, func(ctx context.Context) (string, error) {
+		return pcruntime.ScheduledProcessingSuccess,
+			runtime.ScopedWrite(ctx, "project:private-scheduled-scope", func(context.Context, string) error { return nil })
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ambient.End()
+
+	spans := recorder.Ended()
+	for _, span := range spans {
+		if span.Name() == operation {
+			t.Fatalf("recorded background root despite injected start failure: %#v", span)
+		}
+	}
+	child := endedSpan(t, spans, "scope.context")
+	if child.Parent().IsValid() {
+		t.Fatalf("child span inherited parent %s after background root failure", child.Parent().SpanID())
+	}
+	if child.SpanContext().TraceID() == ambient.SpanContext().TraceID() {
+		t.Fatalf("child span retained ambient trace ID %s after background root failure", child.SpanContext().TraceID())
+	}
+}
+
+type failNamedTracerProvider struct {
+	trace.TracerProvider
+	name string
+}
+
+func (p failNamedTracerProvider) Tracer(name string, options ...trace.TracerOption) trace.Tracer {
+	return failNamedTracer{Tracer: p.TracerProvider.Tracer(name, options...), name: p.name}
+}
+
+type failNamedTracer struct {
+	trace.Tracer
+	name string
+}
+
+func (t failNamedTracer) Start(ctx context.Context, name string, options ...trace.SpanStartOption) (context.Context, trace.Span) {
+	if name == t.name {
+		panic("injected background root tracer failure")
+	}
+	return t.Tracer.Start(ctx, name, options...)
 }
 
 func hasTraceAttributes(attributes []attribute.KeyValue, want map[string]string) bool {

--- a/test/conformance/parity-inventory-rules.json
+++ b/test/conformance/parity-inventory-rules.json
@@ -400,7 +400,24 @@
     },
     "tests/test_server_tracing.py": {
       "mode": "go-port",
-      "reason": "Background and runtime trace-root outcomes map to Go Server tracing orchestration."
+      "reason": "Background and runtime trace-root outcomes map to Go Server tracing orchestration.",
+      "cases": {
+        "test_runtime_stage_records_explicit_noop_and_failure_outcomes": {
+          "evidence": [
+            "go:internal/runtime/scheduled_processor_test.go#TestScheduledProcessorRecordsBackgroundRootsAndOutcomes"
+          ]
+        },
+        "test_background_stage_starts_a_fresh_trace_outside_an_ambient_span": {
+          "evidence": [
+            "go:server/runtime_tracing_test.go#TestRuntimeBackgroundOperationStartsIndependentRootWithoutRawScope"
+          ]
+        },
+        "test_background_isolates_child_spans_when_root_start_fails": {
+          "evidence": [
+            "go:server/runtime_tracing_test.go#TestRuntimeBackgroundRootFailureStartsUnparentedChildSpans"
+          ]
+        }
+      }
     },
     "e2e/bub/tests/test_bub_transport_trust.py": {
       "mode": "retained-host",

--- a/test/conformance/parity-inventory.json
+++ b/test/conformance/parity-inventory.json
@@ -4,8 +4,8 @@
   "oracle_commit": "3a6cb0151670eaff7dc0293466edd673124e80da",
   "python_test_file_count": 132,
   "python_test_case_count": 812,
-  "mapped_case_count": 752,
-  "pending_case_count": 60,
+  "mapped_case_count": 755,
+  "pending_case_count": 57,
   "entries": [
     {
       "python": {
@@ -12683,8 +12683,15 @@
         "line": 234
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/runtime/scheduled_processor_test.go",
+          "test": "TestScheduledProcessorRecordsBackgroundRootsAndOutcomes"
+        }
+      ]
     },
     {
       "python": {
@@ -12693,8 +12700,15 @@
         "line": 254
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "server/runtime_tracing_test.go",
+          "test": "TestRuntimeBackgroundOperationStartsIndependentRootWithoutRawScope"
+        }
+      ]
     },
     {
       "python": {
@@ -12703,8 +12717,15 @@
         "line": 280
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "server/runtime_tracing_test.go",
+          "test": "TestRuntimeBackgroundRootFailureStartsUnparentedChildSpans"
+        }
+      ]
     },
     {
       "python": {


### PR DESCRIPTION
## Summary

- preserve cancellation and value context while clearing the ambient trace parent when a Server background root cannot start
- add a regression test that injects a background-root tracer failure and proves child spans are unparented and use a new trace ID
- map the remaining v0.1.0 Server tracing cases and regenerate inventory from 752 mapped / 60 pending to 755 mapped / 57 pending

## Root Cause

The generic runtime fallback recovered a background tracer panic by returning the original context. For the Go Server adapter, that original context retained the ambient OpenTelemetry span, so later child stages could be recorded as request children. The Server adapter now recovers before the generic fallback and replaces only the SpanContext with an invalid value.

## Verification

- demonstrated the new regression test fails before the fix because `scope.context` inherited the ambient parent
- `go test -count=1 ./server -run '^(TestRuntimeBackgroundRootFailureStartsUnparentedChildSpans|TestRuntimeBackgroundOperationStartsIndependentRootWithoutRawScope|TestRuntimeStageSpansInheritApplicationContextWithoutRawScope)$'`
- `go test -count=1 ./internal/runtime -run '^(TestScheduledProcessorRecordsBackgroundRootsAndOutcomes|TestRuntimeStageClassifiesFailureAndCancellation|TestRuntimeBackgroundTracerFailureDoesNotChangeOperation)$'`
- `go vet ./server` and `go vet ./internal/runtime`
- exact v0.1.0/previous-target `parity-inventory-generate -check -check-delta`
- `go test -count=1 ./test/conformance -run '^TestParityInventoryMatchesContract$'`

`make lint` reaches only the pre-existing staticcheck diagnostics in unchanged `internal/sqlstore/database.go:269` and `:272`; exact-Head CI lint is the merge gate.

Part of #3.