### PR TITLE
feat(evaluation): add WP5 P2a single-arm execution

### DIFF
--- a/docs/superpowers/plans/2026-09-02-wp5-single-arm-execution.md
+++ b/docs/superpowers/plans/2026-09-02-wp5-single-arm-execution.md
@@ -49,6 +49,8 @@ models, SQLite-backed task store, Docker SUT runner.
 - [x] Add `TreatmentMode`, nullable report/result fields, and strict selected
   arm validation; render a single-arm report without a comparison section.
 - [x] Run the report test and its paired-report regression tests.
+- [x] Reject a retained `arms/off` or `arms/on` entry that is absent from the
+  declared single-arm mode through the already-opened directory descriptor.
 - [x] Commit the model/report contract change.
 
 ### Task 2: Run Only Requested Arms
@@ -90,6 +92,9 @@ models, SQLite-backed task store, Docker SUT runner.
 - [x] Run it and verify the current worker accepts the mismatched result.
 - [x] Pass the task mode into `_batch_run_config`; compare non-null runner
   result arms with `task.request.treatment_mode.arms` in `_validated_result`.
+- [x] Bind the loaded retained report's mode, report/evidence arm sets, and
+  resolved outcomes to the requested arms and validated runner result before
+  persistence; prove rejection with real retained artifacts.
 - [x] Run focused worker tests, including existing paired success and retry
   cases.
 - [x] Commit the worker change.

--- a/docs/superpowers/plans/2026-09-02-wp5-single-arm-execution.md
+++ b/docs/superpowers/plans/2026-09-02-wp5-single-arm-execution.md
@@ -42,14 +42,14 @@ models, SQLite-backed task store, Docker SUT runner.
   absent from `treatment_mode.arms`.
 - Produces nullable `TaskResult.off_resolved` and `TaskResult.on_resolved`.
 
-- [ ] Write a parametrized failing report-loader test for `on_only` and
+- [x] Write a parametrized failing report-loader test for `on_only` and
   `off_only` artifacts containing exactly one evidence directory.
-- [ ] Run that test and verify current code rejects the artifact because it
+- [x] Run that test and verify current code rejects the artifact because it
   unconditionally loads both arms.
-- [ ] Add `TreatmentMode`, nullable report/result fields, and strict selected
+- [x] Add `TreatmentMode`, nullable report/result fields, and strict selected
   arm validation; render a single-arm report without a comparison section.
-- [ ] Run the report test and its paired-report regression tests.
-- [ ] Commit the model/report contract change.
+- [x] Run the report test and its paired-report regression tests.
+- [x] Commit the model/report contract change.
 
 ### Task 2: Run Only Requested Arms
 
@@ -63,15 +63,15 @@ models, SQLite-backed task store, Docker SUT runner.
 - Uses `DockerSut.run_pair` exclusively for `off_on` and `DockerSut.run_arm`
   for `on_only` or `off_only`.
 
-- [ ] Write a parametrized failing runner test for `on_only` and `off_only`
+- [x] Write a parametrized failing runner test for `on_only` and `off_only`
   that asserts one SUT arm, one official evaluation, one report arm, and an
   absent unexecuted result.
-- [ ] Run the new test and verify current code invokes both arms.
-- [ ] Add `RunConfig.treatment_mode`, select `TreatmentMode.arms`, and build
+- [x] Run the new test and verify current code invokes both arms.
+- [x] Add `RunConfig.treatment_mode`, select `TreatmentMode.arms`, and build
   paths, stores, context traces, official evaluations, and report arms only
   for that set.
-- [ ] Run focused runner phase tests and the existing paired runner tests.
-- [ ] Commit the runner change.
+- [x] Run focused runner phase tests and the existing paired runner tests.
+- [x] Commit the runner change.
 
 ### Task 3: Persist and Validate Selected Outcomes in the Worker
 
@@ -85,14 +85,14 @@ models, SQLite-backed task store, Docker SUT runner.
 - Rejects a runner result whose non-null outcome arms differ from the requested
   set before `TaskStore.succeed` persists it.
 
-- [ ] Write a failing worker test for an `on_only` task whose runner returns an
+- [x] Write a failing worker test for an `on_only` task whose runner returns an
   OFF outcome, asserting safe failure instead of success.
-- [ ] Run it and verify the current worker accepts the mismatched result.
-- [ ] Pass the task mode into `_batch_run_config`; compare non-null runner
+- [x] Run it and verify the current worker accepts the mismatched result.
+- [x] Pass the task mode into `_batch_run_config`; compare non-null runner
   result arms with `task.request.treatment_mode.arms` in `_validated_result`.
-- [ ] Run focused worker tests, including existing paired success and retry
+- [x] Run focused worker tests, including existing paired success and retry
   cases.
-- [ ] Commit the worker change.
+- [x] Commit the worker change.
 
 ### Task 4: Validate the Complete P2a Contract
 
@@ -101,11 +101,11 @@ models, SQLite-backed task store, Docker SUT runner.
 - Test: `evaluation/tests/web/test_reporting.py`
 - Test: `evaluation/tests/web/test_worker.py`
 
-- [ ] Run the three focused test files with the project Linux runtime.
-- [ ] Run `ruff check evaluation`, `ruff format --check evaluation`, and
+- [x] Run the three focused test files with the project Linux runtime.
+- [x] Run `ruff check evaluation`, `ruff format --check evaluation`, and
   `ty check src`.
-- [ ] Run the evaluation control-plane test suite or record any reproduced
+- [x] Run the evaluation control-plane test suite and record the six reproduced
   environment-only gap against an unmodified baseline.
-- [ ] Inspect `git diff --check` and the exact changed-file inventory.
+- [x] Inspect `git diff --check` and the exact changed-file inventory.
 - [ ] Commit only P2a files; push, open the P2a PR, and verify exact-Head and
   post-main CI before updating Issue #109.

--- a/docs/superpowers/plans/2026-09-02-wp5-single-arm-execution.md
+++ b/docs/superpowers/plans/2026-09-02-wp5-single-arm-execution.md
@@ -1,0 +1,111 @@
+# WP5 Single-Arm Execution Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> `superpowers:executing-plans` to implement this plan task-by-task. Steps use
+> checkbox syntax for tracking.
+
+**Goal:** Enable internal OFF-only and ON-only evaluation runs while preserving
+the default OFF/ON workflow.
+
+**Architecture:** `TreatmentMode` is the single source of truth for selected
+arms. The runner iterates that ordered set, the worker persists only those
+outcomes, and report models/loaders require evidence exactly for those arms.
+
+**Tech Stack:** Python 3.11+, Pydantic v2, pytest, FastAPI control-plane
+models, SQLite-backed task store, Docker SUT runner.
+
+**Spec:** `docs/superpowers/specs/2026-09-02-wp5-single-arm-execution-design.md`
+
+## Global Constraints
+
+- Keep `off_on` as the default and preserve observable paired behavior.
+- Do not modify `evaluation/src/powercontext_eval/web/api.py`, `cli.py`,
+  `web/baselines.py`, or the React console; they belong to P2 API/CLI and P3.
+- Do not copy unrelated upstream `SutConfig` cleanup from `f4c7ce10`.
+- Use real Pydantic objects, retained artifacts, and SQLite-backed tests; mock
+  only process, Docker, HTTP, or time boundaries already mocked by the suite.
+
+---
+
+### Task 1: Define Exact Treatment-Mode Report Contracts
+
+**Files:**
+- Modify: `evaluation/src/powercontext_eval/models.py`
+- Modify: `evaluation/src/powercontext_eval/report.py`
+- Modify: `evaluation/src/powercontext_eval/web/batches.py`
+- Modify: `evaluation/src/powercontext_eval/web/models.py`
+- Test: `evaluation/tests/web/test_reporting.py`
+
+**Interfaces:**
+- Produces `TreatmentMode.arms: tuple[Arm, ...]`.
+- Produces a `ReportBundle` whose `off` and `on` values are optional only when
+  absent from `treatment_mode.arms`.
+- Produces nullable `TaskResult.off_resolved` and `TaskResult.on_resolved`.
+
+- [ ] Write a parametrized failing report-loader test for `on_only` and
+  `off_only` artifacts containing exactly one evidence directory.
+- [ ] Run that test and verify current code rejects the artifact because it
+  unconditionally loads both arms.
+- [ ] Add `TreatmentMode`, nullable report/result fields, and strict selected
+  arm validation; render a single-arm report without a comparison section.
+- [ ] Run the report test and its paired-report regression tests.
+- [ ] Commit the model/report contract change.
+
+### Task 2: Run Only Requested Arms
+
+**Files:**
+- Modify: `evaluation/src/powercontext_eval/runner.py`
+- Test: `evaluation/tests/unit/test_runner_phases.py`
+
+**Interfaces:**
+- Consumes `RunConfig.treatment_mode: TreatmentMode`.
+- Produces `RunResult` with `None` only for unexecuted arms.
+- Uses `DockerSut.run_pair` exclusively for `off_on` and `DockerSut.run_arm`
+  for `on_only` or `off_only`.
+
+- [ ] Write a parametrized failing runner test for `on_only` and `off_only`
+  that asserts one SUT arm, one official evaluation, one report arm, and an
+  absent unexecuted result.
+- [ ] Run the new test and verify current code invokes both arms.
+- [ ] Add `RunConfig.treatment_mode`, select `TreatmentMode.arms`, and build
+  paths, stores, context traces, official evaluations, and report arms only
+  for that set.
+- [ ] Run focused runner phase tests and the existing paired runner tests.
+- [ ] Commit the runner change.
+
+### Task 3: Persist and Validate Selected Outcomes in the Worker
+
+**Files:**
+- Modify: `evaluation/src/powercontext_eval/web/worker.py`
+- Test: `evaluation/tests/web/test_worker.py`
+
+**Interfaces:**
+- Consumes `TaskRecord.request.treatment_mode`.
+- Passes that mode to `RunConfig`.
+- Rejects a runner result whose non-null outcome arms differ from the requested
+  set before `TaskStore.succeed` persists it.
+
+- [ ] Write a failing worker test for an `on_only` task whose runner returns an
+  OFF outcome, asserting safe failure instead of success.
+- [ ] Run it and verify the current worker accepts the mismatched result.
+- [ ] Pass the task mode into `_batch_run_config`; compare non-null runner
+  result arms with `task.request.treatment_mode.arms` in `_validated_result`.
+- [ ] Run focused worker tests, including existing paired success and retry
+  cases.
+- [ ] Commit the worker change.
+
+### Task 4: Validate the Complete P2a Contract
+
+**Files:**
+- Test: `evaluation/tests/unit/test_runner_phases.py`
+- Test: `evaluation/tests/web/test_reporting.py`
+- Test: `evaluation/tests/web/test_worker.py`
+
+- [ ] Run the three focused test files with the project Linux runtime.
+- [ ] Run `ruff check evaluation`, `ruff format --check evaluation`, and
+  `ty check src`.
+- [ ] Run the evaluation control-plane test suite or record any reproduced
+  environment-only gap against an unmodified baseline.
+- [ ] Inspect `git diff --check` and the exact changed-file inventory.
+- [ ] Commit only P2a files; push, open the P2a PR, and verify exact-Head and
+  post-main CI before updating Issue #109.

