### PR TITLE
feat(runtime): add scope resolution application

### DIFF
--- a/internal/runtime/scope_application.go
+++ b/internal/runtime/scope_application.go
@@ -1,0 +1,117 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtime
+
+import (
+	"context"
+	"errors"
+
+	"github.com/ob-labs/powercontext-go/internal/scope"
+)
+
+// ScopeStore is the transaction-owning persistence boundary consumed by ScopeApplication.
+type ScopeStore interface {
+	Create(context.Context, string, scope.Draft) (scope.Descriptor, error)
+	Get(context.Context, string) (scope.Descriptor, bool, error)
+	SetDefault(context.Context, string) (scope.Descriptor, error)
+	Default(context.Context) (scope.Descriptor, bool, error)
+	SetBinding(context.Context, scope.BindingKey, string) (scope.Binding, error)
+	Binding(context.Context, scope.BindingKey) (scope.Binding, bool, error)
+}
+
+// ScopeApplication owns lifecycle admission and resolution order for durable Scopes.
+type ScopeApplication struct {
+	runtime *Runtime
+	store   ScopeStore
+	newID   func() string
+}
+
+func NewScopeApplication(runtime *Runtime, store ScopeStore, newID func() string) (*ScopeApplication, error) {
+	if runtime == nil || store == nil || newID == nil {
+		return nil, errors.New("runtime: Scope application dependencies must not be nil")
+	}
+	return &ScopeApplication{runtime: runtime, store: store, newID: newID}, nil
+}
+
+func (a *ScopeApplication) Create(ctx context.Context, draft scope.Draft) (result scope.Descriptor, err error) {
+	err = a.runtime.Operation(ctx, func(ctx context.Context) error {
+		created, createErr := a.store.Create(ctx, a.newID(), draft)
+		result = created
+		return createErr
+	})
+	return result, err
+}
+
+func (a *ScopeApplication) SetDefault(ctx context.Context, id string) (result scope.Descriptor, err error) {
+	err = a.runtime.Operation(ctx, func(ctx context.Context) error {
+		value, setErr := a.store.SetDefault(ctx, id)
+		result = value
+		return setErr
+	})
+	return result, err
+}
+
+func (a *ScopeApplication) Bind(ctx context.Context, key scope.BindingKey, id string) (result scope.Binding, err error) {
+	err = a.runtime.Operation(ctx, func(ctx context.Context) error {
+		value, bindErr := a.store.SetBinding(ctx, key, id)
+		result = value
+		return bindErr
+	})
+	return result, err
+}
+
+func (a *ScopeApplication) Resolve(ctx context.Context, explicitID string, keys []scope.BindingKey) (result scope.Descriptor, err error) {
+	err = a.runtime.Operation(ctx, func(ctx context.Context) error {
+		if explicitID != "" {
+			value, found, getErr := a.store.Get(ctx, explicitID)
+			if getErr != nil {
+				return getErr
+			}
+			if !found {
+				return errors.New("runtime: requested Scope was not found")
+			}
+			result = value
+			return nil
+		}
+		for _, key := range keys {
+			binding, found, bindingErr := a.store.Binding(ctx, key)
+			if bindingErr != nil {
+				return bindingErr
+			}
+			if !found {
+				continue
+			}
+			value, scopeFound, getErr := a.store.Get(ctx, binding.ScopeID())
+			if getErr != nil {
+				return getErr
+			}
+			if !scopeFound {
+				return errors.New("runtime: bound Scope was not found")
+			}
+			result = value
+			return nil
+		}
+		value, found, defaultErr := a.store.Default(ctx)
+		if defaultErr != nil {
+			return defaultErr
+		}
+		if !found {
+			return errors.New("runtime: no Scope binding is available")
+		}
+		result = value
+		return nil
+	})
+	return result, err
+}

