### PR TITLE
fix(hermes): recover the plugin pair atomically

### DIFF
--- a/integrations/hermes/plugins/powercontext-command/__init__.py
+++ b/integrations/hermes/plugins/powercontext-command/__init__.py
@@ -1,0 +1,27 @@
+# Copyright (c) 2026 OceanBase.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Register PowerContext command aliases before Hermes creates its Agent."""
+
+from __future__ import annotations
+
+
+def register(context):
+    """Expose aliases without selecting a provider from another session."""
+
+    def unavailable(_arguments: str) -> str:
+        return "PowerContext is not initialized for this Hermes session yet."
+
+    for name in ("pc", "powercontext"):
+        context.register_command(name, unavailable, description="Inspect PowerContext memory.")

--- a/integrations/hermes/plugins/powercontext-command/plugin.yaml
+++ b/integrations/hermes/plugins/powercontext-command/plugin.yaml
@@ -1,0 +1,18 @@
+# Copyright (c) 2026 OceanBase.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: powercontext-command
+version: 0.1.0
+description: "Early slash-command registration for the PowerContext Hermes provider."
+kind: standalone

--- a/internal/cli/integration_catalog.go
+++ b/internal/cli/integration_catalog.go
@@ -60,7 +60,7 @@ var firstClassIntegrationHosts = [...]integrationHostSpec{
 		missingDetail: "Pi CLI is not installed or is not on PATH", probe: runPiDiagnostics,
 	},
 	{
-		name: "hermes", label: "Hermes", cliKey: "hermes", integrationKeys: []string{"plugin"},
+		name: "hermes", label: "Hermes", cliKey: "hermes", integrationKeys: []string{"plugin", "command_plugin"},
 		missingDetail: "Hermes CLI is not installed or is not on PATH", probe: runHermesDiagnostics,
 	},
 }

--- a/internal/cli/integration_hermes.go
+++ b/internal/cli/integration_hermes.go
@@ -288,11 +288,11 @@ func installHermesPlugins(ctx context.Context, commands systemCommandExecutor, e
 				rollback()
 				return errors.New("cannot create Hermes plugin backup")
 			}