--- a/docs/superpowers/specs/2026-09-02-wp5-single-arm-execution-design.md
+++ b/docs/superpowers/specs/2026-09-02-wp5-single-arm-execution-design.md
@@ -1,0 +1,66 @@
+# WP5 Single-Arm Execution Design
+
+## Goal
+
+Complete the internal execution portion of WP5 P2 so an evaluation task can
+run `off_on`, `off_only`, or `on_only` without inventing an unexecuted arm.
+
+## Scope
+
+This slice owns the evaluation domain, runner, worker, retained report, and
+batch model paths. It does not modify the evaluation HTTP API, CLI commands,
+Baseline storage contracts, React console, generated files, or Go product
+surface. PR #167 remains the independent API/CLI slice; the Baseline Library
+remains P3 work.
+
+## Contract
+
+- `TreatmentMode` declares the exact ordered arm set: `off_on`, `on_only`, or
+  `off_only`.
+- A single-arm run creates workspaces, evidence, official evaluation output,
+  context trace, report data, and result state only for its selected arm.
+- `ReportBundle` and the web report projection reject a missing required arm or
+  an extra unrequested arm. OFF/ON comparison data is present only for
+  `off_on`.
+- A completed task result has `None` for the unexecuted arm. The worker checks
+  that returned arm outcomes exactly match the requested mode before persisting
+  success.
+- The default remains `off_on`; all paired behavior, paired acceptance rules,
+  and existing public API response shapes remain compatible.
+
+## Error Handling
+
+- A report with missing, malformed, or extra treatment evidence is rejected as
+  an invalid retained report.
+- A runner outcome whose populated arms differ from the requested mode is an
+  invalid report bundle and fails the claimed task through the existing safe
+  worker failure path.
+- A single-arm report has no OFF/ON comparison. It does not synthesize zeroes,
+  failures, treatment evidence, or metrics for the absent arm.
+
+## File Boundaries
+
+- `evaluation/src/powercontext_eval/models.py`: `TreatmentMode` value object.
+- `evaluation/src/powercontext_eval/report.py`: retained report arm invariants
+  and comparison rendering.
+- `evaluation/src/powercontext_eval/runner.py`: arm selection, run result, and
+  persisted report construction.
+- `evaluation/src/powercontext_eval/web/batches.py` and `web/models.py`:
+  task/batch treatment mode and nullable unexecuted results.
+- `evaluation/src/powercontext_eval/web/worker.py`: pass the selected mode and
+  validate exact returned outcomes.
+- `evaluation/src/powercontext_eval/web/reporting.py`: load only selected-arm
+  evidence and project an absent arm as `null`.
+- Adjacent unit and web tests prove the execution and retained-artifact
+  contracts with real model and filesystem state.
+
+## Acceptance
+
+1. Tests prove `on_only` and `off_only` run exactly one requested arm and
+   persist only that arm's report/outcome.
+2. Tests prove the web loader accepts a valid single-arm artifact and rejects
+   missing or extra evidence for its declared mode.
+3. Tests prove the worker refuses a runner result that reports an unrequested
+   arm and preserves the existing `off_on` flow.
+4. Focused Python tests, lint, format, and type checks pass on Linux; the full
+   evaluation control-plane CI remains the final delivery signal.

--- a/evaluation/src/powercontext_eval/models.py
+++ b/evaluation/src/powercontext_eval/models.py
@@ -28,6 +28,22 @@ class Arm(StrEnum):
     ON = "on"
 
 
+class TreatmentMode(StrEnum):
+    """The exact treatment arms executed for one evaluation task."""
+
+    OFF_ON = "off_on"
+    ON_ONLY = "on_only"
+    OFF_ONLY = "off_only"
+
+    @property
+    def arms(self) -> tuple[Arm, ...]:
+        if self is TreatmentMode.OFF_ON:
+            return (Arm.OFF, Arm.ON)
+        if self is TreatmentMode.ON_ONLY:
+            return (Arm.ON,)
+        return (Arm.OFF,)
+
+
 class PowerContextRef(BaseModel):
     """An explicit, immutable PowerContext source reference."""
 

--- a/evaluation/src/powercontext_eval/report.py
+++ b/evaluation/src/powercontext_eval/report.py
@@ -39,6 +39,7 @@ from powercontext_eval.benchmarks.swebench_pro.gold_overrides import (
     SOURCE595_DATASET_PATCH_SHA256,
     SOURCE595_INSTANCE_ID,
 )
+from powercontext_eval.models import Arm, TreatmentMode
 
 
 class MetricSet(BaseModel):
@@ -190,9 +191,26 @@ class ReportBundle(BaseModel):
     title: str
     revisions: Mapping[str, str]
     configuration: Mapping[str, str]
-    off: ArmReport
-    on: ArmReport
+    treatment_mode: TreatmentMode = TreatmentMode.OFF_ON
+    off: ArmReport | None = None
+    on: ArmReport | None = None
     gold_validation: GoldValidationAudit | None = None
+
+    @field_validator("treatment_mode", mode="before")
+    @classmethod
+    def parse_treatment_mode(cls, value: object) -> object:
+        return TreatmentMode(value) if isinstance(value, str) else value
+
+    @model_validator(mode="after")
+    def validate_arms(self) -> Self:
+        present = {arm for arm, report in ((Arm.OFF, self.off), (Arm.ON, self.on)) if report is not None}
+        if present != set(self.treatment_mode.arms):
+            raise ValueError("Report arms do not match the treatment mode")
+        if self.off is not None and self.off.arm != "off":
+            raise ValueError("OFF report is bound to the wrong arm")
+        if self.on is not None and self.on.arm != "on":
+            raise ValueError("ON report is bound to the wrong arm")
+        return self
 
     @model_validator(mode="after")
     def validate_gold_binding(self) -> Self:
@@ -332,6 +350,8 @@ def _gold_validation_section(audit: GoldValidationAudit) -> list[str]:
 
 def _comparison(bundle: ReportBundle) -> list[str]:
     lines = ["## Comparison", ""]