--- a/internal/runtime/scope_application_test.go
+++ b/internal/runtime/scope_application_test.go
@@ -1,0 +1,111 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtime
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ob-labs/powercontext-go/internal/scope"
+)
+
+func TestScopeApplicationResolvesExplicitBindingAndDefaultInOrder(t *testing.T) {
+	store := &memoryScopeStore{scopes: map[string]scope.Descriptor{}}
+	application, err := NewScopeApplication(New(), store, func() string { return "scope-created" })
+	if err != nil {
+		t.Fatal(err)
+	}
+	draft, err := scope.NewDraft("title", "summary", "", nil, nil, "create")
+	if err != nil {
+		t.Fatal(err)
+	}
+	created, err := application.Create(t.Context(), draft)
+	if err != nil || created.ID() != "scope-created" {
+		t.Fatalf("created Scope = %#v, %v", created, err)
+	}
+	if _, setDefaultErr := application.SetDefault(t.Context(), created.ID()); setDefaultErr != nil {
+		t.Fatal(setDefaultErr)
+	}
+	key, err := scope.NewBindingKey("codex", "project", "repository")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, bindErr := application.Bind(t.Context(), key, created.ID()); bindErr != nil {
+		t.Fatal(bindErr)
+	}
+	for _, test := range []struct {
+		name     string
+		explicit string
+		keys     []scope.BindingKey
+	}{
+		{name: "explicit", explicit: created.ID()},
+		{name: "binding", keys: []scope.BindingKey{key}},
+		{name: "default"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			resolved, resolveErr := application.Resolve(t.Context(), test.explicit, test.keys)
+			if resolveErr != nil || resolved.ID() != created.ID() {
+				t.Fatalf("resolved Scope = %#v, %v", resolved, resolveErr)
+			}
+		})
+	}
+}
+
+type memoryScopeStore struct {
+	scopes    map[string]scope.Descriptor
+	defaultID string
+	bindings  map[scope.BindingKey]scope.Binding
+}
+
+func (s *memoryScopeStore) Create(_ context.Context, id string, draft scope.Draft) (scope.Descriptor, error) {
+	created, err := scope.NewDescriptor(id, draft.Title(), draft.Summary(), draft.ParentScopeID(), draft.ContextReferences(), draft.ExternalReferences(), 1)
+	if err == nil {
+		s.scopes[id] = created
+	}
+	return created, err
+}
+
+func (s *memoryScopeStore) Get(_ context.Context, id string) (scope.Descriptor, bool, error) {
+	value, found := s.scopes[id]
+	return value, found, nil
+}
+
+func (s *memoryScopeStore) SetDefault(_ context.Context, id string) (scope.Descriptor, error) {
+	value := s.scopes[id]
+	s.defaultID = id
+	return value, nil
+}
+
+func (s *memoryScopeStore) Default(_ context.Context) (scope.Descriptor, bool, error) {
+	value, found := s.scopes[s.defaultID]
+	return value, found, nil
+}
+
+func (s *memoryScopeStore) SetBinding(_ context.Context, key scope.BindingKey, id string) (scope.Binding, error) {
+	binding, err := scope.NewBinding(key, id)
+	if err != nil {
+		return scope.Binding{}, err
+	}
+	if s.bindings == nil {
+		s.bindings = make(map[scope.BindingKey]scope.Binding)
+	}
+	s.bindings[key] = binding
+	return binding, nil
+}
+
+func (s *memoryScopeStore) Binding(_ context.Context, key scope.BindingKey) (scope.Binding, bool, error) {
+	binding, found := s.bindings[key]
+	return binding, found, nil
+}


### PR DESCRIPTION
Part of #202 Phase 2.

## Scope

- Adds `internal/runtime.ScopeApplication` with a high-level `ScopeStore` boundary.
- Resolves Scope identity in exact order: caller-supplied explicit Scope, durable external binding, then default Scope.
- Routes create/default/binding operations through Runtime lifecycle admission.

## Boundary

`internal/runtime` does not import `internal/sqlstore` or open transactions. The later server-side adapter will own transaction lifecycles while satisfying `ScopeStore`.

## Deferred

- Scope mutation through `ScopedWrite`, hierarchy/subtree validation, and real server adapter.
- Source Definition/Observation and Connector checkpoint runtime wiring.