### PR TITLE
feat(scope): add SQLite scope repository foundation

### DIFF
--- a/internal/scope/models.go
+++ b/internal/scope/models.go
@@ -1,0 +1,355 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package scope owns immutable Scope identity, organization, and selection values.
+package scope
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+const (
+	MaxIDLength                     = 256
+	MaxTitleLength                  = 256
+	MaxSummaryLength                = 2_000
+	MaxExternalReferenceKindLength  = 128
+	MaxExternalReferenceValueLength = 2_000
+	MaxIdempotencyKeyLength         = 256
+	MaxBindingIntegrationLength     = 128
+	MaxBindingKindLength            = 64
+	MaxBindingExternalIDLength      = 256
+)
+
+// IdempotencyConflictError reports a Scope creation key reused with different input.
+type IdempotencyConflictError struct{}
+
+func (*IdempotencyConflictError) Error() string {
+	return "Scope creation key was reused with different parameters"
+}
+
+// VersionConflictError reports a Scope mutation against a stale revision.
+type VersionConflictError struct {
+	Expected int64
+	Actual   int64
+}
+
+func (*VersionConflictError) Error() string {
+	return "Scope metadata changed since it was read"
+}
+
+// ExternalReference identifies an external system value associated with a Scope.
+type ExternalReference struct {
+	kind  string
+	value string
+}
+
+// NewExternalReference validates one opaque external Scope reference.
+func NewExternalReference(kind, value string) (ExternalReference, error) {
+	if err := requiredText("external reference kind", kind, MaxExternalReferenceKindLength); err != nil {
+		return ExternalReference{}, err
+	}
+	if err := requiredText("external reference value", value, MaxExternalReferenceValueLength); err != nil {
+		return ExternalReference{}, err
+	}
+	return ExternalReference{kind: kind, value: value}, nil
+}
+
+func (r ExternalReference) Kind() string  { return r.kind }
+func (r ExternalReference) Value() string { return r.value }
+
+// Draft is the immutable input for one idempotent Scope creation.
+type Draft struct {
+	title              string
+	summary            string
+	parentScopeID      string
+	contextReferences  []string
+	externalReferences []ExternalReference
+	idempotencyKey     string
+}
+
+// NewDraft validates and canonicalizes Scope creation input.
+func NewDraft(
+	title, summary, parentScopeID string,
+	contextReferences []string, externalReferences []ExternalReference, idempotencyKey string,
+) (Draft, error) {
+	metadata, err := newMetadata(title, summary, parentScopeID, contextReferences, externalReferences)
+	if err != nil {
+		return Draft{}, err
+	}
+	if err := requiredText("idempotency key", idempotencyKey, MaxIdempotencyKeyLength); err != nil {
+		return Draft{}, err
+	}
+	return Draft{
+		title: metadata.title, summary: metadata.summary, parentScopeID: metadata.parentScopeID,
+		contextReferences: metadata.contextReferences, externalReferences: metadata.externalReferences, idempotencyKey: idempotencyKey,
+	}, nil
+}
+
+func (d Draft) Title() string                           { return d.title }
+func (d Draft) Summary() string                         { return d.summary }
+func (d Draft) ParentScopeID() string                   { return d.parentScopeID }
+func (d Draft) ContextReferences() []string             { return slices.Clone(d.contextReferences) }
+func (d Draft) ExternalReferences() []ExternalReference { return slices.Clone(d.externalReferences) }
+func (d Draft) IdempotencyKey() string                  { return d.idempotencyKey }
+
+// BindingKey identifies a durable external-to-Scope binding.
+type BindingKey struct {
+	integration string
+	kind        string
+	externalID  string
+}
+
+// NewBindingKey validates one external Scope binding identity.
+func NewBindingKey(integration, kind, externalID string) (BindingKey, error) {
+	if err := requiredText("binding integration", integration, MaxBindingIntegrationLength); err != nil {
+		return BindingKey{}, err
+	}
+	if err := requiredText("binding kind", kind, MaxBindingKindLength); err != nil {
+		return BindingKey{}, err
+	}
+	if err := requiredText("binding external ID", externalID, MaxBindingExternalIDLength); err != nil {
+		return BindingKey{}, err
+	}
+	return BindingKey{integration: integration, kind: kind, externalID: externalID}, nil
+}
+
+func (k BindingKey) Integration() string { return k.integration }
+func (k BindingKey) Kind() string        { return k.kind }
+func (k BindingKey) ExternalID() string  { return k.externalID }
+
+// Descriptor is one immutable persisted Scope revision.
+type Descriptor struct {
+	id                 string
+	title              string
+	summary            string
+	parentScopeID      string
+	contextReferences  []string
+	externalReferences []ExternalReference
+	version            int64
+}
+
+// NewDescriptor validates one persisted Scope view.
+func NewDescriptor(
+	id, title, summary, parentScopeID string,
+	contextReferences []string, externalReferences []ExternalReference, version int64,
+) (Descriptor, error) {
+	if err := validateID(id); err != nil {
+		return Descriptor{}, err
+	}
+	metadata, err := newMetadata(title, summary, parentScopeID, contextReferences, externalReferences)
+	if err != nil {
+		return Descriptor{}, err
+	}
+	if version < 1 {
+		return Descriptor{}, fmt.Errorf("Scope version must be positive")
+	}
+	return Descriptor{
+		id: id, title: metadata.title, summary: metadata.summary, parentScopeID: metadata.parentScopeID,
+		contextReferences: metadata.contextReferences, externalReferences: metadata.externalReferences, version: version,
+	}, nil
+}
+
+func (d Descriptor) ID() string                  { return d.id }
+func (d Descriptor) Title() string               { return d.title }
+func (d Descriptor) Summary() string             { return d.summary }
+func (d Descriptor) ParentScopeID() string       { return d.parentScopeID }
+func (d Descriptor) ContextReferences() []string { return slices.Clone(d.contextReferences) }
+func (d Descriptor) ExternalReferences() []ExternalReference {
+	return slices.Clone(d.externalReferences)
+}
+func (d Descriptor) Version() int64 { return d.version }
+
+// Mutation is one complete compare-and-swap Scope metadata replacement.
+type Mutation struct {
+	expectedVersion    int64
+	title              string
+	summary            string
+	parentScopeID      string
+	contextReferences  []string
+	externalReferences []ExternalReference
+}
+
+// NewMutation validates one full Scope metadata replacement.
+func NewMutation(
+	expectedVersion int64, title, summary, parentScopeID string,
+	contextReferences []string, externalReferences []ExternalReference,
+) (Mutation, error) {
+	if expectedVersion < 1 {
+		return Mutation{}, fmt.Errorf("expected Scope version must be positive")
+	}
+	metadata, err := newMetadata(title, summary, parentScopeID, contextReferences, externalReferences)
+	if err != nil {
+		return Mutation{}, err
+	}
+	return Mutation{
+		expectedVersion: expectedVersion, title: metadata.title, summary: metadata.summary,
+		parentScopeID: metadata.parentScopeID, contextReferences: metadata.contextReferences, externalReferences: metadata.externalReferences,
+	}, nil
+}
+
+func (m Mutation) ExpectedVersion() int64      { return m.expectedVersion }
+func (m Mutation) Title() string               { return m.title }
+func (m Mutation) Summary() string             { return m.summary }
+func (m Mutation) ParentScopeID() string       { return m.parentScopeID }
+func (m Mutation) ContextReferences() []string { return slices.Clone(m.contextReferences) }
+
+func (m Mutation) ExternalReferences() []ExternalReference { return slices.Clone(m.externalReferences) }
+
+// Binding pairs a durable external key with one Scope.
+type Binding struct {
+	key     BindingKey
+	scopeID string
+}
+
+func NewBinding(key BindingKey, scopeID string) (Binding, error) {
+	if key.integration == "" || key.kind == "" || key.externalID == "" {
+		return Binding{}, fmt.Errorf("Scope binding key must be constructed")
+	}
+	if err := validateID(scopeID); err != nil {
+		return Binding{}, err
+	}
+	return Binding{key: key, scopeID: scopeID}, nil
+}
+
+func (b Binding) Key() BindingKey { return b.key }
+func (b Binding) ScopeID() string { return b.scopeID }
+
+// SelectionMode defines a closed Scope selection shape.
+type SelectionMode string
+
+const (
+	SelectionAll     SelectionMode = "all"
+	SelectionExact   SelectionMode = "exact"
+	SelectionSubtree SelectionMode = "subtree"
+)
+
+// Selection identifies all Scopes, an exact canonical set, or one subtree root.
+type Selection struct {
+	mode        SelectionMode
+	scopeIDs    []string
+	rootScopeID string
+}
+
+func AllSelection() Selection { return Selection{mode: SelectionAll} }
+
+func NewExactSelection(scopeIDs []string) (Selection, error) {
+	ids, err := canonicalScopeIDs(scopeIDs, true)
+	if err != nil {
+		return Selection{}, err
+	}
+	return Selection{mode: SelectionExact, scopeIDs: ids}, nil
+}
+
+func NewSubtreeSelection(rootScopeID string) (Selection, error) {
+	if err := validateID(rootScopeID); err != nil {
+		return Selection{}, err
+	}
+	return Selection{mode: SelectionSubtree, rootScopeID: rootScopeID}, nil
+}
+
+func (s Selection) Mode() SelectionMode { return s.mode }
+func (s Selection) ScopeIDs() []string  { return slices.Clone(s.scopeIDs) }
+func (s Selection) RootScopeID() string { return s.rootScopeID }
+
+func canonicalScopeIDs(values []string, requireNonEmpty bool) ([]string, error) {
+	if requireNonEmpty && len(values) == 0 {
+		return nil, fmt.Errorf("exact Scope selection requires scope IDs")
+	}
+	result := slices.Clone(values)
+	for _, value := range result {
+		if err := validateID(value); err != nil {
+			return nil, err
+		}
+	}
+	slices.Sort(result)
+	compacted := slices.Compact(result)
+	if len(compacted) != len(values) {
+		return nil, fmt.Errorf("Scope references must be unique")
+	}
+	return compacted, nil
+}
+
+type metadata struct {
+	title              string
+	summary            string
+	parentScopeID      string
+	contextReferences  []string
+	externalReferences []ExternalReference
+}
+
+func newMetadata(title, summary, parentScopeID string, contextReferences []string, externalReferences []ExternalReference) (metadata, error) {
+	if err := requiredText("title", title, MaxTitleLength); err != nil {
+		return metadata{}, err
+	}
+	if err := requiredText("summary", summary, MaxSummaryLength); err != nil {
+		return metadata{}, err
+	}
+	if parentScopeID != "" {
+		if err := validateID(parentScopeID); err != nil {
+			return metadata{}, err
+		}
+	}
+	references, err := canonicalScopeIDs(contextReferences, false)
+	if err != nil {
+		return metadata{}, err
+	}
+	external := slices.Clone(externalReferences)
+	if slices.ContainsFunc(external, func(reference ExternalReference) bool { return reference.kind == "" || reference.value == "" }) {
+		return metadata{}, fmt.Errorf("Scope external references must be constructed values")
+	}
+	if hasDuplicateExternalReference(external) {
+		return metadata{}, fmt.Errorf("Scope external references must be unique")
+	}
+	return metadata{title: title, summary: summary, parentScopeID: parentScopeID, contextReferences: references, externalReferences: external}, nil
+}
+
+func hasDuplicateExternalReference(values []ExternalReference) bool {
+	seen := make(map[ExternalReference]struct{}, len(values))
+	for _, value := range values {
+		if _, exists := seen[value]; exists {
+			return true
+		}
+		seen[value] = struct{}{}
+	}
+	return false
+}
+
+func validateID(value string) error {
+	if !utf8.ValidString(value) || strings.TrimSpace(value) == "" {
+		return fmt.Errorf("scope ID must not be empty")
+	}
+	if utf8.RuneCountInString(value) > MaxIDLength {
+		return fmt.Errorf("scope ID must not exceed %d characters", MaxIDLength)
+	}
+	return nil
+}
+
+func requiredText(field, value string, maximum int) error {
+	trimmed := strings.TrimFunc(value, isPythonWhitespace)
+	if trimmed == "" || value != trimmed {
+		return fmt.Errorf("%s must be non-empty without surrounding whitespace", field)
+	}
+	if utf8.RuneCountInString(value) > maximum {
+		return fmt.Errorf("%s must not exceed %d characters", field, maximum)
+	}
+	return nil
+}
+
+func isPythonWhitespace(value rune) bool {
+	return unicode.IsSpace(value) || value >= '\u001c' && value <= '\u001f'
+}