+    if bundle.off is None or bundle.on is None:
+        return lines + ["Comparison unavailable: this run contains one treatment arm.", ""]
     comparable_states = {ArmState.TREATMENT_VALIDATED, ArmState.REPORTED}
     if not (
         bundle.off.state in comparable_states
@@ -374,10 +394,9 @@ def _validated_bundle(bundle: ReportBundle) -> ReportBundle:
         expected_bundle_fields = set(ReportBundle.model_fields)
         if set(bundle.__dict__) != expected_bundle_fields:
             raise ValueError
-        for model, model_type in (
-            (bundle.off, ArmReport),
-            (bundle.on, ArmReport),
-        ):
+        for model, model_type in ((bundle.off, ArmReport), (bundle.on, ArmReport)):
+            if model is None:
+                continue
             if type(model) is not model_type or set(model.__dict__) != set(model_type.model_fields):
                 raise ValueError
             if type(model.metrics) is not MetricSet or set(model.metrics.__dict__) != set(MetricSet.model_fields):
@@ -400,14 +419,15 @@ def render_report(bundle: ReportBundle) -> str:
     """Render only the supplied validated bundle, with no external reads."""
 
     bundle = _validated_bundle(bundle)
-    if bundle.off.arm != "off" or bundle.on.arm != "on":
-        raise ValueError("Report arms must be supplied in OFF then ON roles")
     lines = [f"# {_cell(bundle.title)}", ""]
     lines.extend(_mapping_table("Resolved revisions", bundle.revisions))
     lines.extend(_mapping_table("Configuration", bundle.configuration))
     if bundle.gold_validation is not None:
         lines.extend(_gold_validation_section(bundle.gold_validation))
-    lines.extend(_arm_section("OFF", bundle.off))
-    lines.extend(_arm_section("ON", bundle.on))
-    lines.extend(_comparison(bundle))
+    if bundle.off is not None:
+        lines.extend(_arm_section("OFF", bundle.off))
+    if bundle.on is not None:
+        lines.extend(_arm_section("ON", bundle.on))
+    if bundle.off is not None and bundle.on is not None:
+        lines.extend(_comparison(bundle))
     return "\n".join(lines)

--- a/evaluation/src/powercontext_eval/runner.py
+++ b/evaluation/src/powercontext_eval/runner.py
@@ -469,9 +469,7 @@ def _run_swebench_pro_instance(
         GoldResult(instance.instance_id, gold.resolved),
         arms,
     )
-    arm_reports = {
-        arm: _arm_report(arm, official[arm], outcomes[arm], patch_sizes[arm]) for arm in selected_arms
-    }
+    arm_reports = {arm: _arm_report(arm, official[arm], outcomes[arm], patch_sizes[arm]) for arm in selected_arms}
     emit_phase(RunPhase.GENERATING_REPORT)
     report = ReportBundle(
         title=(

--- a/evaluation/src/powercontext_eval/runner.py
+++ b/evaluation/src/powercontext_eval/runner.py
@@ -49,7 +49,7 @@ from powercontext_eval.codex import DEFAULT_CODEX_MODEL, DEFAULT_REASONING_EFFOR
 from powercontext_eval.context_trace import write_context_trace
 from powercontext_eval.errors import CommandFailed
 from powercontext_eval.git_source import GitSource
-from powercontext_eval.models import Arm, PowerContextRef
+from powercontext_eval.models import Arm, PowerContextRef, TreatmentMode
 from powercontext_eval.paths import EvaluationPaths
 from powercontext_eval.powercontext_sut import (
     DEFAULT_DOCKER_NETWORK_POOL,
@@ -152,6 +152,7 @@ class RunConfig:
     registry_binary: Path
     auth_json: Path
     run_id: str
+    treatment_mode: TreatmentMode = TreatmentMode.OFF_ON
     tokensflow_enabled: bool = False
     tokensflow_binary: Path | None = None
     tokensflow_user_home: Path | None = None
@@ -167,6 +168,8 @@ class RunConfig:
     cancel_event: threading.Event | None = field(default=None, repr=False, compare=False)
 
     def __post_init__(self) -> None:
+        if isinstance(self.treatment_mode, str):
+            object.__setattr__(self, "treatment_mode", TreatmentMode(self.treatment_mode))
         if not is_safe_codex_model(self.model):
             raise ValueError("Codex model is unsafe")
         if self.reasoning_effort != DEFAULT_REASONING_EFFORT:
@@ -188,8 +191,8 @@ class RunResult:
 
     run_id: str
     report_path: Path
-    off_resolved: bool
-    on_resolved: bool
+    off_resolved: bool | None
+    on_resolved: bool | None
 
 
 # Public compatibility name retained while the web task schema migrates from a single task to batches.
@@ -352,11 +355,13 @@ def _run_swebench_pro_instance(
     )
     run_store.write_json("gold/validation.json", gold_audit.model_dump(mode="json"))
 
-    def arms() -> tuple[OfficialEvaluation, OfficialEvaluation, Mapping[Arm, SutOutcome], dict[Arm, int]]:
+    selected_arms = config.treatment_mode.arms
+
+    def arms() -> tuple[dict[Arm, OfficialEvaluation], Mapping[Arm, SutOutcome], dict[Arm, int]]:
         codex_secrets = auth_secret_variants(config.auth_json)
         arm_paths: dict[Arm, ArmPaths] = {}
         stores: dict[Arm, ArtifactStore] = {}
-        for arm in (Arm.OFF, Arm.ON):
+        for arm in selected_arms:
             arm_work = layout.arm_work(arm)
             runtime = arm_work / "runtime"
             root_home = runtime / "root-home"
@@ -387,34 +392,41 @@ def _run_swebench_pro_instance(
                 secrets += tokensflow_secret_variants(tokensflow_credentials)
             stores[arm] = ArtifactStore(layout.arm_artifacts(arm), forbidden_values=secrets)
         prompt = instance.codex_prompt().encode()
-        outcomes = DockerSut(process).run_pair(
-            SutConfig(
-                run_id=run_id,
-                task_image=task_image_id,
-                codex_binary=config.codex_binary,
-                uv_binary=config.uv_binary,
-                source_checkout=materialized,
-                plugin_checkout_sha=resolved.sha,
-                proxy=ProxyRelayConfig(config.proxy_url) if config.proxy_url is not None else None,
-                docker_network_pool=config.docker_network_pool,
-                extra_no_proxy_hosts=config.extra_no_proxy_hosts,
-                tokensflow_enabled=config.tokensflow_enabled,
-                tokensflow_binary=config.tokensflow_binary,
-                tokensflow_egress_network=config.tokensflow_egress_network,
-                model=config.model,
-                reasoning_effort=config.reasoning_effort,
-                finalization_registrar=config.finalization_registrar,
-                container_env=config.container_env,
-            ),
-            paths=arm_paths,
-            prompts={Arm.OFF: prompt, Arm.ON: prompt},
-            stores=stores,
-            before_arm=lambda arm: emit_phase(RunPhase.RUNNING_OFF if arm is Arm.OFF else RunPhase.RUNNING_ON),
+        sut_config = SutConfig(
+            run_id=run_id,
+            task_image=task_image_id,
+            codex_binary=config.codex_binary,
+            uv_binary=config.uv_binary,
+            source_checkout=materialized,
+            plugin_checkout_sha=resolved.sha,
+            proxy=ProxyRelayConfig(config.proxy_url) if config.proxy_url is not None else None,
+            docker_network_pool=config.docker_network_pool,
+            extra_no_proxy_hosts=config.extra_no_proxy_hosts,
+            tokensflow_enabled=config.tokensflow_enabled,
+            tokensflow_binary=config.tokensflow_binary,
+            tokensflow_egress_network=config.tokensflow_egress_network,
+            model=config.model,
+            reasoning_effort=config.reasoning_effort,
+            finalization_registrar=config.finalization_registrar,
+            container_env=config.container_env,
         )
+        sut = DockerSut(process)
+        if config.treatment_mode is TreatmentMode.OFF_ON:
+            outcomes = sut.run_pair(
+                sut_config,
+                paths=arm_paths,
+                prompts={arm: prompt for arm in selected_arms},
+                stores=stores,
+                before_arm=lambda arm: emit_phase(RunPhase.RUNNING_OFF if arm is Arm.OFF else RunPhase.RUNNING_ON),
+            )
+        else:
+            arm = selected_arms[0]
+            emit_phase(RunPhase.RUNNING_OFF if arm is Arm.OFF else RunPhase.RUNNING_ON)
+            outcomes = {arm: sut.run_arm(sut_config, arm, arm_paths[arm], prompt, stores[arm])}
         official: dict[Arm, OfficialEvaluation] = {}
         patch_sizes: dict[Arm, int] = {}
         emit_phase(RunPhase.OFFICIAL_EVALUATION)
-        for arm in (Arm.OFF, Arm.ON):
+        for arm in selected_arms:
             patch = process.run(
                 ("git", "diff", "--binary", "--full-index", instance.base_commit, "--"),
                 cwd=arm_paths[arm].workspace,
@@ -451,17 +463,22 @@ def _run_swebench_pro_instance(
                 official=official[arm],
                 official_observed_at=datetime.now(UTC),
             )
-        return official[Arm.OFF], official[Arm.ON], outcomes, patch_sizes
+        return official, outcomes, patch_sizes
 
-    off_eval, on_eval, outcomes, patch_sizes = run_after_gold(
+    official, outcomes, patch_sizes = run_after_gold(
         GoldResult(instance.instance_id, gold.resolved),
         arms,
     )
-    off_outcome = outcomes[Arm.OFF]
-    on_outcome = outcomes[Arm.ON]
+    arm_reports = {
+        arm: _arm_report(arm, official[arm], outcomes[arm], patch_sizes[arm]) for arm in selected_arms
+    }
     emit_phase(RunPhase.GENERATING_REPORT)
     report = ReportBundle(
-        title="PowerContext Codex SWE-bench Pro comparison",
+        title=(
+            "PowerContext Codex SWE-bench Pro comparison"
+            if config.treatment_mode is TreatmentMode.OFF_ON
+            else f"PowerContext Codex SWE-bench Pro {selected_arms[0].value.upper()} run"
+        ),
         revisions={
             "dataset": DATASET_REVISION,
             "harness": HARNESS_COMMIT,
@@ -476,9 +493,11 @@ def _run_swebench_pro_instance(
             "extra_no_proxy_hosts": ",".join(config.extra_no_proxy_hosts),
             "proxy": "enabled" if config.proxy_url is not None else "disabled",
             "tokensflow": "enabled" if config.tokensflow_enabled else "disabled",
+            "treatment_mode": config.treatment_mode.value,
         },
-        off=_arm_report(Arm.OFF, off_eval, off_outcome, patch_sizes[Arm.OFF]),
-        on=_arm_report(Arm.ON, on_eval, on_outcome, patch_sizes[Arm.ON]),
+        treatment_mode=config.treatment_mode,
+        off=arm_reports.get(Arm.OFF),
+        on=arm_reports.get(Arm.ON),
         gold_validation=gold_audit,
     )
     rendered = render_report(report)
@@ -486,7 +505,12 @@ def _run_swebench_pro_instance(
         raise RuntimeError("Report rendering is not deterministic")
     report_path = run_store.create_text("report.md", rendered)
     run_store.create_json("report.json", report.model_dump(mode="json"))
-    return RunResult(run_id, report_path, off_eval.resolved, on_eval.resolved)
+    return RunResult(
+        run_id,
+        report_path,
+        official[Arm.OFF].resolved if Arm.OFF in official else None,
+        official[Arm.ON].resolved if Arm.ON in official else None,
+    )
 
 
 def _evaluator_test_requirements(

--- a/evaluation/src/powercontext_eval/web/batches.py
+++ b/evaluation/src/powercontext_eval/web/batches.py
@@ -24,7 +24,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from powercontext_eval.benchmarks.swebench_pro.catalog import TaskSet
 from powercontext_eval.codex import DEFAULT_CODEX_MODEL, DEFAULT_REASONING_EFFORT, is_safe_codex_model
-from powercontext_eval.models import PowerContextRef
+from powercontext_eval.models import PowerContextRef, TreatmentMode
 from powercontext_eval.web.controls import BatchControlState
 from powercontext_eval.web.estimation import BatchEstimate
 from powercontext_eval.web.models import FailureCategory, FailureCode, TaskPhase, TaskStatus
@@ -41,11 +41,16 @@ class BatchCreate(_FrozenModel):
     task_set: TaskSet
     model: str = DEFAULT_CODEX_MODEL
     reasoning_effort: Literal["medium"] = DEFAULT_REASONING_EFFORT
-    treatment_mode: Literal["off_on"]
+    treatment_mode: TreatmentMode
     idempotency_key: str = Field(min_length=8, max_length=128, pattern=r"^[A-Za-z0-9._-]+$")
     usage_pause_percent: Annotated[int, Field(ge=1, le=100)] = 80
     initial_control_intent: Literal["run", "pause"] = "run"
     container_env: dict[str, str] = Field(default_factory=dict)
+
+    @field_validator("treatment_mode", mode="before")
+    @classmethod
+    def parse_treatment_mode(cls, value: object) -> object:
+        return TreatmentMode(value) if isinstance(value, str) else value
 
     @field_validator("powercontext_ref")
     @classmethod
@@ -69,13 +74,18 @@ class BatchPreviewResponse(_FrozenModel):
     task_set: TaskSet
     model: str
     reasoning_effort: Literal["medium"]
-    treatment_mode: Literal["off_on"]
+    treatment_mode: TreatmentMode
     total_tasks: Annotated[int, Field(ge=1)]
     usage_pause_percent: Annotated[int, Field(ge=1, le=100)]
     usage: UsageSnapshot | None
     estimate: BatchEstimate
     can_start: bool
     block_reason: Literal["usage_threshold_reached"] | None = None
+
+    @field_validator("treatment_mode", mode="before")
+    @classmethod
+    def parse_treatment_mode(cls, value: object) -> object:
+        return TreatmentMode(value) if isinstance(value, str) else value
 
 
 class TaskRetryRequest(_FrozenModel):

--- a/evaluation/src/powercontext_eval/web/batches.py
+++ b/evaluation/src/powercontext_eval/web/batches.py
@@ -221,11 +221,11 @@ class ResolutionAggregate(_FrozenModel):
 
 
 class TokenMetricAggregate(_FrozenModel):
-    off: Annotated[int, Field(ge=0)]
-    on: Annotated[int, Field(ge=0)]
-    delta: int
-    off_measured_tasks: Annotated[int, Field(ge=0)]
-    on_measured_tasks: Annotated[int, Field(ge=0)]
+    off: Annotated[int, Field(ge=0)] | None = None
+    on: Annotated[int, Field(ge=0)] | None = None
+    delta: int | None = None
+    off_measured_tasks: Annotated[int, Field(ge=0)] | None = None
+    on_measured_tasks: Annotated[int, Field(ge=0)] | None = None
 
 
 class TokenAggregate(_FrozenModel):
@@ -236,16 +236,17 @@ class TokenAggregate(_FrozenModel):
 
 class BatchReportResponse(_FrozenModel):
     batch_id: str
+    treatment_mode: TreatmentMode = TreatmentMode.OFF_ON
     report_revision: Annotated[int, Field(ge=0)]
     total_tasks: Annotated[int, Field(ge=1)]
     terminal_tasks: Annotated[int, Field(ge=0)]
-    comparable_pairs: Annotated[int, Field(ge=0)]
+    comparable_pairs: Annotated[int, Field(ge=0)] | None = None
     execution_failures: Annotated[int, Field(ge=0)]
     cancelled_tasks: Annotated[int, Field(ge=0)]
-    off: ResolutionAggregate
-    on: ResolutionAggregate
-    resolution_rate_delta_points: Annotated[float, Field(allow_inf_nan=False)]
-    pair_categories: dict[PairCategory, Annotated[int, Field(ge=0)]]
+    off: ResolutionAggregate | None = None
+    on: ResolutionAggregate | None = None
+    resolution_rate_delta_points: Annotated[float, Field(allow_inf_nan=False)] | None = None
+    pair_categories: dict[PairCategory, Annotated[int, Field(ge=0)]] | None = None
     task_statuses: dict[TaskStatus, Annotated[int, Field(ge=0)]]
     tokens: TokenAggregate
     control: BatchControlState
@@ -253,6 +254,11 @@ class BatchReportResponse(_FrozenModel):
     estimate: BatchEstimate
     revisions: dict[str, str]
     configuration: dict[str, str]
+
+    @field_validator("treatment_mode", mode="before")
+    @classmethod
+    def parse_report_treatment_mode(cls, value: object) -> object:
+        return TreatmentMode(value) if isinstance(value, str) else value
 
 
 class TaskArmSummary(_FrozenModel):

--- a/evaluation/src/powercontext_eval/web/models.py
+++ b/evaluation/src/powercontext_eval/web/models.py
@@ -24,7 +24,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_serializer, field_valid
 
 from powercontext_eval.artifacts import ArmState
 from powercontext_eval.codex import DEFAULT_CODEX_MODEL, DEFAULT_REASONING_EFFORT, is_safe_codex_model
-from powercontext_eval.models import PowerContextRef
+from powercontext_eval.models import Arm, PowerContextRef, TreatmentMode
 from powercontext_eval.report import GoldValidationAudit
 from powercontext_eval.runner import INSTANCE_ID
 
@@ -120,9 +120,14 @@ class TaskCreate(FrozenModel):
     instance_id: str = Field(min_length=1, max_length=300, pattern=r"^[A-Za-z0-9._-]+$")
     model: str = DEFAULT_CODEX_MODEL
     reasoning_effort: Literal["medium"] = DEFAULT_REASONING_EFFORT
-    treatment_mode: Literal["off_on"]
+    treatment_mode: TreatmentMode
     idempotency_key: str = Field(min_length=8, max_length=128, pattern=r"^[A-Za-z0-9._-]+$")
     container_env: dict[str, str] = Field(default_factory=dict)
+
+    @field_validator("treatment_mode", mode="before")
+    @classmethod
+    def parse_treatment_mode(cls, value: object) -> object:
+        return TreatmentMode(value) if isinstance(value, str) else value
 
     @field_validator("powercontext_ref")
     @classmethod
@@ -157,8 +162,11 @@ class SafeFailure(FrozenModel):
 class TaskResult(FrozenModel):
     artifact_dir: str
     report_path: str
-    off_resolved: bool
-    on_resolved: bool
+    off_resolved: bool | None = None
+    on_resolved: bool | None = None
+
+    def resolved_for(self, arm: Arm) -> bool | None:
+        return self.off_resolved if arm is Arm.OFF else self.on_resolved
 
 
 class TaskRecord(FrozenModel):
@@ -325,7 +333,14 @@ class Capabilities(FrozenModel):
     instances: tuple[Literal["instance_flipt-io__flipt-518ec324b66a07fdd95464a5e9ca5fe7681ad8f9"], ...] = (INSTANCE_ID,)
     models: tuple[str, ...] = (DEFAULT_CODEX_MODEL,)
     reasoning_efforts: tuple[Literal["medium"], ...] = ("medium",)
-    treatment_modes: tuple[Literal["off_on"], ...] = ("off_on",)
+    treatment_modes: tuple[TreatmentMode, ...] = tuple(TreatmentMode)
+
+    @field_validator("treatment_modes", mode="before")
+    @classmethod
+    def parse_treatment_modes(cls, value: object) -> object:
+        if isinstance(value, (list, tuple)):
+            return tuple(TreatmentMode(item) if isinstance(item, str) else item for item in value)
+        return value
 
 
 class HealthResponse(FrozenModel):
@@ -391,16 +406,17 @@ class TreatmentEvidence(FrozenModel):
 
 
 class EvidenceResponse(FrozenModel):
-    off: TreatmentEvidence
-    on: TreatmentEvidence
+    off: TreatmentEvidence | None = None
+    on: TreatmentEvidence | None = None
 
 
 class ReportResponse(FrozenModel):
     task_id: str
     acceptance_valid: bool
-    off: ArmResponse
-    on: ArmResponse
-    comparison: ComparisonResponse
+    treatment_mode: TreatmentMode = TreatmentMode.OFF_ON
+    off: ArmResponse | None = None
+    on: ArmResponse | None = None
+    comparison: ComparisonResponse | None = None
     evidence: EvidenceResponse
     gold_validation: GoldValidationAudit | None = None
     revisions: Mapping[str, str]
@@ -408,6 +424,11 @@ class ReportResponse(FrozenModel):
     generated_at: datetime
 
     _utc_timestamp = field_validator("generated_at")(_require_utc)
+
+    @field_validator("treatment_mode", mode="before")
+    @classmethod
+    def parse_report_treatment_mode(cls, value: object) -> object:
+        return TreatmentMode(value) if isinstance(value, str) else value
 
     @field_validator("revisions", "configuration")
     @classmethod
@@ -420,6 +441,16 @@ class ReportResponse(FrozenModel):
 
     @model_validator(mode="after")
     def require_distinct_arms(self) -> Self:
-        if self.off.arm != "off" or self.on.arm != "on":
-            raise ValueError("Report arms must preserve OFF/ON roles")
+        present = {arm for arm, response in ((Arm.OFF, self.off), (Arm.ON, self.on)) if response is not None}
+        evidence = {
+            arm for arm, response in ((Arm.OFF, self.evidence.off), (Arm.ON, self.evidence.on)) if response is not None
+        }
+        if present != set(self.treatment_mode.arms) or evidence != present:
+            raise ValueError("Report arms and evidence must match the treatment mode")
+        if self.off is not None and self.off.arm != "off":
+            raise ValueError("Report OFF arm has the wrong role")
+        if self.on is not None and self.on.arm != "on":
+            raise ValueError("Report ON arm has the wrong role")
+        if (self.comparison is None) is (self.treatment_mode is TreatmentMode.OFF_ON):
+            raise ValueError("Only paired reports contain an OFF/ON comparison")
         return self

--- a/evaluation/src/powercontext_eval/web/models.py
+++ b/evaluation/src/powercontext_eval/web/models.py
@@ -333,7 +333,7 @@ class Capabilities(FrozenModel):
     instances: tuple[Literal["instance_flipt-io__flipt-518ec324b66a07fdd95464a5e9ca5fe7681ad8f9"], ...] = (INSTANCE_ID,)
     models: tuple[str, ...] = (DEFAULT_CODEX_MODEL,)
     reasoning_efforts: tuple[Literal["medium"], ...] = ("medium",)
-    treatment_modes: tuple[TreatmentMode, ...] = tuple(TreatmentMode)
+    treatment_modes: tuple[TreatmentMode, ...] = (TreatmentMode.OFF_ON,)
 
     @field_validator("treatment_modes", mode="before")
     @classmethod

--- a/evaluation/src/powercontext_eval/web/reporting.py
+++ b/evaluation/src/powercontext_eval/web/reporting.py
@@ -229,6 +229,27 @@ def _load_evidence(run_fd: int, arm: str) -> TreatmentEvidence:
         raise InvalidReportArtifact from None
 
 
+def _reject_unrequested_arm_artifacts(run_fd: int, treatment_mode: TreatmentMode) -> None:
+    arms_fd = -1
+    try:
+        arms_fd = _open_relative_directory(run_fd, ("arms",))
+        for arm in Arm:
+            if arm in treatment_mode.arms:
+                continue
+            try:
+                os.stat(arm.value, dir_fd=arms_fd, follow_symlinks=False)
+            except FileNotFoundError:
+                continue
+            raise InvalidReportArtifact
+    except InvalidReportArtifact:
+        raise
+    except (NotADirectoryError, OSError, RuntimeError):
+        raise InvalidReportArtifact from None
+    finally:
+        if arms_fd >= 0:
+            os.close(arms_fd)
+
+
 def _validate_evidence(
     bundle: ReportBundle,
     run_id: str,
@@ -321,6 +342,7 @@ def load_report(run_dir: Path, run_root: Path | None = None) -> ReportResponse:
     run_fd, run_id = _open_run(run_dir, run_root)
     try:
         bundle, report_metadata = _load_bundle(run_fd)
+        _reject_unrequested_arm_artifacts(run_fd, bundle.treatment_mode)
         evidence = {arm: _load_evidence(run_fd, arm.value) for arm in bundle.treatment_mode.arms}
         _validate_evidence(bundle, run_id, evidence)
         return ReportResponse(

--- a/evaluation/src/powercontext_eval/web/reporting.py
+++ b/evaluation/src/powercontext_eval/web/reporting.py
@@ -30,7 +30,7 @@ from pydantic import ValidationError
 
 from powercontext_eval.artifacts import ArmState
 from powercontext_eval.benchmarks.swebench_pro.adapter import DATASET_REVISION, HARNESS_COMMIT, SweBenchProInstance
-from powercontext_eval.models import Arm
+from powercontext_eval.models import Arm, TreatmentMode
 from powercontext_eval.report import ArmReport, ReportBundle, TestGroupReport
 from powercontext_eval.web.baselines import (
     BaselineComparison,
@@ -214,8 +214,6 @@ def _load_bundle(run_fd: int) -> tuple[ReportBundle, os.stat_result]:
         bundle = ReportBundle.model_validate_json(raw, strict=True)
     except (ValidationError, ValueError, UnicodeDecodeError):
         raise InvalidReportArtifact from None
-    if bundle.off.arm != "off" or bundle.on.arm != "on":
-        raise InvalidReportArtifact
     return bundle, metadata
 
 
@@ -234,29 +232,32 @@ def _load_evidence(run_fd: int, arm: str) -> TreatmentEvidence:
 def _validate_evidence(
     bundle: ReportBundle,
     run_id: str,
-    off: TreatmentEvidence,
-    on: TreatmentEvidence,
+    evidence: Mapping[Arm, TreatmentEvidence],
 ) -> None:
     expected_sha = bundle.revisions.get("powercontext")
     configured_plugin_id = bundle.configuration.get("plugin_id", _PLUGIN_ID)
-    configured_plugin_version = bundle.configuration.get("plugin_version", off.plugin_version)
-    common = (
-        expected_sha is not None
-        and off.plugin_checkout_sha == expected_sha
-        and on.plugin_checkout_sha == expected_sha
-        and off.plugin_id == configured_plugin_id == on.plugin_id == _PLUGIN_ID
-        and bool(off.plugin_version)
-        and off.plugin_version == configured_plugin_version == on.plugin_version
-        and off.plugin_installed
-        and on.plugin_installed
-        and off.server_ready
-        and on.server_ready
-        and off.scope_id == f"eval:{run_id}:off"
-        and on.scope_id == f"eval:{run_id}:on"
-    )
-    activity = off.prompt_sources == 0 and off.mcp_requests == 0 and on.prompt_sources > 0 and on.mcp_requests > 0
-    if not common or not activity:
+    if set(evidence) != set(bundle.treatment_mode.arms) or expected_sha is None:
         raise InvalidReportArtifact
+    versions = {item.plugin_version for item in evidence.values()}
+    configured_plugin_version = bundle.configuration.get("plugin_version", next(iter(versions), ""))
+    if len(versions) != 1 or not configured_plugin_version:
+        raise InvalidReportArtifact
+    for arm, item in evidence.items():
+        common = (
+            item.plugin_checkout_sha == expected_sha
+            and item.plugin_id == configured_plugin_id == _PLUGIN_ID
+            and item.plugin_version == configured_plugin_version
+            and item.plugin_installed
+            and item.server_ready
+            and item.scope_id == f"eval:{run_id}:{arm.value}"
+        )
+        activity = (
+            (item.prompt_sources == 0 and item.mcp_requests == 0)
+            if arm is Arm.OFF
+            else (item.prompt_sources > 0 and item.mcp_requests > 0)
+        )
+        if not common or not activity:
+            raise InvalidReportArtifact
 
 
 def _arm_response(arm: Literal["off", "on"], report: ArmReport) -> ArmResponse:
@@ -298,6 +299,10 @@ def _comparisons(off: ArmReport, on: ArmReport) -> ComparisonResponse:
 
 
 def _acceptance_valid(bundle: ReportBundle) -> bool:
+    if bundle.treatment_mode is not TreatmentMode.OFF_ON:
+        return False
+    if bundle.off is None or bundle.on is None:
+        return False
     lifecycle_is_comparable = bundle.off.state == bundle.on.state and bundle.off.state in _COMPARABLE_STATES
     official_outcomes_are_coherent = (
         bundle.off.passed is True and bundle.on.passed is True and bundle.off.resolved and bundle.on.resolved
@@ -316,16 +321,18 @@ def load_report(run_dir: Path, run_root: Path | None = None) -> ReportResponse:
     run_fd, run_id = _open_run(run_dir, run_root)
     try:
         bundle, report_metadata = _load_bundle(run_fd)
-        off_evidence = _load_evidence(run_fd, "off")
-        on_evidence = _load_evidence(run_fd, "on")
-        _validate_evidence(bundle, run_id, off_evidence, on_evidence)
+        evidence = {arm: _load_evidence(run_fd, arm.value) for arm in bundle.treatment_mode.arms}
+        _validate_evidence(bundle, run_id, evidence)
         return ReportResponse(
             task_id=run_id,
             acceptance_valid=_acceptance_valid(bundle),
-            off=_arm_response("off", bundle.off),
-            on=_arm_response("on", bundle.on),
-            comparison=_comparisons(bundle.off, bundle.on),
-            evidence=EvidenceResponse(off=off_evidence, on=on_evidence),
+            treatment_mode=bundle.treatment_mode,
+            off=_arm_response("off", bundle.off) if bundle.off is not None else None,
+            on=_arm_response("on", bundle.on) if bundle.on is not None else None,
+            comparison=(
+                _comparisons(bundle.off, bundle.on) if bundle.off is not None and bundle.on is not None else None
+            ),
+            evidence=EvidenceResponse(off=evidence.get(Arm.OFF), on=evidence.get(Arm.ON)),
             gold_validation=bundle.gold_validation,
             revisions=bundle.revisions,
             configuration=bundle.configuration,

--- a/evaluation/src/powercontext_eval/web/reporting.py
+++ b/evaluation/src/powercontext_eval/web/reporting.py
@@ -383,12 +383,13 @@ def _bundle_for_task(task: TaskRecord, runs_root: Path) -> ReportBundle:
     if task.status is not TaskStatus.SUCCEEDED or task.result is None:
         raise InvalidReportArtifact
     bundle = _load_batch_bundle(task_run_dir(task, runs_root), runs_root)
+    present = {arm for arm, report in ((Arm.OFF, bundle.off), (Arm.ON, bundle.on)) if report is not None}
     if (
-        bundle.off.arm != "off"
-        or bundle.on.arm != "on"
+        bundle.treatment_mode is not task.request.treatment_mode
+        or present != set(task.request.treatment_mode.arms)
         or bundle.configuration.get("instance") != task.request.instance_id
-        or bundle.off.resolved != task.result.off_resolved
-        or bundle.on.resolved != task.result.on_resolved
+        or (bundle.off.resolved if bundle.off is not None else None) != task.result.off_resolved
+        or (bundle.on.resolved if bundle.on is not None else None) != task.result.on_resolved
     ):
         raise InvalidReportArtifact
     return bundle
@@ -420,7 +421,9 @@ def _pair_category(off_resolved: bool, on_resolved: bool) -> PairCategory:
     return PairCategory.BOTH_FAIL
 
 
-def _arm_total(arm: ArmReport) -> int | None:
+def _arm_total(arm: ArmReport | None) -> int | None:
+    if arm is None:
+        return None
     metrics = arm.metrics
     if metrics.input_tokens is None or metrics.output_tokens is None:
         return None
@@ -451,11 +454,22 @@ def _task_item(
     tokens = TaskTokenDelta()
     if task.status is TaskStatus.SUCCEEDED:
         bundle = _bundle_for_task(task, runs_root)
-        category = _pair_category(bundle.off.resolved, bundle.on.resolved)
-        off = _task_arm(bundle.off)
-        on = _task_arm(bundle.on)
-        delta = None if off.total_tokens is None or on.total_tokens is None else on.total_tokens - off.total_tokens
-        tokens = TaskTokenDelta(off=off.total_tokens, on=on.total_tokens, delta=delta)
+        if bundle.off is not None:
+            off = _task_arm(bundle.off)
+        if bundle.on is not None:
+            on = _task_arm(bundle.on)
+        if bundle.off is not None and bundle.on is not None:
+            category = _pair_category(bundle.off.resolved, bundle.on.resolved)
+        delta = (
+            None
+            if off is None or on is None or off.total_tokens is None or on.total_tokens is None
+            else on.total_tokens - off.total_tokens
+        )
+        tokens = TaskTokenDelta(
+            off=off.total_tokens if off is not None else None,
+            on=on.total_tokens if on is not None else None,
+            delta=delta,
+        )
     elif task.status in _EXECUTION_FAILURE_STATES:
         category = PairCategory.EXECUTION_FAILURE
     return BatchTaskItem(
@@ -479,15 +493,15 @@ def _task_item(
     )
 
 
-def _metric_aggregate(values: dict[str, list[int]]) -> TokenMetricAggregate:
-    off = sum(values["off"])
-    on = sum(values["on"])
+def _metric_aggregate(values: dict[str, list[int]], treatment_mode: TreatmentMode) -> TokenMetricAggregate:
+    off = sum(values["off"]) if Arm.OFF in treatment_mode.arms else None
+    on = sum(values["on"]) if Arm.ON in treatment_mode.arms else None
     return TokenMetricAggregate(
         off=off,
         on=on,
-        delta=on - off,
-        off_measured_tasks=len(values["off"]),
-        on_measured_tasks=len(values["on"]),
+        delta=on - off if off is not None and on is not None else None,
+        off_measured_tasks=len(values["off"]) if off is not None else None,
+        on_measured_tasks=len(values["on"]) if on is not None else None,
     )
 
 
@@ -498,7 +512,7 @@ def load_batch_estimate_samples(
     runs_root: Path,
     catalog: BenchmarkCatalog,
 ) -> tuple[EstimateSample, ...]:
-    """Return only complete paired metrics compatible with the current runner schema."""
+    """Return metrics from the exact treatment arms executed by the batch."""
 
     _validate_batch_tasks(batch, tasks)
     samples: list[EstimateSample] = []
@@ -516,13 +530,14 @@ def load_batch_estimate_samples(
             or task.finished_at is None
         ):
             continue
-        off_total = _arm_total(bundle.off)
-        on_total = _arm_total(bundle.on)
-        if off_total is None or on_total is None:
+        selected_totals = [
+            _arm_total(bundle.off if arm is Arm.OFF else bundle.on) for arm in batch.request.treatment_mode.arms
+        ]
+        if any(total is None for total in selected_totals):
             continue
         samples.append(
             EstimateSample(
-                tokens=off_total + on_total,
+                tokens=sum(total for total in selected_totals if total is not None),
                 duration_seconds=max(0, round((task.finished_at - task.started_at).total_seconds())),
             )
         )
@@ -556,30 +571,45 @@ def load_batch_report(
         catalog.require(task.request.instance_id)
         if task.status is TaskStatus.SUCCEEDED:
             bundle = _bundle_for_task(task, runs_root)
-            category = _pair_category(bundle.off.resolved, bundle.on.resolved)
-            categories[category] += 1
-            comparable += 1
-            off_resolved += int(bundle.off.resolved)
-            on_resolved += int(bundle.on.resolved)
-            metric_pairs = {
-                "input": (bundle.off.metrics.input_tokens, bundle.on.metrics.input_tokens),
-                "output": (bundle.off.metrics.output_tokens, bundle.on.metrics.output_tokens),
-                "total": (_arm_total(bundle.off), _arm_total(bundle.on)),
+            if bundle.off is not None:
+                off_resolved += int(bundle.off.resolved)
+            if bundle.on is not None:
+                on_resolved += int(bundle.on.resolved)
+            if bundle.off is not None and bundle.on is not None:
+                category = _pair_category(bundle.off.resolved, bundle.on.resolved)
+                categories[category] += 1
+                comparable += 1
+            metric_values = {
+                "input": {
+                    "off": bundle.off.metrics.input_tokens if bundle.off is not None else None,
+                    "on": bundle.on.metrics.input_tokens if bundle.on is not None else None,
+                },
+                "output": {
+                    "off": bundle.off.metrics.output_tokens if bundle.off is not None else None,
+                    "on": bundle.on.metrics.output_tokens if bundle.on is not None else None,
+                },
+                "total": {
+                    "off": _arm_total(bundle.off) if bundle.off is not None else None,
+                    "on": _arm_total(bundle.on) if bundle.on is not None else None,
+                },
             }
-            for metric_name, (off_value, on_value) in metric_pairs.items():
-                if off_value is not None and on_value is not None:
-                    token_values[metric_name]["off"].append(off_value)
-                    token_values[metric_name]["on"].append(on_value)
-            paired_tokens = metric_pairs["total"]
+            for metric_name, arm_values in metric_values.items():
+                if batch.request.treatment_mode is TreatmentMode.OFF_ON and any(
+                    value is None for value in arm_values.values()
+                ):
+                    continue
+                for arm_name, value in arm_values.items():
+                    if value is not None:
+                        token_values[metric_name][arm_name].append(value)
+            selected_totals = [metric_values["total"][arm.value] for arm in batch.request.treatment_mode.arms]
             if (
-                paired_tokens[0] is not None
-                and paired_tokens[1] is not None
+                all(value is not None for value in selected_totals)
                 and task.started_at is not None
                 and task.finished_at is not None
             ):
                 estimate_samples.append(
                     EstimateSample(
-                        tokens=paired_tokens[0] + paired_tokens[1],
+                        tokens=sum(value for value in selected_totals if value is not None),
                         duration_seconds=max(0, round((task.finished_at - task.started_at).total_seconds())),
                     )
                 )
@@ -591,7 +621,8 @@ def load_batch_report(
             elif revisions != candidate_revisions or configuration != candidate_configuration:
                 raise InvalidReportArtifact
         elif task.status in _EXECUTION_FAILURE_STATES:
-            categories[PairCategory.EXECUTION_FAILURE] += 1
+            if batch.request.treatment_mode is TreatmentMode.OFF_ON:
+                categories[PairCategory.EXECUTION_FAILURE] += 1
             execution_failures += 1
 
     if revisions is None:
@@ -618,21 +649,32 @@ def load_batch_report(
     on_rate = on_resolved / denominator * 100
     return BatchReportResponse(
         batch_id=batch.batch_id,
+        treatment_mode=batch.request.treatment_mode,
         report_revision=batch.control.version + sum(task.attempt_count * 100 + task.version for task in tasks),
         total_tasks=total,
         terminal_tasks=terminal_tasks,
-        comparable_pairs=comparable,
+        comparable_pairs=comparable if batch.request.treatment_mode is TreatmentMode.OFF_ON else None,
         execution_failures=execution_failures,
         cancelled_tasks=status_counts[TaskStatus.CANCELLED],
-        off=ResolutionAggregate(resolved=off_resolved, total=terminal_tasks, rate_percent=off_rate),
-        on=ResolutionAggregate(resolved=on_resolved, total=terminal_tasks, rate_percent=on_rate),
-        resolution_rate_delta_points=on_rate - off_rate,
-        pair_categories=categories,
+        off=(
+            ResolutionAggregate(resolved=off_resolved, total=terminal_tasks, rate_percent=off_rate)
+            if Arm.OFF in batch.request.treatment_mode.arms
+            else None
+        ),
+        on=(
+            ResolutionAggregate(resolved=on_resolved, total=terminal_tasks, rate_percent=on_rate)
+            if Arm.ON in batch.request.treatment_mode.arms
+            else None
+        ),
+        resolution_rate_delta_points=(
+            on_rate - off_rate if batch.request.treatment_mode is TreatmentMode.OFF_ON else None
+        ),
+        pair_categories=categories if batch.request.treatment_mode is TreatmentMode.OFF_ON else None,
         task_statuses={status: status_counts[status] for status in TaskStatus},
         tokens=TokenAggregate(
-            input=_metric_aggregate(token_values["input"]),
-            output=_metric_aggregate(token_values["output"]),
-            total=_metric_aggregate(token_values["total"]),
+            input=_metric_aggregate(token_values["input"], batch.request.treatment_mode),
+            output=_metric_aggregate(token_values["output"], batch.request.treatment_mode),
+            total=_metric_aggregate(token_values["total"], batch.request.treatment_mode),
         ),
         control=batch.control,
         latest_usage=latest_usage,
@@ -673,6 +715,8 @@ def create_baseline_snapshot(
 
     if batch.status is not BatchStatus.COMPLETED:
         raise ValueError("Only completed batches can be saved as baselines")
+    if arm not in batch.request.treatment_mode.arms:
+        raise ValueError("The selected baseline arm was not executed")
     report = load_batch_report(batch, tasks, runs_root=runs_root, catalog=catalog)
     if report.report_revision != expected_report_revision:
         raise StaleReportRevision
@@ -686,6 +730,8 @@ def create_baseline_snapshot(
         if task.status is TaskStatus.SUCCEEDED:
             bundle = _bundle_for_task(task, runs_root)
             arm_report = bundle.off if arm is Arm.OFF else bundle.on
+            if arm_report is None:
+                raise InvalidReportArtifact
             resolved = arm_report.resolved
             input_tokens = arm_report.metrics.input_tokens
             output_tokens = arm_report.metrics.output_tokens
@@ -751,6 +797,8 @@ def baseline_compatibility(
     hard_reasons = [reason for baseline_value, current_value, reason in checks if baseline_value != current_value]
     if baseline.codex_version is not None and baseline.codex_version != report.configuration.get("codex"):
         hard_reasons.append("Codex version differs")
+    if current_arm not in batch.request.treatment_mode.arms:
+        hard_reasons.append("current arm was not executed")
     if hard_reasons:
         return BaselineCompatibility(status=CompatibilityStatus.INCOMPATIBLE, reasons=tuple(hard_reasons))
     if baseline.source_arm is not current_arm:
@@ -823,6 +871,8 @@ def compare_batch_to_baseline(
         if task.status is TaskStatus.SUCCEEDED:
             bundle = _bundle_for_task(task, runs_root)
             arm_report = bundle.off if current_arm is Arm.OFF else bundle.on
+            if arm_report is None:
+                raise InvalidReportArtifact
             current_result = arm_report.resolved
             current_resolved += int(current_result)
             values = {
@@ -985,8 +1035,8 @@ def load_batch_task_detail(
     on = None
     if task.status is TaskStatus.SUCCEEDED:
         bundle = _bundle_for_task(task, runs_root)
-        off = _detail_arm(bundle.off)
-        on = _detail_arm(bundle.on)
+        off = _detail_arm(bundle.off) if bundle.off is not None else None
+        on = _detail_arm(bundle.on) if bundle.on is not None else None
     finalization_by_arm = {record.arm: tokensflow_finalization_summary(record) for record in finalizations}
     return BatchTaskDetailResponse(
         task=item,

--- a/evaluation/src/powercontext_eval/web/worker.py
+++ b/evaluation/src/powercontext_eval/web/worker.py
@@ -38,7 +38,7 @@ from powercontext_eval.benchmarks.swebench_pro.prediction import BinaryPatchErro
 from powercontext_eval.codex import CodexCapacityError, CodexInfrastructureError, UnsafeCodexInvocation
 from powercontext_eval.errors import CommandCancelled, CommandError, GitSourceError, PowerContextEvalError
 from powercontext_eval.git_source import GitSource
-from powercontext_eval.models import PowerContextRef
+from powercontext_eval.models import Arm, PowerContextRef
 from powercontext_eval.paths import EvaluationPaths
 from powercontext_eval.powercontext_sut import (
     InvalidTreatment,
@@ -324,6 +324,7 @@ class TaskPairWorker:
             docker_network_pool=self._config.docker_network_pool,
             extra_no_proxy_hosts=self._config.extra_no_proxy_hosts,
             run_id=_execution_run_id(task),
+            treatment_mode=task.request.treatment_mode,
             model=task.request.model,
             reasoning_effort=task.request.reasoning_effort,
             finalization_registrar=self._finalization_registrar(task),
@@ -464,6 +465,13 @@ class TaskPairWorker:
                 os.close(descriptor)
         except (FileNotFoundError, OSError, RuntimeError, ValueError, InvalidReportBundle):
             raise InvalidReportBundle("Runner returned an unsafe report path") from None
+        returned_arms = {
+            arm
+            for arm, resolved in ((Arm.OFF, result.off_resolved), (Arm.ON, result.on_resolved))
+            if resolved is not None
+        }
+        if returned_arms != set(task.request.treatment_mode.arms):
+            raise InvalidReportBundle("Runner outcomes do not match the requested treatment mode")
         return TaskResult(
             artifact_dir=os.fspath(layout.run_artifacts.relative_to(self._config.run_root)),
             report_path=os.fspath(expected_report.relative_to(self._config.run_root)),

--- a/evaluation/src/powercontext_eval/web/worker.py
+++ b/evaluation/src/powercontext_eval/web/worker.py
@@ -63,6 +63,7 @@ from powercontext_eval.web.finalization import DockerFinalizationRuntime, Tokens
 from powercontext_eval.web.models import (
     FailureCategory,
     FailureCode,
+    ReportResponse,
     RetryDisposition,
     SafeFailure,
     TaskPhase,
@@ -247,7 +248,8 @@ class TaskPairWorker:
             if ownership_lost.is_set():
                 return True
             task_result = self._validated_result(task, result)
-            load_report(layout.run_artifacts, self._config.run_root / "runs")
+            report = load_report(layout.run_artifacts, self._config.run_root / "runs")
+            self._validated_retained_report(task, task_result, report)
             self._store.succeed(task.task_id, self._worker_id, task_result, now=self._clock())
             attempt_finished = True
         except (TaskOwnershipError, TaskConflict):
@@ -478,6 +480,31 @@ class TaskPairWorker:
             off_resolved=result.off_resolved,
             on_resolved=result.on_resolved,
         )
+
+    def _validated_retained_report(self, task: TaskRecord, result: TaskResult, report: ReportResponse) -> None:
+        expected_arms = set(task.request.treatment_mode.arms)
+        report_arms = {arm for arm, value in ((Arm.OFF, report.off), (Arm.ON, report.on)) if value is not None}
+        evidence_arms = {
+            arm for arm, value in ((Arm.OFF, report.evidence.off), (Arm.ON, report.evidence.on)) if value is not None
+        }
+        result_arms = {
+            arm for arm, value in ((Arm.OFF, result.off_resolved), (Arm.ON, result.on_resolved)) if value is not None
+        }
+        if (
+            report.treatment_mode is not task.request.treatment_mode
+            or report_arms != expected_arms
+            or evidence_arms != expected_arms
+            or result_arms != expected_arms
+        ):
+            raise InvalidReportBundle("Retained report does not match the requested treatment mode")
+        for arm, report_arm, resolved in (
+            (Arm.OFF, report.off, result.off_resolved),
+            (Arm.ON, report.on, result.on_resolved),
+        ):
+            if arm not in expected_arms:
+                continue
+            if report_arm is None or resolved is None or (report_arm.resolution == "resolved") is not resolved:
+                raise InvalidReportBundle("Retained report outcomes do not match the runner result")
 
     def _fail(self, task: TaskRecord, failure: SafeFailure, ownership_lost: threading.Event) -> bool:
         if ownership_lost.is_set():

--- a/evaluation/tests/unit/test_runner_phases.py
+++ b/evaluation/tests/unit/test_runner_phases.py
@@ -402,8 +402,7 @@ def _run_with_fakes(
             observed_at = datetime.now(UTC).isoformat(timespec="microseconds").replace("+00:00", "Z")
             store.write_text(
                 "context/codex-observed.jsonl",
-                f'{{"sequence":1,"observed_at":"{observed_at}",'
-                '"event":{"type":"agent_message","message":"done"}}\n',
+                f'{{"sequence":1,"observed_at":"{observed_at}","event":{{"type":"agent_message","message":"done"}}}}\n',
             )
             return SimpleNamespace(codex=CodexOutcome("", None))
 

--- a/evaluation/tests/unit/test_runner_phases.py
+++ b/evaluation/tests/unit/test_runner_phases.py
@@ -40,7 +40,7 @@ from powercontext_eval.benchmarks.swebench_pro.gold_overrides import (
 )
 from powercontext_eval.codex import CodexOutcome
 from powercontext_eval.errors import CommandFailed
-from powercontext_eval.models import Arm
+from powercontext_eval.models import Arm, TreatmentMode
 from powercontext_eval.powercontext_sut import ProxyRelayConfig, SutConfig
 from powercontext_eval.process import CommandResult, ProcessRunner
 from powercontext_eval.report import ReportBundle
@@ -295,8 +295,9 @@ def _run_with_fakes(
     model: str | None = None,
     docker_network_pool: str | None = None,
     extra_no_proxy_hosts: tuple[str, ...] | None = None,
+    treatment_mode: TreatmentMode = TreatmentMode.OFF_ON,
 ) -> tuple[RunConfig, MinimalRunResult, dict[str, object]]:
-    config = _config(tmp_path)
+    config = replace(_config(tmp_path), treatment_mode=treatment_mode)
     if model is not None:
         config = replace(config, model=model)
     if docker_network_pool is not None:
@@ -396,6 +397,28 @@ def _run_with_fakes(
             return OfficialEvaluation(instance.instance_id, True, "", "")
 
     class FakeSut:
+        @staticmethod
+        def _outcome(arm: Arm, store: ArtifactStore) -> object:
+            observed_at = datetime.now(UTC).isoformat(timespec="microseconds").replace("+00:00", "Z")
+            store.write_text(
+                "context/codex-observed.jsonl",
+                f'{{"sequence":1,"observed_at":"{observed_at}",'
+                '"event":{"type":"agent_message","message":"done"}}\n',
+            )
+            return SimpleNamespace(codex=CodexOutcome("", None))
+
+        def run_arm(
+            self,
+            sut_config: object,
+            arm: Arm,
+            _paths: object,
+            _prompt: bytes,
+            store: ArtifactStore,
+        ) -> object:
+            observed["sut_config"] = sut_config
+            observed["single_arm"] = arm
+            return self._outcome(arm, store)
+
         def run_pair(
             self,
             sut_config: object,
@@ -412,14 +435,7 @@ def _run_with_fakes(
             for arm in (Arm.OFF, Arm.ON):
                 before_arm(arm)
                 events.append(arm)
-                observed_at = datetime.now(UTC).isoformat(timespec="microseconds").replace("+00:00", "Z")
-                stores[arm].write_text(
-                    "context/codex-observed.jsonl",
-                    f'{{"sequence":1,"observed_at":"{observed_at}",'
-                    '"event":{"type":"agent_message","message":"done"}}\n',
-                )
-            outcome = SimpleNamespace(codex=CodexOutcome("", None))
-            return {Arm.OFF: outcome, Arm.ON: outcome}
+            return {arm: self._outcome(arm, stores[arm]) for arm in (Arm.OFF, Arm.ON)}
 
     monkeypatch.setattr("powercontext_eval.runner.ProcessRunner", FakeProcess)
     monkeypatch.setattr("powercontext_eval.runner.GitSource", lambda **kwargs: FakeSource())
@@ -448,6 +464,36 @@ def test_runner_propagates_batch_model_to_codex_pair_and_report(
     assert (sut_config.model, sut_config.reasoning_effort) == ("gpt-5.6-luna", "medium")
     assert report.configuration["model"] == "gpt-5.6-luna"
     assert report.configuration["reasoning_effort"] == "medium"
+
+
+@pytest.mark.parametrize(
+    ("mode", "arm"),
+    ((TreatmentMode.ON_ONLY, Arm.ON), (TreatmentMode.OFF_ONLY, Arm.OFF)),
+)
+def test_runner_executes_and_reports_exactly_one_requested_arm(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    mode: TreatmentMode,
+    arm: Arm,
+) -> None:
+    config, result, observed = _run_with_fakes(
+        tmp_path,
+        monkeypatch,
+        [],
+        treatment_mode=mode,
+    )
+
+    assert observed["single_arm"] is arm
+    assert result.off_resolved is (True if arm is Arm.OFF else None)
+    assert result.on_resolved is (True if arm is Arm.ON else None)
+    report = ReportBundle.model_validate_json(
+        (config.root / "runs" / result.run_id / "report.json").read_text(),
+        strict=True,
+    )
+    assert report.treatment_mode is mode
+    assert (report.off is not None) is (arm is Arm.OFF)
+    assert (report.on is not None) is (arm is Arm.ON)
+    assert len(cast(list[EvaluatorCall], observed["evaluator_calls"])) == 2
 
 
 def test_runner_propagates_portable_network_configuration_to_sut_evaluator_and_report(

--- a/evaluation/tests/web/test_reporting.py
+++ b/evaluation/tests/web/test_reporting.py
@@ -142,6 +142,32 @@ def test_loads_single_arm_report_without_inventing_the_missing_arm(
 
 
 @pytest.mark.parametrize(
+    ("mode", "selected_arm", "unexpected_arm"),
+    (("on_only", "on", "off"), ("off_only", "off", "on")),
+)
+def test_rejects_unrequested_arm_evidence_from_single_arm_run(
+    tmp_path: Path,
+    mode: str,
+    selected_arm: str,
+    unexpected_arm: str,
+) -> None:
+    runs_root = tmp_path / "runs"
+    run_dir = runs_root / "run-extra-arm"
+    payload = json.loads(_bundle().model_dump_json())
+    payload["treatment_mode"] = mode
+    payload["off" if selected_arm == "on" else "on"] = None
+    (run_dir / "report.json").parent.mkdir(parents=True)
+    (run_dir / "report.json").write_text(json.dumps(payload))
+    for arm in (selected_arm, unexpected_arm):
+        evidence_dir = run_dir / "arms" / arm / "powercontext"
+        evidence_dir.mkdir(parents=True)
+        (evidence_dir / "treatment.json").write_text(json.dumps(_evidence(run_dir.name, arm)))
+
+    with pytest.raises(InvalidReportArtifact):
+        load_report(run_dir, runs_root)
+
+
+@pytest.mark.parametrize(
     ("relative_path", "contents"),
     [
         ("report.json", None),

--- a/evaluation/tests/web/test_reporting.py
+++ b/evaluation/tests/web/test_reporting.py
@@ -117,6 +117,30 @@ def test_loads_validated_report_and_derives_exact_comparisons(tmp_path: Path) ->
     assert dict(response.configuration) == dict(_bundle().configuration)
 
 
+@pytest.mark.parametrize(("mode", "arm"), (("on_only", "on"), ("off_only", "off")))
+def test_loads_single_arm_report_without_inventing_the_missing_arm(
+    tmp_path: Path,
+    mode: str,
+    arm: str,
+) -> None:
+    runs_root = tmp_path / "runs"
+    run_dir = runs_root / "run-single"
+    evidence_dir = run_dir / "arms" / arm / "powercontext"
+    evidence_dir.mkdir(parents=True)
+    (evidence_dir / "treatment.json").write_text(json.dumps(_evidence(run_dir.name, arm)))
+    payload = json.loads(_bundle().model_dump_json())
+    payload["treatment_mode"] = mode
+    payload["off" if arm == "on" else "on"] = None
+    (run_dir / "report.json").write_text(json.dumps(payload))
+
+    response = load_report(run_dir, runs_root)
+
+    assert response.treatment_mode.value == mode
+    assert (response.off is not None) is (arm == "off")
+    assert (response.on is not None) is (arm == "on")
+    assert response.comparison is None
+
+
 @pytest.mark.parametrize(
     ("relative_path", "contents"),
     [

--- a/evaluation/tests/web/test_worker.py
+++ b/evaluation/tests/web/test_worker.py
@@ -30,7 +30,7 @@ from powercontext_eval.benchmarks.swebench_pro.adapter import DatasetSchemaError
 from powercontext_eval.benchmarks.swebench_pro.evaluator import OfficialResultError
 from powercontext_eval.codex import CodexCapacityError, CodexInfrastructureError
 from powercontext_eval.errors import CommandFailed, GitSourceError
-from powercontext_eval.models import Arm
+from powercontext_eval.models import Arm, TreatmentMode
 from powercontext_eval.powercontext_sut import (
     InvalidTreatment,
     PluginInspectionFailure,
@@ -40,6 +40,7 @@ from powercontext_eval.powercontext_sut import (
     UnsafeSutConfiguration,
 )
 from powercontext_eval.process import CommandResult
+from powercontext_eval.report import InvalidReportBundle
 from powercontext_eval.runner import MinimalRunConfig, MinimalRunResult, RunConfig, RunPhase
 from powercontext_eval.tokensflow import TokensFlowFinalizationDescriptor, TokensFlowInfrastructureError
 from powercontext_eval.web.batches import BatchControlEventType, BatchCreate, BatchStatus
@@ -178,6 +179,7 @@ def _create_batch(
     key: str = "batch-worker-test",
     instance_ids: tuple[str, ...] = ("instance_owner__repo-a", "instance_owner__repo-b"),
     model: str = "gpt-5.6-sol",
+    treatment_mode: TreatmentMode = TreatmentMode.OFF_ON,
 ) -> Any:
     return store.create_batch(
         BatchCreate(
@@ -186,7 +188,7 @@ def _create_batch(
             task_set="swebench-pro-public-v2",
             model=model,
             reasoning_effort="medium",
-            treatment_mode="off_on",
+            treatment_mode=treatment_mode,
             idempotency_key=key,
         ),
         instance_ids,
@@ -551,6 +553,33 @@ def test_worker_uses_each_batch_immutable_model_for_runner_configuration(
     assert worker.run_once() is True
     assert calls[0][0].model == batch.request.model == "gpt-5.6-luna"
     assert calls[0][0].reasoning_effort == batch.request.reasoning_effort == "medium"
+
+
+def test_worker_rejects_runner_outcomes_outside_the_requested_treatment_mode(
+    tmp_path: Path,
+) -> None:
+    config = _config(tmp_path)
+    store = _store(config)
+    batch = _create_batch(
+        store,
+        key="on-only-worker-outcome",
+        instance_ids=("instance_owner__repo-a",),
+        treatment_mode=TreatmentMode.ON_ONLY,
+    )
+
+    task = store.list_batch_tasks(batch.batch_id)[0]
+    report = config.run_root / "runs" / task.task_id / "report.md"
+    report.parent.mkdir(parents=True)
+    report.write_text("safe")
+    worker = TaskPairWorker(
+        config,
+        store,
+        worker_id="single-arm-validator",
+        clock=lambda: NOW,
+    )
+
+    with pytest.raises(InvalidReportBundle, match="requested treatment mode"):
+        worker._validated_result(task, MinimalRunResult(task.task_id, report, True, None))
 
 
 def test_only_one_child_runs_physically_across_multiple_batches(tmp_path: Path) -> None:

--- a/evaluation/tests/web/test_worker.py
+++ b/evaluation/tests/web/test_worker.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import json
 import sqlite3
 import threading
 import time
@@ -25,6 +26,7 @@ from typing import Any
 
 import pytest
 
+from powercontext_eval.artifacts import ArmState
 from powercontext_eval.benchmarks.base import GoldCheckFailed
 from powercontext_eval.benchmarks.swebench_pro.adapter import DatasetSchemaError, SweBenchProInstance
 from powercontext_eval.benchmarks.swebench_pro.evaluator import OfficialResultError
@@ -40,20 +42,25 @@ from powercontext_eval.powercontext_sut import (
     UnsafeSutConfiguration,
 )
 from powercontext_eval.process import CommandResult
-from powercontext_eval.report import InvalidReportBundle
+from powercontext_eval.report import ArmReport, InvalidReportBundle, MetricSet, ReportBundle
 from powercontext_eval.runner import MinimalRunConfig, MinimalRunResult, RunConfig, RunPhase
 from powercontext_eval.tokensflow import TokensFlowFinalizationDescriptor, TokensFlowInfrastructureError
 from powercontext_eval.web.batches import BatchControlEventType, BatchCreate, BatchStatus
 from powercontext_eval.web.config import WebConfig
 from powercontext_eval.web.controls import BatchControlIntent, BatchPauseReason
 from powercontext_eval.web.models import (
+    ArmResponse,
+    ComparisonResponse,
+    EvidenceResponse,
     FailureCategory,
     FailureCode,
+    ReportResponse,
     RetryDisposition,
     SafeFailure,
     TaskCreate,
     TaskPhase,
     TaskStatus,
+    TreatmentEvidence,
 )
 from powercontext_eval.web.resources import FilesystemCapacity, FilesystemResourceProbe
 from powercontext_eval.web.revision import RUNTIME_SCHEMA_VERSION, current_build_revision
@@ -62,6 +69,53 @@ from powercontext_eval.web.usage import CodexUsageProbe, UsageSnapshot, UsageUna
 from powercontext_eval.web.worker import EvaluationWorker, TaskPairWorker
 
 NOW = datetime(2026, 7, 29, 1, 2, 3, tzinfo=UTC)
+
+
+def _loaded_pair_report(*, off_resolved: bool = True, on_resolved: bool = True) -> ReportResponse:
+    return ReportResponse(
+        task_id="mocked-report",
+        acceptance_valid=off_resolved and on_resolved,
+        off=ArmResponse(
+            arm="off",
+            state=ArmState.TREATMENT_VALIDATED,
+            resolution="resolved" if off_resolved else "unresolved",
+            passed=off_resolved,
+            treatment_valid=True,
+        ),
+        on=ArmResponse(
+            arm="on",
+            state=ArmState.TREATMENT_VALIDATED,
+            resolution="resolved" if on_resolved else "unresolved",
+            passed=on_resolved,
+            treatment_valid=True,
+        ),
+        comparison=ComparisonResponse(),
+        evidence=EvidenceResponse(
+            off=TreatmentEvidence(
+                mcp_requests=0,
+                prompt_sources=0,
+                plugin_checkout_sha="a" * 40,
+                plugin_id="powercontext@powercontext",
+                plugin_installed=True,
+                plugin_version="0.1.0",
+                scope_id="eval:mocked-report:off",
+                server_ready=True,
+            ),
+            on=TreatmentEvidence(
+                mcp_requests=1,
+                prompt_sources=1,
+                plugin_checkout_sha="a" * 40,
+                plugin_id="powercontext@powercontext",
+                plugin_installed=True,
+                plugin_version="0.1.0",
+                scope_id="eval:mocked-report:on",
+                server_ready=True,
+            ),
+        ),
+        revisions={},
+        configuration={},
+        generated_at=NOW,
+    )
 
 
 def _usage(used_percent: int, *, observed_at: datetime = NOW) -> UsageSnapshot:
@@ -333,7 +387,7 @@ def test_worker_finishes_current_task_before_honoring_user_pause(
         report.write_text("safe")
         return MinimalRunResult(run_config.run_id, report, True, True)
 
-    monkeypatch.setattr("powercontext_eval.web.worker.load_report", lambda *args: object())
+    monkeypatch.setattr("powercontext_eval.web.worker.load_report", lambda *args: _loaded_pair_report())
     worker = EvaluationWorker(
         config,
         store,
@@ -370,7 +424,10 @@ def test_worker_finishes_current_task_before_cancelling_remaining_tasks(
         report.write_text("safe")
         return MinimalRunResult(run_config.run_id, report, False, False)
 
-    monkeypatch.setattr("powercontext_eval.web.worker.load_report", lambda *args: object())
+    monkeypatch.setattr(
+        "powercontext_eval.web.worker.load_report",
+        lambda *args: _loaded_pair_report(off_resolved=False, on_resolved=False),
+    )
     worker = EvaluationWorker(
         config,
         store,
@@ -507,7 +564,10 @@ def test_latest_is_pinned_once_and_every_child_uses_catalog_instance(
     source = FakeSource()
     catalog = FakeCatalog(instance_ids)
     calls: list[tuple[RunConfig, SweBenchProInstance]] = []
-    monkeypatch.setattr("powercontext_eval.web.worker.load_report", lambda *args: object())
+    monkeypatch.setattr(
+        "powercontext_eval.web.worker.load_report",
+        lambda *args: _loaded_pair_report(on_resolved=False),
+    )
     worker = EvaluationWorker(
         config,
         store,
@@ -540,7 +600,10 @@ def test_worker_uses_each_batch_immutable_model_for_runner_configuration(
         model="gpt-5.6-luna",
     )
     calls: list[tuple[RunConfig, SweBenchProInstance]] = []
-    monkeypatch.setattr("powercontext_eval.web.worker.load_report", lambda *args: object())
+    monkeypatch.setattr(
+        "powercontext_eval.web.worker.load_report",
+        lambda *args: _loaded_pair_report(on_resolved=False),
+    )
     worker = EvaluationWorker(
         config,
         store,
@@ -580,6 +643,99 @@ def test_worker_rejects_runner_outcomes_outside_the_requested_treatment_mode(
 
     with pytest.raises(InvalidReportBundle, match="requested treatment mode"):
         worker._validated_result(task, MinimalRunResult(task.task_id, report, True, None))
+
+
+@pytest.mark.parametrize(
+    ("retained_mode", "retained_on_resolved"),
+    ((TreatmentMode.OFF_ON, True), (TreatmentMode.ON_ONLY, False)),
+)
+def test_worker_rejects_retained_report_that_does_not_match_the_task(
+    retained_mode: TreatmentMode,
+    retained_on_resolved: bool,
+    tmp_path: Path,
+) -> None:
+    config = _config(tmp_path)
+    store = _store(config)
+    batch = _create_batch(
+        store,
+        key="on-only-retained-pair",
+        instance_ids=("instance_owner__repo-a",),
+        treatment_mode=TreatmentMode.ON_ONLY,
+    )
+    task = store.list_batch_tasks(batch.batch_id)[0]
+
+    def runner(run_config: RunConfig, *, instance: SweBenchProInstance, on_phase: Any) -> MinimalRunResult:
+        del instance, on_phase
+        run_dir = config.run_root / "runs" / run_config.run_id
+        report_path = run_dir / "report.md"
+        report_path.parent.mkdir(parents=True)
+        report_path.write_text("safe")
+        bundle = ReportBundle(
+            title="SWE-bench Pro evaluation",
+            revisions={"harness": "b" * 40, "powercontext": "a" * 40},
+            configuration={
+                "instance": task.instance_id or "",
+                "model": batch.request.model,
+                "reasoning_effort": batch.request.reasoning_effort,
+            },
+            treatment_mode=retained_mode,
+            off=(
+                ArmReport(
+                    arm="off",
+                    state=ArmState.TREATMENT_VALIDATED,
+                    resolved=False,
+                    passed=False,
+                    treatment_valid=True,
+                    metrics=MetricSet(input_tokens=1, output_tokens=1, elapsed_seconds=1, patch_bytes=1),
+                )
+                if Arm.OFF in retained_mode.arms
+                else None
+            ),
+            on=ArmReport(
+                arm="on",
+                state=ArmState.TREATMENT_VALIDATED,
+                resolved=retained_on_resolved,
+                passed=retained_on_resolved,
+                treatment_valid=True,
+                metrics=MetricSet(input_tokens=1, output_tokens=1, elapsed_seconds=1, patch_bytes=1),
+            ),
+        )
+        (run_dir / "report.json").write_text(bundle.model_dump_json())
+        for arm in retained_mode.arms:
+            evidence_dir = run_dir / "arms" / arm.value / "powercontext"
+            evidence_dir.mkdir(parents=True)
+            (evidence_dir / "treatment.json").write_text(
+                json.dumps(
+                    {
+                        "mcp_requests": 0 if arm is Arm.OFF else 1,
+                        "plugin_checkout_sha": "a" * 40,
+                        "plugin_id": "powercontext@powercontext",
+                        "plugin_installed": True,
+                        "plugin_version": "0.1.0",
+                        "prompt_sources": 0 if arm is Arm.OFF else 1,
+                        "scope_id": f"eval:{run_config.run_id}:{arm.value}",
+                        "server_ready": True,
+                    }
+                )
+            )
+        return MinimalRunResult(run_config.run_id, report_path, None, True)
+
+    worker = EvaluationWorker(
+        config,
+        store,
+        runner=runner,
+        source=FakeSource(),
+        catalog=FakeCatalog(("instance_owner__repo-a",)),
+        clock=lambda: NOW,
+    )
+
+    assert worker.run_once() is True
+
+    failed = store.get(task.task_id)
+    assert failed.status is TaskStatus.FAILED
+    assert failed.result is None
+    assert failed.failure_category is FailureCategory.REPORT_GENERATION
+    assert failed.failure_summary == "Evaluation report validation failed."
 
 
 def test_only_one_child_runs_physically_across_multiple_batches(tmp_path: Path) -> None:
@@ -651,7 +807,7 @@ def test_failed_batch_child_does_not_block_later_children(monkeypatch: pytest.Mo
         report.write_text("safe")
         return MinimalRunResult(run_config.run_id, report, True, True)
 
-    monkeypatch.setattr("powercontext_eval.web.worker.load_report", lambda *args: object())
+    monkeypatch.setattr("powercontext_eval.web.worker.load_report", lambda *args: _loaded_pair_report())
     worker = EvaluationWorker(
         config,
         store,
@@ -709,7 +865,7 @@ def test_upstream_capacity_failure_requeues_the_child_without_pausing_the_batch(
         report.write_text("safe")
         return MinimalRunResult(run_config.run_id, report, True, True)
 
-    monkeypatch.setattr("powercontext_eval.web.worker.load_report", lambda *args: object())
+    monkeypatch.setattr("powercontext_eval.web.worker.load_report", lambda *args: _loaded_pair_report())
     worker = _capacity_worker(config, store, instance_ids, runner)
 
     assert worker.run_once() is True
@@ -856,7 +1012,10 @@ def test_restart_reuses_persisted_batch_sha_and_completed_children(
     batch = _create_batch(store, instance_ids=instance_ids)
     catalog = FakeCatalog(instance_ids)
     calls: list[tuple[RunConfig, SweBenchProInstance]] = []
-    monkeypatch.setattr("powercontext_eval.web.worker.load_report", lambda *args: object())
+    monkeypatch.setattr(
+        "powercontext_eval.web.worker.load_report",
+        lambda *args: _loaded_pair_report(on_resolved=False),
+    )
     first_source = FakeSource()
     first = EvaluationWorker(
         config,
@@ -921,7 +1080,7 @@ def test_run_once_maps_config_phases_and_success(monkeypatch: pytest.MonkeyPatch
     loaded = []
     monkeypatch.setattr(
         "powercontext_eval.web.worker.load_report",
-        lambda run_dir, run_root: loaded.append((run_dir, run_root)) or object(),
+        lambda run_dir, run_root: loaded.append((run_dir, run_root)) or _loaded_pair_report(on_resolved=False),
     )
     worker = EvaluationWorker(config, store, runner=runner, clock=lambda: NOW)
 
@@ -1258,7 +1417,7 @@ def test_heartbeat_thread_stops_and_joins(succeeds: bool, monkeypatch: pytest.Mo
         path.write_text("report")
         return MinimalRunResult(task.task_id, path, True, True)
 
-    monkeypatch.setattr("powercontext_eval.web.worker.load_report", lambda *args: object())
+    monkeypatch.setattr("powercontext_eval.web.worker.load_report", lambda *args: _loaded_pair_report())
 
     def thread_factory(**kwargs: Any) -> RecordingThread:
         thread = RecordingThread(**kwargs)
@@ -1417,7 +1576,6 @@ def test_runner_report_must_be_exact_regular_canonical_report(
             returned = expected
         return MinimalRunResult(task.task_id, returned, True, True)
 
-    monkeypatch.setattr("powercontext_eval.web.worker.load_report", lambda *args: object())
     assert EvaluationWorker(config, store, runner=runner, clock=lambda: NOW).run_once() is True
     failed = store.get(task.task_id)
     assert failed.status is TaskStatus.FAILED
@@ -1569,7 +1727,7 @@ def test_supervisor_respects_configured_isolated_task_pair_capacity_and_stop_pre
         report.write_text("safe")
         return MinimalRunResult(run_config.run_id, report, True, True)
 
-    monkeypatch.setattr("powercontext_eval.web.worker.load_report", lambda *args: object())
+    monkeypatch.setattr("powercontext_eval.web.worker.load_report", lambda *args: _loaded_pair_report())
     worker = EvaluationWorker(
         config,
         store,
@@ -1616,7 +1774,7 @@ def test_task_pair_worker_directly_preserves_phase_order_and_report_boundary(
         report.write_text("safe")
         return MinimalRunResult(run_config.run_id, report, True, True)
 
-    monkeypatch.setattr("powercontext_eval.web.worker.load_report", lambda *args: object())
+    monkeypatch.setattr("powercontext_eval.web.worker.load_report", lambda *args: _loaded_pair_report())
     slot = TaskPairWorker(config, store, runner=runner, worker_id="direct-slot", clock=lambda: NOW)
 
     assert slot.run_once() is True
@@ -1771,7 +1929,7 @@ def test_supervisor_slot_failure_stops_replacements_joins_active_slots_and_raise
         report.write_text("safe")
         return MinimalRunResult(run_config.run_id, report, True, True)
 
-    monkeypatch.setattr("powercontext_eval.web.worker.load_report", lambda *args: object())
+    monkeypatch.setattr("powercontext_eval.web.worker.load_report", lambda *args: _loaded_pair_report())
     worker = EvaluationWorker(config, store, runner=runner, worker_id="failing-supervisor", clock=lambda: NOW)
     failing_slot = worker._slots[0]
 

--- a/evaluation/tests/web/test_worker.py
+++ b/evaluation/tests/web/test_worker.py
@@ -731,11 +731,14 @@ def test_worker_rejects_retained_report_that_does_not_match_the_task(
 
     assert worker.run_once() is True
 
-    failed = store.get(task.task_id)
-    assert failed.status is TaskStatus.FAILED
-    assert failed.result is None
-    assert failed.failure_category is FailureCategory.REPORT_GENERATION
-    assert failed.failure_summary == "Evaluation report validation failed."
+    current = store.get(task.task_id)
+    assert current.status is not TaskStatus.SUCCEEDED
+    assert current.result is None
+    attempts = store.list_task_attempts(batch.batch_id, task.task_id)
+    assert attempts[0].status is TaskStatus.FAILED
+    assert attempts[0].result is None
+    assert attempts[0].failure_category is FailureCategory.REPORT_GENERATION
+    assert attempts[0].failure_summary == "Evaluation report validation failed."
 
 
 def test_only_one_child_runs_physically_across_multiple_batches(tmp_path: Path) -> None:


### PR DESCRIPTION
## Tracking

- Tracking issue: #3
- Relationship: Part of #3

## Problem and rationale

WP5 needs an internal execution core that can run exactly one requested treatment arm without inventing the unexecuted arm. This PR keeps that slice separate from the draft API/CLI work in #167 and the P3 console work.

## Changes

- Add the internal `TreatmentMode` contract for `off_on`, `on_only`, and `off_only` through retained reports, runner execution, worker outcomes, and batch reporting.
- Run a Docker pair only for `off_on`; run exactly one Docker arm for one-arm modes.
- Reject unrequested OFF/ON entries in retained single-arm artifact directories through the safe directory-fd path.
- Bind a loaded report's mode, report/evidence arm sets, and resolved outcomes to the validated runner result before task success is persisted.

## Behavior and compatibility

- User-visible behavior: internal worker execution can retain one-arm artifacts and outcomes; paired behavior remains unchanged.
- Public API or protocol impact: none. Public capabilities remain `off_on` pending #167.
- Breaking changes or migration requirements: none.
- Explicit non-goals: API/CLI routes, baseline selection flows, frontend console, generated contracts, and OpenAPI changes.

## Generated, dependency, and workflow impact

- [x] No generated contract changed.
- [x] No dependency changed.
- [x] No CI or release contract changed.
- [x] No credential, private Source/Memory content, or unredacted production log is included.

## Validation

```text
WSL Ubuntu, offline evaluation environment
pytest -c evaluation/pyproject.toml evaluation/tests -q
1032 passed, 6 failed, 1 warning

The six failures reproduce the unmodified baseline:
- TokensFlow wrapper test observes inherited GOPROXY.
- Five worker cleanup/retry tests defer cleanup with RuntimeError and therefore do not schedule a retry.

ruff check src tests
ruff format --check src tests
ty check src
All passed.
```

- [x] `git diff --check`
- [x] `git status --short` was inspected after validation.
- [x] Formatter evidence is recorded above.
- [x] Generated-consumer evidence is not applicable because no generator output changed.
- [x] Compatibility evidence is the full retained-report, worker, and runner test suite; no public Go API changed.
- [x] Relevant retained-artifact and worker process tests were run.
- [x] The unavailable clean full-suite result is identified above and is not represented as passing.

## AI usage

AI assistance implemented the bounded P2a slice and regression tests. The submitted diff received an independent read-only review and was verified with the commands above.