### PR TITLE
feat(workbuddy): replace installed Python hook with released Go binary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -427,3 +427,12 @@ source / artifact / trigger / inference
   the router would reject only after the bypass. Verify with a regression test
   that an oversized body is rejected before the handler runs and that a
   state-changing verb on an exempted public path still requires credentials.
+- When a host hook captures content and emits a size-bounded JSON protocol,
+  preserve its provenance and nonblank correlation metadata, and enforce the
+  output limit after encoding. Verify identifier fallbacks and that escaping
+  expansion produces the exact required empty-context response.
+- When setup migrates an owned release-binary hook, parse only the exact command
+  shape setup emits and revalidate a prior binary against the release-root
+  invariants without executing it. Scan every matching hook entry in setup and
+  diagnostics; verify prior-release rollback and upgrade, sibling preservation,
+  external-command rejection before mutation, and duplicate-candidate failure.

--- a/docs/superpowers/plans/2026-09-04-workbuddy-go-hook.md
+++ b/docs/superpowers/plans/2026-09-04-workbuddy-go-hook.md
@@ -1,0 +1,279 @@
+# WorkBuddy Go Hook Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace only the installed WorkBuddy Python `UserPromptSubmit` driver with the released PowerContext Go binary while preserving WorkBuddy's observable hook, configuration, security, and SQLite service-chain contracts.
+
+**Architecture:** Keep Host process I/O, configuration, scope resolution, and HTTP orchestration in `internal/cli`. Add one `powercontext hook workbuddy` child and a narrow runtime value object in the same package; it uses the generated public Go client for `/v1/context/prepare`, `/v1/sources/content`, and `/v1/memory/flush`. `setup workbuddy` resolves the running release binary and persists its shell-quoted absolute path, instead of installing a Python driver.
+
+**Tech Stack:** Go 1.27, Cobra, generated `api/v1` and `client` packages, `internal/transportpolicy`, SQLite server, MCP Go SDK, Go test, release archive test harness.
+
+**Spec:** `docs/superpowers/specs/2026-09-03-workbuddy-go-hook-design.md`
+
+## Global Constraints
+
+- Modify no generated `api/v1` or `client` files; `openapi/powercontext.yaml` remains the HTTP source of truth.
+- Keep the Go-hook implementation under `internal/cli`; add no top-level package, cross-Host hook framework, seekDB, OceanBase, or external consumer work.
+- Read endpoint, authorization-environment reference, scope mode, timeouts, budgets, and byte limits from persisted `WORKBUDDY_HOME/powercontext.json`; only existing runtime-owned scope/capture/flush controls may come from environment.
+- Treat missing or invalid persisted configuration as fail-open: emit no recalled context, capture nothing, and exit zero.
+- Never persist or render prompts, source content, bearer values, raw scope IDs, configured URLs, database locations, request bodies, or response bodies.
+- Use the existing loopback/remote plaintext transport policy and preserve public plus bearer-authenticated operation.
+- `setup workbuddy` accepts only a resolved regular release binary under `<archive-root>/bin/powercontext`; reject checkout-local, `go run`, temporary, and PATH-only targets.
+- Keep the WorkBuddy Host timeout at 10 seconds; individual hook calls share the persisted bounded request budget.
+- Keep all code comments and maintained documentation in English.
+
+---
+
+### Task 1: Add the WorkBuddy Hook Command and Protocol Tests
+
+**Files:**
+- Create: `internal/cli/workbuddy_hook.go`
+- Create: `internal/cli/workbuddy_hook_test.go`
+- Modify: `internal/cli/root.go:130-158`
+- Test: `internal/cli/root_test.go`
+
+**Interfaces:**
+- Consumes: `workBuddyConfiguration`, `readWorkBuddyConfiguration`, `workBuddyHome`, and `transportpolicy.IsPlaintextNonLoopback` from the existing CLI boundary.
+- Produces: `newHookCommand(state *commandState) *cobra.Command` and `runWorkBuddyHook(ctx context.Context, input io.Reader, output, diagnostics io.Writer, runtime workBuddyHookRuntime) error`.
+- Produces: a Task 1 `workBuddyHookRuntime` with `configuration workBuddyConfiguration`. Task 2 extends that private value with injected environment, HTTP client, and clock dependencies when those values first affect behavior.
+
+- [ ] **Step 1: Write failing command-discovery and stdout-contract tests**
+
+Add tests that construct `newCommandWithAllDependencies`, find `hook workbuddy`, supply one `UserPromptSubmit` JSON payload, and assert exact compact JSON output:
+
+```go
+want := `{"hookSpecificOutput":{"hookEventName":"UserPromptSubmit","additionalContext":""}}\n`
+if got := stdout.String(); got != want {
+	t.Fatalf("hook stdout = %q, want %q", got, want)
+}
+```
+
+Cover non-`UserPromptSubmit` events, malformed/oversized stdin, missing configuration, invalid configuration, a blank prompt, and a missing `cwd`. Also set invalid non-empty `POWERCONTEXT_CLIENT_SERVER_URL` and invalid `POWERCONTEXT_CLIENT_TIMEOUT` while persisted WorkBuddy configuration is valid; the Hook must still exit successfully with the exact response and no diagnostics. Each case must disclose neither the prompt nor the authorization value. Recall-generated content is owned by Task 2, not this protocol-boundary task.
+
+- [ ] **Step 2: Run the focused test before implementation**
+
+Run: `go test -count=1 ./internal/cli -run 'TestWorkBuddyHook(Command|FailOpen)'`
+
+Expected: FAIL because `hook` is absent and `runWorkBuddyHook` does not exist.
+
+- [ ] **Step 3: Register the command and implement bounded payload handling**
+
+Add `newHookCommand` to the root command list. In `workbuddy_hook.go`, define bounded input and output constants, strict UTF-8 JSON decoding with duplicate/unknown-field rejection, and these private types:
+
+```go
+type workBuddyHookPayload struct {
+	HookEventName string `json:"hook_event_name"`
+	Prompt        string `json:"prompt"`
+	UserPrompt    string `json:"user_prompt"`
+	CWD           string `json:"cwd"`
+	SessionID     string `json:"session_id"`
+	PromptID      string `json:"prompt_id"`
+	RequestID     string `json:"request_id"`
+}
+
+type workBuddyHookResponse struct {
+	HookSpecificOutput struct {
+		HookEventName    string `json:"hookEventName"`
+		AdditionalContext string `json:"additionalContext"`
+	} `json:"hookSpecificOutput"`
+}
+```
+
+For every handled failure, write only the compact empty-context response and return `nil`. Read persisted configuration before any legacy environment fallback. Do not emit output for an unrelated event.
+
+- [ ] **Step 4: Run protocol tests and the command inventory test**
+
+Run: `go test -count=1 ./internal/cli -run 'Test(WorkBuddyHook|SetupAndDoctorExposeCurrentHostMatrix)'`
+
+Expected: PASS; the root has `hook workbuddy`, invalid inputs fail open, and exact JSON is stable.
+
+- [ ] **Step 5: Commit the protocol boundary**
+
+```bash
+git add internal/cli/root.go internal/cli/workbuddy_hook.go internal/cli/workbuddy_hook_test.go internal/cli/root_test.go
+git commit -m "feat(workbuddy): add fail-open Go hook command"
+```
+
+### Task 2: Implement WorkBuddy Scope, Client Operations, and Security Regressions
+
+**Files:**
+- Modify: `internal/cli/workbuddy_hook.go`
+- Modify: `internal/cli/workbuddy_hook_test.go`
+- Test: `client/client_test.go` only if an existing generated-client behavior lacks a required regression; do not edit generated source.
+
+**Interfaces:**
+- Consumes: `pcclient.New`, `pcclient.Client.PrepareContext`, `CaptureContentSource`, and `FlushMemory`; `v1.PrepareContextRequest`, `v1.CaptureContentSourceRequest`, and `v1.FlushMemoryRequest`.
+- Produces: private `resolveWorkBuddyHookScope`, `recallWorkBuddyContext`, `captureWorkBuddyPrompt`, and `flushWorkBuddyPrompt` helpers, each taking `context.Context` first.
+- Produces: deterministic source IDs `workbuddy-user-prompt:<sha256(scope + "\\x00" + session + "\\x00" + promptID + "\\x00" + prompt)>`.
+
+- [ ] **Step 1: Write failing operation tests through an HTTP test server**
+
+In `workbuddy_hook_test.go`, use an `httptest.Server` and assert the exact ordered public calls:
+
+```go
+wantPaths := []string{"/v1/context/prepare", "/v1/sources/content", "/v1/memory/flush"}
+if diff := cmp.Diff(wantPaths, gotPaths); diff != "" {
+	t.Fatalf("request paths (-want +got):\n%s", diff)
+}
+```
+
+Assert request scope, configured `max_bytes`, deterministic `source_id`, optional flush behavior, one shared deadline, and empty context for 401, 404, 503, invalid prepared-context payload, too-large response, and timeout. Add a transport probe proving 127.0.0.0/8 and IPv6 loopback bypass a proxy while remote HTTP is refused before the test transport runs.
+
+- [ ] **Step 2: Run the operation tests before implementation**
+
+Run: `go test -count=1 ./internal/cli -run 'TestWorkBuddyHook(RecallCaptureFlush|Transport|Redaction)'`
+
+Expected: FAIL because the Go hook has no scope/client operation flow.
+
+- [ ] **Step 3: Implement scope and generated-client operation flow**
+
+Implement project scope in the CLI package with the existing observable rules: explicit runtime scope, `workbuddy:agent`, Git-private `powercontext/codex-workspace.json`, normalized `remote.origin.url`, then a SHA-256 local-path fallback. Bound emitted scope values to 256 bytes exactly as the retained WorkBuddy resolver does.
+
+Construct `pcclient.New` using the persisted server URL, runtime authorization value from the persisted environment-name field, the lesser of persisted request timeout and remaining shared budget, and a loopback-aware HTTP client. Convert all client/server/validation errors to the empty-context fail-open response without copying their text to output.
+
+Use the generated request/response types. Validate `PreparedContext` schema/status/content before use; capture only a nonblank prompt that fits `SourceMaxBytes`; stop flushing when the returned cursor reaches the capture position or the runtime-owned `POWERCONTEXT_WORKBUDDY_FLUSH_MAX_CALLS` limit.
+
+- [ ] **Step 4: Run focused behavior and race checks**
+
+Run: `go test -count=1 -race ./internal/cli -run 'TestWorkBuddyHook(RecallCaptureFlush|Transport|Redaction)'`
+
+Expected: PASS with no proxy credential, prompt, authorization, configured URL, or scope value in stdout/stderr/assertion failures.
+
+- [ ] **Step 5: Commit the operation flow**
+
+```bash
+git add internal/cli/workbuddy_hook.go internal/cli/workbuddy_hook_test.go
+git commit -m "feat(workbuddy): route hook through Go server client"
+```
+
+### Task 3: Make Setup Register a Released Binary and Migrate Existing Hook Ownership
+
+**Files:**
+- Modify: `internal/cli/integration_workbuddy.go:39-90,223-315,399-416,760-845`
+- Modify: `internal/cli/integration_workbuddy_test.go`
+- Modify: `integrations/workbuddy/plugins/powercontext/hooks/hooks.workbuddy.json`
+- Modify: `integrations/workbuddy/README.md`
+
+**Interfaces:**
+- Consumes: `os.Executable`, `filepath.EvalSymlinks`, `workBuddyConfiguration`, existing snapshot/rollback helpers, and `shellQuoteWorkBuddy`.
+- Produces: `resolveWorkBuddyReleaseBinary() (string, error)` and `workBuddyHookCommand(binary string) string`.
+- Produces: setup registration `'<absolute-binary>' hook workbuddy`, with the existing 10-second WorkBuddy timeout and existing custom hook fields preserved.
+
+- [ ] **Step 1: Write failing setup and diagnostics tests**
+
+Add tests that create a release-shaped root containing `bin/powercontext`, `BUILD-INFO.json`, `.env.example`, `openapi/powercontext.yaml`, and the WorkBuddy integration. Assert setup writes the resolved binary path plus `hook workbuddy`, preserves a foreign sibling hook and custom fields, migrates an owned Python command, and never copies `workbuddy_powercontext_hook.py`, `workbuddy_settings.py`, `prepared_context.py`, or `powercontext_project_scope.py` into `WORKBUDDY_HOME`.
+
+Add negative tests for executable paths outside a release root, a missing/nonregular binary, a `go-build` temporary path, and a legacy hook whose binary ownership cannot be established. Each negative case must leave settings, MCP, configuration, hook directory, and skill unchanged.
+
+- [ ] **Step 2: Run setup tests before implementation**
+
+Run: `go test -count=1 ./internal/cli -run 'Test(SetupWorkBuddy.*(Release|Binary|Hook)|DoctorWorkBuddy)'`
+
+Expected: FAIL because setup still writes `python3 ...workbuddy_powercontext_hook.py` and installs Python files.
+
+- [ ] **Step 3: Implement release-binary resolution and atomic migration**
+
+Resolve and evaluate symlinks for `os.Executable`. Require a regular file named `powercontext` under `bin/`, and require its parent archive root to contain `BUILD-INFO.json`, `.env.example`, `openapi/powercontext.yaml`, and `integrations/workbuddy/plugins/powercontext`. Return a redacted operator-facing error if any invariant fails.
+
+Pass the resolved binary through `installWorkBuddyPlugin` before snapshots are mutated. Change `mergeWorkBuddySettings` and `isWorkBuddyHook` to recognize both the legacy Python command and the owned `hook workbuddy` command, then replace only owned entries with the shell-quoted Go command. Remove Python hook installation from `installWorkBuddyHooks`; update diagnostics to validate the registered Go command rather than the retired script files. Update the static template and README to describe the Go binary contract without exposing a real binary path or token.
+
+- [ ] **Step 4: Run setup, diagnostic, and documentation checks**
+
+Run: `go test -count=1 ./internal/cli -run 'Test(SetupWorkBuddy|DoctorWorkBuddy|BundledWorkBuddy)'`
+
+Run: `make docs-test`
+
+Expected: PASS; an installed WorkBuddy registration calls only the release binary and the credential-free persisted schema remains unchanged.
+
+- [ ] **Step 5: Commit release-binary installation**
+
+```bash
+git add internal/cli/integration_workbuddy.go internal/cli/integration_workbuddy_test.go integrations/workbuddy/plugins/powercontext/hooks/hooks.workbuddy.json integrations/workbuddy/README.md
+git commit -m "feat(workbuddy): install released Go hook binary"
+```
+
+### Task 4: Prove the Archive Consumer and Real SQLite/MCP Service Chain
+
+**Files:**
+- Modify: `test/e2e/workbuddy_service_chain_test.go`
+- Modify: `tools/release/main_test.go:424-570`
+- Modify: `.github/workflows/migration-gates.yml` only if a current required host-adapter command cannot invoke the new Go service-chain test; preserve separate Codex and WorkBuddy evidence steps.
+- Modify: `tools/release/workflow_test.go` only if the workflow contract changes.
+
+**Interfaces:**
+- Consumes: `server.OpenApplication`, generated WorkBuddy release archive fixture, `cli.New`, and MCP `search_memory`.
+- Produces: an installed-binary service-chain proof that invokes `<release-root>/bin/powercontext hook workbuddy` for public and bearer-authenticated Server modes.
+- Produces: a release-consumer proof that rejects a hook command outside the unpacked release root.
+
+- [ ] **Step 1: Rewrite the existing Python service-chain test as a failing Go-binary test**
+
+Replace the Python interpreter and installed `.py` driver invocation in `TestWorkBuddyHookAndMCPShareOneGoServiceConfiguration` with a subprocess of the built Go binary and `hook workbuddy`. Keep the existing two-mode table, real SQLite application, first-prompt capture, second-prompt recall, and MCP `search_memory` assertion. Add an assertion that the installed `settings.json` command names the extracted archive's binary and does not contain `python`, `.py`, a checkout root, or a bearer token.
+
+- [ ] **Step 2: Run the service-chain test before implementation**
+
+Run: `go test -count=1 -tags sqlite_fts5 ./test/e2e -run TestWorkBuddyHookAndMCPShareOneGoServiceConfiguration`
+
+Expected: FAIL until setup and the Go hook are implemented because the existing installed command still needs Python.
+
+- [ ] **Step 3: Extend the release consumer test**
+
+In `TestReleaseArchiveProvidesConsumableAdapterSources`, include the WorkBuddy archive entry and run `<release-root>/bin/powercontext setup workbuddy --source <release-root>`. Assert `settings.json` points at the extracted binary, invoke the command with a valid Hook payload, and prove that replacing the registered command with a path outside the extracted root is rejected by diagnostics or setup without mutation.
+
+- [ ] **Step 4: Run the integration and release-focused gates**
+
+Run: `go test -count=1 ./tools/release -run 'Test(ReleaseArchiveProvidesConsumableAdapterSources|StageIntegrationsIncludesEveryRuntimeAdapter)'`
+
+Run: `go test -count=1 -tags sqlite_fts5 ./test/e2e -run TestWorkBuddyHookAndMCPShareOneGoServiceConfiguration`
+
+Run: `go test -count=1 ./internal/cli`
+
+Expected: PASS for public and bearer-authenticated capture/recall/MCP paths and release-owned binary registration.
+
+- [ ] **Step 5: Commit the end-to-end proof**
+
+```bash
+git add test/e2e/workbuddy_service_chain_test.go tools/release/main_test.go .github/workflows/migration-gates.yml tools/release/workflow_test.go
+git commit -m "test(workbuddy): prove released Go hook service chain"
+```
+
+### Task 5: Final Validation, Tracker Evidence, and Pull Request
+
+**Files:**
+- Modify: `docs/release/INSTALL.md` only if the release archive installation section still describes a Python WorkBuddy runtime.
+- Modify: `https://github.com/ob-labs/powercontext-go/issues/194` only after merged and post-main evidence exists.
+
+**Interfaces:**
+- Consumes: the completed Hook, setup, archive, e2e, and workflow contracts.
+- Produces: exact-Head and post-main evidence for the WorkBuddy Go-hook checkbox; it does not claim other Host migrations or a Python-free repository.
+
+- [ ] **Step 1: Verify generated and formatting boundaries before broad validation**
+
+Run: `make check-generated`
+
+Run: `gofmt -d internal/cli/workbuddy_hook.go internal/cli/workbuddy_hook_test.go internal/cli/integration_workbuddy.go internal/cli/integration_workbuddy_test.go`
+
+Expected: no generated diff and no Go formatting output.
+
+- [ ] **Step 2: Run the changed-surface quality gates**
+
+Run: `go test -count=1 -race ./internal/cli`
+
+Run: `go test -count=1 ./tools/release`
+
+Run: `go test -count=1 -tags sqlite_fts5 ./test/e2e -run TestWorkBuddyHookAndMCPShareOneGoServiceConfiguration`
+
+Run: `make lint`
+
+Expected: all pass; report any missing Windows SQLite header or unsupported local native prerequisite as an environment gap rather than weakening the assertions.
+
+- [ ] **Step 3: Reconcile the final diff and create the implementation PR**
+
+Before opening the PR, verify that every changed file belongs to the five planned boundaries and that no generated `api/v1` or `client` file changed. The PR body must reference #194 and #159, state that the slice migrates only WorkBuddy, and include the exact targeted commands and their results.
+
+- [ ] **Step 4: Confirm exact-Head and post-merge evidence**
+
+Require the PR's exact Head `Main`, Pre-WP6 host adapters, Post-WP6 retained host adapters, release-contract/archive, E2E, Windows, CodeQL, and License Check workflows to complete. After squash merge, refetch the exact `main` SHA and record each post-main conclusion before changing Issue #194.
+
+- [ ] **Step 5: Update tracking only after evidence is complete**
+
+Mark the Independent v0.1.x WorkBuddy Go-hook slice in #194 complete only when the exact implementation Head and the merged `main` both pass the relevant release, adapter, and service-chain evidence. Update/close #159 only with a readback that says the delivered scope is WorkBuddy-only and that no multi-Host migration was delivered.

