### PR TITLE
fix(release): stage assets before publishing

### DIFF
--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -202,7 +202,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Run the published standard image by digest
-        id: image_runtime
+        id: standard_image_runtime
         shell: bash
         env:
           BUILD_DATE: ${{ steps.release.outputs.build_date }}
@@ -210,7 +210,46 @@ jobs:
           IMAGE: ${{ steps.images.outputs.standard }}
           VERSION: ${{ steps.release.outputs.version }}
         run: |
-          container="powercontext-release-verify-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          container="powercontext-release-verify-standard-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          cleanup() {
+            docker rm --force "$container" >/dev/null 2>&1 || true
+          }
+          trap cleanup EXIT
+          docker pull "$IMAGE"
+          test "$(docker image inspect "$IMAGE" --format '{{ index .Config.Labels "org.opencontainers.image.version" }}')" = "$VERSION"
+          test "$(docker image inspect "$IMAGE" --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}')" = "$COMMIT"
+          test "$(docker image inspect "$IMAGE" --format '{{ index .Config.Labels "org.opencontainers.image.created" }}')" = "$BUILD_DATE"
+          docker run \
+            --detach \
+            --name "$container" \
+            --env POWERCONTEXT_SERVER_HTTP_HOST=0.0.0.0 \
+            --env POWERCONTEXT_SERVER_HTTP_PORT=8000 \
+            --publish 127.0.0.1::8000 \
+            "$IMAGE" server run
+          endpoint="$(docker port "$container" 8000/tcp | head -n 1)"
+          ready=false
+          for _ in $(seq 1 45); do
+            if curl --fail --silent --show-error "http://${endpoint}/health/ready" >/dev/null; then
+              ready=true
+              break
+            fi
+            sleep 1
+          done
+          if [ "$ready" != true ]; then
+            docker logs "$container"
+            exit 1
+          fi
+
+      - name: Run the published Full image by digest
+        id: full_image_runtime
+        shell: bash
+        env:
+          BUILD_DATE: ${{ steps.release.outputs.build_date }}
+          COMMIT: ${{ steps.release.outputs.commit }}
+          IMAGE: ${{ steps.images.outputs.full }}
+          VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          container="powercontext-release-verify-full-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           cleanup() {
             docker rm --force "$container" >/dev/null 2>&1 || true
           }
@@ -246,11 +285,12 @@ jobs:
           ARCHIVES: ${{ steps.archives.outcome }}
           ASSETS: ${{ steps.assets.outcome }}
           FULL_SMOKE: ${{ steps.full_smoke.outcome }}
-          IMAGE_RUNTIME: ${{ steps.image_runtime.outcome }}
+          FULL_IMAGE_RUNTIME: ${{ steps.full_image_runtime.outcome }}
           IMAGES: ${{ steps.images.outcome }}
           RELEASE_TAG: ${{ inputs.release_tag }}
           VERSION: ${{ steps.release.outputs.version }}
           STANDARD_SMOKE: ${{ steps.standard_smoke.outcome }}
+          STANDARD_IMAGE_RUNTIME: ${{ steps.standard_image_runtime.outcome }}
         run: |
           {
             echo "## Release health"
@@ -262,5 +302,6 @@ jobs:
             echo "- Standard process contract: **$STANDARD_SMOKE**"
             echo "- Full process contract: **$FULL_SMOKE**"
             echo "- Immutable GHCR manifests: **$IMAGES**"
-            echo "- Published image runtime: **$IMAGE_RUNTIME**"
+            echo "- Published standard image runtime: **$STANDARD_IMAGE_RUNTIME**"
+            echo "- Published Full image runtime: **$FULL_IMAGE_RUNTIME**"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,22 @@
 name: Release
 
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - "v[0-9]*"
+      - "powercontext-v[0-9]*"
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Existing release tag to build, stage, and publish
+        required: true
+        type: string
 
 permissions:
   contents: read
 
 concurrency:
-  group: release-${{ github.event.release.tag_name }}
+  group: release-${{ inputs.release_tag || github.ref_name }}
   cancel-in-progress: false
 
 env:
@@ -23,19 +31,20 @@ jobs:
       build_date: ${{ steps.release.outputs.build_date }}
       commit: ${{ steps.release.outputs.commit }}
       image_tag: ${{ steps.release.outputs.image_tag }}
+      release_tag: ${{ steps.release.outputs.release_tag }}
       version: ${{ steps.release.outputs.version }}
     steps:
       - name: Check out the released commit
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ inputs.release_tag || github.ref_name }}
           fetch-depth: 0
 
       - name: Resolve and validate immutable release metadata
         id: release
         shell: bash
         env:
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_TAG: ${{ inputs.release_tag || github.ref_name }}
         run: |
           version="${RELEASE_TAG#powercontext-v}"
           version="${version#v}"
