### PR TITLE
test(conformance): map OpenCode retry recovery

### DIFF
--- a/test/conformance/parity-inventory-rules.json
+++ b/test/conformance/parity-inventory-rules.json
@@ -718,6 +718,11 @@
       "mode": "go-port",
       "reason": "OpenCode activation probe CLI commands; the CLI is Go (internal/cli).",
       "cases": {
+        "test_interrupted_plugin_install_recovers_on_retry": {
+          "evidence": [
+            "go:internal/cli/integration_hosts_test.go#TestInterruptedOpenCodePluginInstallRecoversOnRetry"
+          ]
+        },
         "test_activation_probe_uses_headless_server_without_model": {
           "evidence": [
             "go:internal/cli/integration_hosts_test.go#TestOpenCodeActivationProbeUsesHeadlessServerWithoutModel"

--- a/test/conformance/parity-inventory.json
+++ b/test/conformance/parity-inventory.json
@@ -4,8 +4,8 @@
   "oracle_commit": "3a6cb0151670eaff7dc0293466edd673124e80da",
   "python_test_file_count": 132,
   "python_test_case_count": 812,
-  "mapped_case_count": 755,
-  "pending_case_count": 57,
+  "mapped_case_count": 756,
+  "pending_case_count": 56,
   "entries": [
     {
       "python": {
@@ -11450,8 +11450,15 @@
         "line": 224
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/integration_hosts_test.go",
+          "test": "TestInterruptedOpenCodePluginInstallRecoversOnRetry"
+        }
+      ]
     },
     {
       "python": {


### PR DESCRIPTION
## Summary

- map the v0.1.0 OpenCode interrupted-plugin-install retry case to its existing Go regression proof
- regenerate release inventory from 755 mapped / 57 pending to 756 mapped / 56 pending

## Evidence

`TestInterruptedOpenCodePluginInstallRecoversOnRetry` injects the ownership-manifest replacement interruption, proves the orphan target and temporary file cleanup state, then proves a retry publishes the owned bundle.

## Verification

- `go test -count=1 ./internal/cli -run '^TestInterruptedOpenCodePluginInstallRecoversOnRetry$'` with the supported local SQLite header include
- exact v0.1.0/previous-target `parity-inventory-generate -check -check-delta`
- `go test -count=1 ./test/conformance -run '^TestParityInventoryMatchesContract$'` with the supported local SQLite header include
- `git diff --check`

Part of #3.