### PR TITLE
ci: add first-release governance contract

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,29 @@
+changelog:
+  categories:
+    - title: Breaking changes
+      labels:
+        - breaking
+    - title: Features
+      labels:
+        - enhancement
+    - title: Bug fixes
+      labels:
+        - bug
+    - title: Security
+      labels:
+        - security
+    - title: Dependencies
+      labels:
+        - dependencies
+    - title: Documentation
+      labels:
+        - documentation
+    - title: Maintenance
+      labels:
+        - maintenance
+  exclude:
+    labels:
+      - duplicate
+      - invalid
+      - question
+      - wontfix

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -24,6 +24,10 @@ Four Go-specific workflows extend, rather than replace, that Python topology:
 | `provider-smoke.yml` | Explicitly dispatched, credentialed, bounded real-provider verification; never required on an ordinary pull request. |
 | `windows-contract.yml` | Windows checkout-only contract guard: verifies LF attributes, both versioned fixture SHA-256 inventories, and generated-contract cleanliness without claiming Windows binary support. |
 
+Release-line governance is checked by `make governance-check` in the `governance-contract` job. The check keeps
+`docs/release/POLICY.md`, `.github/release.yml`, and the `release.yml` tag/manual-dispatch triggers aligned so
+branch/version/tag/backport/release-note consistency does not depend on prose review alone.
+
 The committed `test/conformance/testdata/python-v0.0.2` baseline remains immutable. The separate
 `test/conformance/testdata/python-v0.1.0` directory freezes exact release metadata and portable fixture evidence;
 it does not silently replace the historical Oracle. Pull requests regenerate both directories from their pinned

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,6 +62,12 @@ the number of open version-update pull requests and follows the live default bra
 target branch. Dependency pull requests must not be auto-merged; they must pass the repository's normal review and CI
 contracts.
 
+## Release governance
+
+The release branch, backport, merge-strategy, version-source, DCO, and release-note rules live in
+`docs/release/POLICY.md`. The `governance-contract` CI job runs `make governance-check`, which verifies that policy,
+the release workflow tag/manual-dispatch triggers, and `.github/release.yml` label categories stay synchronized.
+
 ## Code and generated contracts
 
 - Match the existing package boundaries, names, and error model. Avoid unrelated refactors or speculative extension
@@ -107,6 +113,7 @@ Every implementation pull request must:
 - identify generated, dependency, workflow, security, or user-facing changes;
 - disclose material AI assistance and describe the human verification performed;
 - avoid weakening assertions, broad exclusions, hidden skips, or unrelated cleanup to make a gate pass.
+- apply the release labels required by `.github/release.yml` when the change should appear in generated release notes.
 
 After every pushed change, recheck the exact pull request Head, current comments, and current CI conclusions before
 claiming the work is ready.

--- a/docs/release/POLICY.md
+++ b/docs/release/POLICY.md
@@ -1,0 +1,50 @@
+# PowerContext Go Release Policy
+
+PowerContext Go publishes from reviewed repository state. The default branch receives features and fixes. Supported
+release branches receive approved fixes and security backports only. In short, the default branch receives features and
+fixes, while supported release branches receive approved fixes and security backports only.
+
+## Branches
+
+`main` is the default integration branch. The release branch naming convention is `release/vX.Y`, where `X.Y` is the
+supported minor release line. Default and release branches must be protected from force-push and deletion in GitHub
+branch rules before a release line is advertised as supported.
+
+Pull requests to a supported release branch must be backport PRs. A backport PR must identify the original Issue and
+change, the target release line, conflict resolution, compatibility impact, and validation performed on that line.
+Feature work belongs on `main`; release branches receive compatibility-preserving fixes and security backports.
+
+## Merge Strategy
+
+PowerContext Go uses squash merge for ordinary pull requests so each reviewed change has one release-note and
+provenance unit. A release-line exception must be explained in the backport PR when preserving original commit identity
+is part of the validation evidence.
+
+## Release Notes
+
+Release notes are generated from reviewed labels and then edited before publication. The `.github/release.yml`
+categories are the release-note contract:
+
+- `breaking`: breaking changes
+- `enhancement`: features
+- `bug`: bug fixes
+- `security`: security fixes
+- `dependencies`: dependency updates
+- `documentation`: documentation updates
+- `maintenance`: maintenance, CI, tooling, and release work
+
+Compatibility-affecting pull requests need an explicit breaking-change label and version decision. Do not infer that
+every release is a patch release. A release draft must be generated with an exact previous-tag comparison and
+contributor attribution, then reviewed before publication.
+
+## Version Sources
+
+Root-module, CLI, generator, adapter, and binary versions must be verified from their authoritative source and tag.
+Do not assume every tool shares the root-module version. Release verification must resolve the tag to the released
+commit, exercise the published binary and image surfaces, and include migration and backport notes for
+compatibility-affecting fixes.
+
+## DCO
+
+DCO sign-off is not required for PowerContext Go pull requests. If the project later adopts DCO, documentation and CI
+must add the enforcement gate in the same reviewed change.

