### PR TITLE
ci: add explicit release-contract job

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -24,9 +24,11 @@ Four Go-specific workflows extend, rather than replace, that Python topology:
 | `provider-smoke.yml` | Explicitly dispatched, credentialed, bounded real-provider verification; never required on an ordinary pull request. |
 | `windows-contract.yml` | Windows checkout-only contract guard: verifies LF attributes, both versioned fixture SHA-256 inventories, and generated-contract cleanliness without claiming Windows binary support. |
 
-Release-line governance is checked by `make governance-check` in the `governance-contract` job. The check keeps
-`docs/release/POLICY.md`, `.github/release.yml`, and the `release.yml` tag/manual-dispatch triggers aligned so
-branch/version/tag/backport/release-note consistency does not depend on prose review alone.
+Release-line governance is checked by `make governance-check` in the `governance-contract` job and by the explicit
+`release-contract` job. The release-contract job also runs `make release-contract-check` against the recorded upstream
+release tag, assets, and PyPI provenance. Together they keep `docs/release/POLICY.md`, `.github/release.yml`, the
+`release.yml` tag/manual-dispatch triggers, and exact release metadata aligned so branch/version/tag/backport/release-note
+consistency does not depend on prose review alone.
 
 The committed `test/conformance/testdata/python-v0.0.2` baseline remains immutable. The separate
 `test/conformance/testdata/python-v0.1.0` directory freezes exact release metadata and portable fixture evidence;

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -194,6 +194,27 @@ jobs:
       - name: Check contribution and review contracts
         run: make governance-check
 
+  release-contract:
+    name: release-contract
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    env:
+      GOTOOLCHAIN: local
+      GOFLAGS: -mod=readonly
+    steps:
+      - name: Check out
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Set up the environment
+        uses: ./.github/actions/setup-go-env
+
+      - name: Check first-release governance and upstream metadata
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          make governance-check
+          make release-contract-check
+
   quality:
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/tools/release/workflow_test.go
+++ b/tools/release/workflow_test.go
@@ -836,6 +836,109 @@ func TestGovernanceJobValidatesPullRequestTitleContract(t *testing.T) {
 	t.Fatal("governance-contract has no pull request title validation step")
 }
 
