### PR TITLE
fix(workbuddy): preserve runtime capture controls

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -332,6 +332,11 @@ source / artifact / trigger / inference
   instead of falling back to legacy environment configuration. Verify through
   the host hook entrypoint that invalid persisted configuration emits no
   recalled context.
+- When an installed host adapter reads a persisted connection configuration,
+  merge only its explicitly runtime-owned scope and capture/flush controls from
+  the environment; do not replace the persisted endpoint, credential reference,
+  scope mode, or request limits. Verify a captured prompt is flushed, recalled,
+  and searchable through the configured Server and MCP endpoint.
 - When a documentation contract test extracts executable shell commands, stop
   parsing at a shell comment before deciding that a command exists. Verify a
   fully commented command cannot satisfy executable-documentation evidence and

--- a/integrations/workbuddy/plugins/powercontext/hooks/workbuddy_settings.py
+++ b/integrations/workbuddy/plugins/powercontext/hooks/workbuddy_settings.py
@@ -161,11 +161,27 @@ def load_settings(
         server_url=_text_field(payload, "server_url"),
         authorization=runtime_environment.get(authorization_environment),
         authorization_environment=authorization_environment,
+        scope_id=runtime_environment.get("POWERCONTEXT_WORKBUDDY_SCOPE_ID"),
         scope_mode=_text_field(payload, "scope_mode"),
+        capture_prompts=_environment_bool(
+            "POWERCONTEXT_WORKBUDDY_CAPTURE_PROMPTS",
+            default=True,
+            environment=runtime_environment,
+        ),
+        flush_on_capture=_environment_bool(
+            "POWERCONTEXT_WORKBUDDY_FLUSH_ON_CAPTURE",
+            default=False,
+            environment=runtime_environment,
+        ),
         request_timeout_seconds=_float_field(payload, "request_timeout_seconds"),
         request_budget_seconds=_float_field(payload, "request_budget_seconds"),
         prepare_max_bytes=_int_field(payload, "prepare_max_bytes"),
         source_max_bytes=_int_field(payload, "source_max_bytes"),
+        flush_max_calls=_environment_int(
+            "POWERCONTEXT_WORKBUDDY_FLUSH_MAX_CALLS",
+            default=4,
+            environment=runtime_environment,
+        ),
     )
 
 
@@ -198,8 +214,13 @@ def _int_field(payload: Mapping[str, object], name: str) -> int:
     return value
 
 
-def _environment_bool(*names: str, default: bool) -> bool:
-    value = _first_environment(*names)
+def _environment_bool(
+    *names: str,
+    default: bool,
+    environment: Mapping[str, str] | None = None,
+) -> bool:
+    source = os.environ if environment is None else environment
+    value = next((source[name] for name in names if name in source), None)
     if value is None:
         return default
     normalized = value.strip().casefold()
@@ -215,8 +236,14 @@ def _environment_float(*names: str, default: float) -> float:
     return default if value is None else float(value)
 
 
-def _environment_int(name: str, *, default: int) -> int:
-    value = os.environ.get(name)
+def _environment_int(
+    name: str,
+    *,
+    default: int,
+    environment: Mapping[str, str] | None = None,
+) -> int:
+    source = os.environ if environment is None else environment
+    value = source.get(name)
     return default if value is None else int(value)
 
 