--- a/tools/governance-check/main.go
+++ b/tools/governance-check/main.go
@@ -116,6 +116,20 @@ type dependabotExpectation struct {
 	Group     string
 }
 
+type releaseNotesConfig struct {
+	Changelog struct {
+		Categories []releaseNoteCategory `yaml:"categories"`
+		Exclude    struct {
+			Labels []string `yaml:"labels"`
+		} `yaml:"exclude"`
+	} `yaml:"changelog"`
+}
+
+type releaseNoteCategory struct {
+	Title  string   `yaml:"title"`
+	Labels []string `yaml:"labels"`
+}
+
 type workflowContract struct {
 	Permissions map[string]any         `yaml:"permissions"`
 	Jobs        map[string]workflowJob `yaml:"jobs"`
@@ -195,6 +209,15 @@ func checkRepository(root string) error {
 		return err
 	}
 	if err := checkDependabotConfig(root); err != nil {
+		return err
+	}
+	if err := checkReleasePolicy(root); err != nil {
+		return err
+	}
+	if err := checkReleaseNotesConfig(root); err != nil {
+		return err
+	}
+	if err := checkReleaseWorkflow(root); err != nil {
 		return err
 	}
 	return checkWorkflowContracts(root)
@@ -373,6 +396,161 @@ func checkDependabotUpdate(update dependabotUpdate, expectation dependabotExpect
 		return fmt.Errorf("group %q must contain only minor and patch updates", expectation.Group)
 	}
 	return nil
+}
+
+func checkReleasePolicy(root string) error {
+	return requirePhrases(root, "docs/release/POLICY.md", []string{
+		"default branch receives features and fixes",
+		"supported release branches receive approved fixes and security backports only",
+		"release branch naming convention",
+		"backport PR",
+		"original Issue",
+		"target release line",
+		"compatibility impact",
+		"validation performed on that line",
+		"force-push and deletion",
+		"squash merge",
+		"breaking-change label",
+		"version decision",
+		"release draft",
+		"previous-tag comparison",
+		"contributor attribution",
+		"root-module",
+		"CLI",
+		"generator",
+		"adapter",
+		"binary versions",
+		"DCO sign-off is not required",
+	})
+}
+
+func checkReleaseNotesConfig(root string) error {
+	const name = ".github/release.yml"
+	contents, err := readRepositoryFile(root, name)
+	if err != nil {
+		return err
+	}
+	var document any
+	if err := yaml.UnmarshalStrict(contents, &document); err != nil {
+		return fmt.Errorf("%s is invalid: %w", name, err)
+	}
+	var config releaseNotesConfig
+	if err := yaml.Unmarshal(contents, &config); err != nil {
+		return fmt.Errorf("%s cannot be inspected: %w", name, err)
+	}
+	expected := []releaseNoteCategory{
+		{Title: "Breaking changes", Labels: []string{"breaking"}},
+		{Title: "Features", Labels: []string{"enhancement"}},
+		{Title: "Bug fixes", Labels: []string{"bug"}},
+		{Title: "Security", Labels: []string{"security"}},
+		{Title: "Dependencies", Labels: []string{"dependencies"}},
+		{Title: "Documentation", Labels: []string{"documentation"}},
+		{Title: "Maintenance", Labels: []string{"maintenance"}},
+	}
+	if len(config.Changelog.Categories) != len(expected) {
+		return fmt.Errorf("%s must define %d release-note categories", name, len(expected))
+	}
+	seen := make(map[string]struct{}, len(config.Changelog.Categories))
+	for _, category := range config.Changelog.Categories {
+		title := strings.TrimSpace(category.Title)
+		if title == "" {
+			return fmt.Errorf("%s contains a release-note category without a title", name)
+		}
+		if _, exists := seen[title]; exists {
+			return fmt.Errorf("%s contains duplicate release-note category %q", name, title)
+		}
+		seen[title] = struct{}{}
+	}
+	for _, category := range expected {
+		if !releaseNotesCategoryContains(config.Changelog.Categories, category.Title, category.Labels[0]) {
+			return fmt.Errorf("%s must define the %q category with label %q", name, category.Title, category.Labels[0])
+		}
+	}
+	for _, label := range []string{"duplicate", "invalid", "question", "wontfix"} {
+		if !slices.Contains(config.Changelog.Exclude.Labels, label) {
+			return fmt.Errorf("%s must exclude label %q from release notes", name, label)
+		}
+	}
+	return nil
+}
+
+func releaseNotesCategoryContains(categories []releaseNoteCategory, title, label string) bool {
+	for _, category := range categories {
+		if category.Title == title && slices.Contains(category.Labels, label) {
+			return true
+		}
+	}
+	return false
+}
+
+func checkReleaseWorkflow(root string) error {
+	const name = ".github/workflows/release.yml"
+	contents, err := readRepositoryFile(root, name)
+	if err != nil {
+		return err
+	}
+	var document map[any]any
+	if err := yaml.UnmarshalStrict(contents, &document); err != nil {
+		return fmt.Errorf("%s is invalid: %w", name, err)
+	}
+	on, ok := document["on"]
+	if !ok {
+		on = document[true]
+	}
+	onMap, ok := on.(map[any]any)
+	if !ok {
+		return fmt.Errorf("%s must define structured workflow triggers", name)
+	}
+	push, ok := onMap["push"].(map[any]any)
+	if !ok {
+		return fmt.Errorf("%s must run on tag pushes", name)
+	}
+	tags, ok := stringSlice(push["tags"])
+	if !ok {
+		return fmt.Errorf("%s push trigger must define tags", name)
+	}
+	for _, pattern := range []string{"v[0-9]*", "powercontext-v[0-9]*"} {
+		if !slices.Contains(tags, pattern) {
+			return fmt.Errorf("release workflow must run for tag pattern %q", pattern)
+		}
+	}
+	dispatch, ok := onMap["workflow_dispatch"].(map[any]any)
+	if !ok {
+		return fmt.Errorf("%s must support workflow_dispatch", name)
+	}
+	inputs, ok := dispatch["inputs"].(map[any]any)
+	if !ok {
+		return errors.New(`release workflow must require workflow_dispatch input "release_tag"`)
+	}
+	releaseTag, ok := inputs["release_tag"].(map[any]any)
+	if !ok {
+		return errors.New(`release workflow must require workflow_dispatch input "release_tag"`)
+	}
+	required, ok := releaseTag["required"].(bool)
+	if !ok || !required {
+		return errors.New(`release workflow must require workflow_dispatch input "release_tag"`)
+	}
+	inputType, ok := releaseTag["type"].(string)
+	if !ok || inputType != "string" {
+		return errors.New(`release workflow workflow_dispatch input "release_tag" must be a string`)
+	}
+	return nil
+}
+
+func stringSlice(value any) ([]string, bool) {
+	items, ok := value.([]any)
+	if !ok {
+		return nil, false
+	}
+	result := make([]string, 0, len(items))
+	for _, item := range items {
+		text, ok := item.(string)
+		if !ok || strings.TrimSpace(text) == "" {
+			return nil, false
+		}
+		result = append(result, text)
+	}
+	return result, true
 }
 
 func checkWorkflowContracts(root string) error {

--- a/tools/governance-check/main_test.go
+++ b/tools/governance-check/main_test.go
@@ -138,6 +138,49 @@ func TestCheckRepositoryEnforcesGovernanceContract(t *testing.T) {
 			wantError: ".github/dependabot.yml is invalid",
 		},
 		{
+			name: "missing release-note category",
+			mutate: func(t *testing.T, root string) {
+				replaceFixtureText(t, root, ".github/release.yml", `    - title: Maintenance
+      labels:
+        - maintenance
+`, "")
+			},
+			wantError: ".github/release.yml must define 7 release-note categories",
+		},
+		{
+			name: "missing release policy",
+			mutate: func(t *testing.T, root string) {
+				if err := os.Remove(filepath.Join(root, "docs", "release", "POLICY.md")); err != nil {
+					t.Fatal(err)
+				}
+			},
+			wantError: "read docs/release/POLICY.md",
+		},
+		{
+			name: "release workflow missing semantic tag trigger",
+			mutate: func(t *testing.T, root string) {
+				replaceFixtureText(t, root, ".github/workflows/release.yml", `      - "v[0-9]*"
+      - "powercontext-v[0-9]*"
+`, `      - "powercontext-v[0-9]*"
+`)
+			},
+			wantError: `release workflow must run for tag pattern "v[0-9]*"`,
+		},
+		{
+			name: "release workflow missing manual release tag input",
+			mutate: func(t *testing.T, root string) {
+				replaceFixtureText(t, root, ".github/workflows/release.yml", `  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Existing release tag
+        required: true
+        type: string
+`, `  workflow_dispatch:
+`)
+			},
+			wantError: ".github/workflows/release.yml must support workflow_dispatch",
+		},
+		{
 			name: "valid reusable workflow caller",
 			mutate: func(t *testing.T, root string) {
 				writeFixtureFile(t, root, ".github/workflows/main.yml", reusableWorkflowCaller())
@@ -342,7 +385,10 @@ func writeGovernanceFixture(t *testing.T) string {
 	}))
 	writeFixtureFile(t, root, ".github/ISSUE_TEMPLATE/config.yml", "blank_issues_enabled: false\ncontact_links: []\n")
 	writeFixtureFile(t, root, ".github/dependabot.yml", validDependabotConfig())
+	writeFixtureFile(t, root, ".github/release.yml", validReleaseNotesConfig())
 	writeFixtureFile(t, root, ".github/workflows/main.yml", validWorkflow(true))
+	writeFixtureFile(t, root, ".github/workflows/release.yml", validReleaseWorkflow())
+	writeFixtureFile(t, root, "docs/release/POLICY.md", validReleasePolicy())
 	return root
 }
 
