### PR TITLE
test(claude-code): split unknown schema evidence

### DIFF
--- a/integrations/claude-code/tests/test_hook.py
+++ b/integrations/claude-code/tests/test_hook.py
@@ -443,7 +443,7 @@ def test_http_failures_are_non_blocking_and_content_free(
     assert "secret" not in errors.getvalue()
 
 
-def test_unknown_schema_and_oversized_content_are_not_injected(
+def test_unknown_schema_is_not_injected(
     hook_module: ModuleType,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -462,10 +462,13 @@ def test_unknown_schema_and_oversized_content_are_not_injected(
         )
         is None
     )
-    with pytest.raises(hook_module._InvalidResponseError):
-        hook_module._validate_prepared_context(_prepared("x" * 8_001))
     assert json.loads(errors.getvalue())["outcome"] == "invalid_response"
     assert "secret" not in errors.getvalue()
+
+
+def test_oversized_prepared_context_is_rejected(hook_module: ModuleType) -> None:
+    with pytest.raises(hook_module._InvalidResponseError):
+        hook_module._validate_prepared_context(_prepared("x" * 8_001))
 
 
 @pytest.mark.parametrize(

--- a/test/conformance/parity-inventory-rules.json
+++ b/test/conformance/parity-inventory-rules.json
@@ -123,7 +123,14 @@
     },
     "tests/claude_code_plugin/test_hook.py": {
       "mode": "retained-host",
-      "reason": "Claude Code prompt hook behavior is owned by the retained Claude Code adapter."
+      "reason": "Claude Code prompt hook behavior is owned by the retained Claude Code adapter.",
+      "cases": {
+        "test_unknown_schema_is_not_injected": {
+          "evidence": [
+            "py:integrations/claude-code/tests/test_hook.py#test_unknown_schema_is_not_injected"
+          ]
+        }
+      }
     },
     "tests/e2e/test_observability.py": {
       "mode": "cross-layer",

--- a/test/conformance/parity-inventory.json
+++ b/test/conformance/parity-inventory.json
@@ -4,8 +4,8 @@
   "oracle_commit": "3a6cb0151670eaff7dc0293466edd673124e80da",
   "python_test_file_count": 132,
   "python_test_case_count": 812,
-  "mapped_case_count": 773,
-  "pending_case_count": 39,
+  "mapped_case_count": 774,
+  "pending_case_count": 38,
   "entries": [
     {
       "python": {
@@ -4114,8 +4114,15 @@
         "line": 408
       },
       "mode": "retained-host",
-      "status": "pending",
-      "source": "rules"
+      "status": "mapped",
+      "source": "rules",
+      "evidence": [
+        {
+          "kind": "py",
+          "file": "integrations/claude-code/tests/test_hook.py",
+          "test": "test_unknown_schema_is_not_injected"
+        }
+      ]
     },
     {
       "python": {

--- a/test/conformance/target-delta.json
+++ b/test/conformance/target-delta.json
@@ -101,7 +101,7 @@
       "disposition": "superseded",
       "reason": "The release split out a focused unknown-schema behavior while retained host evidence keeps the oversized boundary.",
       "replacements": [{"file": "tests/claude_code_plugin/test_hook.py", "name": "test_unknown_schema_is_not_injected"}],
-      "evidence": ["py:integrations/claude-code/tests/test_hook.py#test_unknown_schema_and_oversized_content_are_not_injected"]
+      "evidence": ["py:integrations/claude-code/tests/test_hook.py#test_unknown_schema_is_not_injected"]
     },
     {
       "case": {"file": "tests/codex_plugin/test_recall.py", "name": "test_context_request_uses_the_prepare_endpoint_once"},

--- a/test/conformance/traceability-rules.json
+++ b/test/conformance/traceability-rules.json
@@ -2333,7 +2333,12 @@
       "mode": "retained-host",
       "case_evidence": [
         "py:integrations/claude-code/tests/test_hook.py#{python_test}"
-      ]
+      ],
+      "cases": {
+        "test_unknown_schema_and_oversized_content_are_not_injected": [
+          "py:integrations/claude-code/tests/test_hook.py#test_unknown_schema_is_not_injected"
+        ]
+      }
     },
     "tests/e2e/test_claude_code_service_chain.py": {
       "mode": "cross-layer",

--- a/test/conformance/traceability.json
+++ b/test/conformance/traceability.json
@@ -3517,7 +3517,7 @@
         {
           "kind": "py",
           "file": "integrations/claude-code/tests/test_hook.py",
-          "test": "test_unknown_schema_and_oversized_content_are_not_injected"
+          "test": "test_unknown_schema_is_not_injected"
         }
       ]
     },


### PR DESCRIPTION
## Scope

Map the final Claude Code hook release-target case with one focused retained-host test.

- split unknown prepared-context schema rejection from the oversized-response boundary
- preserve the existing fail-closed hook behavior and oversized-content regression
- update superseded v0.0.2 delta evidence to the focused replacement
- regenerate parity inventory from `773 mapped / 39 pending` to `774 mapped / 38 pending`

## Validation

- `uv run --with pytest pytest -q integrations/claude-code/tests/test_hook.py`
- `go run ./tools/parity-inventory-generate ... -check -check-delta ...`