+func TestReleaseContractJobRunsFirstReleaseChecks(t *testing.T) {
+	repository := filepath.Clean(filepath.Join("..", ".."))
+	payload, err := os.ReadFile(filepath.Join(repository, ".github", "workflows", "master.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := validateReleaseContractJob(payload); err != nil {
+		t.Fatal(err)
+	}
+
+	mutations := []struct {
+		name string
+		old  string
+		new  string
+	}{
+		{name: "missing job", old: "  release-contract:\n", new: "  release-metadata:\n"},
+		{
+			name: "mutable runner",
+			old:  "  release-contract:\n    name: release-contract\n    runs-on: ubuntu-24.04\n",
+			new:  "  release-contract:\n    name: release-contract\n    runs-on: ubuntu-latest\n",
+		},
+		{
+			name: "writable modules",
+			old:  "  release-contract:\n    name: release-contract\n    runs-on: ubuntu-24.04\n    timeout-minutes: 10\n    env:\n      GOTOOLCHAIN: local\n      GOFLAGS: -mod=readonly\n",
+			new:  "  release-contract:\n    name: release-contract\n    runs-on: ubuntu-24.04\n    timeout-minutes: 10\n    env:\n      GOTOOLCHAIN: local\n      GOFLAGS: -mod=mod\n",
+		},
+		{name: "missing governance check", old: "          make governance-check\n", new: ""},
+		{name: "missing metadata check", old: "          make release-contract-check\n", new: ""},
+	}
+	for _, mutation := range mutations {
+		t.Run(mutation.name, func(t *testing.T) {
+			contents := string(payload)
+			if !strings.Contains(contents, mutation.old) {
+				t.Fatalf("test mutation source %q is missing", mutation.old)
+			}
+			mutant := strings.Replace(contents, mutation.old, mutation.new, 1)
+			if err := validateReleaseContractJob([]byte(mutant)); err == nil {
+				t.Fatal("invalid release-contract job was accepted")
+			}
+		})
+	}
+}
+
+func validateReleaseContractJob(payload []byte) error {
+	var workflow struct {
+		Jobs map[string]struct {
+			Name           string            `yaml:"name"`
+			RunsOn         string            `yaml:"runs-on"`
+			TimeoutMinutes int               `yaml:"timeout-minutes"`
+			Env            map[string]string `yaml:"env"`
+			Steps          []struct {
+				Name string            `yaml:"name"`
+				Uses string            `yaml:"uses"`
+				Env  map[string]string `yaml:"env"`
+				Run  string            `yaml:"run"`
+			} `yaml:"steps"`
+		} `yaml:"jobs"`
+	}
+	if err := yaml.Unmarshal(payload, &workflow); err != nil {
+		return err
+	}
+	job, ok := workflow.Jobs["release-contract"]
+	if !ok {
+		return fmt.Errorf("master.yml has no release-contract job")
+	}
+	if job.Name != "release-contract" || job.RunsOn != "ubuntu-24.04" || job.TimeoutMinutes != 10 {
+		return fmt.Errorf(
+			"release-contract identity = (%q, %q, %d), want (%q, %q, %d)",
+			job.Name, job.RunsOn, job.TimeoutMinutes, "release-contract", "ubuntu-24.04", 10,
+		)
+	}
+	if job.Env["GOTOOLCHAIN"] != "local" || job.Env["GOFLAGS"] != "-mod=readonly" {
+		return fmt.Errorf("release-contract Go environment = %#v", job.Env)
+	}
+	wantSteps := []struct {
+		name string
+		uses string
+		env  map[string]string
+		run  string
+	}{
+		{name: "Check out", uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"},
+		{name: "Set up the environment", uses: "./.github/actions/setup-go-env"},
+		{
+			name: "Check first-release governance and upstream metadata",
+			env:  map[string]string{"GITHUB_TOKEN": "${{ github.token }}"},
+			run:  "make governance-check\nmake release-contract-check",
+		},
+	}
+	if len(job.Steps) != len(wantSteps) {
+		return fmt.Errorf("release-contract step count = %d, want %d", len(job.Steps), len(wantSteps))
+	}
+	for index, want := range wantSteps {
+		got := job.Steps[index]
+		if got.Name != want.name || got.Uses != want.uses || !maps.Equal(got.Env, want.env) || strings.TrimSpace(got.Run) != want.run {
+			return fmt.Errorf(
+				"release-contract step %d = (%q, %q, %#v, %q), want (%q, %q, %#v, %q)",
+				index, got.Name, got.Uses, got.Env, strings.TrimSpace(got.Run), want.name, want.uses, want.env, want.run,
+			)
+		}
+	}
+	return nil
+}
+
 func runPullRequestTitleContract(t *testing.T, script, title string) error {
 	t.Helper()
 	command := exec.CommandContext(t.Context(), "bash", "-c", script)


### PR DESCRIPTION
## Tracking

- Tracking issue: #3
- Relationship: Part of #3, advancing the `release-contract` item under `Post-WP0 governance and first-release backlog`.

## Problem and rationale

PR #192 added the first-release governance policy and made it machine-checkable, but Issue #3 also calls out an explicit `release-contract` CI job. This follow-up gives that contract a stable job identity instead of relying on the broader `governance-contract` job name.

## Changes

- Add a `release-contract` job to the Main workflow.
- Run both `make governance-check` and `make release-contract-check` in that job so branch/version/tag/backport/release-note consistency and exact upstream release metadata are checked together.
- Update the workflow README to document the explicit job.
- Add a workflow contract test that rejects removing or weakening the `release-contract` job, including its stable runner, readonly Go environment, and required Make targets.

## Behavior and compatibility

- User-visible behavior: pull requests and main pushes now expose a dedicated `release-contract` status.
- Public API or protocol impact: none.
- Breaking changes or migration requirements: none.
- Explicit non-goals: no branch ruleset mutation, release publication behavior, runtime behavior, generated contract, or parity inventory changes.

## Generated, dependency, and workflow impact

- [x] No generated contract changed, or every required output was regenerated from its source.
- [x] No dependency changed, or `go.mod` and `go.sum` are complete and verified.
- [x] No CI or release contract changed, or stable job names, permissions, timeouts, and failure evidence were reviewed.
- [x] No credential, private Source/Memory content, or unredacted production log is included.

## Validation

```text
go test -count=1 ./tools/release -run '^TestReleaseContractJobRunsFirstReleaseChecks$'
ok  	github.com/ob-labs/powercontext-go/tools/release	0.273s

go test -count=1 ./tools/release -run '^(TestReleaseContractJobRunsFirstReleaseChecks|TestGovernanceJobValidatesPullRequestTitleContract|TestContinuousIntegrationPreservesPythonTopologyAndGoAssurance)$'
ok  	github.com/ob-labs/powercontext-go/tools/release	0.312s

make governance-check
go run ./tools/governance-check

make release-contract-check
go run ./tools/release-contract-verify
verified release contract

make docs-test
Build started
No issues found
Build finished in 0.30s

.tools/bin/actionlint.exe .github/workflows/master.yml .github/workflows/migration-gates.yml .github/workflows/release.yml .github/workflows/release-verify.yml
passed

git diff --check
passed
```

Additional attempted validation:

```text
make fmt-check
failed on this Windows checkout because golangci-lint fmt --diff reported broad pre-existing CRLF/LF formatting differences outside this PR; the touched Go file was formatted with gofmt.

go test -count=1 ./tools/release
failed in TestReleaseArchiveKeepsStableExecutablePathAndMode with packaged binary mode = 0644. The same command fails the same way on origin/main@653b8a3 in a temporary baseline worktree, so this is not introduced by this PR.

make actionlint
previously failed before actionlint diagnostics on this Windows/Bash surface with: /usr/bin/bash: -c: line 1: unexpected EOF while looking for matching `"'
```

The direct pinned actionlint binary was run against the affected workflows and passed.

- [x] `git diff --check`
- [x] `git status --short` was inspected after validation.
- [x] Formatter evidence (`make fmt-check` or an explained equivalent) is recorded.
- [x] Generated-consumer evidence (`make generated-consumers` when generator outputs change, or an explained equivalent) is recorded.
- [x] Compatibility evidence (`make api-compat` for public Go changes, relevant contract/downstream checks otherwise) is recorded.
- [x] Relevant generated, race, compatibility, process, adapter, documentation, or release checks were run.
- [x] Any skipped or unavailable check is identified above and is not represented as passing.

## AI usage

AI assistance was used to inspect the merged Issue #3 state, add the workflow job, add regression coverage for the workflow contract, run local validation, and prepare this PR. The result was checked against current workflow files and command output above.
