### PR TITLE
feat(source): persist connector checkpoints with CAS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -459,3 +459,9 @@ source / artifact / trigger / inference
   the comparison in one dedicated CI job with full history and an exact external
   revision. Verify both the ordinary no-input path and the dedicated exact-input
   path.
+- When a cross-language Connector checkpoint persists an opaque JSON value,
+  encode and validate its exact envelope, preserve integer precision, compare
+  JSON value semantics before using the actual stored bytes for CAS, and let the
+  unique key decide an initial-create race. Verify real multi-connection
+  contention and that cancellation or non-constraint storage failures remain
+  distinguishable from a typed checkpoint conflict.

--- a/internal/sqlstore/connector_checkpoints.go
+++ b/internal/sqlstore/connector_checkpoints.go
@@ -1,0 +1,190 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sqlstore
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json/jsontext"
+	"encoding/json/v2"
+	"errors"
+
+	"github.com/ob-labs/powercontext-go/source"
+)
+
+// CheckpointConflictError reports an optimistic Connector checkpoint mismatch.
+type CheckpointConflictError struct{}
+
+func (*CheckpointConflictError) Error() string {
+	return "Connector checkpoint changed during the run"
+}
+
+// ConnectorCheckpointRepository persists opaque JSON checkpoint values.
+type ConnectorCheckpointRepository struct{}
+
+type connectorCheckpointRow struct {
+	value   []byte
+	payload []byte
+}
+
+type connectorCheckpointEnvelope struct {
+	Value jsontext.Value `json:"value"`
+}
+
+func (repository ConnectorCheckpointRepository) Load(
+	ctx context.Context,
+	db DBTX,
+	binding source.ConnectorBinding,
+) ([]byte, bool, error) {
+	if err := binding.Validate(); err != nil {
+		return nil, false, err
+	}
+	row, found, err := repository.load(ctx, db, binding)
+	if err != nil || !found {
+		return nil, found, err
+	}
+	return bytes.Clone(row.value), true, nil
+}
+
+func (ConnectorCheckpointRepository) load(
+	ctx context.Context,
+	db DBTX,
+	binding source.ConnectorBinding,
+) (connectorCheckpointRow, bool, error) {
+	var connectorName, connectorVersion string
+	var checkpoint any
+	err := db.QueryRowContext(ctx, `SELECT connector_name, connector_version, checkpoint
+        FROM pc_connector_checkpoints WHERE scope_id = ? AND binding_id = ?`, binding.ScopeID(), binding.ID()).Scan(&connectorName, &connectorVersion, &checkpoint)
+	if errors.Is(err, sql.ErrNoRows) {
+		return connectorCheckpointRow{}, false, nil
+	}
+	if err != nil {
+		return connectorCheckpointRow{}, false, err
+	}
+	if connectorName != binding.ConnectorName() || connectorVersion != binding.ConnectorVersion() {
+		return connectorCheckpointRow{}, false, invalidStoredCheckpoint("binding identity does not match request")
+	}
+	payload, err := storedBytes(checkpoint, "checkpoint")
+	if err != nil {
+		return connectorCheckpointRow{}, false, err
+	}
+	value, err := decodeCheckpoint(payload)
+	if err != nil {
+		return connectorCheckpointRow{}, false, err
+	}
+	return connectorCheckpointRow{value: value, payload: payload}, true, nil
+}
+
+func (ConnectorCheckpointRepository) Save(
+	ctx context.Context,
+	db DBTX,
+	binding source.ConnectorBinding,
+	checkpoint, expected []byte,
+	expectedFound bool,
+) error {
+	if err := binding.Validate(); err != nil {
+		return err
+	}
+	payload, _, err := encodeCheckpointArgument("checkpoint", checkpoint)
+	if err != nil {
+		return err
+	}
+	if !expectedFound {
+		// The primary key is the atomic create CAS. A read before this insert
+		// would pin a SQLite snapshot and turn a lost race into SQLITE_BUSY.
+		_, insertErr := db.ExecContext(ctx, `INSERT INTO pc_connector_checkpoints
+            (scope_id, binding_id, connector_name, connector_version, checkpoint) VALUES (?, ?, ?, ?, ?)`,
+			binding.ScopeID(), binding.ID(), binding.ConnectorName(), binding.ConnectorVersion(), payload,
+		)
+		if insertErr != nil {
+			if !isIntegrityConstraint(insertErr) {
+				return insertErr
+			}
+			_, found, loadErr := (ConnectorCheckpointRepository{}).load(ctx, db, binding)
+			if loadErr != nil {
+				return loadErr
+			}
+			if found {
+				return &CheckpointConflictError{}
+			}
+			return insertErr
+		}
+		return nil
+	}
+
+	expectedPayload, expectedValue, err := encodeCheckpointArgument("expected", expected)
+	if err != nil {
+		return err
+	}
+	actual, found, err := (ConnectorCheckpointRepository{}).load(ctx, db, binding)
+	if err != nil {
+		return err
+	}
+	if !found || !bytes.Equal(actual.value, expectedValue) {
+		return &CheckpointConflictError{}
+	}
+	// A Python-written row may use different object member ordering. Its raw
+	// envelope remains the exact row version for CAS after semantic equality is
+	// established; rows written here use expectedPayload directly.
+	comparisonPayload := expectedPayload
+	if !bytes.Equal(actual.payload, expectedPayload) {
+		comparisonPayload = actual.payload
+	}
+	result, err := db.ExecContext(ctx, `UPDATE pc_connector_checkpoints SET checkpoint = ?
+		WHERE scope_id = ? AND binding_id = ? AND checkpoint = ?`,
+		payload, binding.ScopeID(), binding.ID(), comparisonPayload)
+	if err != nil {
+		return err
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affected != 1 {
+		return &CheckpointConflictError{}
+	}
+	return nil
+}
+
+func encodeCheckpointArgument(field string, checkpoint []byte) ([]byte, []byte, error) {
+	value := jsontext.Value(bytes.Clone(checkpoint))
+	if len(value) == 0 {
+		return nil, nil, &InvalidRepositoryArgumentError{Field: field, Detail: "must be valid JSON"}
+	}
+	if err := value.Canonicalize(jsontext.CanonicalizeRawInts(false)); err != nil {
+		return nil, nil, &InvalidRepositoryArgumentError{Field: field, Detail: "must be valid JSON"}
+	}
+	payload, err := json.Marshal(connectorCheckpointEnvelope{Value: value})
+	if err != nil {
+		return nil, nil, &InvalidRepositoryArgumentError{Field: field, Detail: "must be valid JSON"}
+	}
+	return payload, value, nil
+}
+
+func decodeCheckpoint(payload []byte) ([]byte, error) {
+	var envelope connectorCheckpointEnvelope
+	if err := json.Unmarshal(payload, &envelope, json.RejectUnknownMembers(true)); err != nil || len(envelope.Value) == 0 {
+		return nil, invalidStoredCheckpoint("payload does not match the model")
+	}
+	if err := envelope.Value.Canonicalize(jsontext.CanonicalizeRawInts(false)); err != nil {
+		return nil, invalidStoredCheckpoint("payload does not match the model")
+	}
+	return bytes.Clone(envelope.Value), nil
+}
+
+func invalidStoredCheckpoint(issue string) error {
+	return &InvalidStoredPayloadError{Kind: "connector-checkpoint", Name: "<redacted>", Issue: issue}
+}

--- a/internal/sqlstore/connector_checkpoints_test.go
+++ b/internal/sqlstore/connector_checkpoints_test.go
@@ -1,0 +1,292 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sqlstore_test
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/ob-labs/powercontext-go/internal/sqlstore"
+	"github.com/ob-labs/powercontext-go/source"
+)
+
+func TestConnectorCheckpointRepositoryUsesPythonEnvelopeAndValueCAS(t *testing.T) {
+	database := openTestDatabase(t)
+	repository := sqlstore.ConnectorCheckpointRepository{}
+	binding, err := source.NewConnectorBinding("scope-a", "repository", "github", "v1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	first := []byte(`{"value":{"right":2,"left":9007199254740993}}`)
+	expected := []byte(`{"left":9007199254740993,"right":2}`)
+	second := []byte(`{"cursor":2}`)
+	if _, err := database.SQLDB().ExecContext(t.Context(), `INSERT INTO pc_connector_checkpoints
+        (scope_id, binding_id, connector_name, connector_version, checkpoint) VALUES (?, ?, ?, ?, ?)`,
+		binding.ScopeID(), binding.ID(), binding.ConnectorName(), binding.ConnectorVersion(), first); err != nil {
+		t.Fatal(err)
+	}
+	if err := database.Transaction(t.Context(), func(tx sqlstore.DBTX) error {
+		loaded, found, loadErr := repository.Load(t.Context(), tx, binding)
+		if loadErr != nil || !found || string(loaded) != string(expected) {
+			t.Fatalf("checkpoint = %q, %t, %v", loaded, found, loadErr)
+		}
+		return repository.Save(t.Context(), tx, binding, second, expected, true)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	var stored any
+	if err := database.SQLDB().QueryRowContext(t.Context(), `SELECT checkpoint FROM pc_connector_checkpoints
+        WHERE scope_id = ? AND binding_id = ?`, binding.ScopeID(), binding.ID()).Scan(&stored); err != nil {
+		t.Fatal(err)
+	}
+	storedBytes, ok := stored.([]byte)
+	if !ok || string(storedBytes) != `{"value":{"cursor":2}}` {
+		t.Fatalf("stored checkpoint = %T %q", stored, stored)
+	}
+	if err := database.Transaction(t.Context(), func(tx sqlstore.DBTX) error {
+		saveErr := repository.Save(t.Context(), tx, binding, first, expected, true)
+		if _, ok := errors.AsType[*sqlstore.CheckpointConflictError](saveErr); !ok {
+			t.Fatalf("stale checkpoint error = %T %v", saveErr, saveErr)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestConnectorCheckpointRepositoryRoundTripsNull(t *testing.T) {
+	database := openTestDatabase(t)
+	repository := sqlstore.ConnectorCheckpointRepository{}
+	binding := checkpointBinding(t, "null")
+	if err := database.Transaction(t.Context(), func(tx sqlstore.DBTX) error {
+		return repository.Save(t.Context(), tx, binding, []byte("null"), nil, false)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	var stored []byte
+	if err := database.SQLDB().QueryRowContext(t.Context(), `SELECT checkpoint FROM pc_connector_checkpoints
+        WHERE scope_id = ? AND binding_id = ?`, binding.ScopeID(), binding.ID()).Scan(&stored); err != nil {
+		t.Fatal(err)
+	}
+	if string(stored) != `{"value":null}` {
+		t.Fatalf("stored checkpoint = %q", stored)
+	}
+	if err := database.Transaction(t.Context(), func(tx sqlstore.DBTX) error {
+		loaded, found, err := repository.Load(t.Context(), tx, binding)
+		if err != nil || !found || string(loaded) != "null" {
+			t.Fatalf("checkpoint = %q, %t, %v", loaded, found, err)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestConnectorCheckpointRepositoryRejectsInvalidBindingAtPersistenceBoundary(t *testing.T) {
+	database := openTestDatabase(t)
+	repository := sqlstore.ConnectorCheckpointRepository{}
+	for _, operation := range []struct {
+		name string
+		run  func(context.Context, sqlstore.DBTX) error
+	}{
+		{name: "load", run: func(ctx context.Context, tx sqlstore.DBTX) error {
+			_, _, err := repository.Load(ctx, tx, source.ConnectorBinding{})
+			return err
+		}},
+		{name: "save", run: func(ctx context.Context, tx sqlstore.DBTX) error {
+			return repository.Save(ctx, tx, source.ConnectorBinding{}, []byte("null"), nil, false)
+		}},
+	} {
+		t.Run(operation.name, func(t *testing.T) {
+			err := database.Transaction(t.Context(), func(tx sqlstore.DBTX) error {
+				return operation.run(t.Context(), tx)
+			})
+			if _, ok := errors.AsType[*source.InvalidConnectorBindingError](err); !ok {
+				t.Fatalf("invalid binding error = %T %v", err, err)
+			}
+		})
+	}
+}
+
+func TestConnectorCheckpointRepositoryRejectsInvalidStoredEnvelope(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		payload []byte
+	}{
+		{name: "not JSON", payload: []byte("not-json")},
+		{name: "missing value", payload: []byte(`{"cursor":1}`)},
+		{name: "unknown member", payload: []byte(`{"value":1,"extra":2}`)},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			database := openTestDatabase(t)
+			binding := checkpointBinding(t, test.name)
+			if _, err := database.SQLDB().ExecContext(t.Context(), `INSERT INTO pc_connector_checkpoints
+                (scope_id, binding_id, connector_name, connector_version, checkpoint) VALUES (?, ?, ?, ?, ?)`,
+				binding.ScopeID(), binding.ID(), binding.ConnectorName(), binding.ConnectorVersion(), test.payload); err != nil {
+				t.Fatal(err)
+			}
+			err := database.Transaction(t.Context(), func(tx sqlstore.DBTX) error {
+				_, _, err := (sqlstore.ConnectorCheckpointRepository{}).Load(t.Context(), tx, binding)
+				return err
+			})
+			if _, ok := errors.AsType[*sqlstore.InvalidStoredPayloadError](err); !ok {
+				t.Fatalf("invalid envelope error = %T %v", err, err)
+			}
+			if strings.Contains(err.Error(), binding.ScopeID()) || strings.Contains(err.Error(), binding.ID()) {
+				t.Fatalf("invalid envelope error disclosed binding identity: %v", err)
+			}
+		})
+	}
+}
+
+func TestConnectorCheckpointRepositoryRejectsStoredBindingMismatchWithoutDisclosure(t *testing.T) {
+	database := openTestDatabase(t)
+	binding := checkpointBinding(t, "requested-secret")
+	if _, err := database.SQLDB().ExecContext(t.Context(), `INSERT INTO pc_connector_checkpoints
+        (scope_id, binding_id, connector_name, connector_version, checkpoint) VALUES (?, ?, ?, ?, ?)`,
+		binding.ScopeID(), binding.ID(), "stored-secret", "stored-version-secret", []byte(`{"value":null}`)); err != nil {
+		t.Fatal(err)
+	}
+	err := database.Transaction(t.Context(), func(tx sqlstore.DBTX) error {
+		_, _, err := (sqlstore.ConnectorCheckpointRepository{}).Load(t.Context(), tx, binding)
+		return err
+	})
+	if _, ok := errors.AsType[*sqlstore.InvalidStoredPayloadError](err); !ok {
+		t.Fatalf("binding mismatch error = %T %v", err, err)
+	}
+	for _, secret := range []string{binding.ScopeID(), binding.ID(), binding.ConnectorName(), binding.ConnectorVersion(), "stored-secret", "stored-version-secret"} {
+		if strings.Contains(err.Error(), secret) {
+			t.Fatalf("binding mismatch error disclosed identity: %v", err)
+		}
+	}
+}
+
+func TestConnectorCheckpointRepositoryConcurrentCreateHasOneTypedConflict(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "checkpoint-race.db")
+	first := openCheckpointDatabase(t, path)
+	second := openCheckpointDatabase(t, path)
+	binding := checkpointBinding(t, "race")
+	repository := sqlstore.ConnectorCheckpointRepository{}
+	start := make(chan struct{})
+	results := make([]error, 2)
+	var wg sync.WaitGroup
+	checkpoints := [][]byte{[]byte(`{"writer":1}`), []byte(`{"writer":2}`)}
+	ctx := t.Context()
+	for index, database := range []*sqlstore.Database{first, second} {
+		wg.Go(func() {
+			<-start
+			results[index] = database.Transaction(ctx, func(tx sqlstore.DBTX) error {
+				return repository.Save(ctx, tx, binding, checkpoints[index], nil, false)
+			})
+		})
+	}
+	close(start)
+	wg.Wait()
+
+	var succeeded, conflicted int
+	for _, err := range results {
+		_, conflict := errors.AsType[*sqlstore.CheckpointConflictError](err)
+		switch {
+		case err == nil:
+			succeeded++
+		case conflict:
+			conflicted++
+			message := strings.ToLower(err.Error())
+			for _, detail := range []string{"sqlite", "constraint", "locked", "busy"} {
+				if strings.Contains(message, detail) {
+					t.Fatalf("checkpoint conflict disclosed driver detail: %v", err)
+				}
+			}
+		default:
+			t.Fatalf("concurrent create error = %T %v", err, err)
+		}
+	}
+	if succeeded != 1 || conflicted != 1 {
+		t.Fatalf("concurrent create outcomes = success:%d conflict:%d", succeeded, conflicted)
+	}
+}
+
+func TestConnectorCheckpointRepositoryPreservesCancellationDuringSave(t *testing.T) {
+	database := openTestDatabase(t)
+	repository := sqlstore.ConnectorCheckpointRepository{}
+	binding := checkpointBinding(t, "cancel")
+	baseContext, cancel := context.WithCancel(t.Context())
+	enteredDatabase := make(chan struct{})
+	continueCancellation := make(chan struct{})
+	ctx := &checkpointCancellationContext{
+		Context: baseContext,
+		beforeDone: sync.OnceFunc(func() {
+			close(enteredDatabase)
+			<-continueCancellation
+		}),
+	}
+	transactionContext := t.Context()
+	result := make(chan error, 1)
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		result <- database.Transaction(transactionContext, func(tx sqlstore.DBTX) error {
+			return repository.Save(ctx, tx, binding, []byte("null"), nil, false)
+		})
+	})
+	<-enteredDatabase
+	cancel()
+	close(continueCancellation)
+	saveErr := <-result
+	wg.Wait()
+
+	if !errors.Is(saveErr, context.Canceled) {
+		t.Fatalf("canceled checkpoint save error = %T %v", saveErr, saveErr)
+	}
+	if _, conflict := errors.AsType[*sqlstore.CheckpointConflictError](saveErr); conflict {
+		t.Fatalf("canceled checkpoint save became a conflict: %v", saveErr)
+	}
+}
+
+type checkpointCancellationContext struct {
+	context.Context
+	beforeDone func()
+}
+
+func (c *checkpointCancellationContext) Done() <-chan struct{} {
+	c.beforeDone()
+	return c.Context.Done()
+}
+
+func checkpointBinding(t *testing.T, suffix string) source.ConnectorBinding {
+	t.Helper()
+	binding, err := source.NewConnectorBinding("scope-secret-"+suffix, "binding-secret-"+suffix, "connector-secret", "version-secret")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return binding
+}
+
+func openCheckpointDatabase(t *testing.T, path string) *sqlstore.Database {
+	t.Helper()
+	database, err := sqlstore.OpenSQLite(t.Context(), sqlstore.DefaultSQLiteConfig(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := database.Close(context.Background()); err != nil {
+			t.Error(err)
+		}
+	})
+	return database
+}

--- a/internal/sqlstore/database_test.go
+++ b/internal/sqlstore/database_test.go
@@ -62,6 +62,7 @@ func TestOpenSQLiteInitializesSchemaAndEveryConnection(t *testing.T) {
 		"pc_scope_creation_requests",
 		"pc_scope_settings",
 		"pc_scope_bindings",
+		"pc_connector_checkpoints",
 		"pc_sources",
 		"pc_source_journal_heads",
 		"pc_artifacts",

--- a/internal/sqlstore/schema.go
+++ b/internal/sqlstore/schema.go
@@ -102,6 +102,14 @@ var builtinSchema = []string{
         CONSTRAINT fk_pc_scope_bindings_scope FOREIGN KEY (scope_id)
             REFERENCES pc_scopes (scope_id) ON DELETE RESTRICT
     )`,
+	`CREATE TABLE IF NOT EXISTS pc_connector_checkpoints (
+        scope_id VARCHAR(256) NOT NULL,
+        binding_id VARCHAR(256) NOT NULL,
+        connector_name VARCHAR(128) NOT NULL,
+        connector_version VARCHAR(128) NOT NULL,
+        checkpoint BLOB NOT NULL,
+        PRIMARY KEY (scope_id, binding_id)
+    )`,
 	`CREATE TABLE IF NOT EXISTS pc_source_journal_heads (
         scope_id VARCHAR(256) NOT NULL,
         position BIGINT NOT NULL,

--- a/source/connector.go
+++ b/source/connector.go
@@ -1,0 +1,97 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package source
+
+import (
+	"fmt"
+	"strings"
+	"unicode/utf8"
+)
+
+// ConnectorBinding identifies one durable Connector checkpoint within a Scope.
+type ConnectorBinding struct {
+	scopeID          string
+	bindingID        string
+	connectorName    string
+	connectorVersion string
+}
+
+// InvalidConnectorBindingError reports an invalid Connector identity without
+// disclosing the rejected value.
+type InvalidConnectorBindingError struct {
+	Field  string
+	Detail string
+}
+
+func (e *InvalidConnectorBindingError) Error() string {
+	return fmt.Sprintf("invalid Connector binding %s: %s", e.Field, e.Detail)
+}
+
+func NewConnectorBinding(scopeID, bindingID, connectorName, connectorVersion string) (ConnectorBinding, error) {
+	binding := ConnectorBinding{
+		scopeID:          scopeID,
+		bindingID:        bindingID,
+		connectorName:    connectorName,
+		connectorVersion: connectorVersion,
+	}
+	if err := binding.Validate(); err != nil {
+		return ConnectorBinding{}, err
+	}
+	return binding, nil
+}
+
+func (b ConnectorBinding) ScopeID() string          { return b.scopeID }
+func (b ConnectorBinding) ID() string               { return b.bindingID }
+func (b ConnectorBinding) ConnectorName() string    { return b.connectorName }
+func (b ConnectorBinding) ConnectorVersion() string { return b.connectorVersion }
+
+// Validate rejects zero-value and otherwise invalid Connector identities at
+// every boundary that accepts an already constructed binding.
+func (b ConnectorBinding) Validate() error {
+	for _, field := range []struct {
+		name    string
+		value   string
+		maximum int
+	}{
+		{name: "scope_id", value: b.scopeID, maximum: MaxIDLength},
+		{name: "binding_id", value: b.bindingID, maximum: MaxIDLength},
+		{name: "connector_name", value: b.connectorName, maximum: MaxTypeLength},
+		{name: "connector_version", value: b.connectorVersion, maximum: MaxTypeLength},
+	} {
+		if err := connectorIdentity(field.name, field.value, field.maximum); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func connectorIdentity(field, value string, maximum int) error {
+	if !utf8.ValidString(value) {
+		return &InvalidConnectorBindingError{Field: field, Detail: "must be valid UTF-8"}
+	}
+	trimmed := strings.TrimFunc(value, isPythonWhitespace)
+	if trimmed == "" {
+		return &InvalidConnectorBindingError{Field: field, Detail: "must be a non-empty string"}
+	}
+	if trimmed != value {
+		return &InvalidConnectorBindingError{Field: field, Detail: "must not contain leading or trailing whitespace"}
+	}
+	if utf8.RuneCountInString(value) > maximum {
+		return &InvalidConnectorBindingError{
+			Field: field, Detail: fmt.Sprintf("must not exceed %d characters", maximum),
+		}
+	}
+	return nil
+}

--- a/source/connector_test.go
+++ b/source/connector_test.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package source
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestConnectorBindingRequiresStableBoundedIdentity(t *testing.T) {
+	binding, err := NewConnectorBinding("scope-a", "github:repository", "github", "v1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := binding.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	if binding.ScopeID() != "scope-a" || binding.ID() != "github:repository" ||
+		binding.ConnectorName() != "github" || binding.ConnectorVersion() != "v1" {
+		t.Fatalf("binding = %#v", binding)
+	}
+
+	invalidUTF8 := string([]byte{0xff})
+	for _, test := range []struct {
+		name  string
+		input [4]string
+		field string
+	}{
+		{name: "empty scope", input: [4]string{"", "binding", "connector", "v1"}, field: "scope_id"},
+		{name: "leading binding whitespace", input: [4]string{"scope", " binding", "connector", "v1"}, field: "binding_id"},
+		{name: "trailing version whitespace", input: [4]string{"scope", "binding", "connector", "v1 "}, field: "connector_version"},
+		{name: "invalid UTF-8 name", input: [4]string{"scope", "binding", invalidUTF8, "v1"}, field: "connector_name"},
+		{name: "oversize scope", input: [4]string{strings.Repeat("s", MaxIDLength+1), "binding", "connector", "v1"}, field: "scope_id"},
+		{name: "oversize binding", input: [4]string{"scope", strings.Repeat("b", MaxIDLength+1), "connector", "v1"}, field: "binding_id"},
+		{name: "oversize connector name", input: [4]string{"scope", "binding", strings.Repeat("c", MaxTypeLength+1), "v1"}, field: "connector_name"},
+		{name: "oversize connector version", input: [4]string{"scope", "binding", "connector", strings.Repeat("v", MaxTypeLength+1)}, field: "connector_version"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := NewConnectorBinding(test.input[0], test.input[1], test.input[2], test.input[3])
+			invalid, ok := errors.AsType[*InvalidConnectorBindingError](err)
+			if !ok || invalid.Field != test.field {
+				t.Fatalf("invalid connector binding error = %T %v", err, err)
+			}
+		})
+	}
+
+	if err := (ConnectorBinding{}).Validate(); err == nil {
+		t.Fatal("zero Connector binding was accepted")
+	} else if _, ok := errors.AsType[*InvalidConnectorBindingError](err); !ok {
+		t.Fatalf("zero Connector binding error = %T %v", err, err)
+	}
+}
+
+func TestConnectorBindingUsesPythonWhitespaceSemantics(t *testing.T) {
+	for character := rune('\u001c'); character <= '\u001f'; character++ {
+		for _, value := range []string{string(character) + "scope-secret", "scope-secret" + string(character)} {
+			_, err := NewConnectorBinding(value, "binding", "connector", "v1")
+			invalid, ok := errors.AsType[*InvalidConnectorBindingError](err)
+			if !ok || invalid.Field != "scope_id" {
+				t.Fatalf("NewConnectorBinding(%U) error = %T %v", character, err, err)
+			}
+			if strings.Contains(err.Error(), "scope-secret") {
+				t.Errorf("NewConnectorBinding(%U) disclosed connector identity: %v", character, err)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Part of #202 Phase 2. This is a narrowly scoped SQLite/source persistence foundation; it does not claim Phase 2 completion.

What it adds:
- immutable, validated Scope-local `source.ConnectorBinding`;
- `pc_connector_checkpoints` SQLite fact storage;
- Python-compatible strict `{"value": ...}` checkpoint envelope with null, JSON-value CAS, raw-integer preservation, redacted corruption handling, and atomic initial-create conflict mapping;
- real SQLite multi-connection contention and cancellation regression coverage;
- a learned prevention rule for cross-language checkpoint persistence.

Boundaries deliberately retained:
- SQLite only; no seekDB/OceanBase behavior is added;
- no external-agent behavior changes beyond the existing Codex/WorkBuddy support matrix;
- no Connector lifecycle, Source Definition/Observation, Scope Server composition, OpenAPI, or generated API changes.

Local evidence:
- `go test -count=1 ./source ./internal/sqlstore`
- `go test -race -count=1 ./source ./internal/sqlstore -run '^(TestConnectorBinding|TestConnectorCheckpointRepository)'`
- `go test -count=50 ./internal/sqlstore -run '^TestConnectorCheckpointRepositoryConcurrentCreateHasOneTypedConflict$'`
- cancellation regression independently repeated 50 times in review
- diff-only `golangci-lint` is clean; full lint retains only pre-existing seekDB `SA4023` diagnostics in untouched `internal/sqlstore/database.go`.

Remaining evidence is intentionally Phase 2 follow-on: Linux CI, Connector lifecycle ordering, Source Definition/Observation, Server scope consumption, and Codex real service chain.