--- a/integrations/workbuddy/tests/test_config.py
+++ b/integrations/workbuddy/tests/test_config.py
@@ -61,3 +61,40 @@ def test_config_uses_credential_free_file_and_runtime_authorization_environment(
     assert configuration.authorization == "Bearer test-token"
     assert configuration.authorization_environment == "WORKBUDDY_TOKEN"
     assert "test-token" not in configuration_path.read_text(encoding="utf-8")
+
+
+def test_config_merges_runtime_hook_controls_without_overriding_persisted_connection(tmp_path: Path) -> None:
+    settings_module = load_config_module()
+    configuration_path = tmp_path / "powercontext.json"
+    configuration_path.write_text(
+        json.dumps(
+            {
+                "schema": 1,
+                "server_url": "http://127.0.0.1:8000",
+                "scope_mode": "project",
+                "authorization_environment": "WORKBUDDY_TOKEN",
+                "request_timeout_seconds": 1.5,
+                "request_budget_seconds": 3.0,
+                "prepare_max_bytes": 8192,
+                "source_max_bytes": 16384,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    configuration = settings_module.load_settings(
+        configuration_path,
+        environment={
+            "WORKBUDDY_TOKEN": "Bearer test-token",
+            "POWERCONTEXT_WORKBUDDY_SCOPE_ID": "project:workbuddy-service-chain",
+            "POWERCONTEXT_WORKBUDDY_CAPTURE_PROMPTS": "false",
+            "POWERCONTEXT_WORKBUDDY_FLUSH_ON_CAPTURE": "true",
+            "POWERCONTEXT_WORKBUDDY_FLUSH_MAX_CALLS": "2",
+        },
+    )
+
+    assert configuration.server_url == "http://127.0.0.1:8000"
+    assert configuration.scope_id == "project:workbuddy-service-chain"
+    assert configuration.capture_prompts is False
+    assert configuration.flush_on_capture is True
+    assert configuration.flush_max_calls == 2

--- a/test/conformance/parity-inventory-rules.json
+++ b/test/conformance/parity-inventory-rules.json
@@ -467,7 +467,14 @@
     },
     "tests/e2e/test_workbuddy_service_chain.py": {
       "mode": "cross-layer",
-      "reason": "End-to-end chain crossing the WorkBuddy hook and the shared MCP service configuration."
+      "reason": "End-to-end chain crossing the WorkBuddy hook and the shared MCP service configuration.",
+      "cases": {
+        "test_workbuddy_hook_and_mcp_share_one_service_configuration": {
+          "evidence": [
+            "go:test/e2e/workbuddy_service_chain_test.go#TestWorkBuddyHookAndMCPShareOneGoServiceConfiguration"
+          ]
+        }
+      }
     },
     "tests/integrations/test_hermes_provider.py": {
       "mode": "retained-host",

--- a/test/conformance/parity-inventory.json
+++ b/test/conformance/parity-inventory.json
@@ -4,8 +4,8 @@
   "oracle_commit": "3a6cb0151670eaff7dc0293466edd673124e80da",
   "python_test_file_count": 132,
   "python_test_case_count": 812,
-  "mapped_case_count": 756,
-  "pending_case_count": 56,
+  "mapped_case_count": 757,
+  "pending_case_count": 55,
   "entries": [
     {
       "python": {
@@ -5876,8 +5876,15 @@
         "line": 51
       },
       "mode": "cross-layer",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "test/e2e/workbuddy_service_chain_test.go",
+          "test": "TestWorkBuddyHookAndMCPShareOneGoServiceConfiguration"
+        }
+      ]
     },
     {
       "python": {

--- a/test/e2e/workbuddy_service_chain_test.go
+++ b/test/e2e/workbuddy_service_chain_test.go
@@ -1,0 +1,325 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/ob-labs/powercontext-go/internal/cli"
+	"github.com/ob-labs/powercontext-go/server"
+)
+
+const workBuddyServiceChainScope = "project:workbuddy-service-chain"
+
+func TestWorkBuddyHookAndMCPShareOneGoServiceConfiguration(t *testing.T) {
+	python := workBuddyPython(t)
+	root, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, test := range []struct {
+		name          string
+		authenticated bool
+	}{
+		{name: "public"},
+		{name: "authenticated", authenticated: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("WORKBUDDY_HOME", filepath.Join(home, "workbuddy"))
+			t.Setenv(server.PowerContextHomeEnv, filepath.Join(home, "powercontext"))
+			t.Setenv("POWERCONTEXT_WORKBUDDY_SCOPE_ID", workBuddyServiceChainScope)
+			t.Setenv("POWERCONTEXT_WORKBUDDY_FLUSH_ON_CAPTURE", "true")
+			t.Setenv("WORKBUDDY_SERVICE_TOKEN", "")
+
+			config, configErr := server.DefaultConfig()
+			if configErr != nil {
+				t.Fatal(configErr)
+			}
+			config.Dashboard.Enabled = false
+			config.HandoffReport.Enabled = false
+			config.Logging.Access = false
+			config.Metrics.Enabled = false
+			config.MCP.Enabled = true
+			config.MCP.Path = server.DefaultMCPPath
+			if test.authenticated {
+				config.Auth.Enabled = true
+				config.Auth.Token = "workbuddy-service-token"
+				t.Setenv("WORKBUDDY_SERVICE_TOKEN", "Bearer "+config.Auth.Token)
+			}
+
+			application, openErr := server.OpenApplication(t.Context(), config, server.Dependencies{
+				MemoryCandidates: fixedMemoryCandidatePipeline{},
+			})
+			if openErr != nil {
+				t.Fatal(openErr)
+			}
+			t.Cleanup(func() {
+				closeContext, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+				defer cancel()
+				if closeErr := application.Close(closeContext); closeErr != nil {
+					t.Error(closeErr)
+				}
+			})
+			handler, handlerErr := application.HTTPHandler()
+			if handlerErr != nil {
+				t.Fatal(handlerErr)
+			}
+			service := httptest.NewServer(handler)
+			t.Cleanup(service.Close)
+			assertWorkBuddyServiceReady(t, service)
+
+			setupWorkBuddy(t, service.URL, root)
+			assertWorkBuddyServerConfiguration(t, service.URL)
+			assertWorkBuddyServiceReady(t, service)
+			hook := filepath.Join(os.Getenv("WORKBUDDY_HOME"), "hooks", "workbuddy_powercontext_hook.py")
+			first := runWorkBuddyHook(t, python, root, hook, "Remember this WorkBuddy service chain.", "prompt-1")
+			if first != "" {
+				t.Fatalf("first hook context = %q, want empty before capture", first)
+			}
+			second := runWorkBuddyHook(t, python, root, hook, "Which WorkBuddy service chain should I use?", "prompt-2")
+			if !strings.Contains(second, "Remember this WorkBuddy service chain.") {
+				t.Fatalf("recalled context = %q, want captured WorkBuddy content", second)
+			}
+
+			mcpURL, authorization := workBuddyMCPConnection(t, service.URL)
+			mcpClient := mcp.NewClient(&mcp.Implementation{Name: "workbuddy-e2e", Version: "test"}, nil)
+			session, connectErr := mcpClient.Connect(t.Context(), &mcp.StreamableClientTransport{
+				Endpoint:             mcpURL,
+				HTTPClient:           &http.Client{Transport: workBuddyAuthorizationTransport{base: service.Client().Transport, authorization: authorization}},
+				DisableStandaloneSSE: true,
+			}, nil)
+			if connectErr != nil {
+				t.Fatal(connectErr)
+			}
+			t.Cleanup(func() { _ = session.Close() })
+			result, callErr := session.CallTool(t.Context(), &mcp.CallToolParams{
+				Name: "search_memory",
+				Arguments: map[string]any{
+					"scope_id": workBuddyServiceChainScope,
+					"query":    "WorkBuddy service chain",
+				},
+			})
+			if callErr != nil {
+				t.Fatal(callErr)
+			}
+			if result.IsError {
+				t.Fatalf("search_memory returned an MCP error: %#v", result.Content)
+			}
+			structured, ok := result.StructuredContent.(map[string]any)
+			if !ok {
+				t.Fatalf("search_memory structured content = %T, want object", result.StructuredContent)
+			}
+			hits, ok := structured["hits"].([]any)
+			if !ok || len(hits) == 0 {
+				t.Fatalf("search_memory hits = %#v, want captured WorkBuddy content", structured["hits"])
+			}
+			hit, ok := hits[0].(map[string]any)
+			if !ok || hit["text"] != "Remember this WorkBuddy service chain." {
+				t.Fatalf("search_memory first hit = %#v", hits[0])
+			}
+		})
+	}
+}
+
+func assertWorkBuddyServiceReady(t *testing.T, service *httptest.Server) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		response, err := service.Client().Get(service.URL + "/health/ready")
+		if err == nil {
+			closeErr := response.Body.Close()
+			if closeErr != nil {
+				t.Fatal(closeErr)
+			}
+			if response.StatusCode == http.StatusOK {
+				return
+			}
+			lastErr = fmt.Errorf("Go Server readiness status = %d", response.StatusCode)
+		} else {
+			lastErr = err
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("reach Go Server readiness before deadline: %v", lastErr)
+}
+
+func setupWorkBuddy(t *testing.T, serverURL, root string) {
+	t.Helper()
+	command := cli.New(cli.VersionInfo{Version: "test"})
+	command.SetArgs([]string{
+		"setup", "workbuddy", "--source", root, "--server-url", serverURL,
+		"--authorization-environment", "WORKBUDDY_SERVICE_TOKEN",
+	})
+	if err := command.ExecuteContext(t.Context()); err != nil {
+		t.Fatalf("setup workbuddy: %v", err)
+	}
+}
+
+func runWorkBuddyHook(t *testing.T, python workBuddyPythonCommand, root, hook, prompt, promptID string) string {
+	t.Helper()
+	context, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+	payload, err := json.Marshal(map[string]string{
+		"hook_event_name": "UserPromptSubmit",
+		"cwd":             root,
+		"prompt":          prompt,
+		"session_id":      "workbuddy-e2e-session",
+		"prompt_id":       promptID,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	command := exec.CommandContext(context, python.path, append(python.arguments, hook)...)
+	command.Dir = root
+	command.Stdin = bytes.NewReader(payload)
+	var stdout, stderr bytes.Buffer
+	command.Stdout = &stdout
+	command.Stderr = &stderr
+	err = command.Run()
+	if err != nil {
+		t.Fatalf("run WorkBuddy hook: %v: %s", err, stderr.String())
+	}
+	var result struct {
+		HookSpecificOutput struct {
+			AdditionalContext string `json:"additionalContext"`
+		} `json:"hookSpecificOutput"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("decode WorkBuddy hook response %q: %v; stderr: %s", stdout.String(), err, stderr.String())
+	}
+	return result.HookSpecificOutput.AdditionalContext
+}
+
+func assertWorkBuddyServerConfiguration(t *testing.T, serverURL string) {
+	t.Helper()
+	configuration, err := os.ReadFile(filepath.Join(os.Getenv("WORKBUDDY_HOME"), "powercontext.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var value struct {
+		ServerURL string `json:"server_url"`
+	}
+	if err := json.Unmarshal(configuration, &value); err != nil {
+		t.Fatal(err)
+	}
+	if value.ServerURL != serverURL {
+		t.Fatalf("WorkBuddy Hook Server URL = %q, want %q", value.ServerURL, serverURL)
+	}
+}
+
+func workBuddyMCPConnection(t *testing.T, serverURL string) (string, string) {
+	t.Helper()
+	configuration, err := os.ReadFile(filepath.Join(os.Getenv("WORKBUDDY_HOME"), "mcp.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var value struct {
+		MCPServers map[string]struct {
+			URL     string            `json:"url"`
+			Headers map[string]string `json:"headers"`
+		} `json:"mcpServers"`
+	}
+	if err := json.Unmarshal(configuration, &value); err != nil {
+		t.Fatal(err)
+	}
+	entry, ok := value.MCPServers["powercontext"]
+	if !ok {
+		t.Fatal("installed WorkBuddy MCP configuration has no PowerContext entry")
+	}
+	if entry.URL != serverURL+"/mcp" {
+		t.Fatalf("WorkBuddy MCP URL = %q, want %q", entry.URL, serverURL+"/mcp")
+	}
+	authorization := entry.Headers["Authorization"]
+	if authorization == "${WORKBUDDY_SERVICE_TOKEN:-}" {
+		authorization = os.Getenv("WORKBUDDY_SERVICE_TOKEN")
+	}
+	return entry.URL + "/", authorization
+}
+
+type workBuddyPythonCommand struct {
+	path      string
+	arguments []string
+}
+
+func workBuddyPython(t *testing.T) workBuddyPythonCommand {
+	t.Helper()
+	for _, candidate := range []workBuddyPythonCommand{
+		{path: "python3"},
+		{path: "python"},
+		{path: "py", arguments: []string{"-3"}},
+	} {
+		path, err := exec.LookPath(candidate.path)
+		if err != nil {
+			continue
+		}
+		output, versionErr := exec.CommandContext(t.Context(), path, append(candidate.arguments, "--version")...).CombinedOutput()
+		if versionErr != nil || !workBuddyPythonSupported(string(output)) {
+			continue
+		}
+		candidate.path = path
+		return candidate
+	}
+	t.Fatal("WorkBuddy service-chain test requires Python 3.10 or newer on PATH")
+	return workBuddyPythonCommand{}
+}
+
+func workBuddyPythonSupported(output string) bool {
+	fields := strings.Fields(output)
+	if len(fields) != 2 || fields[0] != "Python" {
+		return false
+	}
+	parts := strings.Split(fields[1], ".")
+	if len(parts) < 2 {
+		return false
+	}
+	major, majorErr := strconv.Atoi(parts[0])
+	minor, minorErr := strconv.Atoi(parts[1])
+	return majorErr == nil && minorErr == nil && (major > 3 || major == 3 && minor >= 10)
+}
+
+type workBuddyAuthorizationTransport struct {
+	base          http.RoundTripper
+	authorization string
+}
+
+func (t workBuddyAuthorizationTransport) RoundTrip(request *http.Request) (*http.Response, error) {
+	base := t.base
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	if t.authorization == "" {
+		return base.RoundTrip(request)
+	}
+	clone := request.Clone(request.Context())
+	clone.Header.Set("Authorization", t.authorization)
+	return base.RoundTrip(clone)
+}

--- a/test/e2e/workbuddy_service_chain_test.go
+++ b/test/e2e/workbuddy_service_chain_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build sqlite_fts5
+
 package e2e_test
 
 import (


### PR DESCRIPTION
## Summary

- preserve runtime WorkBuddy scope, capture, flush, and flush-count controls when an installed hook reads its credential-free persisted configuration
- add a real Go Server, installed Hook, and Streamable HTTP MCP `search_memory` service-chain regression for public and Bearer-authenticated operation
- map the exact v0.1.0 WorkBuddy service-chain case and regenerate the parity inventory to `757 mapped / 55 pending`

## Constraint

The persisted endpoint, credential environment reference, scope mode, and request limits remain authoritative. This PR does not expand Hermes, LangChain, Pydantic AI, or other retained-host behavior.

## Validation

- `uv run --with pytest pytest integrations/workbuddy/tests -q` (50 passed)
- WSL Go 1.27: `go test -count=1 -tags sqlite_fts5 ./test/e2e -run '^TestWorkBuddyHookAndMCPShareOneGoServiceConfiguration$' -v` (public and Bearer-authenticated service chains passed)
- `go test -count=1 ./test/conformance -run '^TestParityInventoryMatchesContract$'`
- exact-target parity inventory and reviewed delta generation checks

## Local limitation

The Windows Go-test process cannot connect to its own loopback listener in this session even while it reports `LISTEN`; the same real E2E passed in WSL. Exact-Head GitHub CI is required for the supported hosted-runner record.