--- a/docs/superpowers/specs/2026-09-03-workbuddy-go-hook-design.md
+++ b/docs/superpowers/specs/2026-09-03-workbuddy-go-hook-design.md
@@ -1,0 +1,172 @@
+# WorkBuddy Go Hook Design
+
+## Status
+
+Approved on 2026-09-04. This document defines the independently scoped
+WorkBuddy Go-hook slice tracked by Issue #194.
+
+## Context
+
+PowerContext Go is Go-primary, but the installed WorkBuddy
+`UserPromptSubmit` hook currently invokes Python. The existing Go CLI already
+owns WorkBuddy installation, credential-free persisted configuration,
+diagnostics, atomic replacement, and the Server/MCP registration. The Go
+Server and SQLite service chain are already the authoritative runtime.
+
+The goal is to replace only the installed WorkBuddy hook driver with the
+released Go binary. The observable WorkBuddy contract remains unchanged.
+
+## Scope
+
+In scope:
+
+- Add `powercontext hook workbuddy` to the existing CLI boundary.
+- Read one WorkBuddy hook payload from stdin and emit one
+  `hookSpecificOutput` JSON object on stdout.
+- Read the existing persisted WorkBuddy configuration and retain its
+  credential-free authorization-environment reference.
+- Resolve agent or project scope, recall prepared context, capture the
+  submitted prompt, and optionally flush captured work through the existing
+  public Server endpoints.
+- Make `setup workbuddy` register a stable absolute path to the released Go
+  executable.
+- Test the installed-binary path with a release-shaped archive and the real
+  SQLite Server/MCP service chain.
+
+Out of scope:
+
+- Migrating Codex, Claude Code, Bub, Hermes, LangChain, LangGraph, Pydantic
+  AI, DSH, Pi, OpenCode, OpenClaw, or any other integration.
+- A cross-host hook framework or a new public Go package.
+- seekDB, OceanBase, and non-SQLite runtime requirements.
+- Persisting bearer tokens, prompts, source content, database locations, or
+  configured URLs in diagnostics.
+- Forking, creating, or maintaining an external consumer repository.
+
+## Options Considered
+
+1. A WorkBuddy-only Go subcommand in `internal/cli` is selected. It keeps
+   installation, persisted configuration, process I/O, and host-specific
+   behavior at the existing CLI boundary, while the Server remains the only
+   persistence owner.
+2. A Go wrapper that starts the existing Python driver is rejected. It keeps
+   the Python runtime dependency and does not establish a release-binary
+   contract.
+3. A generic multi-host hook framework is rejected. Existing hosts have
+   different payload, installation, and lifecycle contracts; adding an
+   abstraction before a second Go hook increases scope without removing
+   present complexity.
+
+## Architecture
+
+### Command boundary
+
+`newHookCommand` gains only a `workbuddy` child. The child owns stdin/stdout,
+runtime environment reads, persisted configuration lookup, and fail-open
+process behavior. It does not expose a new library API.
+
+The command accepts no positional arguments. It reads a bounded UTF-8 JSON
+object from stdin. Only a `UserPromptSubmit` event is processed; other valid
+events return successfully without output. A processed event writes exactly:
+
+```json
+{"hookSpecificOutput":{"hookEventName":"UserPromptSubmit","additionalContext":"..."}}
+```
+
+`additionalContext` is an empty string when no context is available. The
+command writes no prompt, authorization value, configured URL, scope ID, or
+Server body to stdout or stderr.
+
+### Configuration and scope
+
+The hook reads the existing `WORKBUDDY_HOME/powercontext.json` schema through
+the same internal configuration decoder used by setup and diagnostics. An
+invalid or missing persisted configuration is authoritative fail-open input:
+the command performs no recall or capture and returns successfully.
+
+The persisted Server URL, authorization-environment name, scope mode, request
+timeout/budget, and byte limits remain authoritative. Environment variables
+may supply only the already-defined runtime-owned scope, capture, and flush
+controls. A Go implementation replaces the installed Python scope resolver;
+the agent/project scope results must match the current WorkBuddy contract.
+
+### Transport and operation flow
+
+The hook uses a CLI-owned HTTP client that enforces the same transport policy
+at client construction and final request dispatch. Loopback requests bypass
+ambient proxies. Remote plaintext endpoints are rejected before a request is
+sent; remote HTTPS retains the configured proxy behavior.
+
+For one valid prompt, the operation is:
+
+1. Resolve scope from `cwd` and persisted/runtime scope controls.
+2. Use one wall-clock request budget for all Server calls.
+3. POST `/v1/context/prepare` with bounded query and configured `max_bytes`.
+4. Validate the public prepared-context response and emit its content, or an
+   empty context for empty, unavailable, invalid, timeout, or authentication
+   outcomes.
+5. When capture is enabled and the prompt fits the configured source limit,
+   derive the existing deterministic WorkBuddy source ID, POST
+   `/v1/sources/content`, and optionally call `/v1/memory/flush` until the
+   returned cursor reaches the captured source position or the bounded flush
+   limit is exhausted.
+
+All hook failures are fail-open. They are represented by empty context and a
+bounded, redacted stderr event only when the existing contract permits an
+event. No failure changes the Hook exit code to nonzero.
+
+### Installation and release archive contract
+
+`setup workbuddy` resolves the executable that is running setup through
+`os.Executable`, resolves symlinks, and validates that it is a regular,
+executable `powercontext` binary beneath a supported released archive root.
+It writes the resolved, shell-quoted absolute path followed by
+`hook workbuddy` into the WorkBuddy `UserPromptSubmit` command registration.
+
+The setup command must reject an unresolved checkout-local, `go run`,
+temporary, or PATH-only binary rather than silently registering one. Existing
+settings, MCP, configuration, ownership, and rollback rules remain in force.
+The installed Python Hook driver and Python scope resolver are no longer
+required runtime artifacts for a successful Go-hook installation; retained
+documentation and unrelated integration assets are not removed in this slice.
+
+## Error and Security Rules
+
+- One malformed payload, invalid configuration, unsupported event, scope
+  failure, transport refusal, Server error, oversized response, or timeout
+  must not leak protected inputs or block WorkBuddy.
+- The authorization environment supplies the value only at invocation time;
+  setup and persisted configuration retain the variable name, never its value.
+- A request body and response are bounded before decoding or logging.
+- Authentication, loopback bypass, public mode, remote HTTPS, and trusted
+  caller-supplied transport behavior use the established host transport
+  policy; this slice does not invent a parallel policy.
+
+## Verification
+
+Focused tests must prove:
+
+- Payload parsing, event filtering, exact stdout JSON, empty context, scope
+  modes, capture/flush, deterministic source IDs, request budgets, malformed
+  inputs, and fail-open behavior.
+- Persisted configuration is authoritative; invalid persisted configuration
+  prevents legacy environment fallback.
+- Public and bearer-authenticated Server operation, loopback proxy bypass,
+  remote plaintext refusal, and redaction of prompts and credentials.
+- `setup workbuddy` records the released binary path, not Python, `go run`, a
+  temporary build, the current directory, or an incidental PATH binary.
+- A release-shaped archive installs the hook and invokes its own binary.
+- A real SQLite Server service chain captures a prompt, recalls it through the
+  Hook, and exposes it through the configured MCP `search_memory` route in
+  both public and bearer-authenticated modes.
+
+The targeted CLI, release, pre-WP6 host-adapter, and service-chain gates run
+before a PR is considered ready. The exact PR Head and post-merge main must
+then be green before the WorkBuddy checkbox in Issue #194 is updated.
+
+## Acceptance Boundary
+
+Completion replaces only WorkBuddy's installed Python Hook driver. It does
+not mean that Python assets have been removed from the repository, and it does
+not reopen completed Codex/WorkBuddy compatibility evidence or make any claim
+about other retained adapters.

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/go-faster/errors v0.7.1
 	github.com/go-faster/jx v1.2.0
 	github.com/go-sql-driver/mysql v1.10.0
+	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/gowebpki/jcs v1.0.1
 	github.com/knights-analytics/hugot v0.7.0
@@ -74,7 +75,6 @@ require (
 	github.com/gomlx/go-xla v0.2.2 // indirect
 	github.com/gomlx/gomlx v0.27.2 // indirect
 	github.com/gomlx/onnx-gomlx v0.4.2-0.20260327164137-4e2832549fc1 // indirect
-	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/google/s2a-go v0.1.8 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.4 // indirect

--- a/integrations/workbuddy/README.md
+++ b/integrations/workbuddy/README.md
@@ -17,7 +17,18 @@ contains the Server URL, scope mode, request limits, and the name of the
 optional authorization environment variable. The authorization value itself is
 read only when the Hook or MCP client runs and is never written by setup.
 
-Run `powercontext doctor workbuddy` to check the installed Python Hook,
+Run setup from the released `powercontext` binary under its release archive.
+Setup resolves that binary and registers its absolute, shell-quoted
+`powercontext hook workbuddy` command. It rejects checkout, temporary, and
+PATH-only executables rather than persisting an unstable hook target.
+
+The checked-in `hooks.workbuddy.json` is intentionally registration-free: it
+does not identify an executable and must not be copied as a runnable hook
+configuration. `powercontext setup workbuddy` is the only supported owner of
+the installed `UserPromptSubmit` command, so the persisted registration always
+names the resolved binary from the release archive.
+
+Run `powercontext doctor workbuddy` to check the released Go Hook command,
 configuration, MCP registration, Skill ownership, and the configured Server
 health endpoints. It reports fixed diagnostic categories and does not print
 configuration credentials, prompt content, retrieved context, or scope IDs.

--- a/integrations/workbuddy/plugins/powercontext/hooks/hooks.workbuddy.json
+++ b/integrations/workbuddy/plugins/powercontext/hooks/hooks.workbuddy.json
@@ -1,17 +1,6 @@
 {
-  "description": "Recall bounded PowerContext context and capture a WorkBuddy prompt.",
+  "description": "Run powercontext setup workbuddy to register the released PowerContext binary for this hook.",
   "hooks": {
-    "UserPromptSubmit": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "\"${POWERCONTEXT_PYTHON}\" \"${WORKBUDDY_HOOKS_DIR}/workbuddy_powercontext_hook.py\"",
-            "timeout": 10,
-            "statusMessage": "Syncing PowerContext"
-          }
-        ]
-      }
-    ]
+    "UserPromptSubmit": []
   }
 }