@@ -50,6 +59,7 @@ jobs:
           build_date="$(date -u -d "@$epoch" +%Y-%m-%dT%H:%M:%SZ)"
           image_tag="${version//+/-}"
           {
+            echo "release_tag=$RELEASE_TAG"
             echo "version=$version"
             echo "commit=$commit"
             echo "build_date=$build_date"
@@ -77,7 +87,7 @@ jobs:
       - name: Check out the released commit
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ needs.prepare.outputs.release_tag }}
           fetch-depth: 0
 
       - name: Set up the Go environment
@@ -170,7 +180,7 @@ jobs:
       - name: Check out the released commit
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ needs.prepare.outputs.release_tag }}
           fetch-depth: 0
 
       - name: Set up the Go environment
@@ -273,7 +283,7 @@ jobs:
       - name: Check out the released commit
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ needs.prepare.outputs.release_tag }}
 
       - name: Set up the Go environment
         uses: ./.github/actions/setup-go-env
@@ -293,10 +303,11 @@ jobs:
           test "$(find dist -name '*.spdx.json' | wc -l | tr -d ' ')" = 8
           test "$(wc -l < dist/SHA256SUMS | tr -d ' ')" = 17
 
-      - name: Upload GitHub Release assets
+      - name: Upload GitHub Release assets as a draft
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
         with:
