### PR TITLE
test(langchain): harden middleware and add regression coverage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -398,6 +398,10 @@ source / artifact / trigger / inference
   context while explicitly clearing the ambient trace parent before later
   stages begin. Verify an injected root-start failure leaves child spans
   unparented and on a different trace ID from the ambient operation.
+- When an integration middleware receives an optional or host-supplied runtime
+  object, treat missing runtime fields as a fail-open boundary. Access context
+  defensively and verify a partial runtime preserves the host operation result
+  without an adapter exception.
 - When transport middleware buffers a request body before routing, bound the
   read with `http.MaxBytesReader` and map `*http.MaxBytesError` to an
   explicit over-limit response before any downstream decoding. When an

--- a/integrations/langchain/src/powercontext_langchain/middleware.py
+++ b/integrations/langchain/src/powercontext_langchain/middleware.py
@@ -211,7 +211,7 @@ class PowerContextMiddleware(AgentMiddleware[AgentState[ResponseT], PowerContext
 
 
 def _runtime_scope(runtime: Any | None) -> PowerContextScope | None:
-    context = None if runtime is None else runtime.context
+    context = None if runtime is None else getattr(runtime, "context", None)
     return context if isinstance(context, PowerContextScope) else None
 
 

--- a/integrations/langchain/tests/test_middleware.py
+++ b/integrations/langchain/tests/test_middleware.py
@@ -1,0 +1,140 @@
+# Copyright (c) 2026 OceanBase.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+"""Public middleware behavior tests with an in-process PowerContext fake."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import Any
+
+from langchain_core.messages import AIMessage, HumanMessage
+
+from powercontext.http import PreparedContextStatus
+from powercontext_langchain import PowerContextMiddleware, PowerContextScope
+from powercontext_langchain.client import ResolvedConfig
+
+
+@dataclass
+class _Request:
+    messages: list[Any]
+    system_message: Any = None
+    runtime: Any = None
+
+    def override(self, **changes: Any) -> "_Request":
+        values = {"messages": self.messages, "system_message": self.system_message, "runtime": self.runtime}
+        values.update(changes)
+        return _Request(**values)
+
+
+class _FakeClient:
+    def __init__(self, *, content: str | None = "remembered", fail: Exception | None = None) -> None:
+        self.content = content
+        self.fail = fail
+        self.prepared: list[Any] = []
+        self.captured: list[Any] = []
+
+    async def __aenter__(self) -> "_FakeClient":
+        return self
+
+    async def __aexit__(self, *_: Any) -> None:
+        return None
+
+    async def prepare_context(self, request: Any) -> Any:
+        if self.fail:
+            raise self.fail
+        self.prepared.append(request)
+        status = PreparedContextStatus.EMPTY if self.content is None else SimpleNamespace(value="ready")
+        return SimpleNamespace(status=status, content=self.content or "")
+
+    async def capture_content_source(self, request: Any) -> None:
+        if self.fail:
+            raise self.fail
+        self.captured.append(request)
+
+
+def _config() -> ResolvedConfig:
+    return ResolvedConfig(
+        base_url="http://127.0.0.1:8000",
+        scope_id="project:test",
+        token=None,
+        timeout=1,
+        max_bytes=8000,
+    )
+
+
+def test_async_model_call_injects_recall_without_mutating_messages(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    fake = _FakeClient()
+    monkeypatch.setattr("powercontext_langchain.middleware.resolve_config", lambda _scope: _config())
+    monkeypatch.setattr("powercontext_langchain.middleware.open_client", lambda _config: fake)
+    request = _Request([HumanMessage(content="question")], runtime=SimpleNamespace(context=PowerContextScope()))
+    seen: list[_Request] = []
+
+    async def handler(value: _Request) -> object:
+        seen.append(value)
+        return object()
+
+    asyncio.run(PowerContextMiddleware().awrap_model_call(request, handler))
+
+    assert len(fake.prepared) == 1
+    assert len(seen) == 1
+    assert "remembered" in str(seen[0].system_message.content)
+    assert request.messages == [request.messages[0]]
+
+
+def test_async_model_call_fails_open_and_preserves_result(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    fake = _FakeClient(fail=OSError("offline"))
+    monkeypatch.setattr("powercontext_langchain.middleware.resolve_config", lambda _scope: _config())
+    monkeypatch.setattr("powercontext_langchain.middleware.open_client", lambda _config: fake)
+    request = _Request([HumanMessage(content="question")])
+    result = object()
+
+    async def handler(value: _Request) -> object:
+        assert value.system_message is None
+        return result
+
+    assert asyncio.run(PowerContextMiddleware().awrap_model_call(request, handler)) is result
+
+
+def test_after_agent_captures_completed_turn(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    fake = _FakeClient()
+    monkeypatch.setattr("powercontext_langchain.middleware.resolve_config", lambda _scope: _config())
+    monkeypatch.setattr("powercontext_langchain.middleware.open_client", lambda _config: fake)
+    state = {"messages": [HumanMessage(content="question"), AIMessage(content="answer")]}
+
+    asyncio.run(PowerContextMiddleware(auto_capture=True).aafter_agent(state, SimpleNamespace(context=None)))
+
+    assert len(fake.captured) == 1
+    assert "question" in fake.captured[0].content
+    assert "answer" in fake.captured[0].content
+    assert fake.captured[0].metadata["integration"] == "langchain"
+
+
+def test_missing_runtime_context_is_fail_open(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    fake = _FakeClient()
+    monkeypatch.setattr("powercontext_langchain.middleware.resolve_config", lambda _scope: _config())
+    monkeypatch.setattr("powercontext_langchain.middleware.open_client", lambda _config: fake)
+    request = _Request([HumanMessage(content="question")], runtime=object())
+
+    async def handler(value: _Request) -> object:
+        return value
+
+    result = asyncio.run(PowerContextMiddleware().awrap_model_call(request, handler))
+    assert result is not None
+
+
+def test_empty_recall_does_not_add_system_message(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    fake = _FakeClient(content=None)
+    monkeypatch.setattr("powercontext_langchain.middleware.resolve_config", lambda _scope: _config())
+    monkeypatch.setattr("powercontext_langchain.middleware.open_client", lambda _config: fake)
+    request = _Request([HumanMessage(content="question")])
+
+    async def handler(value: _Request) -> _Request:
+        return value
+
+    result = asyncio.run(PowerContextMiddleware().awrap_model_call(request, handler))
+    assert result.system_message is None


### PR DESCRIPTION
## Summary

PR #186 completed the primary WP1 LangChain retained configuration adapter, including package scaffolding, settings, scope resolution, client wiring, transport-trust validation, packaging metadata, and the initial middleware implementation.

This PR is the middleware hardening and regression-coverage follow-up for issue #110. It complements PR #187, which provides real Go Server integration evidence for the retained adapters.

## Changes

- Add regression coverage for:
  - request-time PowerContext recall injection;
  - empty recall responses;
  - completed user/assistant turn capture;
  - PowerContext service failures while preserving the host result;
  - partial runtime objects without a `context` field.
- Make runtime scope extraction defensive so incomplete host runtime values do not interrupt LangChain execution.
- Document the fail-open runtime boundary as a reusable repository rule.

## Validation

- `python3 -m py_compile integrations/langchain/src/powercontext_langchain/middleware.py integrations/langchain/tests/test_middleware.py`
- `git diff --check`
- `uv run pytest -q`

Result:

- 21 tests passed.

## Relationship to related work

- PR #186 delivered the primary LangChain retained configuration adapter and the initial middleware implementation.
- PR #187 is adding real Go-compatible Server, SQLite, HTTP, and cross-layer evidence for the retained adapters.
- This PR focuses on middleware-level behavior, fail-open robustness, and deterministic regression coverage.

## Scope

This PR is part of issue #110 and does not claim to replace the real Go Server evidence or host-adapter CI validation provided by PR #187.