-			if err := os.Remove(backup); err != nil {
+			if removeErr := os.Remove(backup); removeErr != nil {
 				rollback()
-				return err
+				return removeErr
 			}
-			if err := hermesRename(plugin.target, backup); err != nil {
+			if renameErr := hermesRename(plugin.target, backup); renameErr != nil {
 				rollback()
 				return errors.New("cannot preserve existing Hermes plugin")
 			}

--- a/internal/cli/integration_hermes.go
+++ b/internal/cli/integration_hermes.go
@@ -251,53 +251,6 @@ func findHermesPlugin(root string) (string, bool) {
 	return "", false
 }
 
-func installHermesPlugin(
-	ctx context.Context,
-	commands systemCommandExecutor,
-	executable, source, target string,
-) error {
-	parent := filepath.Dir(target)
-	if err := os.MkdirAll(parent, 0o755); err != nil {
-		return errors.New("cannot create Hermes plugin directory")
-	}
-	staging, err := os.MkdirTemp(parent, ".powercontext-")
-	if err != nil {
-		return errors.New("cannot create Hermes plugin staging directory")
-	}
-	defer func() { _ = os.RemoveAll(staging) }()
-	if err := copyRegularTree(source, staging); err != nil {
-		return errors.New("cannot copy the PowerContext Hermes plugin")
-	}
-	if _, doctorErr := commands.Run(ctx, executable, "plugins", "doctor", "--ci", staging); doctorErr != nil {
-		return doctorErr
-	}
-	backup := ""
-	if _, err := os.Lstat(target); err == nil {
-		backup, err = os.MkdirTemp(parent, ".powercontext-backup-")
-		if err != nil {
-			return errors.New("cannot create Hermes plugin backup")
-		}
-		if removeErr := os.Remove(backup); removeErr != nil {
-			return removeErr
-		}
-		if renameErr := os.Rename(target, backup); renameErr != nil {
-			return errors.New("cannot preserve existing Hermes plugin")
-		}
-	} else if !errors.Is(err, os.ErrNotExist) {
-		return errors.New("cannot inspect existing Hermes plugin")
-	}
-	if activateErr := os.Rename(staging, target); activateErr != nil {
-		if backup != "" {
-			_ = os.Rename(backup, target)
-		}
-		return errors.New("cannot activate Hermes plugin")
-	}
-	if backup != "" {
-		_ = os.RemoveAll(backup)
-	}
-	return nil
-}
-
 func installHermesPlugins(ctx context.Context, commands systemCommandExecutor, executable string, sources, targets map[string]string) error {
 	type stagedPlugin struct{ name, target, staging, backup string }
 	plugins := make([]stagedPlugin, 0, 2)
@@ -330,8 +283,8 @@ func installHermesPlugins(ctx context.Context, commands systemCommandExecutor, e
 	for index := range plugins {
 		plugin := &plugins[index]
 		if _, err := os.Lstat(plugin.target); err == nil {
-			backup, err := os.MkdirTemp(filepath.Dir(plugin.target), ".powercontext-backup-")
-			if err != nil {
+			backup, backupErr := os.MkdirTemp(filepath.Dir(plugin.target), ".powercontext-backup-")
+			if backupErr != nil {
 				rollback()
 				return errors.New("cannot create Hermes plugin backup")
 			}

--- a/internal/cli/integration_hermes.go
+++ b/internal/cli/integration_hermes.go
@@ -30,11 +30,16 @@ import (
 )
 
 const (
-	hermesPluginName = "powercontext"
-	hermesRelative   = "integrations/hermes/plugins/powercontext"
+	hermesPluginName        = "powercontext"
+	hermesCommandPluginName = "powercontext-command"
+	hermesRelative          = "integrations/hermes/plugins/powercontext"
+	hermesCommandRelative   = "integrations/hermes/plugins/powercontext-command"
 )
 
-var hermesVersionPattern = regexp.MustCompile(`Hermes Agent v?(\d+)\.(\d+)\.(\d+)`)
+var (
+	hermesVersionPattern = regexp.MustCompile(`Hermes Agent v?(\d+)\.(\d+)\.(\d+)`)
+	hermesRename         = os.Rename
+)
 
 func newSetupHermesCommand(state *commandState) *cobra.Command {
 	var source, ref string
@@ -52,7 +57,7 @@ func newSetupHermesCommand(state *commandState) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			sourcePlugin, err := resolveHermesPlugin(command.Context(), state.system, source, ref, dataDirectory)
+			sourcePlugins, err := resolveHermesPlugins(command.Context(), state.system, source, ref, dataDirectory)
 			if err != nil {
 				return err
 			}
@@ -61,7 +66,8 @@ func newSetupHermesCommand(state *commandState) *cobra.Command {
 				return err
 			}
 			target := filepath.Join(home, "plugins", hermesPluginName)
-			if installErr := installHermesPlugin(command.Context(), state.system, executable, sourcePlugin, target); installErr != nil {
+			commandTarget := filepath.Join(home, "plugins", hermesCommandPluginName)
+			if installErr := installHermesPlugins(command.Context(), state.system, executable, sourcePlugins, map[string]string{hermesPluginName: target, hermesCommandPluginName: commandTarget}); installErr != nil {
 				return installErr
 			}
 			checks := runHermesDiagnostics(command.Context(), state.system)
@@ -72,7 +78,7 @@ func newSetupHermesCommand(state *commandState) *cobra.Command {
 				return alreadyReported(setupVerificationError(checks))
 			}
 			result := map[string]string{
-				"plugin": hermesPluginName, "plugin_path": target, "hermes_home": home, "data_dir": dataDirectory,
+				"plugin": hermesPluginName, "plugin_path": target, "command_plugin_path": commandTarget, "hermes_home": home, "data_dir": dataDirectory,
 			}
 			if state.json {
 				return writeJSON(state.stdout, result)
@@ -87,6 +93,57 @@ func newSetupHermesCommand(state *commandState) *cobra.Command {
 	command.Flags().StringVar(&source, "source", defaultMarketplaceSource, "PowerContext Git source or local checkout path.")
 	command.Flags().StringVar(&ref, "ref", defaultMarketplaceRef, "Git ref used for a remote source.")
 	return command
+}
+
+func resolveHermesPlugins(ctx context.Context, commands systemCommandExecutor, source, ref, dataDirectory string) (map[string]string, error) {
+	root, local, err := normalizeMarketplaceSource(source)
+	if err != nil {
+		return nil, err
+	}
+	if !local {
+		if err := validateRemoteRef(ref); err != nil {
+			return nil, errors.New("invalid Hermes ref")
+		}
+		cloneURL, err := githubRepositoryCloneURL(source)
+		if err != nil {
+			return nil, errors.New("invalid Hermes source")
+		}
+		sourceHash, refHash := sha256.Sum256([]byte(strings.ToLower(cloneURL))), sha256.Sum256([]byte(ref))
+		target := filepath.Join(dataDirectory, "checkouts", "hermes", hex.EncodeToString(sourceHash[:8]), hex.EncodeToString(refHash[:8]), "current")
+		root, err = refreshIntegrationCheckout(ctx, commands, cloneURL, ref, target, func(path string) error {
+			_, ok := findHermesPluginPair(path)
+			if !ok {
+				return errors.New("PowerContext Hermes plugins were not found under the selected source")
+			}
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+	pair, ok := findHermesPluginPair(root)
+	if !ok {
+		return nil, errors.New("PowerContext Hermes plugins were not found under the selected source")
+	}
+	return pair, nil
+}
+
+func findHermesPluginPair(root string) (map[string]string, bool) {
+	for _, candidate := range []string{root, filepath.Join(root, filepath.FromSlash("integrations/hermes/plugins"))} {
+		result := map[string]string{}
+		for name := range map[string]string{hermesPluginName: hermesPluginName, hermesCommandPluginName: hermesCommandPluginName} {
+			path := filepath.Join(candidate, name)
+			if _, ok := findHermesPlugin(path); !ok {
+				result = nil
+				break
+			}
+			result[name] = path
+		}
+		if result != nil {
+			return result, true
+		}
+	}
+	return nil, false
 }
 
 func newDoctorHermesCommand(state *commandState) *cobra.Command {
@@ -241,19 +298,92 @@ func installHermesPlugin(
 	return nil
 }
 
+func installHermesPlugins(ctx context.Context, commands systemCommandExecutor, executable string, sources, targets map[string]string) error {
+	type stagedPlugin struct{ name, target, staging, backup string }
+	plugins := make([]stagedPlugin, 0, 2)
+	for _, name := range []string{hermesPluginName, hermesCommandPluginName} {
+		target := targets[name]
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return errors.New("cannot create Hermes plugin directory")
+		}
+		staging, err := os.MkdirTemp(filepath.Dir(target), ".powercontext-")
+		if err != nil {
+			return errors.New("cannot create Hermes plugin staging directory")
+		}
+		plugins = append(plugins, stagedPlugin{name: name, target: target, staging: staging})
+		if err := copyRegularTree(sources[name], staging); err != nil {
+			return errors.New("cannot copy the PowerContext Hermes plugin")
+		}
+		if _, err := commands.Run(ctx, executable, "plugins", "doctor", "--ci", staging); err != nil {
+			return err
+		}
+	}
+	rollback := func() {
+		for _, plugin := range plugins {
+			_ = os.RemoveAll(plugin.staging)
+			if plugin.backup != "" {
+				_ = os.RemoveAll(plugin.target)
+				_ = hermesRename(plugin.backup, plugin.target)
+			}
+		}
+	}
+	for index := range plugins {
+		plugin := &plugins[index]
+		if _, err := os.Lstat(plugin.target); err == nil {
+			backup, err := os.MkdirTemp(filepath.Dir(plugin.target), ".powercontext-backup-")
+			if err != nil {
+				rollback()
+				return errors.New("cannot create Hermes plugin backup")
+			}
+			if err := os.Remove(backup); err != nil {
+				rollback()
+				return err
+			}
+			if err := hermesRename(plugin.target, backup); err != nil {
+				rollback()
+				return errors.New("cannot preserve existing Hermes plugin")
+			}
+			plugin.backup = backup
+		} else if !errors.Is(err, os.ErrNotExist) {
+			rollback()
+			return errors.New("cannot inspect existing Hermes plugin")
+		}
+	}
+	for index := range plugins {
+		plugin := &plugins[index]
+		if err := hermesRename(plugin.staging, plugin.target); err != nil {
+			rollback()
+			return errors.New("cannot activate Hermes plugin")
+		}
+		plugin.staging = ""
+	}
+	if _, err := commands.Run(ctx, executable, "plugins", "enable", hermesCommandPluginName); err != nil {
+		rollback()
+		return err
+	}
+	for _, plugin := range plugins {
+		if plugin.backup != "" {
+			_ = os.RemoveAll(plugin.backup)
+		}
+	}
+	return nil
+}
+
 func runHermesDiagnostics(ctx context.Context, commands systemCommandExecutor) map[string]diagnostic {
 	executable, err := commands.LookPath("hermes")
 	if err != nil {
 		return map[string]diagnostic{
-			"hermes": {Status: "failed", Detail: "Hermes CLI is not installed or is not on PATH"},
-			"plugin": {Status: "skipped", Detail: "not checked because Hermes CLI is unavailable"},
+			"hermes":         {Status: "failed", Detail: "Hermes CLI is not installed or is not on PATH"},
+			"plugin":         {Status: "skipped", Detail: "not checked because Hermes CLI is unavailable"},
+			"command_plugin": {Status: "skipped", Detail: "not checked because Hermes CLI is unavailable"},
 		}
 	}
 	version, err := hermesVersion(ctx, commands, executable)
 	if err != nil {
 		return map[string]diagnostic{
-			"hermes": {Status: "failed", Detail: err.Error()},
-			"plugin": {Status: "skipped", Detail: "not checked because Hermes version validation failed"},
+			"hermes":         {Status: "failed", Detail: err.Error()},
+			"plugin":         {Status: "skipped", Detail: "not checked because Hermes version validation failed"},
+			"command_plugin": {Status: "skipped", Detail: "not checked because Hermes version validation failed"},
 		}
 	}
 	home, err := hermesHome()
@@ -264,18 +394,37 @@ func runHermesDiagnostics(ctx context.Context, commands systemCommandExecutor) m
 		}
 	}
 	pluginPath := filepath.Join(home, "plugins", hermesPluginName)
+	commandPath := filepath.Join(home, "plugins", hermesCommandPluginName)
 	if _, ok := findHermesPlugin(pluginPath); !ok {
 		return map[string]diagnostic{
-			"hermes": {OK: true, Status: "ok", Detail: fmt.Sprintf("%s (Hermes Agent v%s)", executable, version)},
-			"plugin": {Status: "failed", Detail: "PowerContext Hermes plugin is not installed"},
+			"hermes":         {OK: true, Status: "ok", Detail: fmt.Sprintf("%s (Hermes Agent v%s)", executable, version)},
+			"plugin":         {Status: "failed", Detail: "PowerContext Hermes plugin is not installed"},
+			"command_plugin": {Status: "skipped", Detail: "not checked because the provider plugin is unavailable"},
+		}
+	}
+	if _, ok := findHermesPlugin(commandPath); !ok {
+		return map[string]diagnostic{
+			"hermes":         {OK: true, Status: "ok", Detail: fmt.Sprintf("%s (Hermes Agent v%s)", executable, version)},
+			"plugin":         {OK: true, Status: "ok", Detail: "powercontext passed Hermes plugin doctor"},
+			"command_plugin": {Status: "failed", Detail: "PowerContext Hermes command plugin is not installed"},
 		}
 	}
 	pluginCheck := diagnostic{OK: true, Status: "ok", Detail: "powercontext passed Hermes plugin doctor"}
 	if _, err := commands.Run(ctx, executable, "plugins", "doctor", "--ci", pluginPath); err != nil {
 		pluginCheck = diagnostic{Status: "failed", Detail: err.Error()}
+		return map[string]diagnostic{
+			"hermes":         {OK: true, Status: "ok", Detail: fmt.Sprintf("%s (Hermes Agent v%s)", executable, version)},
+			"plugin":         pluginCheck,
+			"command_plugin": {Status: "skipped", Detail: "not checked because the provider plugin doctor failed"},
+		}
+	}
+	commandCheck := diagnostic{OK: true, Status: "ok", Detail: "powercontext-command passed Hermes plugin doctor"}
+	if _, err := commands.Run(ctx, executable, "plugins", "doctor", "--ci", commandPath); err != nil {
+		commandCheck = diagnostic{Status: "failed", Detail: err.Error()}
 	}
 	return map[string]diagnostic{
-		"hermes": {OK: true, Status: "ok", Detail: fmt.Sprintf("%s (Hermes Agent v%s)", executable, version)},
-		"plugin": pluginCheck,
+		"hermes":         {OK: true, Status: "ok", Detail: fmt.Sprintf("%s (Hermes Agent v%s)", executable, version)},
+		"plugin":         pluginCheck,
+		"command_plugin": commandCheck,
 	}
 }

--- a/internal/cli/integration_hosts_test.go
+++ b/internal/cli/integration_hosts_test.go
@@ -829,7 +829,7 @@ func TestSetupHermesStagesDoctorAndAtomicallyReplacesPlugin(t *testing.T) {
 	commands := &scriptedSystemCommands{
 		t: t, paths: map[string]string{"hermes": "/usr/bin/hermes"},
 		results: []systemCommandResult{
-			{output: "Hermes Agent v0.20.4\n"}, {}, {output: "Hermes Agent v0.20.4\n"}, {},
+			{output: "Hermes Agent v0.20.4\n"}, {}, {}, {}, {output: "Hermes Agent v0.20.4\n"}, {}, {},
 		},
 	}
 	stdout, _, err := executeSystemCLI(t, nil, commands, "setup", "hermes", "--source", checkout, "--json")
@@ -844,6 +844,79 @@ func TestSetupHermesStagesDoctorAndAtomicallyReplacesPlugin(t *testing.T) {
 	}
 	if _, ok := findHermesPlugin(target); !ok {
 		t.Fatal("installed Hermes plugin is incomplete")
+	}
+}
+
+func TestHermesPluginPairRestoresBothTargetsWhenSecondActivationFails(t *testing.T) {
+	checkout := filepath.Join(t.TempDir(), "checkout")
+	writeHermesPlugin(t, checkout)
+	home := filepath.Join(t.TempDir(), "hermes")
+	provider := filepath.Join(home, "plugins", hermesPluginName)
+	command := filepath.Join(home, "plugins", hermesCommandPluginName)
+	for path, marker := range map[string]string{provider: "old provider\n", command: "old command\n"} {
+		writeTestFile(t, filepath.Join(path, "__init__.py"), "def register(): pass\n")
+		writeTestFile(t, filepath.Join(path, "plugin.yaml"), "name: test\n")
+		writeTestFile(t, filepath.Join(path, "version.txt"), marker)
+	}
+	writeTestFile(t, filepath.Join(home, "plugins", "other", "keep.txt"), "keep\n")
+	sources, ok := findHermesPluginPair(checkout)
+	if !ok {
+		t.Fatal("source pair is missing")
+	}
+	original := hermesRename
+	t.Cleanup(func() { hermesRename = original })
+	failed := false
+	hermesRename = func(source, target string) error {
+		if !failed && target == command && strings.HasPrefix(filepath.Base(source), ".powercontext-") {
+			failed = true
+			return errors.New("injected second activation failure")
+		}
+		return original(source, target)
+	}
+	err := installHermesPlugins(t.Context(), &scriptedSystemCommands{t: t, results: []systemCommandResult{{}, {}}}, "/usr/bin/hermes", sources, map[string]string{hermesPluginName: provider, hermesCommandPluginName: command})
+	if err == nil || !failed {
+		t.Fatalf("install error = %v, failed = %t", err, failed)
+	}
+	for path, want := range map[string]string{provider: "old provider\n", command: "old command\n"} {
+		got, readErr := os.ReadFile(filepath.Join(path, "version.txt"))
+		if readErr != nil || string(got) != want {
+			t.Fatalf("restored %s = %q, %v", path, got, readErr)
+		}
+	}
+	if got, err := os.ReadFile(filepath.Join(home, "plugins", "other", "keep.txt")); err != nil || string(got) != "keep\n" {
+		t.Fatalf("unrelated plugin = %q, %v", got, err)
+	}
+}
+
+func TestHermesPluginPairRestoresBothTargetsWhenEnableFails(t *testing.T) {
+	checkout := filepath.Join(t.TempDir(), "checkout")
+	writeHermesPlugin(t, checkout)
+	home := filepath.Join(t.TempDir(), "hermes")
+	provider := filepath.Join(home, "plugins", hermesPluginName)
+	command := filepath.Join(home, "plugins", hermesCommandPluginName)
+	for path, marker := range map[string]string{provider: "old provider\n", command: "old command\n"} {
+		writeTestFile(t, filepath.Join(path, "__init__.py"), "def register(): pass\n")
+		writeTestFile(t, filepath.Join(path, "plugin.yaml"), "name: test\n")
+		writeTestFile(t, filepath.Join(path, "version.txt"), marker)
+	}
+	writeTestFile(t, filepath.Join(home, "plugins", "other", "keep.txt"), "keep\n")
+	sources, ok := findHermesPluginPair(checkout)
+	if !ok {
+		t.Fatal("source pair is missing")
+	}
+	commands := &scriptedSystemCommands{t: t, results: []systemCommandResult{{}, {}, {err: errors.New("enable failed")}}}
+	err := installHermesPlugins(t.Context(), commands, "/usr/bin/hermes", sources, map[string]string{hermesPluginName: provider, hermesCommandPluginName: command})
+	if err == nil {
+		t.Fatal("enable failure unexpectedly succeeded")
+	}
+	for path, want := range map[string]string{provider: "old provider\n", command: "old command\n"} {
+		got, readErr := os.ReadFile(filepath.Join(path, "version.txt"))
+		if readErr != nil || string(got) != want {
+			t.Fatalf("restored %s = %q, %v", path, got, readErr)
+		}
+	}
+	if got, err := os.ReadFile(filepath.Join(home, "plugins", "other", "keep.txt")); err != nil || string(got) != "keep\n" {
+		t.Fatalf("unrelated plugin = %q, %v", got, err)
 	}
 }
 
@@ -903,9 +976,12 @@ func TestHermesDiagnosticsCoverInstalledMissingBrokenAndUnsupportedProviders(t *
 		plugin := filepath.Join(home, "plugins", hermesPluginName)
 		writeTestFile(t, filepath.Join(plugin, "__init__.py"), "def register(): pass\n")
 		writeTestFile(t, filepath.Join(plugin, "plugin.yaml"), "name: powercontext\n")
+		commandPlugin := filepath.Join(home, "plugins", hermesCommandPluginName)
+		writeTestFile(t, filepath.Join(commandPlugin, "__init__.py"), "def register(context): pass\n")
+		writeTestFile(t, filepath.Join(commandPlugin, "plugin.yaml"), "name: powercontext-command\nkind: standalone\n")
 		commands := &scriptedSystemCommands{
 			t: t, paths: map[string]string{"hermes": "/resolved/bin/hermes"},
-			results: []systemCommandResult{{output: "Hermes Agent v0.20.4\n"}, {}},
+			results: []systemCommandResult{{output: "Hermes Agent v0.20.4\n"}, {}, {}},
 		}
 		checks := runHermesDiagnostics(t.Context(), commands)
 		if checks["hermes"].Status != "ok" || checks["plugin"].Status != "ok" {
@@ -930,6 +1006,9 @@ func TestHermesDiagnosticsCoverInstalledMissingBrokenAndUnsupportedProviders(t *
 		plugin := filepath.Join(home, "plugins", hermesPluginName)
 		writeTestFile(t, filepath.Join(plugin, "__init__.py"), "def register(): pass\n")
 		writeTestFile(t, filepath.Join(plugin, "plugin.yaml"), "name: powercontext\n")
+		commandPlugin := filepath.Join(home, "plugins", hermesCommandPluginName)
+		writeTestFile(t, filepath.Join(commandPlugin, "__init__.py"), "def register(context): pass\n")
+		writeTestFile(t, filepath.Join(commandPlugin, "plugin.yaml"), "name: powercontext-command\nkind: standalone\n")
 		commands := &scriptedSystemCommands{
 			t: t, paths: map[string]string{"hermes": "/resolved/bin/hermes"},
 			results: []systemCommandResult{{output: "Hermes Agent v0.20.4\n"}, {err: errors.New("provider doctor failed")}},
@@ -1127,6 +1206,9 @@ func writeHermesPlugin(t *testing.T, root string) string {
 	path := filepath.Join(root, filepath.FromSlash(hermesRelative))
 	writeTestFile(t, filepath.Join(path, "__init__.py"), "def register(): pass\n")
 	writeTestFile(t, filepath.Join(path, "plugin.yaml"), "name: powercontext\n")
+	command := filepath.Join(root, filepath.FromSlash(hermesCommandRelative))
+	writeTestFile(t, filepath.Join(command, "__init__.py"), "def register(context): pass\n")
+	writeTestFile(t, filepath.Join(command, "plugin.yaml"), "name: powercontext-command\nkind: standalone\n")
 	resolved, err := resolvePath(path)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/cli/setup_select_test.go
+++ b/internal/cli/setup_select_test.go
@@ -299,6 +299,8 @@ func TestSetupSelectFailsRowsWhenPostInstallVerificationFails(t *testing.T) {
 					results: []systemCommandResult{
 						{output: "Hermes Agent v0.20.4\n"},
 						{},
+						{},
+						{},
 						{output: "Hermes Agent v0.20.4\n"},
 						{err: errors.New("provider doctor failed")},
 					},
@@ -328,7 +330,7 @@ func TestSetupSelectPrintsHermesNextStepOnlyWhenInstalled(t *testing.T) {
 	hermesCommands := &scriptedSystemCommands{
 		t: t, paths: map[string]string{"hermes": "/usr/bin/hermes"},
 		results: []systemCommandResult{
-			{output: "Hermes Agent v0.20.4\n"}, {}, {output: "Hermes Agent v0.20.4\n"}, {},
+			{output: "Hermes Agent v0.20.4\n"}, {}, {}, {}, {output: "Hermes Agent v0.20.4\n"}, {}, {},
 		},
 	}
 	installed, _, err := executeSystemCLIWithInput(

--- a/test/conformance/parity-inventory-rules.json
+++ b/test/conformance/parity-inventory-rules.json
@@ -726,7 +726,15 @@
     },
     "tests/test_hermes_cli.py": {
       "mode": "go-port",
-      "reason": "Hermes setup CLI commands; the CLI is Go (internal/cli)."
+      "reason": "Hermes setup CLI commands; the CLI is Go (internal/cli).",
+      "cases": {
+        "test_setup_hermes_restores_both_plugins_when_second_replace_fails": {
+          "evidence": ["go:internal/cli/integration_hosts_test.go#TestHermesPluginPairRestoresBothTargetsWhenSecondActivationFails"]
+        },
+        "test_setup_hermes_restores_both_plugins_when_enable_fails": {
+          "evidence": ["go:internal/cli/integration_hosts_test.go#TestHermesPluginPairRestoresBothTargetsWhenEnableFails"]
+        }
+      }
     },
     "tests/test_opencode_cli.py": {
       "mode": "go-port",

--- a/test/conformance/parity-inventory.json
+++ b/test/conformance/parity-inventory.json
@@ -4,8 +4,8 @@
   "oracle_commit": "3a6cb0151670eaff7dc0293466edd673124e80da",
   "python_test_file_count": 132,
   "python_test_case_count": 812,
-  "mapped_case_count": 758,
-  "pending_case_count": 54,
+  "mapped_case_count": 760,
+  "pending_case_count": 52,
   "entries": [
     {
       "python": {
@@ -10698,8 +10698,15 @@
         "line": 105
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/integration_hosts_test.go",
+          "test": "TestHermesPluginPairRestoresBothTargetsWhenSecondActivationFails"
+        }
+      ]
     },
     {
       "python": {
@@ -10708,8 +10715,15 @@
         "line": 146
       },
       "mode": "go-port",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "go",
+          "file": "internal/cli/integration_hosts_test.go",
+          "test": "TestHermesPluginPairRestoresBothTargetsWhenEnableFails"
+        }
+      ]
     },
     {
       "python": {


### PR DESCRIPTION
## Summary

- install the released Hermes provider and command companion as one staged, recoverable pair
- restore both old targets when the second activation or command-plugin enable fails
- report the command companion separately in Hermes and integration diagnostics
- map exactly two v0.1.0 Hermes CLI recovery cases; generated inventory becomes `760 mapped / 52 pending`

## Validation

- focused Hermes setup, activation rollback, enable rollback, diagnostics, and setup-select tests
- parity inventory and reviewed delta checks
- conformance inventory contract

## Scope

No Hermes provider session, tool, trace, workstream, Pydantic AI, or LangChain behavior is included.