--- a/internal/scope/models_test.go
+++ b/internal/scope/models_test.go
@@ -1,0 +1,134 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scope
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestNewDraftNormalizesContextReferencesAndCopiesValues(t *testing.T) {
+	reference, err := NewExternalReference("repository", "ob-labs/powercontext-go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	draft, err := NewDraft(
+		"PowerContext", "Repository context", "parent", []string{"scope-z", "scope-a"},
+		[]ExternalReference{reference}, "powercontext-create",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := draft.ContextReferences(); !slices.Equal(got, []string{"scope-a", "scope-z"}) {
+		t.Fatalf("context references = %v", got)
+	}
+	contextReferences := draft.ContextReferences()
+	contextReferences[0] = "mutated"
+	if got := draft.ContextReferences(); !slices.Equal(got, []string{"scope-a", "scope-z"}) {
+		t.Fatalf("context references changed through accessor: %v", got)
+	}
+	externalReferences := draft.ExternalReferences()
+	externalReferences[0] = ExternalReference{}
+	if got := draft.ExternalReferences(); !slices.Equal(got, []ExternalReference{reference}) {
+		t.Fatalf("external references changed through accessor: %v", got)
+	}
+}
+
+func TestScopeValuesRejectInvalidIdentityAndSelectionShapes(t *testing.T) {
+	for _, input := range []struct {
+		name string
+		call func() error
+	}{
+		{"blank external reference kind", func() error { _, err := NewExternalReference("", "value"); return err }},
+		{"padded binding integration", func() error { _, err := NewBindingKey(" codex", "project", "repo"); return err }},
+		{"duplicate draft context", func() error {
+			_, err := NewDraft("title", "summary", "", []string{"scope", "scope"}, nil, "key")
+			return err
+		}},
+		{"exact selection is empty", func() error { _, err := NewExactSelection(nil); return err }},
+		{"exact selection is duplicate", func() error { _, err := NewExactSelection([]string{"scope", "scope"}); return err }},
+		{"subtree selection is blank", func() error { _, err := NewSubtreeSelection(""); return err }},
+	} {
+		t.Run(input.name, func(t *testing.T) {
+			if err := input.call(); err == nil {
+				t.Fatal("invalid Scope value was accepted")
+			}
+		})
+	}
+}
+
+func TestScopeSelectionsAreCanonicalAndImmutable(t *testing.T) {
+	exact, err := NewExactSelection([]string{"scope-z", "scope-a"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exact.Mode() != SelectionExact || !slices.Equal(exact.ScopeIDs(), []string{"scope-a", "scope-z"}) || exact.RootScopeID() != "" {
+		t.Fatalf("exact selection = %#v", exact)
+	}
+	ids := exact.ScopeIDs()
+	ids[0] = "mutated"
+	if got := exact.ScopeIDs(); !slices.Equal(got, []string{"scope-a", "scope-z"}) {
+		t.Fatalf("exact selection changed through accessor: %v", got)
+	}
+
+	subtree, err := NewSubtreeSelection("scope-root")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if subtree.Mode() != SelectionSubtree || subtree.RootScopeID() != "scope-root" || len(subtree.ScopeIDs()) != 0 {
+		t.Fatalf("subtree selection = %#v", subtree)
+	}
+	if all := AllSelection(); all.Mode() != SelectionAll || all.RootScopeID() != "" || len(all.ScopeIDs()) != 0 {
+		t.Fatalf("all selection = %#v", all)
+	}
+}
+
+func TestDescriptorMutationAndBindingPreserveScopeContracts(t *testing.T) {
+	reference, err := NewExternalReference("repository", "ob-labs/powercontext-go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	descriptor, err := NewDescriptor(
+		"scope-a", "title", "summary", "", []string{"scope-z", "scope-b"}, []ExternalReference{reference}, 3,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if descriptor.ID() != "scope-a" || descriptor.Version() != 3 ||
+		!slices.Equal(descriptor.ContextReferences(), []string{"scope-b", "scope-z"}) {
+		t.Fatalf("descriptor = %#v", descriptor)
+	}
+	mutation, err := NewMutation(3, "next title", "next summary", "", []string{"scope-b"}, []ExternalReference{reference})
+	if err != nil || mutation.ExpectedVersion() != 3 || mutation.Title() != "next title" {
+		t.Fatalf("mutation = %#v, %v", mutation, err)
+	}
+	key, err := NewBindingKey("codex", "project", "ob-labs/powercontext-go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	binding, err := NewBinding(key, "scope-a")
+	if err != nil || binding.Key() != key || binding.ScopeID() != "scope-a" {
+		t.Fatalf("binding = %#v, %v", binding, err)
+	}
+	for _, call := range []func() error{
+		func() error { _, err := NewDescriptor("scope", "title", "summary", "", nil, nil, 0); return err },
+		func() error { _, err := NewMutation(0, "title", "summary", "", nil, nil); return err },
+		func() error { _, err := NewBinding(key, ""); return err },
+	} {
+		if err := call(); err == nil {
+			t.Fatal("invalid Scope repository value was accepted")
+		}
+	}
+}

--- a/internal/sqlstore/database_test.go
+++ b/internal/sqlstore/database_test.go
@@ -56,6 +56,12 @@ func TestOpenSQLiteInitializesSchemaAndEveryConnection(t *testing.T) {
 	})
 
 	for _, name := range []string{
+		"pc_scopes",
+		"pc_scope_context_references",
+		"pc_scope_external_references",
+		"pc_scope_creation_requests",
+		"pc_scope_settings",
+		"pc_scope_bindings",
 		"pc_sources",
 		"pc_source_journal_heads",
 		"pc_artifacts",

--- a/internal/sqlstore/schema.go
+++ b/internal/sqlstore/schema.go
@@ -48,6 +48,60 @@ func mysqlIdentityColumns(statement string) string {
 // and key orders are the Python v0.0.1 on-disk contract; Go-only state must not
 // be added to these tables.
 var builtinSchema = []string{
+	`CREATE TABLE IF NOT EXISTS pc_scopes (
+        scope_id VARCHAR(256) NOT NULL PRIMARY KEY,
+        title VARCHAR(256) NOT NULL,
+        summary VARCHAR(2000) NOT NULL,
+        parent_scope_id VARCHAR(256),
+        version INTEGER NOT NULL,
+        CONSTRAINT fk_pc_scopes_parent FOREIGN KEY (parent_scope_id)
+            REFERENCES pc_scopes (scope_id) ON DELETE RESTRICT,
+        CONSTRAINT ck_pc_scopes_version_positive CHECK (version > 0)
+    )`,
+	`CREATE TABLE IF NOT EXISTS pc_scope_context_references (
+        scope_id VARCHAR(256) NOT NULL,
+        referenced_scope_id VARCHAR(256) NOT NULL,
+        PRIMARY KEY (scope_id, referenced_scope_id),
+        CONSTRAINT fk_pc_scope_context_references_scope FOREIGN KEY (scope_id)
+            REFERENCES pc_scopes (scope_id) ON DELETE CASCADE,
+        CONSTRAINT fk_pc_scope_context_references_referenced FOREIGN KEY (referenced_scope_id)
+            REFERENCES pc_scopes (scope_id) ON DELETE RESTRICT,
+        CONSTRAINT ck_pc_scope_context_references_not_self CHECK (scope_id <> referenced_scope_id)
+    )`,
+	`CREATE TABLE IF NOT EXISTS pc_scope_external_references (
+        scope_id VARCHAR(256) NOT NULL,
+        ordinal INTEGER NOT NULL,
+        kind VARCHAR(128) NOT NULL,
+        value VARCHAR(2000) NOT NULL,
+        value_digest VARCHAR(64) NOT NULL,
+        PRIMARY KEY (scope_id, ordinal),
+        CONSTRAINT uq_pc_scope_external_references_value UNIQUE (scope_id, kind, value_digest),
+        CONSTRAINT fk_pc_scope_external_references_scope FOREIGN KEY (scope_id)
+            REFERENCES pc_scopes (scope_id) ON DELETE CASCADE,
+        CONSTRAINT ck_pc_scope_external_references_ordinal_nonnegative CHECK (ordinal >= 0)
+    )`,
+	`CREATE TABLE IF NOT EXISTS pc_scope_creation_requests (
+        idempotency_key VARCHAR(256) NOT NULL PRIMARY KEY,
+        request_digest VARCHAR(64) NOT NULL,
+        scope_id VARCHAR(256) NOT NULL,
+        CONSTRAINT fk_pc_scope_creation_requests_scope FOREIGN KEY (scope_id)
+            REFERENCES pc_scopes (scope_id) ON DELETE RESTRICT
+    )`,
+	`CREATE TABLE IF NOT EXISTS pc_scope_settings (
+        name VARCHAR(64) NOT NULL PRIMARY KEY,
+        scope_id VARCHAR(256) NOT NULL,
+        CONSTRAINT fk_pc_scope_settings_scope FOREIGN KEY (scope_id)
+            REFERENCES pc_scopes (scope_id) ON DELETE RESTRICT
+    )`,
+	`CREATE TABLE IF NOT EXISTS pc_scope_bindings (
+        integration VARCHAR(128) NOT NULL,
+        kind VARCHAR(64) NOT NULL,
+        external_id VARCHAR(256) NOT NULL,
+        scope_id VARCHAR(256) NOT NULL,
+        PRIMARY KEY (integration, kind, external_id),
+        CONSTRAINT fk_pc_scope_bindings_scope FOREIGN KEY (scope_id)
+            REFERENCES pc_scopes (scope_id) ON DELETE RESTRICT
+    )`,
 	`CREATE TABLE IF NOT EXISTS pc_source_journal_heads (
         scope_id VARCHAR(256) NOT NULL,
         position BIGINT NOT NULL,

--- a/internal/sqlstore/scopes.go
+++ b/internal/sqlstore/scopes.go
@@ -1,0 +1,285 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sqlstore
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json/v2"
+	"errors"
+	"fmt"
+
+	"github.com/ob-labs/powercontext-go/internal/scope"
+)
+
+// ScopeRepository persists Scope metadata and durable external bindings.
+type ScopeRepository struct{}
+
+func (ScopeRepository) Create(ctx context.Context, db DBTX, id string, draft scope.Draft) (scope.Descriptor, error) {
+	if _, err := scope.NewDescriptor(id, draft.Title(), draft.Summary(), draft.ParentScopeID(), draft.ContextReferences(), draft.ExternalReferences(), 1); err != nil {
+		return scope.Descriptor{}, err
+	}
+	digest, err := draftDigest(draft)
+	if err != nil {
+		return scope.Descriptor{}, err
+	}
+	var existingDigest, existingID string
+	err = db.QueryRowContext(ctx, `SELECT request_digest, scope_id FROM pc_scope_creation_requests
+        WHERE idempotency_key = ?`, draft.IdempotencyKey()).Scan(&existingDigest, &existingID)
+	if err == nil {
+		if existingDigest != digest {
+			return scope.Descriptor{}, &scope.IdempotencyConflictError{}
+		}
+		return ScopeRepository{}.Get(ctx, db, existingID)
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		return scope.Descriptor{}, err
+	}
+	if _, err := db.ExecContext(ctx, `INSERT INTO pc_scopes (scope_id, title, summary, parent_scope_id, version)
+        VALUES (?, ?, ?, NULLIF(?, ''), 1)`, id, draft.Title(), draft.Summary(), draft.ParentScopeID()); err != nil {
+		return scope.Descriptor{}, err
+	}
+	if err := writeScopeRelationships(ctx, db, id, draft.ContextReferences(), draft.ExternalReferences()); err != nil {
+		return scope.Descriptor{}, err
+	}
+	if _, err := db.ExecContext(ctx, `INSERT INTO pc_scope_creation_requests
+        (idempotency_key, request_digest, scope_id) VALUES (?, ?, ?)`, draft.IdempotencyKey(), digest, id); err != nil {
+		return scope.Descriptor{}, err
+	}
+	return ScopeRepository{}.Get(ctx, db, id)
+}
+
+func (ScopeRepository) Update(ctx context.Context, db DBTX, id string, mutation scope.Mutation) (scope.Descriptor, error) {
+	result, err := db.ExecContext(ctx, `UPDATE pc_scopes
+        SET title = ?, summary = ?, parent_scope_id = NULLIF(?, ''), version = ?
+        WHERE scope_id = ? AND version = ?`,
+		mutation.Title(), mutation.Summary(), mutation.ParentScopeID(), mutation.ExpectedVersion()+1, id, mutation.ExpectedVersion(),
+	)
+	if err != nil {
+		return scope.Descriptor{}, err
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return scope.Descriptor{}, err
+	}
+	if affected != 1 {
+		current, getErr := ScopeRepository{}.Get(ctx, db, id)
+		if getErr != nil {
+			return scope.Descriptor{}, getErr
+		}
+		return scope.Descriptor{}, &scope.VersionConflictError{Expected: mutation.ExpectedVersion(), Actual: current.Version()}
+	}
+	if _, err := db.ExecContext(ctx, `DELETE FROM pc_scope_context_references WHERE scope_id = ?`, id); err != nil {
+		return scope.Descriptor{}, err
+	}
+	if _, err := db.ExecContext(ctx, `DELETE FROM pc_scope_external_references WHERE scope_id = ?`, id); err != nil {
+		return scope.Descriptor{}, err
+	}
+	if err := writeScopeRelationships(ctx, db, id, mutation.ContextReferences(), mutation.ExternalReferences()); err != nil {
+		return scope.Descriptor{}, err
+	}
+	return ScopeRepository{}.Get(ctx, db, id)
+}
+
+func writeScopeRelationships(ctx context.Context, db DBTX, id string, contextReferences []string, externalReferences []scope.ExternalReference) error {
+	for _, referenceID := range contextReferences {
+		if _, err := db.ExecContext(ctx, `INSERT INTO pc_scope_context_references
+            (scope_id, referenced_scope_id) VALUES (?, ?)`, id, referenceID); err != nil {
+			return err
+		}
+	}
+	for ordinal, reference := range externalReferences {
+		digest := sha256.Sum256([]byte(reference.Value()))
+		if _, err := db.ExecContext(ctx, `INSERT INTO pc_scope_external_references
+            (scope_id, ordinal, kind, value, value_digest) VALUES (?, ?, ?, ?, ?)`,
+			id, ordinal, reference.Kind(), reference.Value(), hex.EncodeToString(digest[:]),
+		); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (ScopeRepository) Get(ctx context.Context, db DBTX, id string) (scope.Descriptor, error) {
+	row := db.QueryRowContext(ctx, `SELECT scope_id, title, summary, parent_scope_id, version
+        FROM pc_scopes WHERE scope_id = ?`, id)
+	return loadScope(ctx, db, row)
+}
+
+func (ScopeRepository) List(ctx context.Context, db DBTX) (result []scope.Descriptor, returnErr error) {
+	rows, err := db.QueryContext(ctx, `SELECT scope_id, title, summary, parent_scope_id, version
+        FROM pc_scopes ORDER BY scope_id`)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { returnErr = errors.Join(returnErr, rows.Close()) }()
+	for rows.Next() {
+		descriptor, err := loadScope(ctx, db, rows)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, descriptor)
+	}
+	return result, rows.Err()
+}
+
+func (ScopeRepository) SetDefault(ctx context.Context, db DBTX, id string) error {
+	result, err := db.ExecContext(ctx, `UPDATE pc_scope_settings SET scope_id = ? WHERE name = 'default'`, id)
+	if err != nil {
+		return err
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affected == 0 {
+		_, err = db.ExecContext(ctx, `INSERT INTO pc_scope_settings (name, scope_id) VALUES ('default', ?)`, id)
+	}
+	return err
+}
+
+func (ScopeRepository) Default(ctx context.Context, db DBTX) (scope.Descriptor, bool, error) {
+	var id string
+	if err := db.QueryRowContext(ctx, `SELECT scope_id FROM pc_scope_settings WHERE name = 'default'`).Scan(&id); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return scope.Descriptor{}, false, nil
+		}
+		return scope.Descriptor{}, false, err
+	}
+	descriptor, err := ScopeRepository{}.Get(ctx, db, id)
+	return descriptor, err == nil, err
+}
+
+func (ScopeRepository) SetBinding(ctx context.Context, db DBTX, key scope.BindingKey, id string) (scope.Binding, error) {
+	if _, err := scope.NewBinding(key, id); err != nil {
+		return scope.Binding{}, err
+	}
+	result, err := db.ExecContext(ctx, `UPDATE pc_scope_bindings SET scope_id = ?
+        WHERE integration = ? AND kind = ? AND external_id = ?`, id, key.Integration(), key.Kind(), key.ExternalID())
+	if err != nil {
+		return scope.Binding{}, err
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return scope.Binding{}, err
+	}
+	if affected == 0 {
+		if _, err := db.ExecContext(ctx, `INSERT INTO pc_scope_bindings
+            (integration, kind, external_id, scope_id) VALUES (?, ?, ?, ?)`, key.Integration(), key.Kind(), key.ExternalID(), id); err != nil {
+			return scope.Binding{}, err
+		}
+	}
+	return scope.NewBinding(key, id)
+}
+
+func (ScopeRepository) Binding(ctx context.Context, db DBTX, key scope.BindingKey) (scope.Binding, bool, error) {
+	var id string
+	err := db.QueryRowContext(ctx, `SELECT scope_id FROM pc_scope_bindings
+        WHERE integration = ? AND kind = ? AND external_id = ?`, key.Integration(), key.Kind(), key.ExternalID()).Scan(&id)
+	if errors.Is(err, sql.ErrNoRows) {
+		return scope.Binding{}, false, nil
+	}
+	if err != nil {
+		return scope.Binding{}, false, err
+	}
+	binding, err := scope.NewBinding(key, id)
+	return binding, err == nil, err
+}
+
+type scopeScanner interface{ Scan(...any) error }
+
+func loadScope(ctx context.Context, db DBTX, row scopeScanner) (scope.Descriptor, error) {
+	var id, title, summary string
+	var parent sql.NullString
+	var version int64
+	if err := row.Scan(&id, &title, &summary, &parent, &version); err != nil {
+		return scope.Descriptor{}, err
+	}
+	contextReferences, err := loadScopeContextReferences(ctx, db, id)
+	if err != nil {
+		return scope.Descriptor{}, err
+	}
+	externalReferences, err := loadScopeExternalReferences(ctx, db, id)
+	if err != nil {
+		return scope.Descriptor{}, err
+	}
+	return scope.NewDescriptor(id, title, summary, parent.String, contextReferences, externalReferences, version)
+}
+
+func loadScopeContextReferences(ctx context.Context, db DBTX, id string) (result []string, returnErr error) {
+	rows, err := db.QueryContext(ctx, `SELECT referenced_scope_id FROM pc_scope_context_references
+        WHERE scope_id = ? ORDER BY referenced_scope_id`, id)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { returnErr = errors.Join(returnErr, rows.Close()) }()
+	for rows.Next() {
+		var reference string
+		if err := rows.Scan(&reference); err != nil {
+			return nil, err
+		}
+		result = append(result, reference)
+	}
+	return result, rows.Err()
+}
+
+func loadScopeExternalReferences(ctx context.Context, db DBTX, id string) (result []scope.ExternalReference, returnErr error) {
+	rows, err := db.QueryContext(ctx, `SELECT kind, value FROM pc_scope_external_references
+        WHERE scope_id = ? ORDER BY ordinal`, id)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { returnErr = errors.Join(returnErr, rows.Close()) }()
+	for rows.Next() {
+		var kind, value string
+		if err := rows.Scan(&kind, &value); err != nil {
+			return nil, err
+		}
+		reference, err := scope.NewExternalReference(kind, value)
+		if err != nil {
+			return nil, fmt.Errorf("decode Scope external reference: %w", err)
+		}
+		result = append(result, reference)
+	}
+	return result, rows.Err()
+}
+
+func draftDigest(draft scope.Draft) (string, error) {
+	type externalReference struct {
+		Kind  string `json:"kind"`
+		Value string `json:"value"`
+	}
+	value := struct {
+		Title              string              `json:"title"`
+		Summary            string              `json:"summary"`
+		ParentScopeID      string              `json:"parent_scope_id"`
+		ContextReferences  []string            `json:"context_references"`
+		ExternalReferences []externalReference `json:"external_references"`
+	}{
+		Title: draft.Title(), Summary: draft.Summary(), ParentScopeID: draft.ParentScopeID(),
+		ContextReferences: draft.ContextReferences(),
+	}
+	for _, reference := range draft.ExternalReferences() {
+		value.ExternalReferences = append(value.ExternalReferences, externalReference{Kind: reference.Kind(), Value: reference.Value()})
+	}
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return "", err
+	}
+	digest := sha256.Sum256(encoded)
+	return hex.EncodeToString(digest[:]), nil
+}

--- a/internal/sqlstore/scopes_test.go
+++ b/internal/sqlstore/scopes_test.go
@@ -1,0 +1,175 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sqlstore_test
+
+import (
+	"errors"
+	"slices"
+	"testing"
+
+	"github.com/ob-labs/powercontext-go/internal/scope"
+	"github.com/ob-labs/powercontext-go/internal/sqlstore"
+)
+
+func TestScopeRepositoryPersistsMetadataDefaultAndBinding(t *testing.T) {
+	database := openTestDatabase(t)
+	repository := sqlstore.ScopeRepository{}
+	reference, err := scope.NewExternalReference("repository", "ob-labs/powercontext-go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	draft, err := scope.NewDraft(
+		"PowerContext", "Repository context", "", nil, []scope.ExternalReference{reference}, "scope-create",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var created scope.Descriptor
+	if transactionErr := database.Transaction(t.Context(), func(tx sqlstore.DBTX) error {
+		var createErr error
+		created, createErr = repository.Create(t.Context(), tx, "scope-a", draft)
+		return createErr
+	}); transactionErr != nil {
+		t.Fatal(transactionErr)
+	}
+	if created.ID() != "scope-a" || created.Version() != 1 ||
+		!slices.Equal(created.ContextReferences(), []string{}) {
+		t.Fatalf("created Scope = %#v", created)
+	}
+
+	key, err := scope.NewBindingKey("codex", "project", "ob-labs/powercontext-go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if transactionErr := database.Transaction(t.Context(), func(tx sqlstore.DBTX) error {
+		if err := repository.SetDefault(t.Context(), tx, created.ID()); err != nil {
+			return err
+		}
+		_, bindErr := repository.SetBinding(t.Context(), tx, key, created.ID())
+		return bindErr
+	}); transactionErr != nil {
+		t.Fatal(transactionErr)
+	}
+
+	if transactionErr := database.Transaction(t.Context(), func(tx sqlstore.DBTX) error {
+		listed, listErr := repository.List(t.Context(), tx)
+		if listErr != nil {
+			return listErr
+		}
+		if len(listed) != 1 || listed[0].ID() != created.ID() {
+			t.Fatalf("listed scopes = %#v", listed)
+		}
+		defaultScope, found, defaultErr := repository.Default(t.Context(), tx)
+		if defaultErr != nil || !found || defaultScope.ID() != created.ID() {
+			t.Fatalf("default Scope = %#v, %t, %v", defaultScope, found, defaultErr)
+		}
+		binding, bindingFound, bindingErr := repository.Binding(t.Context(), tx, key)
+		if bindingErr != nil || !bindingFound || binding.ScopeID() != created.ID() {
+			t.Fatalf("binding = %#v, %t, %v", binding, bindingFound, bindingErr)
+		}
+		return nil
+	}); transactionErr != nil {
+		t.Fatal(transactionErr)
+	}
+}
+
+func TestScopeRepositoryHonorsIdempotentCreation(t *testing.T) {
+	database := openTestDatabase(t)
+	repository := sqlstore.ScopeRepository{}
+	draft, err := scope.NewDraft("title", "summary", "", nil, nil, "same-key")
+	if err != nil {
+		t.Fatal(err)
+	}
+	create := func(id string, value scope.Draft) (scope.Descriptor, error) {
+		var result scope.Descriptor
+		transactionErr := database.Transaction(t.Context(), func(tx sqlstore.DBTX) error {
+			var createErr error
+			result, createErr = repository.Create(t.Context(), tx, id, value)
+			return createErr
+		})
+		return result, transactionErr
+	}
+	first, err := create("scope-first", draft)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := create("scope-second", draft)
+	if err != nil || second.ID() != first.ID() {
+		t.Fatalf("idempotent creation = %#v, %v", second, err)
+	}
+	changed, err := scope.NewDraft("changed", "summary", "", nil, nil, "same-key")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = create("scope-third", changed)
+	var conflict *scope.IdempotencyConflictError
+	if !errors.As(err, &conflict) {
+		t.Fatalf("conflicting idempotency error = %T %v", err, err)
+	}
+	if transactionErr := database.Transaction(t.Context(), func(tx sqlstore.DBTX) error {
+		listed, listErr := repository.List(t.Context(), tx)
+		if listErr != nil {
+			return listErr
+		}
+		if len(listed) != 1 || listed[0].ID() != first.ID() {
+			t.Fatalf("scopes after idempotency conflict = %#v", listed)
+		}
+		return nil
+	}); transactionErr != nil {
+		t.Fatal(transactionErr)
+	}
+}
+
+func TestScopeRepositoryUpdatesMetadataWithVersionCAS(t *testing.T) {
+	database := openTestDatabase(t)
+	repository := sqlstore.ScopeRepository{}
+	createDraft, err := scope.NewDraft("title", "summary", "", nil, nil, "create-key")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var created scope.Descriptor
+	if transactionErr := database.Transaction(t.Context(), func(tx sqlstore.DBTX) error {
+		var createErr error
+		created, createErr = repository.Create(t.Context(), tx, "scope-a", createDraft)
+		return createErr
+	}); transactionErr != nil {
+		t.Fatal(transactionErr)
+	}
+	mutation, err := scope.NewMutation(1, "updated", "updated summary", "", nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var updated scope.Descriptor
+	if err := database.Transaction(t.Context(), func(tx sqlstore.DBTX) error {
+		var updateErr error
+		updated, updateErr = repository.Update(t.Context(), tx, created.ID(), mutation)
+		return updateErr
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if updated.Version() != 2 || updated.Title() != "updated" || updated.Summary() != "updated summary" {
+		t.Fatalf("updated Scope = %#v", updated)
+	}
+	if err := database.Transaction(t.Context(), func(tx sqlstore.DBTX) error {
+		_, updateErr := repository.Update(t.Context(), tx, created.ID(), mutation)
+		var conflict *scope.VersionConflictError
+		if !errors.As(updateErr, &conflict) {
+			t.Fatalf("stale update error = %T %v", updateErr, updateErr)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Part of #202 Phase 2.

## Scope

- Adds immutable Scope values for Draft, Descriptor, Mutation, external references, durable bindings, and all/exact/subtree selections.
- Adds SQLite Scope metadata, relationship, default, idempotency, and binding schema.
- Adds a caller-owned transaction repository with metadata create/list/get, idempotent creation, default/binding reads and writes, and expected-version CAS update.

## Invariants

- No SQL, HTTP, environment, goroutine, or process ownership enters `internal/scope`.
- Reused creation keys return the original Scope only for the same canonical Draft; a changed Draft gets a typed conflict.
- Metadata relationships are replaced only after a successful version CAS.
- External reference uniqueness uses SHA-256 digest keys rather than long raw values.

## Deferred

- Hierarchy/subtree graph validation and concurrent idempotency recovery.
- Runtime Scope application and Source/Connector checkpoint wiring.
- OpenAPI/HTTP transport work remains Phase 3.