@@ -428,6 +474,88 @@ func validWorkflowWithoutPermissions() string {
 		"    timeout-minutes: 10",
 		"    steps: []",
 	}, "\n") + "\n"
+}
+
+func validReleaseWorkflow() string {
+	return `name: Release
+on:
+  push:
+    tags:
+      - "v[0-9]*"
+      - "powercontext-v[0-9]*"
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Existing release tag
+        required: true
+        type: string
+permissions:
+  contents: read
+jobs:
+  prepare:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps: []
+`
+}
+
+func validReleaseNotesConfig() string {
+	return `changelog:
+  categories:
+    - title: Breaking changes
+      labels:
+        - breaking
+    - title: Features
+      labels:
+        - enhancement
+    - title: Bug fixes
+      labels:
+        - bug
+    - title: Security
+      labels:
+        - security
+    - title: Dependencies
+      labels:
+        - dependencies
+    - title: Documentation
+      labels:
+        - documentation
+    - title: Maintenance
+      labels:
+        - maintenance
+  exclude:
+    labels:
+      - duplicate
+      - invalid
+      - question
+      - wontfix
+`
+}
+
+func validReleasePolicy() string {
+	return strings.Join([]string{
+		"default branch receives features and fixes",
+		"supported release branches receive approved fixes and security backports only",
+		"release branch naming convention",
+		"backport PR",
+		"original Issue",
+		"target release line",
+		"compatibility impact",
+		"validation performed on that line",
+		"force-push and deletion",
+		"squash merge",
+		"breaking-change label",
+		"version decision",
+		"release draft",
+		"previous-tag comparison",
+		"contributor attribution",
+		"root-module",
+		"CLI",
+		"generator",
+		"adapter",
+		"binary versions",
+		"DCO sign-off is not required",
+	}, "\n")
 }
 
 func reusableWorkflowCaller(extraLines ...string) string {


### PR DESCRIPTION
## Tracking

- Tracking issue: #3
- Relationship: Part of #3, advancing `Post-WP0 governance and first-release backlog`.

## Problem and rationale

Issue #3 preserved the first-release backlog after WP0, but the release-branch, backport, version-source, DCO, and release-note rules were still only checklist text. This slice records those decisions in repository files and extends the existing governance gate so the policy cannot drift silently.

## Changes

- Add `.github/release.yml` with release-note categories for breaking changes, features, bug fixes, security, dependencies, documentation, and maintenance.
- Add `docs/release/POLICY.md` covering default and release branch scope, `release/vX.Y` branch naming, backport PR evidence, branch protection expectations, squash-merge strategy, release draft review, version-source verification, and the explicit DCO decision.
- Extend `tools/governance-check` to verify the release policy, release-note categories, excluded labels, and release workflow tag/manual-dispatch triggers.
- Document the checked release governance contract in `CONTRIBUTING.md` and `.github/workflows/README.md`.

## Behavior and compatibility

- User-visible behavior: maintainers get a machine-checked first-release governance contract and GitHub generated release-note grouping.
- Public API or protocol impact: none.
- Breaking changes or migration requirements: none.
- Explicit non-goals: no runtime behavior, parity inventory, adapter, generated OpenAPI/MCP, branch-protection API, or release publication changes.

## Generated, dependency, and workflow impact

- [x] No generated contract changed, or every required output was regenerated from its source.
- [x] No dependency changed, or `go.mod` and `go.sum` are complete and verified.
- [x] No CI or release contract changed, or stable job names, permissions, timeouts, and failure evidence were reviewed.
- [x] No credential, private Source/Memory content, or unredacted production log is included.

## Validation

```text
go test -count=1 ./tools/governance-check
ok  github.com/ob-labs/powercontext-go/tools/governance-check 0.339s

make governance-check
go run ./tools/governance-check

make docs-test
Build started
No issues found
Build finished in 0.32s

go vet ./tools/governance-check
passed

.tools/bin/golangci-lint.exe fmt --diff tools/governance-check
passed

make release-contract-check
go run ./tools/release-contract-verify
verified release contract

git diff --check
passed
```

Additional attempted validation:

```text
make check
failed at go mod tidy -diff because this Windows checkout reports full-file go.sum LF/CRLF differences.

make vet
failed on this Windows host because sqlite3.h is not installed for the CGO sqlitevec package.

make fmt-check
failed on this Windows checkout because the repository-wide formatter diff reports full-file LF/CRLF differences in unrelated Go files.
```

These environment limitations were not caused by this change; the focused package vet/test/formatter checks and governance/docs/release-contract gates passed.

- [x] `git diff --check`
- [x] `git status --short` was inspected after validation.
- [x] Formatter evidence (`make fmt-check` or an explained equivalent) is recorded.
- [x] Generated-consumer evidence (`make generated-consumers` when generator outputs change, or an explained equivalent) is recorded.
- [x] Compatibility evidence (`make api-compat` for public Go changes, relevant contract/downstream checks otherwise) is recorded.
- [x] Relevant generated, race, compatibility, process, adapter, documentation, or release checks were run.
- [x] Any skipped or unavailable check is identified above and is not represented as passing.

## AI usage

AI assistance was used to inspect Issue #3, draft the governance contract update, implement the checker and regression tests, run validation, and prepare this PR. The submitted result was reviewed against the current repository state and command output above.