-          tag_name: ${{ github.event.release.tag_name }}
+          tag_name: ${{ needs.prepare.outputs.release_tag }}
+          draft: true
           files: |
             dist/*.tar.gz
             dist/*.spdx.json
@@ -304,15 +315,22 @@ jobs:
             dist/SHA256SUMS
           fail_on_unmatched_files: true
 
+      - name: Publish GitHub Release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ needs.prepare.outputs.release_tag }}
+        run: gh release edit "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --draft=false
+
   release-verify:
     name: Verify the published release
-    needs: publish
+    needs: [prepare, publish]
     permissions:
       contents: read
       packages: read
     uses: ./.github/workflows/release-verify.yml
     with:
-      release_tag: ${{ github.event.release.tag_name }}
+      release_tag: ${{ needs.prepare.outputs.release_tag }}
 
   deploy-docs:
     name: Deploy documentation

--- a/test/conformance/target-delta.json
+++ b/test/conformance/target-delta.json
@@ -175,20 +175,20 @@
       "case": {"file": "tests/test_ci_release_verification.py", "name": "test_github_release_allows_prereleases"},
       "disposition": "superseded",
       "reason": "Go release workflow tests own prerelease and published-asset verification for the shipped implementation.",
-      "evidence": ["go:tools/release/main_test.go#TestReleaseWorkflowPublishesCompleteAssetsAndAllowsPrereleases"]
+      "evidence": ["go:tools/release/main_test.go#TestReleaseWorkflowStagesAssetsBeforePublishingImmutableRelease"]
     },
     {
       "case": {"file": "tests/test_ci_release_verification.py", "name": "test_github_release_requires_published_state_and_expected_assets"},
       "disposition": "superseded",
       "reason": "Go release workflow tests own published-state and complete-asset verification for the shipped implementation.",
-      "evidence": ["go:tools/release/main_test.go#TestReleaseWorkflowPublishesCompleteAssetsAndAllowsPrereleases"]
+      "evidence": ["go:tools/release/main_test.go#TestReleaseWorkflowStagesAssetsBeforePublishingImmutableRelease"]
     },
     {
       "case": {"file": "tests/test_ci_release_verification.py", "name": "test_pypi_release_requires_wheel_and_sdist"},
       "disposition": "superseded",
       "reason": "The Go release contract records and verifies the complete distribution asset set.",
       "evidence": [
-        "go:tools/release/main_test.go#TestReleaseWorkflowPublishesCompleteAssetsAndAllowsPrereleases",
+        "go:tools/release/main_test.go#TestReleaseWorkflowStagesAssetsBeforePublishingImmutableRelease",
         "go:tools/release/main_test.go#TestNativeAssetManifestSupportsReleaseMatrix"
       ]
     },
@@ -196,7 +196,7 @@
       "case": {"file": "tests/test_ci_release_verification.py", "name": "test_pypi_verification_retries_until_release_is_complete"},
       "disposition": "superseded",
       "reason": "The Go release workflow owns bounded publication verification for the shipped release process.",
-      "evidence": ["go:tools/release/main_test.go#TestReleaseWorkflowPublishesCompleteAssetsAndAllowsPrereleases"]
+      "evidence": ["go:tools/release/main_test.go#TestReleaseWorkflowStagesAssetsBeforePublishingImmutableRelease"]
     },
     {
       "case": {"file": "tests/test_transport.py", "name": "test_vendored_plugin_shares_the_loopback_host_set"},

--- a/test/conformance/traceability-rules.json
+++ b/test/conformance/traceability-rules.json
@@ -1443,17 +1443,17 @@
           "go:tools/release/main_test.go#TestReleaseArchiveKeepsStableExecutablePathAndMode"
         ],
         "test_pypi_release_requires_wheel_and_sdist": [
-          "go:tools/release/main_test.go#TestReleaseWorkflowPublishesCompleteAssetsAndAllowsPrereleases",
+          "go:tools/release/main_test.go#TestReleaseWorkflowStagesAssetsBeforePublishingImmutableRelease",
           "go:tools/release/main_test.go#TestNativeAssetManifestSupportsReleaseMatrix"
         ],
         "test_pypi_verification_retries_until_release_is_complete": [
-          "go:tools/release/main_test.go#TestReleaseWorkflowPublishesCompleteAssetsAndAllowsPrereleases"
+          "go:tools/release/main_test.go#TestReleaseWorkflowStagesAssetsBeforePublishingImmutableRelease"
         ],
         "test_github_release_requires_published_state_and_expected_assets": [
-          "go:tools/release/main_test.go#TestReleaseWorkflowPublishesCompleteAssetsAndAllowsPrereleases"
+          "go:tools/release/main_test.go#TestReleaseWorkflowStagesAssetsBeforePublishingImmutableRelease"
         ],
         "test_github_release_allows_prereleases": [
-          "go:tools/release/main_test.go#TestReleaseWorkflowPublishesCompleteAssetsAndAllowsPrereleases"
+          "go:tools/release/main_test.go#TestReleaseWorkflowStagesAssetsBeforePublishingImmutableRelease"
         ]
       }
     },

--- a/test/conformance/traceability.json
+++ b/test/conformance/traceability.json
@@ -6565,7 +6565,7 @@
         {
           "kind": "go",
           "file": "tools/release/main_test.go",
-          "test": "TestReleaseWorkflowPublishesCompleteAssetsAndAllowsPrereleases"
+          "test": "TestReleaseWorkflowStagesAssetsBeforePublishingImmutableRelease"
         },
         {
           "kind": "go",
@@ -6586,7 +6586,7 @@
         {
           "kind": "go",
           "file": "tools/release/main_test.go",
-          "test": "TestReleaseWorkflowPublishesCompleteAssetsAndAllowsPrereleases"
+          "test": "TestReleaseWorkflowStagesAssetsBeforePublishingImmutableRelease"
         }
       ]
     },
@@ -6602,7 +6602,7 @@
         {
           "kind": "go",
           "file": "tools/release/main_test.go",
-          "test": "TestReleaseWorkflowPublishesCompleteAssetsAndAllowsPrereleases"
+          "test": "TestReleaseWorkflowStagesAssetsBeforePublishingImmutableRelease"
         }
       ]
     },
@@ -6618,7 +6618,7 @@
         {
           "kind": "go",
           "file": "tools/release/main_test.go",
-          "test": "TestReleaseWorkflowPublishesCompleteAssetsAndAllowsPrereleases"
+          "test": "TestReleaseWorkflowStagesAssetsBeforePublishingImmutableRelease"
         }
       ]
     },

--- a/tools/release/main_test.go
+++ b/tools/release/main_test.go
@@ -905,7 +905,7 @@ func TestReleaseArchiveKeepsStableExecutablePathAndMode(t *testing.T) {
 	}
 }
 
-func TestReleaseWorkflowPublishesCompleteAssetsAndAllowsPrereleases(t *testing.T) {
+func TestReleaseWorkflowStagesAssetsBeforePublishingImmutableRelease(t *testing.T) {
 	repository := filepath.Clean(filepath.Join("..", ".."))
 	payload, err := os.ReadFile(filepath.Join(repository, ".github", "workflows", "release.yml"))
 	if err != nil {
@@ -913,8 +913,13 @@ func TestReleaseWorkflowPublishesCompleteAssetsAndAllowsPrereleases(t *testing.T
 	}
 	workflow := string(payload)
 	for _, required := range []string{
-		"types: [published]",
+		"workflow_dispatch:",
+		"release_tag:",
+		"tags:",
+		"v[0-9]*",
+		"needs.prepare.outputs.release_tag",
 		"needs: [prepare, binaries, images]",
+		"needs: [prepare, publish]",
 		"make package-standard",
 		"make package-full",
 		"Smoke test both released process surfaces",
@@ -924,15 +929,61 @@ func TestReleaseWorkflowPublishesCompleteAssetsAndAllowsPrereleases(t *testing.T
 		"dist/IMAGE-DIGESTS.json",
 		"dist/SHA256SUMS",
 		"fail_on_unmatched_files: true",
+		"draft: true",
+		`gh release edit "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --draft=false`,
 		"uses: ./.github/workflows/release-verify.yml",
 	} {
 		if !strings.Contains(workflow, required) {
 			t.Errorf("release workflow is missing %q", required)
 		}
 	}
+	for _, publishedReleaseTrigger := range []string{"types: [published]", "github.event.release.tag_name"} {
+		if strings.Contains(workflow, publishedReleaseTrigger) {
+			t.Errorf("release workflow publishes assets after an immutable release through %q", publishedReleaseTrigger)
+		}
+	}
 	for _, prereleaseFilter := range []string{"prerelease == false", "prerelease: false", "!github.event.release.prerelease"} {
 		if strings.Contains(workflow, prereleaseFilter) {
 			t.Errorf("release workflow rejects published prereleases through %q", prereleaseFilter)
+		}
+	}
+}
+
+func TestReleaseVerificationSmokesEveryPublishedImageByDigest(t *testing.T) {
+	repository := filepath.Clean(filepath.Join("..", ".."))
+	payload, err := os.ReadFile(filepath.Join(repository, ".github", "workflows", "release-verify.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	workflow := string(payload)
+	for _, runtime := range []struct {
+		name  string
+		id    string
+		image string
+	}{
+		{name: "standard", id: "standard_image_runtime", image: "${{ steps.images.outputs.standard }}"},
+		{name: "Full", id: "full_image_runtime", image: "${{ steps.images.outputs.full }}"},
+	} {
+		stepName := "Run the published " + runtime.name + " image by digest"
+		stepStart := strings.Index(workflow, stepName)
+		if stepStart < 0 {
+			t.Errorf("release verification does not smoke the published %s image by digest: missing %q", runtime.name, stepName)
+			continue
+		}
+		step := workflow[stepStart:]
+		if nextStep := strings.Index(step, "\n      - name:"); nextStep >= 0 {
+			step = step[:nextStep]
+		}
+		for _, required := range []string{
+			"id: " + runtime.id,
+			"IMAGE: " + runtime.image,
+			`docker pull "$IMAGE"`,
+			`"$IMAGE" server run`,
+			"/health/ready",
+		} {
+			if !strings.Contains(step, required) {
+				t.Errorf("release verification does not smoke the published %s image by digest: missing %q", runtime.name, required)
+			}
 		}
 	}
 }

--- a/tools/release/workflow_test.go
+++ b/tools/release/workflow_test.go
@@ -149,7 +149,7 @@ func TestContinuousIntegrationPreservesPythonTopologyAndGoAssurance(t *testing.T
 			"run: make docs-build", "actions/deploy-pages@",
 		},
 		"release.yml": {
-			"name: Release", "types: [published]", "release-verify:", "deploy-docs:",
+			"name: Release", "push:", "tags:", "workflow_dispatch:", "release-verify:", "deploy-docs:",
 			"uses: ./.github/workflows/release-verify.yml", "uses: ./.github/workflows/deploy-docs.yml",
 		},
 	}


### PR DESCRIPTION
## Summary
- create release assets in a draft before publishing an immutable GitHub Release
- pass the prepared tag through declared job dependencies and permit recovery dispatches for an existing tag
- smoke both standard and Full GHCR images by their recorded immutable digests

## Verification
- go test ./tools/release -run '^(TestReleaseWorkflowStagesAssetsBeforePublishingImmutableRelease|TestReleaseVerificationSmokesEveryPublishedImageByDigest|TestContinuousIntegrationPreservesPythonTopologyAndGoAssurance)$' -count=1
- actionlint v1.7.12

## Local limitation
- the full tools/release package suite still has an existing Windows executable-mode failure in TestReleaseArchiveKeepsStableExecutablePathAndMode; exact-Head Linux CI validates the release tooling.