--- a/internal/cli/integration_workbuddy.go
+++ b/internal/cli/integration_workbuddy.go
@@ -50,6 +50,9 @@ const (
 	workBuddyConfigSchema          = 1
 	workBuddyPythonPlaceholder     = "${POWERCONTEXT_PYTHON}"
 	workBuddyScopePlaceholder      = "${POWERCONTEXT_PROJECT_SCOPE_SCRIPT}"
+	workBuddyReleasePlaceholder    = "${POWERCONTEXT_RELEASE_BINARY}"
+	workBuddyScopeSectionStart     = "## Resolve scope\n"
+	workBuddyScopeSectionEnd       = "\n## Read\n"
 	workBuddyServerURLTemplate     = "${POWERCONTEXT_WORKBUDDY_SERVER_URL:-http://127.0.0.1:8000}/mcp"
 	workBuddyAuthorizationTemplate = "${POWERCONTEXT_WORKBUDDY_AUTHORIZATION:-}"
 	workBuddyLegacyMCPURL          = "http://127.0.0.1:8000/mcp"
@@ -67,6 +70,7 @@ const (
 
 var (
 	workBuddyAuthorizationEnvironmentPattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+	workBuddyExecutable                      = os.Executable
 	workBuddyHookModules                     = [...]string{
 		workBuddyHookDriver,
 		"workbuddy_settings.py",
@@ -226,6 +230,10 @@ func installWorkBuddyPlugin(
 	source, ref string,
 	configuration workBuddyConfiguration,
 ) (workBuddySetupResult, error) {
+	binary, err := resolveWorkBuddyReleaseBinary()
+	if err != nil {
+		return workBuddySetupResult{}, err
+	}
 	dataDir, err := prepareDataDirectory()
 	if err != nil {
 		return workBuddySetupResult{}, err
@@ -251,6 +259,9 @@ func installWorkBuddyPlugin(
 	}
 	if _, _, configErr := readWorkBuddyConfiguration(configFile); configErr != nil {
 		return workBuddySetupResult{}, errors.New("existing WorkBuddy configuration is not owned by PowerContext")
+	}
+	if hookErr := requireReplaceableWorkBuddyHook(settingsFile, binary); hookErr != nil {
+		return workBuddySetupResult{}, hookErr
 	}
 	settingsSnapshot, err := snapshotWorkBuddyFile(settingsFile)
 	if err != nil {
@@ -289,7 +300,7 @@ func installWorkBuddyPlugin(
 	if hooksErr := installWorkBuddyHooks(plugin, hooksDir); hooksErr != nil {
 		return workBuddySetupResult{}, hooksErr
 	}
-	if settingsErr := mergeWorkBuddySettings(settingsFile, hooksDir); settingsErr != nil {
+	if settingsErr := mergeWorkBuddySettings(settingsFile, binary); settingsErr != nil {
 		return workBuddySetupResult{}, settingsErr
 	}
 	if mcpErr := mergeWorkBuddyMCP(mcpFile, configuration); mcpErr != nil {
@@ -307,7 +318,7 @@ func installWorkBuddyPlugin(
 	}); configErr != nil {
 		return workBuddySetupResult{}, errors.New("cannot write WorkBuddy configuration")
 	}
-	if skillErr := installWorkBuddySkill(plugin, skillDir, hooksDir); skillErr != nil {
+	if skillErr := installWorkBuddySkill(plugin, skillDir, binary); skillErr != nil {
 		return workBuddySetupResult{}, skillErr
 	}
 	succeeded = true
@@ -396,24 +407,45 @@ func workBuddyHome() (string, error) {
 	return resolvePath(configured)
 }
 
-func installWorkBuddyHooks(plugin, hooksDir string) error {
-	if err := os.MkdirAll(hooksDir, 0o755); err != nil {
-		return errors.New("cannot create WorkBuddy hooks directory")
+func resolveWorkBuddyReleaseBinary() (string, error) {
+	executable, err := workBuddyExecutable()
+	if err != nil {
+		return "", errors.New("PowerContext must run from a released archive to set up WorkBuddy")
 	}
-	for _, name := range workBuddyHookModules {
-		if err := copyWorkBuddyFile(filepath.Join(plugin, "hooks", name), filepath.Join(hooksDir, name)); err != nil {
-			return errors.New("cannot install WorkBuddy hooks")
+	return validateWorkBuddyReleaseBinary(executable)
+}
+
+func validateWorkBuddyReleaseBinary(executable string) (string, error) {
+	resolved, err := filepath.EvalSymlinks(executable)
+	if err != nil {
+		return "", errors.New("PowerContext must run from a released archive to set up WorkBuddy")
+	}
+	info, err := os.Stat(resolved)
+	if err != nil || !info.Mode().IsRegular() ||
+		(runtime.GOOS != "windows" && info.Mode().Perm()&0o111 == 0) ||
+		filepath.Base(resolved) != "powercontext" || filepath.Base(filepath.Dir(resolved)) != "bin" {
+		return "", errors.New("PowerContext must run from a released archive to set up WorkBuddy")
+	}
+	root := filepath.Dir(filepath.Dir(resolved))
+	for _, path := range []string{"BUILD-INFO.json", ".env.example", filepath.Join("openapi", "powercontext.yaml")} {
+		artifact, artifactErr := os.Stat(filepath.Join(root, path))
+		if artifactErr != nil || !artifact.Mode().IsRegular() {
+			return "", errors.New("PowerContext must run from a released archive to set up WorkBuddy")
 		}
 	}
-	if err := copyWorkBuddyFile(
-		filepath.Join(plugin, "scripts", "project_scope.py"), filepath.Join(hooksDir, workBuddyScopeResolver),
-	); err != nil {
-		return errors.New("cannot install WorkBuddy scope resolver")
+	if _, ok := findWorkBuddyPlugin(root); !ok {
+		return "", errors.New("PowerContext must run from a released archive to set up WorkBuddy")
 	}
+	return resolved, nil
+}
+
+func installWorkBuddyHooks(plugin, hooksDir string) error {
+	_ = plugin
+	_ = hooksDir
 	return nil
 }
 
-func mergeWorkBuddySettings(settingsFile, hooksDir string) error {
+func mergeWorkBuddySettings(settingsFile, binary string) error {
 	settings, err := loadWorkBuddyJSON(settingsFile)
 	if err != nil {
 		return errors.New("cannot update WorkBuddy settings")
@@ -434,7 +466,7 @@ func mergeWorkBuddySettings(settingsFile, hooksDir string) error {
 		matchers = make([]any, 0, 1)
 	}
 	entry := map[string]any{
-		"type": "command", "command": workBuddyHookCommand(hooksDir), "timeout": 10, "statusMessage": "Syncing PowerContext",
+		"type": "command", "command": workBuddyHookCommand(binary), "timeout": 10, "statusMessage": "Syncing PowerContext",
 	}
 	updated := false
 	for _, matcher := range matchers {
@@ -451,8 +483,11 @@ func mergeWorkBuddySettings(settingsFile, hooksDir string) error {
 		}
 		for index, existing := range group {
 			value, ok := existing.(map[string]any)
-			if !ok || !isWorkBuddyHook(value) {
+			if !ok || !isWorkBuddyHookCandidate(value) {
 				continue
+			}
+			if !isOwnedWorkBuddyHook(value, binary, filepath.Dir(settingsFile)) {
+				return errors.New("existing WorkBuddy hook is not owned by PowerContext")
 			}
 			for name, item := range entry {
 				value[name] = item
@@ -504,7 +539,7 @@ func mergeWorkBuddyMCP(mcpFile string, configuration workBuddyConfiguration) err
 	return writeWorkBuddyJSON(mcpFile, config)
 }
 
-func installWorkBuddySkill(plugin, target, hooksDir string) error {
+func installWorkBuddySkill(plugin, target, binary string) error {
 	parent := filepath.Dir(target)
 	if mkdirErr := os.MkdirAll(parent, 0o755); mkdirErr != nil {
 		return errors.New("cannot create WorkBuddy Skill directory")
@@ -522,10 +557,10 @@ func installWorkBuddySkill(plugin, target, hooksDir string) error {
 	if err != nil {
 		return errors.New("cannot read WorkBuddy Skill")
 	}
-	content = []byte(strings.ReplaceAll(
-		strings.ReplaceAll(string(content), workBuddyPythonPlaceholder, workBuddyPythonCommand()),
-		workBuddyScopePlaceholder, shellQuoteWorkBuddy(filepath.Join(hooksDir, workBuddyScopeResolver)),
-	))
+	content, err = renderWorkBuddySkill(content, binary)
+	if err != nil {
+		return err
+	}
 	if writeErr := os.WriteFile(skillPath, content, 0o644); writeErr != nil {
 		return errors.New("cannot write WorkBuddy Skill")
 	}
@@ -572,23 +607,19 @@ func runWorkBuddyDiagnostics() map[string]diagnostic {
 			"skill":    {Status: "failed", Detail: "cannot resolve WorkBuddy home"},
 		}
 	}
-	hooksDir := filepath.Join(home, "hooks")
 	configuration, present, configErr := readWorkBuddyConfiguration(filepath.Join(home, workBuddyConfigFilename))
 	config := diagnostic{OK: true, Status: "ok", Detail: "credential-free WorkBuddy configuration is valid"}
 	if configErr != nil || !present {
 		config = diagnostic{Status: "failed", Detail: "PowerContext WorkBuddy configuration is missing or invalid"}
 	}
-	hooks := diagnostic{OK: true, Status: "ok", Detail: "hooks installed in " + hooksDir}
-	for _, name := range workBuddyHookModules {
-		if !isRegularWorkBuddyFile(filepath.Join(hooksDir, name)) {
-			hooks = diagnostic{Status: "failed", Detail: "PowerContext WorkBuddy hooks are not installed"}
-			break
-		}
+	settingsFile := filepath.Join(home, "settings.json")
+	binary, executableErr := resolveWorkBuddyReleaseBinary()
+	registered := executableErr == nil && settingsHaveWorkBuddyHookCommand(settingsFile, binary)
+	hooks := diagnostic{Status: "failed", Detail: "PowerContext WorkBuddy Go hook is not registered from a released archive"}
+	if registered {
+		hooks = diagnostic{OK: true, Status: "ok", Detail: "released PowerContext Go hook is registered"}
 	}
-	if !isRegularWorkBuddyFile(filepath.Join(hooksDir, workBuddyScopeResolver)) {
-		hooks = diagnostic{Status: "failed", Detail: "PowerContext WorkBuddy hooks are not installed"}
-	}
-	settings := workBuddySettingsDiagnostic(filepath.Join(home, "settings.json"))
+	settings := workBuddySettingsDiagnostic(settingsFile, registered)
 	mcp := diagnostic{Status: "failed", Detail: "PowerContext WorkBuddy MCP server is not registered in mcp.json"}
 	if config.OK {
 		mcp = workBuddyMCPDiagnostic(filepath.Join(home, "mcp.json"), configuration)
@@ -597,12 +628,54 @@ func runWorkBuddyDiagnostics() map[string]diagnostic {
 	return map[string]diagnostic{"config": config, "hooks": hooks, "settings": settings, "mcp": mcp, "skill": skill}
 }
 
-func workBuddySettingsDiagnostic(path string) diagnostic {
-	settings, err := loadWorkBuddyJSON(path)
-	if err != nil || !settingsHaveWorkBuddyHook(settings) {
+func workBuddySettingsDiagnostic(path string, registered bool) diagnostic {
+	if !registered {
 		return diagnostic{Status: "failed", Detail: "PowerContext WorkBuddy hook is not registered in settings.json"}
 	}
 	return diagnostic{OK: true, Status: "ok", Detail: path}
+}
+
+func settingsHaveWorkBuddyHookCommand(path, binary string) bool {
+	settings, err := loadWorkBuddyJSON(path)
+	if err != nil {
+		return false
+	}
+	hooks, ok := settings["hooks"].(map[string]any)
+	if !ok {
+		return false
+	}
+	matchers, ok := hooks["UserPromptSubmit"].([]any)
+	if !ok {
+		return false
+	}
+	want := workBuddyHookCommand(binary)
+	found := false
+	for _, matcher := range matchers {
+		matcherObject, ok := matcher.(map[string]any)
+		if !ok {
+			continue
+		}
+		entries, ok := matcherObject["hooks"].([]any)
+		if !ok {
+			continue
+		}
+		for _, entry := range entries {
+			value, ok := entry.(map[string]any)
+			if !ok {
+				continue
+			}
+			if !isWorkBuddyHookCandidate(value) {
+				continue
+			}
+			command, commandOK := value["command"].(string)
+			kind, kindOK := value["type"].(string)
+			if found || !commandOK || !kindOK || kind != "command" || command != want {
+				return false
+			}
+			found = true
+		}
+	}
+	return found
 }
 
 func workBuddyConfiguredServerURL() (string, bool) {
@@ -646,8 +719,8 @@ func workBuddySkillDiagnostic(path string) diagnostic {
 		return diagnostic{Status: "failed", Detail: "PowerContext WorkBuddy skill is not installed"}
 	}
 	content, err := os.ReadFile(skill)
-	if err != nil || strings.Contains(string(content), workBuddyPythonPlaceholder) || strings.Contains(string(content), workBuddyScopePlaceholder) {
-		return diagnostic{Status: "failed", Detail: "PowerContext WorkBuddy skill still contains an unresolved command placeholder"}
+	if err != nil || hasRetiredWorkBuddySkillMaterial(string(content)) {
+		return diagnostic{Status: "failed", Detail: "PowerContext WorkBuddy skill contains retired runtime material"}
 	}
 	return diagnostic{OK: true, Status: "ok", Detail: path}
 }
@@ -761,14 +834,18 @@ func writeWorkBuddyJSON(path string, value map[string]any) error {
 	return writeFileAtomically(path, append(payload, '\n'), 0o600)
 }
 
-func settingsHaveWorkBuddyHook(settings map[string]any) bool {
+func requireReplaceableWorkBuddyHook(path, binary string) error {
+	settings, err := loadWorkBuddyJSON(path)
+	if err != nil {
+		return errors.New("cannot update WorkBuddy settings")
+	}
 	hooks, ok := settings["hooks"].(map[string]any)
 	if !ok {
-		return false
+		return nil
 	}
 	matchers, ok := hooks["UserPromptSubmit"].([]any)
 	if !ok {
-		return false
+		return nil
 	}
 	for _, matcher := range matchers {
 		matcherObject, ok := matcher.(map[string]any)
@@ -781,17 +858,64 @@ func settingsHaveWorkBuddyHook(settings map[string]any) bool {
 		}
 		for _, entry := range entries {
 			value, ok := entry.(map[string]any)
-			if ok && isWorkBuddyHook(value) {
-				return true
+			if ok && isWorkBuddyHookCandidate(value) && !isOwnedWorkBuddyHook(value, binary, filepath.Dir(path)) {
+				return errors.New("existing WorkBuddy hook is not owned by PowerContext")
 			}
 		}
 	}
-	return false
+	return nil
 }
 
-func isWorkBuddyHook(entry map[string]any) bool {
+func isWorkBuddyHookCandidate(entry map[string]any) bool {
 	command, _ := entry["command"].(string)
-	return strings.Contains(command, workBuddyHookDriver)
+	return strings.Contains(command, workBuddyHookDriver) ||
+		(strings.Contains(command, "powercontext") && strings.HasSuffix(strings.TrimSpace(command), " hook workbuddy"))
+}
+
+func isOwnedWorkBuddyHook(entry map[string]any, binary, home string) bool {
+	command, commandOK := entry["command"].(string)
+	kind, kindOK := entry["type"].(string)
+	if !commandOK || !kindOK || kind != "command" {
+		return false
+	}
+	if command == workBuddyHookCommand(binary) || command == workBuddyLegacyHookCommand(home) {
+		return true
+	}
+	previousBinary, ok := workBuddyHookCommandBinary(command)
+	if !ok {
+		return false
+	}
+	_, err := validateWorkBuddyReleaseBinary(previousBinary)
+	return err == nil
+}
+
+func workBuddyHookCommandBinary(command string) (string, bool) {
+	encoded, ok := strings.CutSuffix(command, " hook workbuddy")
+	if !ok || encoded == "" {
+		return "", false
+	}
+	var binary string
+	if runtime.GOOS == "windows" {
+		inner, quoted := strings.CutPrefix(encoded, `"`)
+		inner, ok = strings.CutSuffix(inner, `"`)
+		if !quoted || !ok {
+			return "", false
+		}
+		binary = strings.ReplaceAll(inner, `\"`, `"`)
+	} else if inner, quoted := strings.CutPrefix(encoded, "'"); quoted {
+		inner, ok = strings.CutSuffix(inner, "'")
+		if !ok {
+			return "", false
+		}
+		binary = strings.ReplaceAll(inner, `'"'"'`, `'`)
+	} else {
+		binary = encoded
+	}
+	return binary, workBuddyHookCommand(binary) == command
+}
+
+func workBuddyLegacyHookCommand(home string) string {
+	return workBuddyPythonCommand() + " " + shellQuoteWorkBuddy(filepath.Join(home, "hooks", workBuddyHookDriver))
 }
 
 func isLegacyWorkBuddyMCP(entry map[string]any) bool {
@@ -834,12 +958,46 @@ func isWorkBuddyAuthorizationTemplate(value string) bool {
 	return ok && workBuddyAuthorizationEnvironmentPattern.MatchString(name)
 }
 
-func workBuddyHookCommand(hooksDir string) string {
-	return workBuddyPythonCommand() + " " + shellQuoteWorkBuddy(filepath.Join(hooksDir, workBuddyHookDriver))
+func workBuddyHookCommand(binary string) string {
+	return shellQuoteWorkBuddy(binary) + " hook workbuddy"
 }
 
 func workBuddyPythonCommand() string {
 	return "python3"
+}
+
+func renderWorkBuddySkill(content []byte, binary string) ([]byte, error) {
+	rendered := string(content)
+	if start := strings.Index(rendered, "<!--\n  Installation note:"); start >= 0 {
+		if end := strings.Index(rendered[start:], "\n-->\n"); end >= 0 {
+			rendered = rendered[:start] + rendered[start+end+len("\n-->\n"):]
+		}
+	}
+	if start := strings.Index(rendered, workBuddyScopeSectionStart); start >= 0 {
+		if end := strings.Index(rendered[start:], workBuddyScopeSectionEnd); end >= 0 {
+			replacement := "## Scope\n\nThe installed UserPromptSubmit command `" + workBuddyHookCommand(binary) +
+				"` resolves scope automatically for each event. Do not run a separate scope resolver.\n"
+			rendered = rendered[:start] + replacement + rendered[start+end:]
+		}
+	}
+	rendered = strings.ReplaceAll(rendered, workBuddyPythonPlaceholder, "")
+	rendered = strings.ReplaceAll(rendered, workBuddyScopePlaceholder, "")
+	if !strings.Contains(rendered, workBuddyHookCommand(binary)) {
+		rendered += "\n## Scope\n\nThe installed UserPromptSubmit command `" + workBuddyHookCommand(binary) +
+			"` resolves scope automatically for each event. Do not run a separate scope resolver.\n"
+	}
+	if hasRetiredWorkBuddySkillMaterial(rendered) {
+		return nil, errors.New("WorkBuddy Skill contains retired runtime material")
+	}
+	return []byte(rendered), nil
+}
+
+func hasRetiredWorkBuddySkillMaterial(content string) bool {
+	return strings.Contains(content, workBuddyPythonCommand()) ||
+		strings.Contains(content, workBuddyScopeResolver) ||
+		strings.Contains(content, workBuddyPythonPlaceholder) ||
+		strings.Contains(content, workBuddyScopePlaceholder) ||
+		strings.Contains(content, workBuddyReleasePlaceholder)
 }
 
 func shellQuoteWorkBuddy(value string) string {
@@ -916,21 +1074,6 @@ func removeWorkBuddyPath(path string) {
 	if path != "" {
 		_ = os.RemoveAll(path)
 	}
-}
-
-func copyWorkBuddyFile(source, target string) error {
-	info, err := os.Stat(source)
-	if err != nil || !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 {
-		return errors.New("WorkBuddy source file is invalid")
-	}
-	content, err := os.ReadFile(source)
-	if err != nil {
-		return err
-	}
-	if mkdirErr := os.MkdirAll(filepath.Dir(target), 0o755); mkdirErr != nil {
-		return mkdirErr
-	}
-	return os.WriteFile(target, content, info.Mode().Perm()&0o755)
 }
 
 func isRegularWorkBuddyFile(path string) bool {

--- a/internal/cli/integration_workbuddy_test.go
+++ b/internal/cli/integration_workbuddy_test.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -45,6 +46,7 @@ func (t *workBuddyDiagnosticTransport) RoundTrip(request *http.Request) (*http.R
 }
 
 func TestSetupWorkBuddyInstallsLocalPluginAndDoctorReportsOK(t *testing.T) {
+	binary := useWorkBuddyReleaseBinary(t)
 	checkout := filepath.Join(t.TempDir(), "powercontext")
 	plugin := writeWorkBuddyPlugin(t, checkout)
 	home := filepath.Join(t.TempDir(), "workbuddy")
@@ -75,12 +77,27 @@ func TestSetupWorkBuddyInstallsLocalPluginAndDoctorReportsOK(t *testing.T) {
 	for _, name := range []string{
 		"workbuddy_powercontext_hook.py", "workbuddy_settings.py", "prepared_context.py", "powercontext_project_scope.py",
 	} {
-		if info, statErr := os.Stat(filepath.Join(home, "hooks", name)); statErr != nil || !info.Mode().IsRegular() {
-			t.Fatalf("installed hook %q error = %v", name, statErr)
+		if _, statErr := os.Stat(filepath.Join(home, "hooks", name)); !os.IsNotExist(statErr) {
+			t.Fatalf("installed Python runtime file %q error = %v", name, statErr)
 		}
 	}
-	if info, statErr := os.Stat(filepath.Join(home, "skills", "project-context", "SKILL.md")); statErr != nil || !info.Mode().IsRegular() {
+	skillPath := filepath.Join(home, "skills", "project-context", "SKILL.md")
+	if info, statErr := os.Stat(skillPath); statErr != nil || !info.Mode().IsRegular() {
 		t.Fatalf("installed Skill error = %v", statErr)
+	}
+	skill, err := os.ReadFile(skillPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, forbidden := range []string{
+		"python3", workBuddyScopeResolver, workBuddyPythonPlaceholder, workBuddyScopePlaceholder, "${POWERCONTEXT_RELEASE_BINARY}",
+	} {
+		if strings.Contains(string(skill), forbidden) {
+			t.Fatalf("installed Skill contains retired material %q: %q", forbidden, skill)
+		}
+	}
+	if !strings.Contains(string(skill), workBuddyHookCommand(binary)) {
+		t.Fatalf("installed Skill does not document its released Go Hook command: %q", skill)
 	}
 
 	var doctorOutput, doctorStderr bytes.Buffer
@@ -105,9 +122,11 @@ func TestSetupWorkBuddyInstallsLocalPluginAndDoctorReportsOK(t *testing.T) {
 }
 
 func TestSetupWorkBuddyPreservesExistingSettingsAndMCP(t *testing.T) {
+	binary := useWorkBuddyReleaseBinary(t)
+	binary = resolveWorkBuddyTestPath(t, binary)
 	checkout := filepath.Join(t.TempDir(), "powercontext")
 	writeWorkBuddyPlugin(t, checkout)
-	home := filepath.Join(t.TempDir(), "workbuddy")
+	home := resolveWorkBuddyTestPath(t, filepath.Join(t.TempDir(), "workbuddy"))
 	t.Setenv("WORKBUDDY_HOME", home)
 	t.Setenv("POWERCONTEXT_HOME", filepath.Join(t.TempDir(), "data"))
 	writeWorkBuddyTestJSON(t, filepath.Join(home, "settings.json"), map[string]any{
@@ -127,7 +146,7 @@ func TestSetupWorkBuddyPreservesExistingSettingsAndMCP(t *testing.T) {
 	settings := readWorkBuddyJSON(t, filepath.Join(home, "settings.json"))
 	if settings["enabledPlugins"].(map[string]any)["other-plugin"] != true ||
 		settings["sandbox"].(map[string]any)["enabled"] != true ||
-		!settingsHaveWorkBuddyHook(settings) {
+		!settingsHaveWorkBuddyHookCommand(filepath.Join(home, "settings.json"), binary) {
 		t.Fatalf("settings = %#v", settings)
 	}
 	mcp := readWorkBuddyJSON(t, filepath.Join(home, "mcp.json"))
@@ -139,6 +158,7 @@ func TestSetupWorkBuddyPreservesExistingSettingsAndMCP(t *testing.T) {
 }
 
 func TestSetupWorkBuddyWritesCredentialFreeConfiguration(t *testing.T) {
+	useWorkBuddyReleaseBinary(t)
 	checkout := filepath.Join(t.TempDir(), "powercontext")
 	writeWorkBuddyPlugin(t, checkout)
 	home := filepath.Join(t.TempDir(), "workbuddy")
@@ -181,6 +201,7 @@ func TestSetupWorkBuddyWritesCredentialFreeConfiguration(t *testing.T) {
 }
 
 func TestSetupWorkBuddyRefreshesOwnedCustomAuthorizationEnvironment(t *testing.T) {
+	useWorkBuddyReleaseBinary(t)
 	checkout := filepath.Join(t.TempDir(), "powercontext")
 	writeWorkBuddyPlugin(t, checkout)
 	home := filepath.Join(t.TempDir(), "workbuddy")
@@ -209,6 +230,7 @@ func TestSetupWorkBuddyRejectsRemotePlaintextBeforePythonLookup(t *testing.T) {
 }
 
 func TestSetupWorkBuddyPreservesRemoteAuthenticatedMCPConfiguration(t *testing.T) {
+	useWorkBuddyReleaseBinary(t)
 	checkout := filepath.Join(t.TempDir(), "powercontext")
 	writeWorkBuddyPlugin(t, checkout)
 	home := filepath.Join(t.TempDir(), "workbuddy")
@@ -238,6 +260,7 @@ func TestSetupWorkBuddyPreservesRemoteAuthenticatedMCPConfiguration(t *testing.T
 }
 
 func TestSetupWorkBuddyMigratesLegacyMCPEntry(t *testing.T) {
+	useWorkBuddyReleaseBinary(t)
 	checkout := filepath.Join(t.TempDir(), "powercontext")
 	writeWorkBuddyPlugin(t, checkout)
 	home := filepath.Join(t.TempDir(), "workbuddy")
@@ -262,6 +285,7 @@ func TestSetupWorkBuddyMigratesLegacyMCPEntry(t *testing.T) {
 }
 
 func TestSetupWorkBuddyRefusesUnownedSkillBeforeWriting(t *testing.T) {
+	useWorkBuddyReleaseBinary(t)
 	checkout := filepath.Join(t.TempDir(), "powercontext")
 	writeWorkBuddyPlugin(t, checkout)
 	home := filepath.Join(t.TempDir(), "workbuddy")
@@ -298,16 +322,18 @@ func TestDoctorWorkBuddyReportsFailuresBeforeInstall(t *testing.T) {
 	}
 }
 
-func TestSetupWorkBuddyUpdatesExistingHookAndPreservesSharedScripts(t *testing.T) {
+func TestSetupWorkBuddyMigratesOwnedPythonHookAndPreservesSharedScripts(t *testing.T) {
+	binary := useWorkBuddyReleaseBinary(t)
+	binary = resolveWorkBuddyTestPath(t, binary)
 	checkout := filepath.Join(t.TempDir(), "powercontext")
 	writeWorkBuddyPlugin(t, checkout)
-	home := filepath.Join(t.TempDir(), "workbuddy")
+	home := resolveWorkBuddyTestPath(t, filepath.Join(t.TempDir(), "workbuddy"))
 	t.Setenv("WORKBUDDY_HOME", home)
 	t.Setenv("POWERCONTEXT_HOME", filepath.Join(t.TempDir(), "data"))
 	writeWorkBuddyTestJSON(t, filepath.Join(home, "settings.json"), map[string]any{
 		"hooks": map[string]any{"UserPromptSubmit": []any{map[string]any{
 			"hooks": []any{map[string]any{
-				"type": "command", "command": "python3 /old/workbuddy_powercontext_hook.py", "timeout": float64(3), "custom": "preserved",
+				"type": "command", "command": workBuddyLegacyHookCommand(home), "timeout": float64(3), "custom": "preserved",
 			}},
 		}}},
 	})
@@ -320,7 +346,7 @@ func TestSetupWorkBuddyUpdatesExistingHookAndPreservesSharedScripts(t *testing.T
 	settings := readWorkBuddyJSON(t, filepath.Join(home, "settings.json"))
 	matchers := settings["hooks"].(map[string]any)["UserPromptSubmit"].([]any)
 	entry := matchers[0].(map[string]any)["hooks"].([]any)[0].(map[string]any)
-	if !strings.Contains(entry["command"].(string), "workbuddy_powercontext_hook.py") ||
+	if entry["command"] != workBuddyHookCommand(binary) ||
 		entry["timeout"] != float64(10) || entry["statusMessage"] != "Syncing PowerContext" || entry["custom"] != "preserved" {
 		t.Fatalf("updated hook = %#v", entry)
 	}
@@ -330,7 +356,194 @@ func TestSetupWorkBuddyUpdatesExistingHookAndPreservesSharedScripts(t *testing.T
 	}
 }
 
+func TestSetupWorkBuddyMigratesPreviousReleaseHookWithRollbackAndSiblingPreservation(t *testing.T) {
+	currentBinary := useWorkBuddyReleaseBinary(t)
+	currentBinary = resolveWorkBuddyTestPath(t, currentBinary)
+	previousBinary := writeWorkBuddyReleaseBinary(t, 0o755)
+	previousBinary = resolveWorkBuddyTestPath(t, previousBinary)
+	checkout := filepath.Join(t.TempDir(), "powercontext")
+	plugin := writeWorkBuddyPlugin(t, checkout)
+	writeTestFile(t, filepath.Join(plugin, "skills", workBuddySkillName, "oversized.bin"), strings.Repeat("x", maximumCommandOutput+1))
+	home := resolveWorkBuddyTestPath(t, filepath.Join(t.TempDir(), "workbuddy"))
+	t.Setenv("WORKBUDDY_HOME", home)
+	t.Setenv("POWERCONTEXT_HOME", filepath.Join(t.TempDir(), "data"))
+	settingsPath := filepath.Join(home, "settings.json")
+	previousSettings := map[string]any{
+		"hooks": map[string]any{"UserPromptSubmit": []any{map[string]any{
+			"hooks": []any{
+				map[string]any{"type": "command", "command": workBuddyHookCommand(previousBinary), "timeout": float64(10), "custom": "preserved"},
+				map[string]any{"type": "command", "command": "echo sibling", "timeout": float64(5)},
+			},
+		}}},
+	}
+	writeWorkBuddyTestJSON(t, settingsPath, previousSettings)
+
+	_, _, err := executeSystemCLI(t, nil, &scriptedSystemCommands{t: t}, "setup", "workbuddy", "--source", checkout)
+	if err == nil || !strings.Contains(err.Error(), "cannot copy WorkBuddy Skill") {
+		t.Fatalf("setup error = %v", err)
+	}
+	if got := readWorkBuddyJSON(t, settingsPath); fmt.Sprint(got) != fmt.Sprint(previousSettings) {
+		t.Fatalf("settings after rollback = %#v, want %#v", got, previousSettings)
+	}
+
+	if err := os.Remove(filepath.Join(plugin, "skills", workBuddySkillName, "oversized.bin")); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := executeSystemCLI(t, nil, &scriptedSystemCommands{t: t}, "setup", "workbuddy", "--source", checkout); err != nil {
+		t.Fatal(err)
+	}
+	settings := readWorkBuddyJSON(t, settingsPath)
+	entries := settings["hooks"].(map[string]any)["UserPromptSubmit"].([]any)[0].(map[string]any)["hooks"].([]any)
+	owned := entries[0].(map[string]any)
+	sibling := entries[1].(map[string]any)
+	if owned["command"] != workBuddyHookCommand(currentBinary) || owned["custom"] != "preserved" || sibling["command"] != "echo sibling" {
+		t.Fatalf("migrated hooks = %#v", entries)
+	}
+}
+
+func TestSetupWorkBuddyRejectsUnreleasedBinaryBeforeWrites(t *testing.T) {
+	checkout := filepath.Join(t.TempDir(), "powercontext")
+	writeWorkBuddyPlugin(t, checkout)
+	home := filepath.Join(t.TempDir(), "workbuddy")
+	t.Setenv("WORKBUDDY_HOME", home)
+	t.Setenv("POWERCONTEXT_HOME", filepath.Join(t.TempDir(), "data"))
+	settingsPath := filepath.Join(home, "settings.json")
+	mcpPath := filepath.Join(home, "mcp.json")
+	settings := []byte(`{"hooks":{"UserPromptSubmit":[{"hooks":[{"type":"command","command":"python3 /old/workbuddy_powercontext_hook.py"}]}]}}`)
+	mcp := []byte(`{"mcpServers":{"other":{"type":"stdio","command":"other"}}}`)
+	writeTestFile(t, settingsPath, string(settings))
+	writeTestFile(t, mcpPath, string(mcp))
+
+	outside := filepath.Join(t.TempDir(), "powercontext")
+	writeTestFile(t, outside, "binary\n")
+	nonregular := filepath.Join(t.TempDir(), "bin", "powercontext")
+	if err := os.MkdirAll(nonregular, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for name, executable := range map[string]string{
+		"outside-release-root": outside,
+		"missing":              filepath.Join(t.TempDir(), "bin", "powercontext"),
+		"nonregular":           nonregular,
+		"go-build-temporary":   filepath.Join(t.TempDir(), "go-build123", "b001", "exe", "powercontext"),
+	} {
+		t.Run(name, func(t *testing.T) {
+			if name == "go-build-temporary" {
+				writeTestFile(t, executable, "binary\n")
+			}
+			previous := workBuddyExecutable
+			workBuddyExecutable = func() (string, error) { return executable, nil }
+			t.Cleanup(func() { workBuddyExecutable = previous })
+
+			_, _, err := executeSystemCLI(t, nil, &scriptedSystemCommands{t: t}, "setup", "workbuddy", "--source", checkout)
+			if err == nil || !strings.Contains(err.Error(), "released archive") || strings.Contains(err.Error(), executable) {
+				t.Fatalf("setup error = %v", err)
+			}
+			for path, want := range map[string][]byte{settingsPath: settings, mcpPath: mcp} {
+				got, readErr := os.ReadFile(path)
+				if readErr != nil || !bytes.Equal(got, want) {
+					t.Fatalf("preserved %q = %q, %v; want %q", path, got, readErr, want)
+				}
+			}
+			for _, path := range []string{filepath.Join(home, workBuddyConfigFilename), filepath.Join(home, "hooks"), filepath.Join(home, "skills", workBuddySkillName)} {
+				if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
+					t.Fatalf("setup wrote %q: %v", path, statErr)
+				}
+			}
+		})
+	}
+}
+
+func TestSetupWorkBuddyRejectsNonExecutableReleaseBinaryBeforeWritesOnUnix(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows does not use Unix executable mode bits")
+	}
+	checkout := filepath.Join(t.TempDir(), "powercontext")
+	writeWorkBuddyPlugin(t, checkout)
+	home := filepath.Join(t.TempDir(), "workbuddy")
+	t.Setenv("WORKBUDDY_HOME", home)
+	t.Setenv("POWERCONTEXT_HOME", filepath.Join(t.TempDir(), "data"))
+	settingsPath := filepath.Join(home, "settings.json")
+	mcpPath := filepath.Join(home, "mcp.json")
+	settings := []byte(`{"hooks":{"UserPromptSubmit":[{"hooks":[{"type":"command","command":"python3 /old/workbuddy_powercontext_hook.py"}]}]}}`)
+	mcp := []byte(`{"mcpServers":{"other":{"type":"stdio","command":"other"}}}`)
+	writeTestFile(t, settingsPath, string(settings))
+	writeTestFile(t, mcpPath, string(mcp))
+	useWorkBuddyReleaseBinaryWithMode(t, 0o644)
+
+	_, _, err := executeSystemCLI(t, nil, &scriptedSystemCommands{t: t}, "setup", "workbuddy", "--source", checkout)
+	if err == nil || !strings.Contains(err.Error(), "released archive") {
+		t.Fatalf("setup error = %v", err)
+	}
+	for path, want := range map[string][]byte{settingsPath: settings, mcpPath: mcp} {
+		got, readErr := os.ReadFile(path)
+		if readErr != nil || !bytes.Equal(got, want) {
+			t.Fatalf("preserved %q = %q, %v; want %q", path, got, readErr, want)
+		}
+	}
+	for _, path := range []string{filepath.Join(home, workBuddyConfigFilename), filepath.Join(home, "hooks"), filepath.Join(home, "skills", workBuddySkillName)} {
+		if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
+			t.Fatalf("setup wrote %q: %v", path, statErr)
+		}
+	}
+}
+
+func TestSetupWorkBuddyRefusesForeignGoHookBeforeWriting(t *testing.T) {
+	useWorkBuddyReleaseBinary(t)
+	checkout := filepath.Join(t.TempDir(), "powercontext")
+	writeWorkBuddyPlugin(t, checkout)
+	home := filepath.Join(t.TempDir(), "workbuddy")
+	t.Setenv("WORKBUDDY_HOME", home)
+	t.Setenv("POWERCONTEXT_HOME", filepath.Join(t.TempDir(), "data"))
+	settingsPath := filepath.Join(home, "settings.json")
+	mcpPath := filepath.Join(home, "mcp.json")
+	configPath := filepath.Join(home, workBuddyConfigFilename)
+	skillPath := filepath.Join(home, "skills", workBuddySkillName, "SKILL.md")
+	hookPath := filepath.Join(home, "hooks", "foreign-hook")
+	foreign := shellQuoteWorkBuddy(filepath.Join(t.TempDir(), "other-powercontext")) + " hook workbuddy"
+	writeWorkBuddyTestJSON(t, settingsPath, map[string]any{
+		"hooks": map[string]any{"UserPromptSubmit": []any{map[string]any{
+			"hooks": []any{map[string]any{"type": "command", "command": foreign}},
+		}}},
+	})
+	writeWorkBuddyTestJSON(t, mcpPath, map[string]any{"mcpServers": map[string]any{"other": map[string]any{"type": "stdio", "command": "other"}}})
+	configuration, err := newWorkBuddyConfiguration("http://127.0.0.1:8000", "project", workBuddyDefaultAuthorizationEnvironment)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeWorkBuddyTestJSON(t, configPath, map[string]any{
+		"schema": configuration.Schema, "server_url": configuration.ServerURL, "scope_mode": configuration.ScopeMode,
+		"authorization_environment": configuration.AuthorizationEnvironment, "request_timeout_seconds": configuration.RequestTimeoutSeconds,
+		"request_budget_seconds": configuration.RequestBudgetSeconds, "prepare_max_bytes": configuration.PrepareMaxBytes,
+		"source_max_bytes": configuration.SourceMaxBytes,
+	})
+	writeTestFile(t, skillPath, "owned Skill\n")
+	writeWorkBuddyTestJSON(t, filepath.Join(filepath.Dir(skillPath), workBuddySkillOwner), map[string]any{
+		"schema": 1, "owner": "powercontext", "integration": "workbuddy",
+	})
+	writeTestFile(t, hookPath, "foreign hook\n")
+
+	before := make(map[string][]byte)
+	for _, path := range []string{settingsPath, mcpPath, configPath, skillPath, filepath.Join(filepath.Dir(skillPath), workBuddySkillOwner), hookPath} {
+		payload, readErr := os.ReadFile(path)
+		if readErr != nil {
+			t.Fatal(readErr)
+		}
+		before[path] = payload
+	}
+	_, _, setupErr := executeSystemCLI(t, nil, &scriptedSystemCommands{t: t}, "setup", "workbuddy", "--source", checkout)
+	if setupErr == nil || !strings.Contains(setupErr.Error(), "hook is not owned") {
+		t.Fatalf("setup error = %v", setupErr)
+	}
+	for path, want := range before {
+		got, readErr := os.ReadFile(path)
+		if readErr != nil || !bytes.Equal(got, want) {
+			t.Fatalf("preserved %q = %q, %v; want %q", path, got, readErr, want)
+		}
+	}
+}
+
 func TestSetupWorkBuddyRefreshesOwnedSkill(t *testing.T) {
+	useWorkBuddyReleaseBinary(t)
 	checkout := filepath.Join(t.TempDir(), "powercontext")
 	plugin := writeWorkBuddyPlugin(t, checkout)
 	home := filepath.Join(t.TempDir(), "workbuddy")
@@ -351,6 +564,7 @@ func TestSetupWorkBuddyRefreshesOwnedSkill(t *testing.T) {
 }
 
 func TestSetupWorkBuddyStopsBeforeWritesWhenSettingsSnapshotIsUnreadable(t *testing.T) {
+	useWorkBuddyReleaseBinary(t)
 	checkout := filepath.Join(t.TempDir(), "powercontext")
 	writeWorkBuddyPlugin(t, checkout)
 	home := filepath.Join(t.TempDir(), "workbuddy")
@@ -361,7 +575,7 @@ func TestSetupWorkBuddyStopsBeforeWritesWhenSettingsSnapshotIsUnreadable(t *test
 	t.Setenv("POWERCONTEXT_HOME", filepath.Join(t.TempDir(), "data"))
 
 	_, _, err := executeSystemCLI(t, nil, &scriptedSystemCommands{t: t}, "setup", "workbuddy", "--source", checkout)
-	if err == nil || !strings.Contains(err.Error(), "Cannot update WorkBuddy settings") {
+	if err == nil || !strings.Contains(err.Error(), "cannot update WorkBuddy settings") {
 		t.Fatalf("setup error = %v", err)
 	}
 	for _, path := range []string{filepath.Join(home, "hooks"), filepath.Join(home, "mcp.json")} {
@@ -372,6 +586,7 @@ func TestSetupWorkBuddyStopsBeforeWritesWhenSettingsSnapshotIsUnreadable(t *test
 }
 
 func TestSetupWorkBuddyRollsBackJSONChangesWhenSkillCopyFails(t *testing.T) {
+	useWorkBuddyReleaseBinary(t)
 	checkout := filepath.Join(t.TempDir(), "powercontext")
 	plugin := writeWorkBuddyPlugin(t, checkout)
 	writeTestFile(t, filepath.Join(plugin, "skills", workBuddySkillName, "oversized.bin"), strings.Repeat("x", maximumCommandOutput+1))
@@ -399,6 +614,7 @@ func TestSetupWorkBuddyRollsBackJSONChangesWhenSkillCopyFails(t *testing.T) {
 }
 
 func TestSetupWorkBuddyRejectsMissingPlugin(t *testing.T) {
+	useWorkBuddyReleaseBinary(t)
 	home := filepath.Join(t.TempDir(), "workbuddy")
 	t.Setenv("WORKBUDDY_HOME", home)
 	t.Setenv("POWERCONTEXT_HOME", filepath.Join(t.TempDir(), "data"))
@@ -474,9 +690,18 @@ func TestBundledWorkBuddyPluginCarriesInstallableHooksSkillAndMCP(t *testing.T) 
 		entry["disabled"] != false {
 		t.Fatalf("bundled WorkBuddy MCP entry = %#v", entry)
 	}
+	hookTemplate, readErr := os.ReadFile(filepath.Join(plugin, "hooks", "hooks.workbuddy.json"))
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if strings.Contains(string(hookTemplate), "${POWERCONTEXT_RELEASE_BINARY}") ||
+		strings.Contains(string(hookTemplate), "${POWERCONTEXT_PYTHON}") {
+		t.Fatalf("bundled WorkBuddy Hook template carries an unowned runtime placeholder: %q", hookTemplate)
+	}
 }
 
 func TestDoctorWorkBuddyChecksTheConfiguredServerReadiness(t *testing.T) {
+	useWorkBuddyReleaseBinary(t)
 	checkout := filepath.Join(t.TempDir(), "powercontext")
 	writeWorkBuddyPlugin(t, checkout)
 	home := filepath.Join(t.TempDir(), "workbuddy")
@@ -507,6 +732,118 @@ func TestDoctorWorkBuddyChecksTheConfiguredServerReadiness(t *testing.T) {
 	}
 }
 
+func TestDoctorWorkBuddyRejectsForeignGoHookInBothRegistrationChecks(t *testing.T) {
+	binary := useWorkBuddyReleaseBinary(t)
+	checkout := filepath.Join(t.TempDir(), "powercontext")
+	writeWorkBuddyPlugin(t, checkout)
+	home := filepath.Join(t.TempDir(), "workbuddy")
+	t.Setenv("WORKBUDDY_HOME", home)
+	t.Setenv("POWERCONTEXT_HOME", filepath.Join(t.TempDir(), "data"))
+	if _, _, err := executeSystemCLI(t, nil, &scriptedSystemCommands{t: t}, "setup", "workbuddy", "--source", checkout); err != nil {
+		t.Fatal(err)
+	}
+	settingsPath := filepath.Join(home, "settings.json")
+	settings := readWorkBuddyJSON(t, settingsPath)
+	matchers := settings["hooks"].(map[string]any)["UserPromptSubmit"].([]any)
+	entry := matchers[0].(map[string]any)["hooks"].([]any)[0].(map[string]any)
+	entry["command"] = shellQuoteWorkBuddy(filepath.Join(filepath.Dir(binary), "other-powercontext")) + " hook workbuddy"
+	writeWorkBuddyTestJSON(t, settingsPath, settings)
+
+	stdout, _, err := executeSystemCLI(t, nil, &scriptedSystemCommands{t: t}, "doctor", "workbuddy", "--json")
+	if err == nil || !ErrorAlreadyReported(err) || ExitCode(err) != 1 {
+		t.Fatalf("doctor error = %v, exit = %d", err, ExitCode(err))
+	}
+	checks := decodeSystemOutput(t, stdout)["checks"].(map[string]any)
+	for _, name := range []string{"hooks", "settings"} {
+		if checks[name].(map[string]any)["status"] != "failed" {
+			t.Fatalf("doctor %s check = %#v", name, checks[name])
+		}
+	}
+}
+
+func TestDoctorWorkBuddyRejectsAdditionalForeignGoHookInBothRegistrationChecks(t *testing.T) {
+	binary := useWorkBuddyReleaseBinary(t)
+	checkout := filepath.Join(t.TempDir(), "powercontext")
+	writeWorkBuddyPlugin(t, checkout)
+	home := filepath.Join(t.TempDir(), "workbuddy")
+	t.Setenv("WORKBUDDY_HOME", home)
+	t.Setenv("POWERCONTEXT_HOME", filepath.Join(t.TempDir(), "data"))
+	if _, _, err := executeSystemCLI(t, nil, &scriptedSystemCommands{t: t}, "setup", "workbuddy", "--source", checkout); err != nil {
+		t.Fatal(err)
+	}
+	settingsPath := filepath.Join(home, "settings.json")
+	settings := readWorkBuddyJSON(t, settingsPath)
+	matchers := settings["hooks"].(map[string]any)["UserPromptSubmit"].([]any)
+	entries := matchers[0].(map[string]any)["hooks"].([]any)
+	entries = append(entries, map[string]any{
+		"type": "command", "command": shellQuoteWorkBuddy(filepath.Join(filepath.Dir(binary), "other-powercontext")) + " hook workbuddy",
+	})
+	matchers[0].(map[string]any)["hooks"] = entries
+	writeWorkBuddyTestJSON(t, settingsPath, settings)
+
+	stdout, _, err := executeSystemCLI(t, nil, &scriptedSystemCommands{t: t}, "doctor", "workbuddy", "--json")
+	if err == nil || !ErrorAlreadyReported(err) || ExitCode(err) != 1 {
+		t.Fatalf("doctor error = %v, exit = %d", err, ExitCode(err))
+	}
+	checks := decodeSystemOutput(t, stdout)["checks"].(map[string]any)
+	for _, name := range []string{"hooks", "settings"} {
+		if checks[name].(map[string]any)["status"] != "failed" {
+			t.Fatalf("doctor %s check = %#v", name, checks[name])
+		}
+	}
+}
+
+func TestDoctorWorkBuddyRejectsNonCommandExactGoHookInBothRegistrationChecks(t *testing.T) {
+	useWorkBuddyReleaseBinary(t)
+	checkout := filepath.Join(t.TempDir(), "powercontext")
+	writeWorkBuddyPlugin(t, checkout)
+	home := filepath.Join(t.TempDir(), "workbuddy")
+	t.Setenv("WORKBUDDY_HOME", home)
+	t.Setenv("POWERCONTEXT_HOME", filepath.Join(t.TempDir(), "data"))
+	if _, _, err := executeSystemCLI(t, nil, &scriptedSystemCommands{t: t}, "setup", "workbuddy", "--source", checkout); err != nil {
+		t.Fatal(err)
+	}
+	settingsPath := filepath.Join(home, "settings.json")
+	settings := readWorkBuddyJSON(t, settingsPath)
+	matchers := settings["hooks"].(map[string]any)["UserPromptSubmit"].([]any)
+	entry := matchers[0].(map[string]any)["hooks"].([]any)[0].(map[string]any)
+	entry["type"] = "script"
+	writeWorkBuddyTestJSON(t, settingsPath, settings)
+
+	stdout, _, err := executeSystemCLI(t, nil, &scriptedSystemCommands{t: t}, "doctor", "workbuddy", "--json")
+	if err == nil || !ErrorAlreadyReported(err) || ExitCode(err) != 1 {
+		t.Fatalf("doctor error = %v, exit = %d", err, ExitCode(err))
+	}
+	checks := decodeSystemOutput(t, stdout)["checks"].(map[string]any)
+	for _, name := range []string{"hooks", "settings"} {
+		if checks[name].(map[string]any)["status"] != "failed" {
+			t.Fatalf("doctor %s check = %#v", name, checks[name])
+		}
+	}
+}
+
+func TestDoctorWorkBuddyRejectsInstalledSkillWithRetiredPythonMaterial(t *testing.T) {
+	useWorkBuddyReleaseBinary(t)
+	checkout := filepath.Join(t.TempDir(), "powercontext")
+	writeWorkBuddyPlugin(t, checkout)
+	home := filepath.Join(t.TempDir(), "workbuddy")
+	t.Setenv("WORKBUDDY_HOME", home)
+	t.Setenv("POWERCONTEXT_HOME", filepath.Join(t.TempDir(), "data"))
+	if _, _, err := executeSystemCLI(t, nil, &scriptedSystemCommands{t: t}, "setup", "workbuddy", "--source", checkout); err != nil {
+		t.Fatal(err)
+	}
+	writeTestFile(t, filepath.Join(home, "skills", workBuddySkillName, "SKILL.md"), "python3 /old/powercontext_project_scope.py\n")
+
+	stdout, _, err := executeSystemCLI(t, nil, &scriptedSystemCommands{t: t}, "doctor", "workbuddy", "--json")
+	if err == nil || !ErrorAlreadyReported(err) || ExitCode(err) != 1 {
+		t.Fatalf("doctor error = %v, exit = %d", err, ExitCode(err))
+	}
+	checks := decodeSystemOutput(t, stdout)["checks"].(map[string]any)
+	if checks["skill"].(map[string]any)["status"] != "failed" {
+		t.Fatalf("doctor skill check = %#v", checks["skill"])
+	}
+}
+
 func TestDoctorWorkBuddyRedactsInvalidCredentialConfiguration(t *testing.T) {
 	home := filepath.Join(t.TempDir(), "workbuddy")
 	secret := "workbuddy-should-not-appear"
@@ -532,6 +869,59 @@ func writeWorkBuddyPlugin(t *testing.T, root string) string {
 	writeTestFile(t, filepath.Join(plugin, "scripts", "project_scope.py"), "def resolve_scope_id(*_args): return 'scope'\n")
 	writeTestFile(t, filepath.Join(plugin, "skills", "project-context", "SKILL.md"), "${POWERCONTEXT_PYTHON} ${POWERCONTEXT_PROJECT_SCOPE_SCRIPT}\n")
 	resolved, err := resolvePath(plugin)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return resolved
+}
+
+func useWorkBuddyReleaseBinary(t *testing.T) string {
+	t.Helper()
+	return useWorkBuddyReleaseBinaryWithMode(t, 0o755)
+}
+
+func useWorkBuddyReleaseBinaryWithMode(t *testing.T, mode os.FileMode) string {
+	t.Helper()
+	binary := writeWorkBuddyReleaseBinary(t, mode)
+	previous := workBuddyExecutable
+	workBuddyExecutable = func() (string, error) { return binary, nil }
+	t.Cleanup(func() { workBuddyExecutable = previous })
+	return binary
+}
+
+func writeWorkBuddyReleaseBinary(t *testing.T, mode os.FileMode) string {
+	t.Helper()
+	root := t.TempDir()
+	binary := filepath.Join(root, "bin", "powercontext")
+	for _, path := range []string{
+		binary,
+		filepath.Join(root, "BUILD-INFO.json"),
+		filepath.Join(root, ".env.example"),
+		filepath.Join(root, "openapi", "powercontext.yaml"),
+		filepath.Join(root, workBuddyRelative, "hooks", "workbuddy_powercontext_hook.py"),
+		filepath.Join(root, workBuddyRelative, "hooks", "workbuddy_settings.py"),
+		filepath.Join(root, workBuddyRelative, "hooks", "prepared_context.py"),
+		filepath.Join(root, workBuddyRelative, "powercontext.json.example"),
+		filepath.Join(root, workBuddyRelative, "scripts", "project_scope.py"),
+		filepath.Join(root, workBuddyRelative, "skills", workBuddySkillName, "SKILL.md"),
+	} {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		fileMode := os.FileMode(0o644)
+		if path == binary {
+			fileMode = mode
+		}
+		if err := os.WriteFile(path, []byte("test\n"), fileMode); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return binary
+}
+
+func resolveWorkBuddyTestPath(t *testing.T, path string) string {
+	t.Helper()
+	resolved, err := resolvePath(path)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -164,7 +164,7 @@ func newCommandWithAllDependencies(
 	root.AddCommand(
 		newCapabilitiesCommand(state), newStatsCommand(state), newLiveCommand(state), newReadyCommand(state),
 		newCandidateCommand(state), newConfigCommand(state), newExperienceCommand(state), newSkillCommand(state), newExternalSkillCommand(state),
-		newServerCommand(state), newSetupCommand(state), newDoctorCommand(state),
+		newServerCommand(state), newSetupCommand(state), newDoctorCommand(state), newHookCommand(state),
 	)
 	return root
 }
@@ -205,7 +205,7 @@ func ErrorAlreadyReported(err error) bool {
 func needsRemoteClient(command *cobra.Command) bool {
 	for current := command; current != nil; current = current.Parent() {
 		switch current.Name() {
-		case "server", "setup", "doctor":
+		case "server", "setup", "doctor", "hook":
 			return false
 		}
 	}

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -30,7 +30,7 @@ func TestCommandTreeContainsProductCommands(t *testing.T) {
 	root := newCommand(VersionInfo{Version: "test"}, &bytes.Buffer{}, &bytes.Buffer{})
 	want := []string{
 		"candidate", "capabilities", "config", "doctor", "experience", "external-skill",
-		"live", "ready", "server", "setup", "skill", "stats",
+		"hook", "live", "ready", "server", "setup", "skill", "stats",
 	}
 	got := make([]string, 0, len(root.Commands()))
 	for _, command := range root.Commands() {

--- a/internal/cli/workbuddy_hook.go
+++ b/internal/cli/workbuddy_hook.go
@@ -1,0 +1,545 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/json/v2"
+	"errors"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/go-faster/jx"
+	"github.com/spf13/cobra"
+
+	v1 "github.com/ob-labs/powercontext-go/api/v1"
+	pcclient "github.com/ob-labs/powercontext-go/client"
+	"github.com/ob-labs/powercontext-go/internal/transportpolicy"
+)
+
+const (
+	workBuddyHookMaximumInputBytes  = 64 * 1024
+	workBuddyHookMaximumOutputBytes = 64 * 1024
+	workBuddyHookMaximumScopeBytes  = 256
+)
+
+var (
+	errWorkBuddyHookPlaintextNonLoopback = errors.New("WorkBuddy Hook refuses plaintext HTTP to a non-loopback host")
+	errWorkBuddyHookResponseTooLarge     = errors.New("WorkBuddy Hook response exceeds the configured byte limit")
+)
+
+const (
+	workBuddyHookScopeEnvironment = "POWERCONTEXT_WORKBUDDY_SCOPE_ID"
+	workBuddyHookWorkspaceSchema  = "powercontext.codex-workspace.v1"
+)
+
+var workBuddyHookSCPRemote = regexp.MustCompile(`^(?:[^@/\s]+@)?([^:/\s]+):(.+)$`)
+
+type workBuddyHookPayload struct {
+	HookEventName string `json:"hook_event_name"`
+	Prompt        string `json:"prompt"`
+	UserPrompt    string `json:"user_prompt"`
+	CWD           string `json:"cwd"`
+	SessionID     string `json:"session_id"`
+	PromptID      string `json:"prompt_id"`
+	RequestID     string `json:"request_id"`
+}
+
+type workBuddyHookResponse struct {
+	HookSpecificOutput struct {
+		HookEventName     string `json:"hookEventName"`
+		AdditionalContext string `json:"additionalContext"`
+	} `json:"hookSpecificOutput"`
+}
+
+type workBuddyHookRuntime struct {
+	configuration workBuddyConfiguration
+	getenv        func(string) string
+	httpClient    *http.Client
+	now           func() time.Time
+}
+
+func newHookCommand(state *commandState) *cobra.Command {
+	command := &cobra.Command{
+		Use:   "hook",
+		Short: "Run PowerContext host integration hooks.",
+		Args:  cobra.NoArgs,
+	}
+	command.AddCommand(newWorkBuddyHookCommand(state))
+	return command
+}
+
+func newWorkBuddyHookCommand(state *commandState) *cobra.Command {
+	return &cobra.Command{
+		Use:   "workbuddy",
+		Short: "Handle one WorkBuddy hook payload.",
+		Args:  cobra.NoArgs,
+		RunE: func(command *cobra.Command, _ []string) error {
+			configuration := workBuddyHookConfiguration()
+			return runWorkBuddyHook(command.Context(), command.InOrStdin(), state.stdout, state.stderr, workBuddyHookRuntime{
+				configuration: configuration,
+			})
+		},
+	}
+}
+
+func workBuddyHookConfiguration() workBuddyConfiguration {
+	home, err := workBuddyHome()
+	if err != nil {
+		return workBuddyConfiguration{}
+	}
+	configuration, present, err := readWorkBuddyConfiguration(filepath.Join(home, workBuddyConfigFilename))
+	if err != nil || !present {
+		return workBuddyConfiguration{}
+	}
+	return configuration
+}
+
+// runWorkBuddyHook implements the process-level fail-open contract. Scope
+func runWorkBuddyHook(
+	ctx context.Context,
+	input io.Reader,
+	output, diagnostics io.Writer,
+	runtime workBuddyHookRuntime,
+) error {
+	_ = diagnostics
+
+	payload, err := decodeWorkBuddyHookPayload(input)
+	if err != nil {
+		return writeWorkBuddyHookResponse(output, "")
+	}
+	if payload.HookEventName != "UserPromptSubmit" {
+		return nil
+	}
+	if validateWorkBuddyConfiguration(runtime.configuration) != nil || strings.TrimSpace(workBuddyHookPrompt(payload)) == "" || payload.CWD == "" {
+		return writeWorkBuddyHookResponse(output, "")
+	}
+
+	getenv := runtime.getenv
+	if getenv == nil {
+		getenv = os.Getenv
+	}
+	now := runtime.now
+	if now == nil {
+		now = time.Now
+	}
+	budget := time.Duration(runtime.configuration.RequestBudgetSeconds * float64(time.Second))
+	operationContext, cancel := context.WithTimeout(ctx, budget)
+	defer cancel()
+
+	scope, ok := resolveWorkBuddyHookScope(operationContext, payload.CWD, runtime.configuration.ScopeMode, getenv)
+	if !ok {
+		return writeWorkBuddyHookResponse(output, "")
+	}
+	client, ok := newWorkBuddyHookClient(operationContext, runtime.configuration, getenv, runtime.httpClient, now)
+	if !ok {
+		return writeWorkBuddyHookResponse(output, "")
+	}
+
+	additionalContext := recallWorkBuddyContext(operationContext, client, payload, scope, runtime.configuration)
+	prompt := workBuddyHookPrompt(payload)
+	if workBuddyHookBool(getenv, "POWERCONTEXT_WORKBUDDY_CAPTURE_PROMPTS", true) && len([]byte(prompt)) <= runtime.configuration.SourceMaxBytes {
+		position := captureWorkBuddyPrompt(operationContext, client, payload, prompt, scope)
+		if workBuddyHookBool(getenv, "POWERCONTEXT_WORKBUDDY_FLUSH_ON_CAPTURE", false) {
+			flushWorkBuddyPrompt(operationContext, client, scope, position, workBuddyHookFlushMaxCalls(getenv))
+		}
+	}
+	return writeWorkBuddyHookResponse(output, additionalContext)
+}
+
+func recallWorkBuddyContext(ctx context.Context, client *pcclient.Client, payload workBuddyHookPayload, scope string, configuration workBuddyConfiguration) string {
+	prompt := workBuddyHookPrompt(payload)
+	prepared, err := client.PrepareContext(ctx, &v1.PrepareContextRequest{ScopeID: scope, Query: prompt, MaxBytes: v1.OptInt{Value: configuration.PrepareMaxBytes, Set: true}})
+	if err != nil {
+		return ""
+	}
+	return preparedWorkBuddyContext(prepared, configuration.PrepareMaxBytes)
+}
+
+func newWorkBuddyHookClient(ctx context.Context, configuration workBuddyConfiguration, getenv func(string) string, supplied *http.Client, now func() time.Time) (*pcclient.Client, bool) {
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		return nil, false
+	}
+	remaining := deadline.Sub(now())
+	if remaining <= 0 {
+		return nil, false
+	}
+	timeout := time.Duration(configuration.RequestTimeoutSeconds * float64(time.Second))
+	if remaining < timeout {
+		timeout = remaining
+	}
+	result, err := pcclient.New(configuration.ServerURL, pcclient.Options{BearerToken: workBuddyHookBearerToken(getenv(configuration.AuthorizationEnvironment)), Timeout: timeout, HTTPClient: workBuddyHookHTTPClient(supplied, workBuddyHookResponseLimit(configuration))})
+	return result, err == nil
+}
+
+func workBuddyHookBearerToken(authorization string) string {
+	value := strings.TrimSpace(authorization)
+	token, hasBearerPrefix := strings.CutPrefix(value, "Bearer ")
+	if !hasBearerPrefix {
+		return value
+	}
+	return strings.TrimSpace(token)
+}
+
+func workBuddyHookResponseLimit(configuration workBuddyConfiguration) int {
+	return max(configuration.PrepareMaxBytes, configuration.SourceMaxBytes)
+}
+
+func workBuddyHookHTTPClient(supplied *http.Client, responseLimit ...int) *http.Client {
+	var result http.Client
+	if supplied != nil {
+		result = *supplied
+	}
+	next := result.Transport
+	transport, ok := next.(*http.Transport)
+	if ok || next == nil {
+		if !ok {
+			transport = http.DefaultTransport.(*http.Transport)
+		}
+		transport = transport.Clone()
+		proxy := transport.Proxy
+		if proxy == nil {
+			proxy = http.ProxyFromEnvironment
+		}
+		transport.Proxy = func(request *http.Request) (*url.URL, error) {
+			if transportpolicy.IsLoopbackHost(request.URL.Hostname()) {
+				return nil, nil
+			}
+			return proxy(request)
+		}
+		next = transport
+	}
+	maximum := workBuddyHookMaximumOutputBytes
+	if len(responseLimit) > 0 && responseLimit[0] > 0 {
+		maximum = responseLimit[0]
+	}
+	result.Transport = workBuddyHookResponseRoundTripper{next: next, maximum: int64(maximum)}
+	return &result
+}
+
+type workBuddyHookResponseRoundTripper struct {
+	next    http.RoundTripper
+	maximum int64
+}
+
+func (transport workBuddyHookResponseRoundTripper) RoundTrip(request *http.Request) (*http.Response, error) {
+	if transportpolicy.IsPlaintextNonLoopback(request.URL) {
+		return nil, errWorkBuddyHookPlaintextNonLoopback
+	}
+	response, err := transport.next.RoundTrip(request)
+	if err != nil || response == nil || response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices || response.Body == nil {
+		return response, err
+	}
+	if response.ContentLength > transport.maximum {
+		return nil, errors.Join(errWorkBuddyHookResponseTooLarge, response.Body.Close())
+	}
+	response.Body = &workBuddyHookResponseBody{body: response.Body, remaining: transport.maximum}
+	return response, nil
+}
+
+type workBuddyHookResponseBody struct {
+	body      io.ReadCloser
+	remaining int64
+	exceeded  bool
+}
+
+func (body *workBuddyHookResponseBody) Read(buffer []byte) (int, error) {
+	if body.exceeded {
+		return 0, errWorkBuddyHookResponseTooLarge
+	}
+	if body.remaining == 0 {
+		var probe [1]byte
+		count, err := body.body.Read(probe[:])
+		if count > 0 {
+			body.exceeded = true
+			return 0, errors.Join(errWorkBuddyHookResponseTooLarge, err)
+		}
+		return 0, err
+	}
+	if int64(len(buffer)) > body.remaining {
+		buffer = buffer[:body.remaining]
+	}
+	count, err := body.body.Read(buffer)
+	body.remaining -= int64(count)
+	return count, err
+}
+
+func (body *workBuddyHookResponseBody) Close() error {
+	return body.body.Close()
+}
+
+func resolveWorkBuddyHookScope(ctx context.Context, cwd, mode string, getenv func(string) string) (string, bool) {
+	if explicit := strings.TrimSpace(getenv(workBuddyHookScopeEnvironment)); explicit != "" {
+		return boundedWorkBuddyScope("", explicit), true
+	}
+	if mode == "agent" {
+		return "workbuddy:agent", true
+	}
+	if mode != "project" {
+		return "", false
+	}
+	if gitDirectory := workBuddyHookGitValue(ctx, cwd, "rev-parse", "--absolute-git-dir"); gitDirectory != "" {
+		if scope, ok := readWorkBuddyHookBoundScope(filepath.Join(gitDirectory, "powercontext", "codex-workspace.json")); ok {
+			return scope, true
+		}
+	}
+	projectRoot := workBuddyHookProjectRoot(cwd)
+	if root := workBuddyHookGitValue(ctx, cwd, "rev-parse", "--show-toplevel"); root != "" {
+		projectRoot = workBuddyHookProjectRoot(root)
+	}
+	if remote := workBuddyHookGitValue(ctx, projectRoot, "config", "--get", "remote.origin.url"); remote != "" {
+		if normalized := normalizeWorkBuddyHookGitRemote(remote); normalized != "" {
+			return boundedWorkBuddyScope("git", normalized), true
+		}
+	}
+	sum := sha256.Sum256([]byte(projectRoot))
+	return "local:" + fmtHex(sum[:]), true
+}
+
+func boundedWorkBuddyScope(prefix, value string) string {
+	candidate := value
+	if prefix != "" {
+		candidate = prefix + ":" + value
+	}
+	if len(candidate) <= workBuddyHookMaximumScopeBytes {
+		return candidate
+	}
+	sum := sha256.Sum256([]byte(value))
+	if prefix == "" {
+		return "sha256:" + fmtHex(sum[:])
+	}
+	return prefix + ":sha256:" + fmtHex(sum[:])
+}
+
+func readWorkBuddyHookBoundScope(path string) (string, bool) {
+	payload, err := os.ReadFile(path)
+	if err != nil {
+		return "", false
+	}
+	var state struct {
+		Schema  string `json:"schema"`
+		ScopeID string `json:"scope_id"`
+	}
+	if err := json.Unmarshal(payload, &state); err != nil || state.Schema != workBuddyHookWorkspaceSchema || strings.TrimSpace(state.ScopeID) != state.ScopeID || state.ScopeID == "" || len(state.ScopeID) > workBuddyHookMaximumScopeBytes {
+		return "", false
+	}
+	return state.ScopeID, true
+}
+
+func workBuddyHookGitValue(ctx context.Context, cwd string, arguments ...string) string {
+	executable, err := exec.LookPath("git")
+	if err != nil {
+		return ""
+	}
+	commandContext, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	command := exec.CommandContext(commandContext, executable, arguments...)
+	command.Dir = cwd
+	output, err := command.Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(output))
+}
+
+func workBuddyHookProjectRoot(cwd string) string {
+	root, err := filepath.Abs(cwd)
+	if err != nil {
+		return filepath.Clean(cwd)
+	}
+	if resolved, err := filepath.EvalSymlinks(root); err == nil {
+		return resolved
+	}
+	return filepath.Clean(root)
+}
+
+func normalizeWorkBuddyHookGitRemote(remote string) string {
+	value := strings.TrimSpace(remote)
+	if value == "" {
+		return ""
+	}
+	if matched := workBuddyHookSCPRemote.FindStringSubmatch(value); matched != nil && !strings.Contains(value, "://") {
+		if path := normalizeWorkBuddyHookGitPath(matched[2]); path != "" {
+			return strings.ToLower(matched[1]) + "/" + path
+		}
+		return ""
+	}
+	parsed, err := url.Parse(value)
+	if err != nil || (parsed.Scheme != "http" && parsed.Scheme != "https" && parsed.Scheme != "ssh" && parsed.Scheme != "git") || parsed.Hostname() == "" {
+		return ""
+	}
+	path := normalizeWorkBuddyHookGitPath(parsed.Path)
+	if path == "" {
+		return ""
+	}
+	host := strings.ToLower(parsed.Hostname())
+	if port := parsed.Port(); port != "" {
+		host += ":" + port
+	}
+	return host + "/" + path
+}
+
+func normalizeWorkBuddyHookGitPath(path string) string {
+	parts := strings.Split(strings.ReplaceAll(path, `\`, "/"), "/")
+	normalized := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if part != "" {
+			normalized = append(normalized, part)
+		}
+	}
+	result := strings.Join(normalized, "/")
+	return strings.TrimSuffix(result, ".git")
+}
+
+func fmtHex(value []byte) string {
+	const digits = "0123456789abcdef"
+	result := make([]byte, len(value)*2)
+	for index, item := range value {
+		result[index*2] = digits[item>>4]
+		result[index*2+1] = digits[item&15]
+	}
+	return string(result)
+}
+
+func preparedWorkBuddyContext(response v1.PrepareContextRes, maximum int) string {
+	value, ok := response.(*v1.PreparedContextHeaders)
+	if !ok || value.Response.Schema != v1.PreparedContextSchemaPowercontextPreparedContextV1 || value.Response.Status != v1.PreparedContextStatusReady || value.Response.ContentBytes < 0 || value.Response.ContentBytes > maximum {
+		return ""
+	}
+	content, ok := value.Response.Content.Get()
+	if !ok || len([]byte(content)) != value.Response.ContentBytes || len([]byte(content)) > maximum {
+		return ""
+	}
+	return content
+}
+
+func captureWorkBuddyPrompt(ctx context.Context, client *pcclient.Client, payload workBuddyHookPayload, prompt, scope string) int {
+	session := strings.TrimSpace(payload.SessionID)
+	promptID := strings.TrimSpace(payload.PromptID)
+	if promptID == "" {
+		promptID = strings.TrimSpace(payload.RequestID)
+	}
+	sum := sha256.Sum256([]byte(scope + "\x00" + session + "\x00" + promptID + "\x00" + prompt))
+	metadata, ok := workBuddyHookCaptureMetadata(payload.CWD, session, promptID)
+	if !ok {
+		return 0
+	}
+	response, err := client.CaptureContentSource(ctx, &v1.CaptureContentSourceRequest{
+		ScopeID: scope, SourceID: "workbuddy-user-prompt:" + fmtHex(sum[:]), Content: prompt,
+		Metadata: v1.NewOptNilCaptureContentSourceRequestMetadata(metadata),
+	})
+	value, ok := response.(*v1.CaptureContentSourceResponseHeaders)
+	if err != nil || !ok || value.Response.Status != v1.CaptureStatusAccepted || value.Response.Position < 1 {
+		return 0
+	}
+	return value.Response.Position
+}
+
+func workBuddyHookCaptureMetadata(cwd, sessionID, promptID string) (v1.CaptureContentSourceRequestMetadata, bool) {
+	values := map[string]string{
+		"origin": "workbuddy",
+		"event":  "user_prompt_submit",
+		"cwd":    cwd,
+	}
+	if sessionID != "" {
+		values["session_id"] = sessionID
+	}
+	if promptID != "" {
+		values["prompt_id"] = promptID
+	}
+	metadata := make(v1.CaptureContentSourceRequestMetadata, len(values))
+	for name, value := range values {
+		encoded, err := json.Marshal(value)
+		if err != nil {
+			return nil, false
+		}
+		metadata[name] = jx.Raw(encoded)
+	}
+	return metadata, true
+}
+
+func flushWorkBuddyPrompt(ctx context.Context, client *pcclient.Client, scope string, position, maximum int) {
+	if position == 0 {
+		return
+	}
+	for range maximum {
+		response, err := client.FlushMemory(ctx, &v1.FlushMemoryRequest{ScopeID: scope})
+		value, ok := response.(*v1.FlushMemoryResponseHeaders)
+		if err != nil || !ok || value.Response.CurrentCursor >= position {
+			return
+		}
+	}
+}
+
+func workBuddyHookBool(getenv func(string) string, name string, fallback bool) bool {
+	value := strings.ToLower(strings.TrimSpace(getenv(name)))
+	if value == "" {
+		return fallback
+	}
+	return value == "1" || value == "true" || value == "yes" || value == "on"
+}
+
+func workBuddyHookFlushMaxCalls(getenv func(string) string) int {
+	value, err := strconv.Atoi(strings.TrimSpace(getenv("POWERCONTEXT_WORKBUDDY_FLUSH_MAX_CALLS")))
+	if err != nil || value < 1 || value > 16 {
+		return 4
+	}
+	return value
+}
+
+func decodeWorkBuddyHookPayload(input io.Reader) (workBuddyHookPayload, error) {
+	payload, err := io.ReadAll(io.LimitReader(input, workBuddyHookMaximumInputBytes+1))
+	if err != nil || len(payload) > workBuddyHookMaximumInputBytes || !utf8.Valid(payload) {
+		return workBuddyHookPayload{}, io.ErrUnexpectedEOF
+	}
+	var decoded workBuddyHookPayload
+	if err := json.Unmarshal(payload, &decoded, json.RejectUnknownMembers(true)); err != nil {
+		return workBuddyHookPayload{}, err
+	}
+	return decoded, nil
+}
+
+func workBuddyHookPrompt(payload workBuddyHookPayload) string {
+	if payload.Prompt != "" {
+		return payload.Prompt
+	}
+	return payload.UserPrompt
+}
+
+func writeWorkBuddyHookResponse(output io.Writer, additionalContext string) error {
+	var response workBuddyHookResponse
+	response.HookSpecificOutput.HookEventName = "UserPromptSubmit"
+	response.HookSpecificOutput.AdditionalContext = additionalContext
+	payload, err := json.Marshal(response)
+	if err != nil || len(payload)+1 > workBuddyHookMaximumOutputBytes {
+		if additionalContext != "" {
+			return writeWorkBuddyHookResponse(output, "")
+		}
+		return nil
+	}
+	_, _ = output.Write(append(payload, '\n'))
+	return nil
+}

--- a/internal/cli/workbuddy_hook_test.go
+++ b/internal/cli/workbuddy_hook_test.go
@@ -1,0 +1,873 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json/v2"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+
+	v1 "github.com/ob-labs/powercontext-go/api/v1"
+)
+
+const workBuddyHookEmptyResponse = `{"hookSpecificOutput":{"hookEventName":"UserPromptSubmit","additionalContext":""}}` + "\n"
+
+func TestWorkBuddyHookCommandWritesStableEmptyContext(t *testing.T) {
+	home := filepath.Join(t.TempDir(), "workbuddy")
+	t.Setenv(workBuddyHomeEnv, home)
+	t.Setenv(clientURLVar, "://invalid-client-url")
+	t.Setenv(clientTimeoutVar, "invalid-client-timeout")
+	writeWorkBuddyHookConfiguration(t, home)
+
+	var stdout, stderr bytes.Buffer
+	command := newCommandWithAllDependencies(
+		VersionInfo{Version: "test"}, &stdout, &stderr, nil, nil, &scriptedSystemCommands{t: t},
+	)
+	command.SetIn(strings.NewReader(`{"hook_event_name":"UserPromptSubmit","prompt":"secret-prompt","cwd":"C:/workspace"}`))
+	command.SetArgs([]string{"hook", "workbuddy"})
+	if err := command.ExecuteContext(t.Context()); err != nil {
+		t.Fatalf("ExecuteContext() error = %v", err)
+	}
+	if got := stdout.String(); got != workBuddyHookEmptyResponse {
+		t.Fatalf("hook stdout = %q, want %q", got, workBuddyHookEmptyResponse)
+	}
+	if got := stderr.String(); got != "" {
+		t.Fatalf("hook diagnostics = %q, want empty", got)
+	}
+}
+
+func TestWorkBuddyHookRecallCaptureFlush(t *testing.T) {
+	var paths []string
+	handler := http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		paths = append(paths, request.URL.Path)
+		switch request.URL.Path {
+		case "/v1/context/prepare":
+			var body struct {
+				ScopeID  string `json:"scope_id"`
+				MaxBytes int    `json:"max_bytes"`
+			}
+			if err := json.UnmarshalRead(request.Body, &body); err != nil {
+				t.Fatal(err)
+			}
+			if body.ScopeID != "workbuddy:agent" || body.MaxBytes != 8000 {
+				t.Fatalf("prepare = %#v", body)
+			}
+			writer.Header().Set("Content-Type", "application/json")
+			_, _ = writer.Write([]byte(`{"schema":"powercontext.prepared-context.v1","status":"ready","content":"remembered","content_bytes":10}`))
+		case "/v1/sources/content":
+			type captureBody struct {
+				ScopeID  string            `json:"scope_id"`
+				SourceID string            `json:"source_id"`
+				Content  string            `json:"content"`
+				Metadata map[string]string `json:"metadata"`
+			}
+			var body captureBody
+			if err := json.UnmarshalRead(request.Body, &body); err != nil {
+				t.Fatal(err)
+			}
+			sum := sha256.Sum256([]byte("workbuddy:agent\x00session\x00request\x00hello"))
+			want := captureBody{
+				ScopeID: "workbuddy:agent", SourceID: "workbuddy-user-prompt:" + hex.EncodeToString(sum[:]), Content: "hello",
+				Metadata: map[string]string{
+					"origin": "workbuddy", "event": "user_prompt_submit", "cwd": "C:/workspace",
+					"session_id": "session", "prompt_id": "request",
+				},
+			}
+			if diff := cmp.Diff(want, body); diff != "" {
+				t.Fatalf("capture body (-want +got):\n%s", diff)
+			}
+			writer.Header().Set("Content-Type", "application/json")
+			writer.WriteHeader(http.StatusAccepted)
+			_, _ = writer.Write([]byte(`{"status":"accepted","source":{"name":"content","source_id":"x"},"position":2}`))
+		case "/v1/memory/flush":
+			writer.Header().Set("Content-Type", "application/json")
+			_, _ = writer.Write([]byte(`{"status":"processed","previous_cursor":0,"current_cursor":2,"high_watermark":2,"processed_source_count":1}`))
+		default:
+			writer.WriteHeader(http.StatusNotFound)
+		}
+	})
+	client := &http.Client{Transport: workBuddyHookRoundTripper(func(request *http.Request) (*http.Response, error) {
+		writer := httptest.NewRecorder()
+		handler.ServeHTTP(writer, request)
+		response := writer.Result()
+		response.Request = request
+		return response, nil
+	})}
+	t.Setenv("POWERCONTEXT_WORKBUDDY_CAPTURE_PROMPTS", "true")
+	t.Setenv("POWERCONTEXT_WORKBUDDY_FLUSH_ON_CAPTURE", "true")
+	var output, diagnostics bytes.Buffer
+	err := runWorkBuddyHook(t.Context(), strings.NewReader(`{"hook_event_name":"UserPromptSubmit","prompt":"hello","cwd":"C:/workspace","session_id":"session","request_id":"request"}`), &output, &diagnostics, workBuddyHookRuntime{configuration: workBuddyConfiguration{
+		Schema: workBuddyConfigSchema, ServerURL: "http://127.0.0.1:8000", ScopeMode: "agent", AuthorizationEnvironment: workBuddyDefaultAuthorizationEnvironment,
+		RequestTimeoutSeconds: 1, RequestBudgetSeconds: 2, PrepareMaxBytes: 8000, SourceMaxBytes: 16384,
+	}, httpClient: client})
+	if err != nil {
+		t.Fatalf("runWorkBuddyHook() error = %v", err)
+	}
+	if got, want := output.String(), `{"hookSpecificOutput":{"hookEventName":"UserPromptSubmit","additionalContext":"remembered"}}`+"\n"; got != want {
+		t.Fatalf("output = %q, want %q", got, want)
+	}
+	wantPaths := []string{"/v1/context/prepare", "/v1/sources/content", "/v1/memory/flush"}
+	if diff := cmp.Diff(wantPaths, paths); diff != "" {
+		t.Fatalf("request paths (-want +got):\n%s", diff)
+	}
+}
+
+func TestWorkBuddyHookEncodedResponseOverLimitWritesEmptyContext(t *testing.T) {
+	content := strings.Repeat("\x01", workBuddyMaximumPrepareBytes)
+	prepared := &v1.PreparedContextHeaders{Response: v1.PreparedContext{
+		Schema:  v1.PreparedContextSchemaPowercontextPreparedContextV1,
+		Status:  v1.PreparedContextStatusReady,
+		Content: v1.NewNilString(content), ContentBytes: len(content),
+	}}
+	additionalContext := preparedWorkBuddyContext(prepared, workBuddyMaximumPrepareBytes)
+	if additionalContext != content {
+		t.Fatal("valid prepared context was rejected before protocol encoding")
+	}
+
+	var output bytes.Buffer
+	if err := writeWorkBuddyHookResponse(&output, additionalContext); err != nil {
+		t.Fatalf("writeWorkBuddyHookResponse() error = %v", err)
+	}
+	if got := output.String(); got != workBuddyHookEmptyResponse {
+		t.Fatalf("output = %q, want exact empty-context response", got)
+	}
+}
+
+func TestWorkBuddyHookPrepareFailureStillCapturesAndFlushes(t *testing.T) {
+	var paths []string
+	client := &http.Client{Transport: workBuddyHookRoundTripper(func(request *http.Request) (*http.Response, error) {
+		paths = append(paths, request.URL.Path)
+		writer := httptest.NewRecorder()
+		writer.Header().Set("Content-Type", "application/json")
+		switch request.URL.Path {
+		case "/v1/context/prepare":
+			writer.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = writer.Write([]byte(`{"error":{"code":"unavailable","message":"try later"}}`))
+		case "/v1/sources/content":
+			writer.WriteHeader(http.StatusAccepted)
+			_, _ = writer.Write([]byte(`{"status":"accepted","source":{"name":"content","source_id":"x"},"position":3}`))
+		case "/v1/memory/flush":
+			_, _ = writer.Write([]byte(`{"status":"processed","previous_cursor":0,"current_cursor":3,"high_watermark":3,"processed_source_count":1}`))
+		default:
+			writer.WriteHeader(http.StatusNotFound)
+		}
+		response := writer.Result()
+		response.Request = request
+		return response, nil
+	})}
+	t.Setenv("POWERCONTEXT_WORKBUDDY_CAPTURE_PROMPTS", "true")
+	t.Setenv("POWERCONTEXT_WORKBUDDY_FLUSH_ON_CAPTURE", "true")
+	var output, diagnostics bytes.Buffer
+	err := runWorkBuddyHook(t.Context(), strings.NewReader(`{"hook_event_name":"UserPromptSubmit","prompt":"hello","cwd":"C:/workspace","session_id":"session","prompt_id":"prompt"}`), &output, &diagnostics, workBuddyHookRuntime{configuration: workBuddyConfiguration{
+		Schema: workBuddyConfigSchema, ServerURL: "http://127.0.0.1:8000", ScopeMode: "agent", AuthorizationEnvironment: workBuddyDefaultAuthorizationEnvironment,
+		RequestTimeoutSeconds: 1, RequestBudgetSeconds: 2, PrepareMaxBytes: 8000, SourceMaxBytes: 16384,
+	}, httpClient: client})
+	if err != nil {
+		t.Fatalf("runWorkBuddyHook() error = %v", err)
+	}
+	if got := output.String(); got != workBuddyHookEmptyResponse {
+		t.Fatalf("output = %q, want empty recalled context", got)
+	}
+	wantPaths := []string{"/v1/context/prepare", "/v1/sources/content", "/v1/memory/flush"}
+	if diff := cmp.Diff(wantPaths, paths); diff != "" {
+		t.Fatalf("request paths (-want +got):\n%s", diff)
+	}
+}
+
+func TestWorkBuddyHookOverLimitPrepareResponseFailsOpenBeforeDecode(t *testing.T) {
+	const prepared = `{"schema":"powercontext.prepared-context.v1","status":"ready","content":"remembered","content_bytes":10}`
+	body := &workBuddyHookTrackedBody{Reader: strings.NewReader(prepared + strings.Repeat(" ", 8*1024))}
+	client := &http.Client{Transport: workBuddyHookRoundTripper(func(request *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode:    http.StatusOK,
+			Header:        http.Header{"Content-Type": []string{"application/json"}},
+			ContentLength: int64(len(prepared) + 8*1024),
+			Body:          body,
+			Request:       request,
+		}, nil
+	})}
+	getenv := func(name string) string {
+		if name == "POWERCONTEXT_WORKBUDDY_CAPTURE_PROMPTS" {
+			return "false"
+		}
+		return ""
+	}
+	var output, diagnostics bytes.Buffer
+	err := runWorkBuddyHook(t.Context(), strings.NewReader(`{"hook_event_name":"UserPromptSubmit","prompt":"hello","cwd":"C:/workspace"}`), &output, &diagnostics, workBuddyHookRuntime{
+		configuration: workBuddyConfiguration{
+			Schema: workBuddyConfigSchema, ServerURL: "http://127.0.0.1:8000", ScopeMode: "agent", AuthorizationEnvironment: workBuddyDefaultAuthorizationEnvironment,
+			RequestTimeoutSeconds: 1, RequestBudgetSeconds: 2, PrepareMaxBytes: 8000, SourceMaxBytes: 64,
+		},
+		getenv: getenv, httpClient: client,
+	})
+	if err != nil {
+		t.Fatalf("runWorkBuddyHook() error = %v", err)
+	}
+	if got := output.String(); got != workBuddyHookEmptyResponse {
+		t.Fatalf("output = %q, want empty recalled context", got)
+	}
+	if body.read > 0 {
+		t.Fatalf("generated client read %d over-limit response bytes", body.read)
+	}
+	if body.closes != 1 {
+		t.Fatalf("response body close calls = %d, want 1", body.closes)
+	}
+}
+
+func TestWorkBuddyHookResponseLimitPreservesErrorAndCloseMatching(t *testing.T) {
+	body := &workBuddyHookTrackedBody{Reader: strings.NewReader(strings.Repeat("x", 8001))}
+	ctx, cancel := context.WithDeadline(t.Context(), time.Now().Add(time.Second))
+	defer cancel()
+	client, ok := newWorkBuddyHookClient(ctx, workBuddyConfiguration{
+		Schema: workBuddyConfigSchema, ServerURL: "http://127.0.0.1:8000", ScopeMode: "agent", AuthorizationEnvironment: workBuddyDefaultAuthorizationEnvironment,
+		RequestTimeoutSeconds: 1, RequestBudgetSeconds: 2, PrepareMaxBytes: 8000, SourceMaxBytes: 64,
+	}, func(string) string { return "" }, &http.Client{Transport: workBuddyHookRoundTripper(func(request *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK, Header: http.Header{"Content-Type": []string{"application/json"}}, ContentLength: 8001, Body: body, Request: request,
+		}, nil
+	})}, time.Now)
+	if !ok {
+		t.Fatal("newWorkBuddyHookClient() did not construct a client")
+	}
+	_, err := client.PrepareContext(t.Context(), &v1.PrepareContextRequest{ScopeID: "scope", Query: "query"})
+	if !errors.Is(err, errWorkBuddyHookResponseTooLarge) {
+		t.Fatalf("PrepareContext() error = %v, want response limit error", err)
+	}
+	if body.read != 0 || body.closes != 1 {
+		t.Fatalf("over-limit body reads/closes = %d/%d, want 0/1", body.read, body.closes)
+	}
+}
+
+func TestWorkBuddyHookUnknownLengthResponseStopsAtLimitBeforeDecode(t *testing.T) {
+	const prepared = `{"schema":"powercontext.prepared-context.v1","status":"ready","content":"remembered","content_bytes":10}`
+	body := &workBuddyHookTrackedBody{Reader: strings.NewReader(prepared + strings.Repeat(" ", 16*1024))}
+	client := &http.Client{Transport: workBuddyHookRoundTripper(func(request *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK, Header: http.Header{"Content-Type": []string{"application/json"}}, ContentLength: -1, Body: body, Request: request,
+		}, nil
+	})}
+	var output, diagnostics bytes.Buffer
+	err := runWorkBuddyHook(t.Context(), strings.NewReader(`{"hook_event_name":"UserPromptSubmit","prompt":"hello","cwd":"C:/workspace"}`), &output, &diagnostics, workBuddyHookRuntime{
+		configuration: workBuddyConfiguration{
+			Schema: workBuddyConfigSchema, ServerURL: "http://127.0.0.1:8000", ScopeMode: "agent", AuthorizationEnvironment: workBuddyDefaultAuthorizationEnvironment,
+			RequestTimeoutSeconds: 1, RequestBudgetSeconds: 2, PrepareMaxBytes: 8000, SourceMaxBytes: 64,
+		},
+		getenv: func(name string) string {
+			if name == "POWERCONTEXT_WORKBUDDY_CAPTURE_PROMPTS" {
+				return "false"
+			}
+			return ""
+		},
+		httpClient: client,
+	})
+	if err != nil {
+		t.Fatalf("runWorkBuddyHook() error = %v", err)
+	}
+	if got := output.String(); got != workBuddyHookEmptyResponse {
+		t.Fatalf("output = %q, want empty recalled context", got)
+	}
+	if want := workBuddyHookResponseLimit(workBuddyConfiguration{PrepareMaxBytes: 8000, SourceMaxBytes: 64}) + 1; body.read != want {
+		t.Fatalf("response body reads = %d, want one bounded probe after %d bytes", body.read, want-1)
+	}
+	if body.closes != 1 {
+		t.Fatalf("response body close calls = %d, want 1", body.closes)
+	}
+}
+
+func TestWorkBuddyHookPrepareFailuresStillCapture(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		prepare func(*http.Request) (*http.Response, error)
+	}{
+		{
+			name: "unauthorized",
+			prepare: func(request *http.Request) (*http.Response, error) {
+				return workBuddyHookJSONResponse(request, http.StatusUnauthorized, `{"error":{"code":"unauthorized","message":"denied"}}`), nil
+			},
+		},
+		{
+			name: "not found",
+			prepare: func(request *http.Request) (*http.Response, error) {
+				return workBuddyHookJSONResponse(request, http.StatusNotFound, `{"error":{"code":"not_found","message":"missing"}}`), nil
+			},
+		},
+		{
+			name: "unavailable",
+			prepare: func(request *http.Request) (*http.Response, error) {
+				return workBuddyHookJSONResponse(request, http.StatusServiceUnavailable, `{"error":{"code":"unavailable","message":"later"}}`), nil
+			},
+		},
+		{
+			name: "invalid prepared body",
+			prepare: func(request *http.Request) (*http.Response, error) {
+				return workBuddyHookJSONResponse(request, http.StatusOK, `{}`), nil
+			},
+		},
+		{
+			name: "request timeout",
+			prepare: func(*http.Request) (*http.Response, error) {
+				return nil, context.DeadlineExceeded
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var paths []string
+			client := &http.Client{Transport: workBuddyHookRoundTripper(func(request *http.Request) (*http.Response, error) {
+				paths = append(paths, request.URL.Path)
+				switch request.URL.Path {
+				case "/v1/context/prepare":
+					return test.prepare(request)
+				case "/v1/sources/content":
+					if err := request.Context().Err(); err != nil {
+						t.Fatalf("capture context error = %v, want time remaining", err)
+					}
+					return workBuddyHookJSONResponse(request, http.StatusAccepted, `{"status":"accepted","source":{"name":"content","source_id":"x"},"position":1}`), nil
+				default:
+					return workBuddyHookJSONResponse(request, http.StatusNotFound, ``), nil
+				}
+			})}
+			var output, diagnostics bytes.Buffer
+			err := runWorkBuddyHook(t.Context(), strings.NewReader(`{"hook_event_name":"UserPromptSubmit","prompt":"hello","cwd":"C:/workspace"}`), &output, &diagnostics, workBuddyHookRuntime{
+				configuration: workBuddyConfiguration{
+					Schema: workBuddyConfigSchema, ServerURL: "http://127.0.0.1:8000", ScopeMode: "agent", AuthorizationEnvironment: workBuddyDefaultAuthorizationEnvironment,
+					RequestTimeoutSeconds: 1, RequestBudgetSeconds: 2, PrepareMaxBytes: 8000, SourceMaxBytes: 16384,
+				},
+				getenv: func(name string) string {
+					if name == "POWERCONTEXT_WORKBUDDY_CAPTURE_PROMPTS" {
+						return "true"
+					}
+					return ""
+				},
+				httpClient: client,
+			})
+			if err != nil {
+				t.Fatalf("runWorkBuddyHook() error = %v", err)
+			}
+			if got := output.String(); got != workBuddyHookEmptyResponse {
+				t.Fatalf("output = %q, want empty recalled context", got)
+			}
+			if diff := cmp.Diff([]string{"/v1/context/prepare", "/v1/sources/content"}, paths); diff != "" {
+				t.Fatalf("request paths (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func workBuddyHookJSONResponse(request *http.Request, status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status, Header: http.Header{"Content-Type": []string{"application/json"}}, Body: io.NopCloser(strings.NewReader(body)), Request: request,
+	}
+}
+
+func TestResolveWorkBuddyHookScope(t *testing.T) {
+	getenv := func(string) string { return "" }
+
+	for _, test := range []struct {
+		name   string
+		mode   string
+		getenv func(string) string
+		setup  func(*testing.T, string)
+		want   func(*testing.T, string) string
+	}{
+		{
+			name: "explicit scope retains 256 byte boundary",
+			mode: "project",
+			getenv: func(name string) string {
+				if name == "POWERCONTEXT_WORKBUDDY_SCOPE_ID" {
+					return strings.Repeat("e", 256)
+				}
+				return ""
+			},
+			want: func(*testing.T, string) string { return strings.Repeat("e", 256) },
+		},
+		{
+			name: "explicit scope hashes above 256 byte boundary",
+			mode: "project",
+			getenv: func(name string) string {
+				if name == "POWERCONTEXT_WORKBUDDY_SCOPE_ID" {
+					return strings.Repeat("e", 257)
+				}
+				return ""
+			},
+			want: func(*testing.T, string) string {
+				sum := sha256.Sum256([]byte(strings.Repeat("e", 257)))
+				return "sha256:" + hex.EncodeToString(sum[:])
+			},
+		},
+		{name: "agent mode", mode: "agent", getenv: getenv, want: func(*testing.T, string) string { return "workbuddy:agent" }},
+		{
+			name:   "git private binding",
+			mode:   "project",
+			getenv: getenv,
+			setup: func(t *testing.T, project string) {
+				gitDirectory := workBuddyHookGitOutput(t, project, "rev-parse", "--absolute-git-dir")
+				writeTestFile(t, filepath.Join(gitDirectory, "powercontext", "codex-workspace.json"), `{"schema":"powercontext.codex-workspace.v1","scope_id":"bound-scope"}`)
+			},
+			want: func(*testing.T, string) string { return "bound-scope" },
+		},
+		{
+			name:   "normalized remote",
+			mode:   "project",
+			getenv: getenv,
+			setup: func(t *testing.T, project string) {
+				workBuddyHookGit(t, project, "config", "remote.origin.url", "ssh://user@GitHub.COM:8443/ob-labs/powercontext-go.git")
+			},
+			want: func(*testing.T, string) string { return "git:github.com:8443/ob-labs/powercontext-go" },
+		},
+		{
+			name:   "local path fallback",
+			mode:   "project",
+			getenv: getenv,
+			want:   workBuddyHookLocalScope,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			project := newWorkBuddyHookGitProject(t)
+			if test.setup != nil {
+				test.setup(t, project)
+			}
+			got, ok := resolveWorkBuddyHookScope(t.Context(), project, test.mode, test.getenv)
+			if want := test.want(t, project); !ok || got != want {
+				t.Fatalf("resolveWorkBuddyHookScope() = %q, %t, want %q, true", got, ok, want)
+			}
+		})
+	}
+}
+
+func TestResolveWorkBuddyHookScopeUTF8ByteBoundaries(t *testing.T) {
+	exactly256 := strings.Repeat("界", 85) + "a"
+	over256 := exactly256 + "b"
+	if got := len([]byte(exactly256)); got != 256 {
+		t.Fatalf("exactly256 byte length = %d, want 256", got)
+	}
+	if got := len([]byte(over256)); got != 257 {
+		t.Fatalf("over256 byte length = %d, want 257", got)
+	}
+
+	for _, test := range []struct {
+		name  string
+		value string
+		want  string
+	}{
+		{name: "explicit exact boundary", value: exactly256, want: exactly256},
+		{
+			name:  "explicit above boundary",
+			value: over256,
+			want: func() string {
+				sum := sha256.Sum256([]byte(over256))
+				return "sha256:" + hex.EncodeToString(sum[:])
+			}(),
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got, ok := resolveWorkBuddyHookScope(t.Context(), t.TempDir(), "project", func(name string) string {
+				if name == workBuddyHookScopeEnvironment {
+					return test.value
+				}
+				return ""
+			})
+			if !ok || got != test.want {
+				t.Fatalf("resolveWorkBuddyHookScope() = %q, %t, want %q, true", got, ok, test.want)
+			}
+		})
+	}
+
+	project := newWorkBuddyHookGitProject(t)
+	gitDirectory := workBuddyHookGitOutput(t, project, "rev-parse", "--absolute-git-dir")
+	writeTestFile(t, filepath.Join(gitDirectory, "powercontext", "codex-workspace.json"), `{"schema":"powercontext.codex-workspace.v1","scope_id":`+strconv.Quote(exactly256)+`}`)
+	got, ok := resolveWorkBuddyHookScope(t.Context(), project, "project", func(string) string { return "" })
+	if !ok || got != exactly256 {
+		t.Fatalf("Git-private UTF-8 boundary scope = %q, %t, want %q, true", got, ok, exactly256)
+	}
+}
+
+func TestResolveWorkBuddyHookScopeInvalidGitPrivateBindingFallsThrough(t *testing.T) {
+	remote := "git@GitHub.COM:ob-labs/powercontext-go.git"
+	const wantRemote = "git:github.com/ob-labs/powercontext-go"
+	over256 := strings.Repeat("界", 85) + "ab"
+
+	for _, test := range []struct {
+		name    string
+		payload string
+		remote  bool
+		want    func(*testing.T, string) string
+	}{
+		{name: "wrong schema", payload: `{"schema":"wrong","scope_id":"bound"}`, remote: true, want: func(*testing.T, string) string { return wantRemote }},
+		{name: "empty scope", payload: `{"schema":"powercontext.codex-workspace.v1","scope_id":""}`, remote: true, want: func(*testing.T, string) string { return wantRemote }},
+		{name: "whitespace padded scope", payload: `{"schema":"powercontext.codex-workspace.v1","scope_id":" bound "}`, remote: true, want: func(*testing.T, string) string { return wantRemote }},
+		{name: "malformed JSON", payload: `{`, remote: true, want: func(*testing.T, string) string { return wantRemote }},
+		{name: "UTF-8 scope above boundary", payload: `{"schema":"powercontext.codex-workspace.v1","scope_id":` + strconv.Quote(over256) + `}`, remote: true, want: func(*testing.T, string) string { return wantRemote }},
+		{name: "no remote uses local fallback", payload: `{`, want: workBuddyHookLocalScope},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			project := newWorkBuddyHookGitProject(t)
+			gitDirectory := workBuddyHookGitOutput(t, project, "rev-parse", "--absolute-git-dir")
+			writeTestFile(t, filepath.Join(gitDirectory, "powercontext", "codex-workspace.json"), test.payload)
+			if test.remote {
+				workBuddyHookGit(t, project, "config", "remote.origin.url", remote)
+			}
+			got, ok := resolveWorkBuddyHookScope(t.Context(), project, "project", func(string) string { return "" })
+			if want := test.want(t, project); !ok || got != want {
+				t.Fatalf("resolveWorkBuddyHookScope() = %q, %t, want %q, true", got, ok, want)
+			}
+		})
+	}
+}
+
+func TestWorkBuddyHookRequestTimeoutUsesRemainingBudget(t *testing.T) {
+	deadline := time.Now().Add(time.Minute)
+	ctx, cancel := context.WithDeadline(t.Context(), deadline)
+	defer cancel()
+	var requestDeadline time.Time
+	client, ok := newWorkBuddyHookClient(ctx, workBuddyConfiguration{
+		ServerURL: "http://127.0.0.1:8000", AuthorizationEnvironment: workBuddyDefaultAuthorizationEnvironment,
+		RequestTimeoutSeconds: 30,
+	}, func(string) string { return "" }, &http.Client{Transport: workBuddyHookRoundTripper(func(request *http.Request) (*http.Response, error) {
+		requestDeadline, _ = request.Context().Deadline()
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`{"schema":"powercontext.prepared-context.v1","status":"ready","content":"ok","content_bytes":2}`)),
+			Request:    request,
+		}, nil
+	})}, func() time.Time {
+		return deadline.Add(-250 * time.Millisecond)
+	})
+	if !ok {
+		t.Fatal("newWorkBuddyHookClient() did not construct a client")
+	}
+	if _, err := client.PrepareContext(ctx, &v1.PrepareContextRequest{ScopeID: "scope", Query: "query"}); err != nil {
+		t.Fatalf("PrepareContext() error = %v", err)
+	}
+	remaining := time.Until(requestDeadline)
+	if remaining < 100*time.Millisecond || remaining > 500*time.Millisecond {
+		t.Fatalf("request deadline remaining = %s, want timeout capped near 250ms", remaining)
+	}
+}
+
+func TestNormalizeWorkBuddyHookGitRemote(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		remote string
+		want   string
+	}{
+		{name: "scp", remote: "git@GitHub.COM:ob-labs/powercontext-go.git", want: "github.com/ob-labs/powercontext-go"},
+		{name: "http strips credentials and retains port", remote: "http://user:secret@GitHub.COM:8443/ob-labs\\powercontext-go.git", want: "github.com:8443/ob-labs/powercontext-go"},
+		{name: "https", remote: "https://GitHub.COM/ob-labs/powercontext-go.git", want: "github.com/ob-labs/powercontext-go"},
+		{name: "ssh", remote: "ssh://git@GitHub.COM/ob-labs/powercontext-go.git", want: "github.com/ob-labs/powercontext-go"},
+		{name: "git", remote: "git://GitHub.COM/ob-labs/powercontext-go.git", want: "github.com/ob-labs/powercontext-go"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := normalizeWorkBuddyHookGitRemote(test.remote); got != test.want {
+				t.Fatalf("normalizeWorkBuddyHookGitRemote() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestResolveWorkBuddyHookScopeHashesLongRemote(t *testing.T) {
+	project := newWorkBuddyHookGitProject(t)
+	path := strings.Repeat("x", 300)
+	workBuddyHookGit(t, project, "config", "remote.origin.url", "git@github.com:"+path+".git")
+
+	got, ok := resolveWorkBuddyHookScope(t.Context(), project, "project", func(string) string { return "" })
+	sum := sha256.Sum256([]byte("github.com/" + path))
+	want := "git:sha256:" + hex.EncodeToString(sum[:])
+	if !ok || got != want {
+		t.Fatalf("resolveWorkBuddyHookScope() = %q, %t, want %q, true", got, ok, want)
+	}
+}
+
+func newWorkBuddyHookGitProject(t *testing.T) string {
+	t.Helper()
+	project := filepath.Join(t.TempDir(), "project")
+	if err := os.MkdirAll(project, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	workBuddyHookGit(t, project, "init")
+	return project
+}
+
+func workBuddyHookGit(t *testing.T, directory string, arguments ...string) {
+	t.Helper()
+	command := exec.CommandContext(t.Context(), "git", arguments...)
+	command.Dir = directory
+	if output, err := command.CombinedOutput(); err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(arguments, " "), err, output)
+	}
+}
+
+func workBuddyHookGitOutput(t *testing.T, directory string, arguments ...string) string {
+	t.Helper()
+	command := exec.CommandContext(t.Context(), "git", arguments...)
+	command.Dir = directory
+	output, err := command.Output()
+	if err != nil {
+		t.Fatalf("git %s: %v", strings.Join(arguments, " "), err)
+	}
+	return strings.TrimSpace(string(output))
+}
+
+func workBuddyHookLocalScope(t *testing.T, project string) string {
+	t.Helper()
+	resolved, err := filepath.EvalSymlinks(project)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sum := sha256.Sum256([]byte(resolved))
+	return "local:" + hex.EncodeToString(sum[:])
+}
+
+type workBuddyHookRoundTripper func(*http.Request) (*http.Response, error)
+
+func (roundTrip workBuddyHookRoundTripper) RoundTrip(request *http.Request) (*http.Response, error) {
+	return roundTrip(request)
+}
+
+type workBuddyHookTrackedBody struct {
+	io.Reader
+	read   int
+	closes int
+}
+
+func (body *workBuddyHookTrackedBody) Read(buffer []byte) (int, error) {
+	count, err := body.Reader.Read(buffer)
+	body.read += count
+	return count, err
+}
+
+func (body *workBuddyHookTrackedBody) Close() error {
+	body.closes++
+	return nil
+}
+
+func TestWorkBuddyHookTransportPolicies(t *testing.T) {
+	proxyURL, err := url.Parse("http://proxy.invalid:8080")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, test := range []struct {
+		name       string
+		endpoint   string
+		wantProxy  bool
+		wantRefuse bool
+	}{
+		{name: "complete IPv4 loopback range bypasses proxy", endpoint: "http://127.0.0.2:8000/v1/context/prepare"},
+		{name: "IPv6 loopback bypasses proxy", endpoint: "http://[::1]:8000/v1/context/prepare"},
+		{name: "remote HTTPS delegates proxy", endpoint: "https://memory.example/v1/context/prepare", wantProxy: true},
+		{name: "remote plaintext is refused before dispatch", endpoint: "http://memory.example/v1/context/prepare", wantRefuse: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			request, err := http.NewRequestWithContext(t.Context(), http.MethodGet, test.endpoint, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if test.wantRefuse {
+				dispatches := 0
+				client := workBuddyHookHTTPClient(&http.Client{Transport: workBuddyHookRoundTripper(func(*http.Request) (*http.Response, error) {
+					dispatches++
+					return nil, errors.New("unexpected transport dispatch")
+				})})
+				response, roundTripErr := client.Transport.RoundTrip(request)
+				if response != nil && response.Body != nil {
+					_ = response.Body.Close()
+				}
+				if !errors.Is(roundTripErr, errWorkBuddyHookPlaintextNonLoopback) || dispatches != 0 {
+					t.Fatalf("remote plaintext error/dispatches = %v/%d, want refusal before dispatch", roundTripErr, dispatches)
+				}
+				return
+			}
+			proxyCalls := 0
+			client := workBuddyHookHTTPClient(&http.Client{Transport: &http.Transport{Proxy: func(*http.Request) (*url.URL, error) {
+				proxyCalls++
+				return proxyURL, nil
+			}}})
+			bounded := client.Transport.(workBuddyHookResponseRoundTripper)
+			transport := bounded.next.(*http.Transport)
+			got, err := transport.Proxy(request)
+			wantCalls := 0
+			if test.wantProxy {
+				wantCalls = 1
+			}
+			if err != nil || (got != nil) != test.wantProxy || proxyCalls != wantCalls {
+				t.Fatalf("proxy/result calls = %v/%v/%d, want proxy=%t", got, err, proxyCalls, test.wantProxy)
+			}
+			if test.wantProxy && got.String() != proxyURL.String() {
+				t.Fatalf("remote HTTPS proxy = %v, want %v", got, proxyURL)
+			}
+		})
+	}
+}
+
+// Regression for #199: WorkBuddy stores an Authorization header while pcclient
+// accepts the bearer token without its scheme prefix.
+func TestWorkBuddyHookClientSendsConfiguredBearerHeaderOnce(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+	const authorization = "Bearer workbuddy-service-token"
+	var receivedAuthorization string
+	client, ok := newWorkBuddyHookClient(ctx, workBuddyConfiguration{
+		ServerURL:                "http://127.0.0.1:8000",
+		AuthorizationEnvironment: "WORKBUDDY_SERVICE_TOKEN",
+		RequestTimeoutSeconds:    1,
+	}, func(name string) string {
+		if name == "WORKBUDDY_SERVICE_TOKEN" {
+			return authorization
+		}
+		return ""
+	}, &http.Client{Transport: workBuddyHookRoundTripper(func(request *http.Request) (*http.Response, error) {
+		receivedAuthorization = request.Header.Get("Authorization")
+		return workBuddyHookJSONResponse(request, http.StatusOK, `{"schema":"powercontext.prepared-context.v1","status":"ready","content":"ok","content_bytes":2}`), nil
+	})}, time.Now)
+	if !ok {
+		t.Fatal("newWorkBuddyHookClient() did not construct a client")
+	}
+	if _, err := client.PrepareContext(ctx, &v1.PrepareContextRequest{ScopeID: "scope", Query: "query"}); err != nil {
+		t.Fatalf("PrepareContext() error = %v", err)
+	}
+	if receivedAuthorization != authorization {
+		t.Fatalf("Authorization = %q, want %q", receivedAuthorization, authorization)
+	}
+}
+
+func TestWorkBuddyHookFailOpen(t *testing.T) {
+	const authorization = "Bearer confidential-value"
+	t.Setenv(clientURLVar, "")
+	for _, test := range []struct {
+		name  string
+		input string
+		setup func(*testing.T, string)
+		want  string
+	}{
+		{
+			name:  "unrelated event is silent",
+			input: `{"hook_event_name":"SessionStart"}`,
+			setup: writeWorkBuddyHookConfiguration,
+		},
+		{
+			name:  "malformed input",
+			input: `{"hook_event_name":`,
+			setup: writeWorkBuddyHookConfiguration,
+			want:  workBuddyHookEmptyResponse,
+		},
+		{
+			name:  "duplicate payload field",
+			input: `{"hook_event_name":"SessionStart","hook_event_name":"SessionStart"}`,
+			setup: writeWorkBuddyHookConfiguration,
+			want:  workBuddyHookEmptyResponse,
+		},
+		{
+			name:  "unknown payload field",
+			input: `{"hook_event_name":"SessionStart","unexpected":true}`,
+			setup: writeWorkBuddyHookConfiguration,
+			want:  workBuddyHookEmptyResponse,
+		},
+		{
+			name:  "oversized input",
+			input: `{"hook_event_name":"UserPromptSubmit","prompt":"` + strings.Repeat("x", 64*1024) + `","cwd":"C:/workspace"}`,
+			setup: writeWorkBuddyHookConfiguration,
+			want:  workBuddyHookEmptyResponse,
+		},
+		{
+			name:  "missing configuration",
+			input: `{"hook_event_name":"UserPromptSubmit","prompt":"secret-prompt","cwd":"C:/workspace"}`,
+			setup: func(*testing.T, string) {},
+			want:  workBuddyHookEmptyResponse,
+		},
+		{
+			name:  "invalid configuration",
+			input: `{"hook_event_name":"UserPromptSubmit","prompt":"secret-prompt","cwd":"C:/workspace"}`,
+			setup: func(t *testing.T, home string) {
+				t.Helper()
+				writeTestFile(t, filepath.Join(home, workBuddyConfigFilename), `{"schema":0}`)
+			},
+			want: workBuddyHookEmptyResponse,
+		},
+		{
+			name:  "blank prompt",
+			input: `{"hook_event_name":"UserPromptSubmit","prompt":"  ","cwd":"C:/workspace"}`,
+			setup: writeWorkBuddyHookConfiguration,
+			want:  workBuddyHookEmptyResponse,
+		},
+		{
+			name:  "missing cwd",
+			input: `{"hook_event_name":"UserPromptSubmit","prompt":"secret-prompt"}`,
+			setup: writeWorkBuddyHookConfiguration,
+			want:  workBuddyHookEmptyResponse,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			home := filepath.Join(t.TempDir(), "workbuddy")
+			t.Setenv(workBuddyHomeEnv, home)
+			t.Setenv(workBuddyDefaultAuthorizationEnvironment, authorization)
+			test.setup(t, home)
+
+			var stdout, stderr bytes.Buffer
+			command := newCommand(VersionInfo{Version: "test"}, &stdout, &stderr)
+			command.SetIn(strings.NewReader(test.input))
+			command.SetArgs([]string{"hook", "workbuddy"})
+			if err := command.ExecuteContext(context.Background()); err != nil {
+				t.Fatalf("ExecuteContext() error = %v", err)
+			}
+			if got := stdout.String(); got != test.want {
+				t.Fatalf("hook stdout = %q, want %q", got, test.want)
+			}
+			for _, protected := range []string{"secret-prompt", authorization} {
+				if strings.Contains(stdout.String(), protected) || strings.Contains(stderr.String(), protected) {
+					t.Fatalf("hook output disclosed protected input %q: stdout=%q stderr=%q", protected, stdout.String(), stderr.String())
+				}
+			}
+		})
+	}
+}
+
+func writeWorkBuddyHookConfiguration(t *testing.T, home string) {
+	t.Helper()
+	configuration, err := newWorkBuddyConfiguration("http://127.0.0.1:8000", "project", workBuddyDefaultAuthorizationEnvironment)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(home, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeWorkBuddyJSON(filepath.Join(home, workBuddyConfigFilename), map[string]any{
+		"schema":                    configuration.Schema,
+		"server_url":                configuration.ServerURL,
+		"scope_mode":                configuration.ScopeMode,
+		"authorization_environment": configuration.AuthorizationEnvironment,
+		"request_timeout_seconds":   configuration.RequestTimeoutSeconds,
+		"request_budget_seconds":    configuration.RequestBudgetSeconds,
+		"prepare_max_bytes":         configuration.PrepareMaxBytes,
+		"source_max_bytes":          configuration.SourceMaxBytes,
+	}); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/test/conformance/parity-inventory-rules.json
+++ b/test/conformance/parity-inventory-rules.json
@@ -754,7 +754,7 @@
         },
         "test_setup_workbuddy_preserves_other_hooks_shared_scripts": {
           "evidence": [
-            "go:internal/cli/integration_workbuddy_test.go#TestSetupWorkBuddyUpdatesExistingHookAndPreservesSharedScripts"
+            "go:internal/cli/integration_workbuddy_test.go#TestSetupWorkBuddyMigratesOwnedPythonHookAndPreservesSharedScripts"
           ]
         },
         "test_setup_workbuddy_refuses_an_unowned_skill": {
@@ -774,7 +774,7 @@
         },
         "test_setup_workbuddy_updates_an_existing_powercontext_hook": {
           "evidence": [
-            "go:internal/cli/integration_workbuddy_test.go#TestSetupWorkBuddyUpdatesExistingHookAndPreservesSharedScripts"
+            "go:internal/cli/integration_workbuddy_test.go#TestSetupWorkBuddyMigratesOwnedPythonHookAndPreservesSharedScripts"
           ]
         },
         "test_setup_workbuddy_rolls_back_json_changes_on_failure": {

--- a/test/conformance/parity-inventory.json
+++ b/test/conformance/parity-inventory.json
@@ -8624,7 +8624,7 @@
         {
           "kind": "go",
           "file": "internal/cli/integration_workbuddy_test.go",
-          "test": "TestSetupWorkBuddyUpdatesExistingHookAndPreservesSharedScripts"
+          "test": "TestSetupWorkBuddyMigratesOwnedPythonHookAndPreservesSharedScripts"
         }
       ]
     },
@@ -8692,7 +8692,7 @@
         {
           "kind": "go",
           "file": "internal/cli/integration_workbuddy_test.go",
-          "test": "TestSetupWorkBuddyUpdatesExistingHookAndPreservesSharedScripts"
+          "test": "TestSetupWorkBuddyMigratesOwnedPythonHookAndPreservesSharedScripts"
         }
       ]
     },

--- a/test/e2e/workbuddy_service_chain_test.go
+++ b/test/e2e/workbuddy_service_chain_test.go
@@ -26,25 +26,23 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
-	"github.com/ob-labs/powercontext-go/internal/cli"
 	"github.com/ob-labs/powercontext-go/server"
 )
 
 const workBuddyServiceChainScope = "project:workbuddy-service-chain"
 
 func TestWorkBuddyHookAndMCPShareOneGoServiceConfiguration(t *testing.T) {
-	python := workBuddyPython(t)
-	root, err := filepath.Abs(filepath.Join("..", ".."))
+	checkoutRoot, err := filepath.Abs(filepath.Join("..", ".."))
 	if err != nil {
 		t.Fatal(err)
 	}
+	releaseRoot, binary := buildWorkBuddyReleaseRoot(t, checkoutRoot)
 
 	for _, test := range []struct {
 		name          string
@@ -98,15 +96,15 @@ func TestWorkBuddyHookAndMCPShareOneGoServiceConfiguration(t *testing.T) {
 			t.Cleanup(service.Close)
 			assertWorkBuddyServiceReady(t, service)
 
-			setupWorkBuddy(t, service.URL, root)
+			setupWorkBuddy(t, service.URL, binary, releaseRoot)
 			assertWorkBuddyServerConfiguration(t, service.URL)
+			assertWorkBuddyHookRegistration(t, binary, checkoutRoot, config.Auth.Token)
 			assertWorkBuddyServiceReady(t, service)
-			hook := filepath.Join(os.Getenv("WORKBUDDY_HOME"), "hooks", "workbuddy_powercontext_hook.py")
-			first := runWorkBuddyHook(t, python, root, hook, "Remember this WorkBuddy service chain.", "prompt-1")
+			first := runWorkBuddyHook(t, binary, releaseRoot, "Remember this WorkBuddy service chain.", "prompt-1")
 			if first != "" {
 				t.Fatalf("first hook context = %q, want empty before capture", first)
 			}
-			second := runWorkBuddyHook(t, python, root, hook, "Which WorkBuddy service chain should I use?", "prompt-2")
+			second := runWorkBuddyHook(t, binary, releaseRoot, "Which WorkBuddy service chain should I use?", "prompt-2")
 			if !strings.Contains(second, "Remember this WorkBuddy service chain.") {
 				t.Fatalf("recalled context = %q, want captured WorkBuddy content", second)
 			}
@@ -174,19 +172,90 @@ func assertWorkBuddyServiceReady(t *testing.T, service *httptest.Server) {
 	t.Fatalf("reach Go Server readiness before deadline: %v", lastErr)
 }
 
-func setupWorkBuddy(t *testing.T, serverURL, root string) {
+func buildWorkBuddyReleaseRoot(t *testing.T, source string) (string, string) {
 	t.Helper()
-	command := cli.New(cli.VersionInfo{Version: "test"})
-	command.SetArgs([]string{
-		"setup", "workbuddy", "--source", root, "--server-url", serverURL,
-		"--authorization-environment", "WORKBUDDY_SERVICE_TOKEN",
-	})
-	if err := command.ExecuteContext(t.Context()); err != nil {
-		t.Fatalf("setup workbuddy: %v", err)
+	releaseRoot := filepath.Join(t.TempDir(), "powercontext-release")
+	binary := filepath.Join(releaseRoot, "bin", "powercontext")
+	if err := os.MkdirAll(filepath.Dir(binary), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	command := exec.CommandContext(t.Context(), "go", "build", "-tags", "sqlite_fts5", "-o", binary, "./cmd/powercontext")
+	command.Dir = source
+	if output, err := command.CombinedOutput(); err != nil {
+		t.Fatalf("build WorkBuddy release binary: %v\n%s", err, output)
+	}
+	if err := os.WriteFile(filepath.Join(releaseRoot, "BUILD-INFO.json"), []byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, path := range []string{".env.example", filepath.Join("openapi", "powercontext.yaml")} {
+		copyWorkBuddyReleaseFile(t, filepath.Join(source, path), filepath.Join(releaseRoot, path))
+	}
+	copyWorkBuddyReleaseTree(t, filepath.Join(source, "integrations", "workbuddy"), filepath.Join(releaseRoot, "integrations", "workbuddy"))
+	return releaseRoot, binary
+}
+
+func copyWorkBuddyReleaseFile(t *testing.T, source, destination string) {
+	t.Helper()
+	payload, err := os.ReadFile(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(destination), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(destination, payload, info.Mode()); err != nil {
+		t.Fatal(err)
 	}
 }
 
-func runWorkBuddyHook(t *testing.T, python workBuddyPythonCommand, root, hook, prompt, promptID string) string {
+func copyWorkBuddyReleaseTree(t *testing.T, source, destination string) {
+	t.Helper()
+	if err := filepath.WalkDir(source, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		relative, err := filepath.Rel(source, path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(destination, relative)
+		if entry.IsDir() {
+			return os.MkdirAll(target, 0o755)
+		}
+		if !entry.Type().IsRegular() {
+			return fmt.Errorf("WorkBuddy release entry %q is not a regular file", path)
+		}
+		payload, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		return os.WriteFile(target, payload, info.Mode())
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func setupWorkBuddy(t *testing.T, serverURL, binary, releaseRoot string) {
+	t.Helper()
+	command := exec.CommandContext(t.Context(), binary,
+		"setup", "workbuddy", "--source", releaseRoot, "--server-url", serverURL,
+		"--authorization-environment", "WORKBUDDY_SERVICE_TOKEN",
+	)
+	command.Dir = releaseRoot
+	if output, err := command.CombinedOutput(); err != nil {
+		t.Fatalf("setup WorkBuddy from release archive: %v\n%s", err, output)
+	}
+}
+
+func runWorkBuddyHook(t *testing.T, binary, root, prompt, promptID string) string {
 	t.Helper()
 	context, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	defer cancel()
@@ -200,8 +269,9 @@ func runWorkBuddyHook(t *testing.T, python workBuddyPythonCommand, root, hook, p
 	if err != nil {
 		t.Fatal(err)
 	}
-	command := exec.CommandContext(context, python.path, append(python.arguments, hook)...)
-	command.Dir = root
+	command := exec.CommandContext(context, binary, "hook", "workbuddy")
+	command.Dir = filepath.Dir(filepath.Dir(binary))
+	command.Env = workBuddyHookSubprocessEnv(t)
 	command.Stdin = bytes.NewReader(payload)
 	var stdout, stderr bytes.Buffer
 	command.Stdout = &stdout
@@ -221,6 +291,25 @@ func runWorkBuddyHook(t *testing.T, python workBuddyPythonCommand, root, hook, p
 	return result.HookSpecificOutput.AdditionalContext
 }
 
+func workBuddyHookSubprocessEnv(t *testing.T) []string {
+	t.Helper()
+	payload, err := os.ReadFile(filepath.Join(os.Getenv("WORKBUDDY_HOME"), "powercontext.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var configuration struct {
+		AuthorizationEnvironment string `json:"authorization_environment"`
+	}
+	if err := json.Unmarshal(payload, &configuration); err != nil {
+		t.Fatal(err)
+	}
+	authorization, ok := os.LookupEnv(configuration.AuthorizationEnvironment)
+	if !ok {
+		t.Fatalf("WorkBuddy authorization environment %q is not set", configuration.AuthorizationEnvironment)
+	}
+	return append(os.Environ(), configuration.AuthorizationEnvironment+"="+authorization)
+}
+
 func assertWorkBuddyServerConfiguration(t *testing.T, serverURL string) {
 	t.Helper()
 	configuration, err := os.ReadFile(filepath.Join(os.Getenv("WORKBUDDY_HOME"), "powercontext.json"))
@@ -236,6 +325,42 @@ func assertWorkBuddyServerConfiguration(t *testing.T, serverURL string) {
 	if value.ServerURL != serverURL {
 		t.Fatalf("WorkBuddy Hook Server URL = %q, want %q", value.ServerURL, serverURL)
 	}
+}
+
+func assertWorkBuddyHookRegistration(t *testing.T, binary, checkoutRoot, bearerToken string) {
+	t.Helper()
+	payload, err := os.ReadFile(filepath.Join(os.Getenv("WORKBUDDY_HOME"), "settings.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var settings struct {
+		Hooks map[string][]struct {
+			Hooks []struct {
+				Type    string `json:"type"`
+				Command string `json:"command"`
+			} `json:"hooks"`
+		} `json:"hooks"`
+	}
+	if err := json.Unmarshal(payload, &settings); err != nil {
+		t.Fatal(err)
+	}
+	for _, matcher := range settings.Hooks["UserPromptSubmit"] {
+		for _, hook := range matcher.Hooks {
+			if hook.Type != "command" || !strings.HasSuffix(hook.Command, " hook workbuddy") {
+				continue
+			}
+			if !strings.Contains(hook.Command, binary) {
+				t.Fatalf("installed WorkBuddy command = %q, want released binary %q", hook.Command, binary)
+			}
+			for _, forbidden := range []string{"python", ".py", checkoutRoot, bearerToken} {
+				if forbidden != "" && strings.Contains(hook.Command, forbidden) {
+					t.Fatalf("installed WorkBuddy command contains forbidden value %q: %q", forbidden, hook.Command)
+				}
+			}
+			return
+		}
+	}
+	t.Fatalf("settings has no released WorkBuddy hook command: %s", payload)
 }
 
 func workBuddyMCPConnection(t *testing.T, serverURL string) (string, string) {
@@ -265,47 +390,6 @@ func workBuddyMCPConnection(t *testing.T, serverURL string) (string, string) {
 		authorization = os.Getenv("WORKBUDDY_SERVICE_TOKEN")
 	}
 	return entry.URL + "/", authorization
-}
-
-type workBuddyPythonCommand struct {
-	path      string
-	arguments []string
-}
-
-func workBuddyPython(t *testing.T) workBuddyPythonCommand {
-	t.Helper()
-	for _, candidate := range []workBuddyPythonCommand{
-		{path: "python3"},
-		{path: "python"},
-		{path: "py", arguments: []string{"-3"}},
-	} {
-		path, err := exec.LookPath(candidate.path)
-		if err != nil {
-			continue
-		}
-		output, versionErr := exec.CommandContext(t.Context(), path, append(candidate.arguments, "--version")...).CombinedOutput()
-		if versionErr != nil || !workBuddyPythonSupported(string(output)) {
-			continue
-		}
-		candidate.path = path
-		return candidate
-	}
-	t.Fatal("WorkBuddy service-chain test requires Python 3.10 or newer on PATH")
-	return workBuddyPythonCommand{}
-}
-
-func workBuddyPythonSupported(output string) bool {
-	fields := strings.Fields(output)
-	if len(fields) != 2 || fields[0] != "Python" {
-		return false
-	}
-	parts := strings.Split(fields[1], ".")
-	if len(parts) < 2 {
-		return false
-	}
-	major, majorErr := strconv.Atoi(parts[0])
-	minor, minorErr := strconv.Atoi(parts[1])
-	return majorErr == nil && minorErr == nil && (major > 3 || major == 3 && minor >= 10)
 }
 
 type workBuddyAuthorizationTransport struct {

--- a/tools/release/main_test.go
+++ b/tools/release/main_test.go
@@ -466,6 +466,10 @@ func TestReleaseArchiveProvidesConsumableAdapterSources(t *testing.T) {
 	}
 
 	repository := filepath.Clean(filepath.Join("..", ".."))
+	checkoutRoot, checkoutErr := filepath.Abs(repository)
+	if checkoutErr != nil {
+		t.Fatal(checkoutErr)
+	}
 	archive := buildAdapterConsumerArchive(t, repository)
 	releaseRoot := unpackReleaseArchive(t, archive)
 
@@ -480,10 +484,12 @@ func TestReleaseArchiveProvidesConsumableAdapterSources(t *testing.T) {
 		"integrations/openclaw/plugins/memory-powercontext/dist/index.js",
 		"integrations/opencode/plugins/powercontext/lib/index.js",
 		"integrations/pi/plugins/powercontext/extensions/powercontext.ts",
+		"integrations/workbuddy/plugins/powercontext/hooks/hooks.workbuddy.json",
+		"integrations/workbuddy/plugins/powercontext/powercontext.json.example",
 	} {
-		info, err := os.Stat(filepath.Join(releaseRoot, filepath.FromSlash(required)))
-		if err != nil || !info.Mode().IsRegular() {
-			t.Errorf("release artifact adapter entrypoint %q is unavailable: %v", required, err)
+		info, statErr := os.Stat(filepath.Join(releaseRoot, filepath.FromSlash(required)))
+		if statErr != nil || !info.Mode().IsRegular() {
+			t.Errorf("release artifact adapter entrypoint %q is unavailable: %v", required, statErr)
 		}
 	}
 
@@ -511,10 +517,69 @@ func TestReleaseArchiveProvidesConsumableAdapterSources(t *testing.T) {
 			}
 		})
 	}
+	t.Run("workbuddy", func(t *testing.T) {
+		home := filepath.Join(t.TempDir(), "workbuddy")
+		t.Setenv("WORKBUDDY_HOME", home)
+		t.Setenv("POWERCONTEXT_HOME", filepath.Join(t.TempDir(), "powercontext-home"))
+		binary := filepath.Join(releaseRoot, "bin", "powercontext")
+		setup := exec.CommandContext(t.Context(), binary, "setup", "workbuddy", "--source", releaseRoot)
+		setup.Dir = releaseRoot
+		if output, setupErr := setup.CombinedOutput(); setupErr != nil {
+			t.Fatalf("packaged WorkBuddy setup failed: %v\n%s", setupErr, output)
+		}
 
-	commands, err := os.ReadFile(commandLog)
-	if err != nil {
-		t.Fatal(err)
+		settingsPath := filepath.Join(home, "settings.json")
+		settings, settingsErr := os.ReadFile(settingsPath)
+		if settingsErr != nil {
+			t.Fatal(settingsErr)
+		}
+		command := releaseWorkBuddyHookCommand(t, settings)
+		if !strings.Contains(command, binary) || strings.Contains(command, "python") || strings.Contains(command, ".py") || strings.Contains(command, checkoutRoot) || strings.Contains(command, "token") {
+			t.Fatalf("packaged WorkBuddy command = %q, want only the extracted release binary", command)
+		}
+
+		hook := exec.CommandContext(t.Context(), binary, "hook", "workbuddy")
+		hook.Dir = releaseRoot
+		hook.Stdin = strings.NewReader(`{"hook_event_name":"UserPromptSubmit","cwd":"` + releaseRoot + `","prompt":"release WorkBuddy hook","session_id":"release-consumer","prompt_id":"prompt-1"}`)
+		hookOutput, hookErr := hook.CombinedOutput()
+		if hookErr != nil {
+			t.Fatalf("packaged WorkBuddy hook failed: %v\n%s", hookErr, hookOutput)
+		}
+		var hookResponse struct {
+			HookSpecificOutput struct {
+				HookEventName string `json:"hookEventName"`
+			} `json:"hookSpecificOutput"`
+		}
+		if decodeErr := json.Unmarshal(hookOutput, &hookResponse); decodeErr != nil || hookResponse.HookSpecificOutput.HookEventName != "UserPromptSubmit" {
+			t.Fatalf("packaged WorkBuddy hook response = %q, error = %v", hookOutput, decodeErr)
+		}
+
+		outside := filepath.Join(t.TempDir(), "powercontext")
+		tampered := replaceReleaseWorkBuddyHookCommand(t, settings, "'"+strings.ReplaceAll(outside, "'", "'\\''")+"' hook workbuddy")
+		if writeErr := os.WriteFile(settingsPath, tampered, 0o600); writeErr != nil {
+			t.Fatal(writeErr)
+		}
+		doctor := exec.CommandContext(t.Context(), binary, "doctor", "workbuddy", "--json")
+		doctor.Dir = releaseRoot
+		diagnostics, doctorErr := doctor.CombinedOutput()
+		if doctorErr == nil {
+			t.Fatalf("packaged WorkBuddy doctor accepted an outside release command: %s", diagnostics)
+		}
+		if !strings.Contains(string(diagnostics), `"hooks"`) || !strings.Contains(string(diagnostics), `"failed"`) {
+			t.Fatalf("packaged WorkBuddy rejection diagnostics = %q", diagnostics)
+		}
+		after, afterErr := os.ReadFile(settingsPath)
+		if afterErr != nil {
+			t.Fatal(afterErr)
+		}
+		if !bytes.Equal(after, tampered) {
+			t.Fatalf("outside WorkBuddy registration mutated settings:\n got %q\nwant %q", after, tampered)
+		}
+	})
+
+	commands, commandLogErr := os.ReadFile(commandLog)
+	if commandLogErr != nil {
+		t.Fatal(commandLogErr)
 	}
 	for _, expected := range []string{
 		"codex|plugin marketplace add " + releaseRoot,
@@ -550,6 +615,58 @@ func TestReleaseArchiveProvidesConsumableAdapterSources(t *testing.T) {
 	}
 }
 
+func releaseWorkBuddyHookCommand(t *testing.T, settings []byte) string {
+	t.Helper()
+	var value map[string]any
+	if err := json.Unmarshal(settings, &value); err != nil {
+		t.Fatal(err)
+	}
+	hooks, ok := value["hooks"].(map[string]any)
+	if !ok {
+		t.Fatalf("WorkBuddy settings hooks = %#v", value["hooks"])
+	}
+	matchers, ok := hooks["UserPromptSubmit"].([]any)
+	if !ok || len(matchers) == 0 {
+		t.Fatalf("WorkBuddy UserPromptSubmit hooks = %#v", hooks["UserPromptSubmit"])
+	}
+	matcher, ok := matchers[0].(map[string]any)
+	if !ok {
+		t.Fatalf("WorkBuddy matcher = %#v", matchers[0])
+	}
+	entries, ok := matcher["hooks"].([]any)
+	if !ok || len(entries) == 0 {
+		t.Fatalf("WorkBuddy hook entries = %#v", matcher["hooks"])
+	}
+	entry, ok := entries[0].(map[string]any)
+	if !ok {
+		t.Fatalf("WorkBuddy hook entry = %#v", entries[0])
+	}
+	command, ok := entry["command"].(string)
+	if !ok {
+		t.Fatalf("WorkBuddy hook command = %#v", entry["command"])
+	}
+	return command
+}
+
+func replaceReleaseWorkBuddyHookCommand(t *testing.T, settings []byte, command string) []byte {
+	t.Helper()
+	var value map[string]any
+	if err := json.Unmarshal(settings, &value); err != nil {
+		t.Fatal(err)
+	}
+	hooks := value["hooks"].(map[string]any)
+	matchers := hooks["UserPromptSubmit"].([]any)
+	matcher := matchers[0].(map[string]any)
+	entries := matcher["hooks"].([]any)
+	entry := entries[0].(map[string]any)
+	entry["command"] = command
+	payload, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return append(payload, '\n')
+}
+
 func buildAdapterConsumerArchive(t *testing.T, repository string) string {
 	t.Helper()
 	binary := filepath.Join(t.TempDir(), "powercontext")
@@ -560,6 +677,9 @@ func buildAdapterConsumerArchive(t *testing.T, repository string) string {
 	}
 	root := filepath.Join(t.TempDir(), "powercontext-0.0.0-linux-amd64")
 	if err := stageRelease(repository, root, packageOptions{Binary: binary}, binaryFacts{}); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "BUILD-INFO.json"), []byte("{}\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	archive := filepath.Join(t.TempDir(), "powercontext.tar.gz")


### PR DESCRIPTION
Implements the approved WorkBuddy-only Go-hook slice for #194 and closes the scoped follow-up from #159.

This replaces only the installed WorkBuddy Python `UserPromptSubmit` driver with the released Go binary. It preserves the credential-free persisted configuration, public and Bearer Server modes, SQLite capture/recall behavior, MCP `search_memory`, fail-open handling, and host transport boundaries. It does not migrate any other host, add a cross-host framework, introduce seekDB/OceanBase work, or create an external consumer repository.

Evidence before exact-Head CI:

- Task-level implementation/review and final re-review completed.
- `go test -count=1 -race ./internal/cli -run 'Test(WorkBuddyHook|SetupWorkBuddy.*(Release|Binary|Hook)|DoctorWorkBuddy)'` passed locally with the supported temporary SQLite header.
- `go test -count=1 ./tools/release -run 'Test(ReleaseArchiveProvidesConsumableAdapterSources|StageIntegrationsIncludesEveryRuntimeAdapter)'` passed.
- The native Windows bridge cannot provide an auditable terminal result for the real `sqlite_fts5` WorkBuddy service-chain test. The exact-Head Linux CI run is the required acceptance evidence for that public/Bearer SQLite/MCP path.