### PR TITLE
test(evaluation): format baseline edge coverage

### DIFF
--- a/evaluation/tests/web/test_api.py
+++ b/evaluation/tests/web/test_api.py
@@ -2930,9 +2930,7 @@ def test_baseline_comparison_cross_arm_returns_warning(config: WebConfig, store:
     assert "cross-arm comparison" in comparison["compatibility"]["reasons"]
 
 
-def test_update_baseline_selections_rejects_incompatible_baseline(
-    config: WebConfig, store: TaskStore
-) -> None:
+def test_update_baseline_selections_rejects_incompatible_baseline(config: WebConfig, store: TaskStore) -> None:
     catalog = _BatchCatalog()
     client = TestClient(create_app(config, store, catalog=catalog))
     batch1 = client.post("/api/batches", json=_batch_payload("baseline-compat-1")).json()
@@ -3104,9 +3102,7 @@ def _finish_batch_subset(
     return children
 
 
-def test_baseline_selection_rejects_incompatible_instance_sets(
-    config: WebConfig, store: TaskStore
-) -> None:
+def test_baseline_selection_rejects_incompatible_instance_sets(config: WebConfig, store: TaskStore) -> None:
     """The API guards against baseline_rate denominator mismatch by rejecting incompatible baselines.
 
     reporting.py:918 computes baseline_rate = baseline.resolved_tasks / len(matched_ids).
@@ -3134,7 +3130,9 @@ def test_baseline_selection_rejects_incompatible_instance_sets(
     subset_client = TestClient(create_app(config, store, catalog=subset_catalog))
     subset_batch = subset_client.post("/api/batches", json=_batch_payload("rate-subset")).json()
     _finish_batch_subset(
-        config, store, subset_batch["batch_id"],
+        config,
+        store,
+        subset_batch["batch_id"],
         outcomes=[
             (True, True, (100, 10), (80, 8)),
             (True, True, (120, 12), (90, 9)),

--- a/evaluation/tests/web/test_cli.py
+++ b/evaluation/tests/web/test_cli.py
@@ -362,12 +362,18 @@ def test_baseline_create_sends_post_and_echoes_result(monkeypatch) -> None:
     result = CliRunner().invoke(
         app,
         [
-            "baseline", "create",
-            "--source-batch-id", "batch-123",
-            "--source-arm", "off",
-            "--name", "my-baseline",
-            "--idempotency-key", "test-key-001",
-            "--expected-report-revision", "42",
+            "baseline",
+            "create",
+            "--source-batch-id",
+            "batch-123",
+            "--source-arm",
+            "off",
+            "--name",
+            "my-baseline",
+            "--idempotency-key",
+            "test-key-001",
+            "--expected-report-revision",
+            "42",
         ],
     )
 
@@ -502,12 +508,18 @@ def test_baseline_create_handles_404(monkeypatch) -> None:
     result = CliRunner().invoke(
         app,
         [
-            "baseline", "create",
-            "--source-batch-id", "missing-batch",
-            "--source-arm", "off",
-            "--name", "test",
-            "--idempotency-key", "err-key-001",
-            "--expected-report-revision", "0",
+            "baseline",
+            "create",
+            "--source-batch-id",
+            "missing-batch",
+            "--source-arm",
+            "off",
+            "--name",
+            "test",
+            "--idempotency-key",
+            "err-key-001",
+            "--expected-report-revision",
+            "0",
         ],
     )
 
@@ -527,12 +539,18 @@ def test_baseline_create_handles_409(monkeypatch) -> None:
     result = CliRunner().invoke(
         app,
         [
-            "baseline", "create",
-            "--source-batch-id", "batch-123",
-            "--source-arm", "off",
-            "--name", "test",
-            "--idempotency-key", "err-key-002",
-            "--expected-report-revision", "0",
+            "baseline",
+            "create",
+            "--source-batch-id",
+            "batch-123",
+            "--source-arm",
+            "off",
+            "--name",
+            "test",
+            "--idempotency-key",
+            "err-key-002",
+            "--expected-report-revision",
+            "0",
         ],
     )
 
@@ -544,13 +562,20 @@ def test_baseline_create_rejects_invalid_console_url(monkeypatch) -> None:
     result = CliRunner().invoke(
         app,
         [
-            "baseline", "create",
-            "--console-url", "ftp://invalid",
-            "--source-batch-id", "batch-123",
-            "--source-arm", "off",
-            "--name", "test",
-            "--idempotency-key", "url-err-key-001",
-            "--expected-report-revision", "0",
+            "baseline",
+            "create",
+            "--console-url",
+            "ftp://invalid",
+            "--source-batch-id",
+            "batch-123",
+            "--source-arm",
+            "off",
+            "--name",
+            "test",
+            "--idempotency-key",
+            "url-err-key-001",
+            "--expected-report-revision",
+            "0",
         ],
     )
 


### PR DESCRIPTION
Repairs the current `main` CI failure introduced by #184.

The evaluation-control-plane job completed `1089` tests and static Ruff checks successfully, then failed only because the two newly added test modules were not formatted by the repository-locked Ruff `0.16.0` formatter. This PR contains formatter-only changes to those two modules and preserves the assertions.

Validation before CI:

- `uv tool run --from ruff==0.16.0 ruff format <both files>`
- `uv tool run --from ruff==0.16.0 ruff format --check <both files>`