### PR TITLE
docs: add full-capability Memory verification

### DIFF
--- a/docs/en/docs/how-to/full-capability-runtime.md
+++ b/docs/en/docs/how-to/full-capability-runtime.md
@@ -1,0 +1,72 @@
+# Full-capability Memory Verification
+
+This guide verifies the existing Go Server Source-to-Memory path. It does not
+require a new API or a provider-specific integration. Run the Server with the
+configuration that owns the SQLite database and the Memory extraction profile:
+
+```sh
+./bin/powercontext server run
+```
+
+Use one stable Scope ID throughout this guide. The capture, flush, entry list,
+and search requests must use the same value.
+
+```sh
+SCOPE_ID=project:quickstart
+SOURCE_ID="quickstart-$(date +%s)-$$"
+```
+
+## Capture a Source
+
+Capture a durable fact with a unique Source ID. The response is accepted when
+it has HTTP status 202, `status` equal to `accepted`, and a numeric `position`.
+
+```sh
+curl -fsS -X POST http://127.0.0.1:8000/v1/sources/content \
+  -H 'content-type: application/json' \
+  -d "{\"scope_id\":\"${SCOPE_ID}\",\"source_id\":\"${SOURCE_ID}\",\"content\":\"Prefer small, verifiable PowerContext changes.\"}"
+```
+
+Keep the response `position`; it is the source journal boundary for the next
+step.
+
+## Flush and Inspect Memory
+
+Flush the Scope to process pending Sources into Memory.
+
+```sh
+curl -fsS -X POST http://127.0.0.1:8000/v1/memory/flush \
+  -H 'content-type: application/json' \
+  -d "{\"scope_id\":\"${SCOPE_ID}\"}"
+```
+
+The response contains `current_cursor`. It must reach the capture `position`.
+An `idle` response is valid only when its `current_cursor` has already reached
+that position; otherwise run the flush again.
+
+List the current Memory entries:
+
+```sh
+curl -fsS -X POST http://127.0.0.1:8000/v1/memory/entries/list \
+  -H 'content-type: application/json' \
+  -d "{\"scope_id\":\"${SCOPE_ID}\"}"
+```
+
+Find the entry whose `source_refs` includes `${SOURCE_ID}`. Record that
+entry's `citation.entry_id`. This is the evidence that the captured Source
+became an authoritative Memory entry.
+
+## Search the Recorded Entry
+
+Search the same Scope and verify the recorded citation is returned:
+
+```sh
+curl -fsS -X POST http://127.0.0.1:8000/v1/memory/search \
+  -H 'content-type: application/json' \
+  -d "{\"scope_id\":\"${SCOPE_ID}\",\"query\":\"verifiable PowerContext changes\",\"mode\":\"auto\",\"limit\":10}"
+```
+
+A successful round trip has a hit with the recorded `citation.entry_id` and a
+non-empty `matched_by` array. The selected search mode depends on the active
+SQLite capabilities: FTS is available without an embedding model, while vector
+and hybrid modes require the configured embedding projection.

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,6 +6,10 @@ Dashboard, integration, and release contracts while using Go-native domain and r
 Start with the [architecture overview](architecture/README.md), then use the
 [release installation guide](release/INSTALL.md) to install a published binary bundle.
 
+For an operator-facing Source to Memory verification loop, use the
+[English full-capability guide](en/docs/how-to/full-capability-runtime.md) or
+[Chinese full-capability guide](zh/docs/how-to/full-capability-runtime.md).
+
 The OpenAPI contract in `openapi/powercontext.yaml` is the transport source of truth. The repository root
 [`README.md`](https://github.com/ob-labs/powercontext-go/blob/main/README.md) contains local build and development
 commands.

--- a/docs/zh/docs/how-to/full-capability-runtime.md
+++ b/docs/zh/docs/how-to/full-capability-runtime.md
@@ -1,0 +1,67 @@
+# 完整能力 Memory 验证
+
+本指南验证现有 Go Server 的 Source 到 Memory 路径。它不要求新的 API 或
+provider 专用集成。使用拥有 SQLite 数据库和 Memory 提取配置的 Server：
+
+```sh
+./bin/powercontext server run
+```
+
+全程使用同一个稳定的 Scope ID。capture、flush、entry list 和 search 请求
+必须使用同一个值。
+
+```sh
+SCOPE_ID=project:quickstart
+SOURCE_ID="quickstart-$(date +%s)-$$"
+```
+
+## Capture Source
+
+用唯一的 Source ID 写入一个可长期保留的事实。只有 HTTP 状态为 202、
+`status` 为 `accepted` 并且包含数字 `position` 的响应，才表示写入已接受。
+
+```sh
+curl -fsS -X POST http://127.0.0.1:8000/v1/sources/content \
+  -H 'content-type: application/json' \
+  -d "{\"scope_id\":\"${SCOPE_ID}\",\"source_id\":\"${SOURCE_ID}\",\"content\":\"Prefer small, verifiable PowerContext changes.\"}"
+```
+
+记录响应中的 `position`；它是下一步要确认的 Source journal 边界。
+
+## Flush 并检查 Memory
+
+对该 Scope 执行 flush，把 pending Source 处理为 Memory。
+
+```sh
+curl -fsS -X POST http://127.0.0.1:8000/v1/memory/flush \
+  -H 'content-type: application/json' \
+  -d "{\"scope_id\":\"${SCOPE_ID}\"}"
+```
+
+响应包含 `current_cursor`，它必须到达 capture 的 `position`。只有
+`current_cursor` 已到达该位置时，`idle` 响应才是有效结果；否则再次 flush。
+
+列出当前 Memory entry：
+
+```sh
+curl -fsS -X POST http://127.0.0.1:8000/v1/memory/entries/list \
+  -H 'content-type: application/json' \
+  -d "{\"scope_id\":\"${SCOPE_ID}\"}"
+```
+
+找到 `source_refs` 中包含 `${SOURCE_ID}` 的 entry，并记录其
+`citation.entry_id`。这才证明刚才 capture 的 Source 已形成权威 Memory。
+
+## 搜索已记录的 Entry
+
+在同一个 Scope 中搜索并确认返回刚才记录的 citation：
+
+```sh
+curl -fsS -X POST http://127.0.0.1:8000/v1/memory/search \
+  -H 'content-type: application/json' \
+  -d "{\"scope_id\":\"${SCOPE_ID}\",\"query\":\"verifiable PowerContext changes\",\"mode\":\"auto\",\"limit\":10}"
+```
+
+完整闭环要求命中结果含有记录的 `citation.entry_id`，并且 `matched_by`
+数组非空。实际搜索模式由当前 SQLite capability 决定：不配置 embedding
+model 时仍可使用 FTS；vector 和 hybrid 需要配置 embedding projection。

--- a/test/conformance/full_capability_docs_test.go
+++ b/test/conformance/full_capability_docs_test.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conformance_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestFullCapabilityGuidesBindMemoryEvidenceToCapturedSource(t *testing.T) {
+	for _, document := range []string{
+		filepath.Join("..", "..", "docs", "en", "docs", "how-to", "full-capability-runtime.md"),
+		filepath.Join("..", "..", "docs", "zh", "docs", "how-to", "full-capability-runtime.md"),
+	} {
+		t.Run(document, func(t *testing.T) {
+			contents, err := os.ReadFile(document)
+			if err != nil {
+				t.Fatal(err)
+			}
+			guide := string(contents)
+			for _, fragment := range []string{
+				`SOURCE_ID="quickstart-$(date +%s)-$$"`,
+				"/v1/memory/entries/list",
+				"source_refs",
+				"current_cursor",
+				"position",
+				"entry_id",
+				"matched_by",
+			} {
+				if !strings.Contains(guide, fragment) {
+					t.Fatalf("guide does not bind captured Memory evidence through %q", fragment)
+				}
+			}
+		})
+	}
+}

--- a/test/conformance/parity-inventory-rules.json
+++ b/test/conformance/parity-inventory-rules.json
@@ -374,7 +374,14 @@
     },
     "tests/test_full_capability_docs.py": {
       "mode": "cross-layer",
-      "reason": "Executable full-capability documentation binds CLI capture, Memory evidence, and cursor behavior across layers."
+      "reason": "Executable full-capability documentation binds CLI capture, Memory evidence, and cursor behavior across layers.",
+      "cases": {
+        "test_full_capability_guide_binds_memory_evidence_to_the_captured_source": {
+          "evidence": [
+            "go:test/conformance/full_capability_docs_test.go#TestFullCapabilityGuidesBindMemoryEvidenceToCapturedSource"
+          ]
+        }
+      }
     },
     "tests/test_mcp.py": {
       "mode": "go-port",

--- a/test/conformance/parity-inventory.json
+++ b/test/conformance/parity-inventory.json
@@ -4,8 +4,8 @@
   "oracle_commit": "3a6cb0151670eaff7dc0293466edd673124e80da",
   "python_test_file_count": 132,
   "python_test_case_count": 812,
-  "mapped_case_count": 757,
-  "pending_case_count": 55,
+  "mapped_case_count": 758,
+  "pending_case_count": 54,
   "entries": [
     {
       "python": {
@@ -9831,8 +9831,15 @@
         "line": 27
       },
       "mode": "cross-layer",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "test/conformance/full_capability_docs_test.go",
+          "test": "TestFullCapabilityGuidesBindMemoryEvidenceToCapturedSource"
+        }
+      ]
     },
     {
       "python": {


### PR DESCRIPTION
## Summary

- add English and Chinese full-capability guides for the existing Go Source -> Memory -> search evidence loop
- add a Go conformance contract that requires both guides to bind capture position, flush cursor, source evidence, citation identity, and search matching fields
- map the exact v0.1.0 full-capability documentation case and regenerate the inventory to `758 mapped / 54 pending`

## Constraint

This PR documents existing HTTP and CLI behavior only. It does not introduce a provider, retained-host, Server, or API change.

## Validation

- `go test -count=1 ./test/conformance`
- focused full-capability documentation contract
- exact-target parity inventory and reviewed delta checks
- WSL zensical rendered both guide pages; its process did not exit cleanly on the mounted worktree, so exact-Head `check-docs` CI remains the authoritative full build gate.