### PR TITLE
feat(source): add immutable definition manifests

### DIFF
--- a/source/definition_manifest.go
+++ b/source/definition_manifest.go
@@ -1,0 +1,653 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package source
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	stdjson "encoding/json"
+	"encoding/json/jsontext"
+	json "encoding/json/v2"
+	"fmt"
+	"math"
+	"math/big"
+	"strconv"
+	"strings"
+	"unicode/utf8"
+)
+
+const maxDefinitionProjections = 16
+
+var maxJSONSafeInteger = func() *big.Int {
+	value, ok := new(big.Int).SetString("9007199254740991", 10)
+	if !ok {
+		panic("invalid JSON safe integer limit")
+	}
+	return value
+}()
+
+// InvalidDefinitionManifestError reports an invalid declarative Source
+// Definition without disclosing the rejected identity or schema contents.
+type InvalidDefinitionManifestError struct {
+	Field  string
+	Detail string
+}
+
+func (e *InvalidDefinitionManifestError) Error() string {
+	return fmt.Sprintf("invalid Source Definition manifest %s: %s", e.Field, e.Detail)
+}
+
+// DefinitionIdentity identifies one immutable version of a Source Definition.
+type DefinitionIdentity struct {
+	name    string
+	version string
+}
+
+// NewDefinitionIdentity validates and constructs a Definition identity.
+func NewDefinitionIdentity(name, version string) (DefinitionIdentity, error) {
+	identity := DefinitionIdentity{name: name, version: version}
+	if err := identity.Validate(); err != nil {
+		return DefinitionIdentity{}, err
+	}
+	return identity, nil
+}
+
+func (i DefinitionIdentity) Name() string    { return i.name }
+func (i DefinitionIdentity) Version() string { return i.version }
+
+// Validate rejects zero-value and otherwise invalid Definition identities.
+func (i DefinitionIdentity) Validate() error {
+	if err := validateManifestIdentity("name", i.name, MaxTypeLength); err != nil {
+		return err
+	}
+	return validateManifestIdentity("version", i.version, MaxTypeLength)
+}
+
+// ProjectionKey identifies one independently versioned Source projection.
+type ProjectionKey struct {
+	name    string
+	version string
+}
+
+// NewProjectionKey validates and constructs a projection key.
+func NewProjectionKey(name, version string) (ProjectionKey, error) {
+	key := ProjectionKey{name: name, version: version}
+	if err := key.Validate(); err != nil {
+		return ProjectionKey{}, err
+	}
+	return key, nil
+}
+
+func (k ProjectionKey) Name() string    { return k.name }
+func (k ProjectionKey) Version() string { return k.version }
+
+// Validate rejects zero-value and otherwise invalid projection keys.
+func (k ProjectionKey) Validate() error {
+	if err := validateManifestIdentity("name", k.name, MaxIDLength); err != nil {
+		return err
+	}
+	return validateManifestIdentity("version", k.version, MaxIDLength)
+}
+
+// ProjectionManifest declares the schema for one worker-owned projection.
+type ProjectionManifest struct {
+	key    ProjectionKey
+	schema jsontext.Value
+}
+
+// NewProjectionManifest validates and freezes one projection declaration.
+// schema must encode a JSON object; jsontext.Value preserves raw JSON numbers.
+func NewProjectionManifest(key ProjectionKey, schema any) (ProjectionManifest, error) {
+	if err := key.Validate(); err != nil {
+		return ProjectionManifest{}, manifestError("key", "must contain a valid name and version")
+	}
+	encoded, err := immutableSchema(schema, "schema")
+	if err != nil {
+		return ProjectionManifest{}, err
+	}
+	return ProjectionManifest{key: key, schema: encoded}, nil
+}
+
+func (m ProjectionManifest) Key() ProjectionKey { return m.key }
+
+// Schema returns an isolated copy of the projection JSON Schema.
+func (m ProjectionManifest) Schema() jsontext.Value {
+	return jsontext.Value(bytes.Clone(m.schema))
+}
+
+// Validate rejects zero-value and otherwise invalid projection declarations.
+func (m ProjectionManifest) Validate() error {
+	if err := m.key.Validate(); err != nil {
+		return manifestError("key", "must contain a valid name and version")
+	}
+	_, err := immutableSchema(m.schema, "schema")
+	return err
+}
+
+// DefinitionManifest is an immutable, content-addressed Source Definition
+// declaration that can be stored without loading worker implementation code.
+type DefinitionManifest struct {
+	identity     DefinitionIdentity
+	fingerprint  string
+	sourceSchema jsontext.Value
+	projections  []ProjectionManifest
+}
+
+// NewDefinitionManifest validates and freezes a Source Definition declaration.
+// sourceSchema must encode a JSON object; projection order is significant.
+func NewDefinitionManifest(
+	identity DefinitionIdentity,
+	sourceSchema any,
+	projections []ProjectionManifest,
+) (DefinitionManifest, error) {
+	if err := identity.Validate(); err != nil {
+		return DefinitionManifest{}, manifestError("identity", "must contain a valid name and version")
+	}
+	if len(projections) > maxDefinitionProjections {
+		return DefinitionManifest{}, manifestError("projections", "must not contain more than 16 entries")
+	}
+
+	frozenProjections := make([]ProjectionManifest, len(projections))
+	seen := make(map[ProjectionKey]struct{}, len(projections))
+	for index, projection := range projections {
+		if err := projection.Validate(); err != nil {
+			return DefinitionManifest{}, manifestError("projections", "must contain valid projection declarations")
+		}
+		if _, exists := seen[projection.key]; exists {
+			return DefinitionManifest{}, manifestError("projections", "keys must be unique")
+		}
+		seen[projection.key] = struct{}{}
+		frozenProjections[index] = cloneProjectionManifest(projection)
+	}
+
+	encodedSchema, err := immutableSchema(sourceSchema, "source_schema")
+	if err != nil {
+		return DefinitionManifest{}, err
+	}
+	manifest := DefinitionManifest{
+		identity:     identity,
+		sourceSchema: encodedSchema,
+		projections:  frozenProjections,
+	}
+	fingerprint, err := definitionFingerprint(manifest)
+	if err != nil {
+		return DefinitionManifest{}, err
+	}
+	manifest.fingerprint = fingerprint
+	return manifest, nil
+}
+
+func (m DefinitionManifest) Identity() DefinitionIdentity { return m.identity }
+func (m DefinitionManifest) Name() string                 { return m.identity.name }
+func (m DefinitionManifest) Version() string              { return m.identity.version }
+func (m DefinitionManifest) Fingerprint() string          { return m.fingerprint }
+
+// SourceSchema returns an isolated copy of the Source JSON Schema.
+func (m DefinitionManifest) SourceSchema() jsontext.Value {
+	return jsontext.Value(bytes.Clone(m.sourceSchema))
+}
+
+// Projections returns isolated copies in declaration order.
+func (m DefinitionManifest) Projections() []ProjectionManifest {
+	result := make([]ProjectionManifest, len(m.projections))
+	for index, projection := range m.projections {
+		result[index] = cloneProjectionManifest(projection)
+	}
+	return result
+}
+
+// Validate rejects zero-value, mutated, and otherwise invalid manifests.
+func (m DefinitionManifest) Validate() error {
+	if err := m.identity.Validate(); err != nil {
+		return manifestError("identity", "must contain a valid name and version")
+	}
+	if !validFingerprint(m.fingerprint) {
+		return manifestError("fingerprint", "must use sha256 followed by lowercase hexadecimal")
+	}
+	if len(m.projections) > maxDefinitionProjections {
+		return manifestError("projections", "must not contain more than 16 entries")
+	}
+	seen := make(map[ProjectionKey]struct{}, len(m.projections))
+	for _, projection := range m.projections {
+		if err := projection.Validate(); err != nil {
+			return manifestError("projections", "must contain valid projection declarations")
+		}
+		if _, exists := seen[projection.key]; exists {
+			return manifestError("projections", "keys must be unique")
+		}
+		seen[projection.key] = struct{}{}
+	}
+	if _, err := immutableSchema(m.sourceSchema, "source_schema"); err != nil {
+		return err
+	}
+	expected, err := definitionFingerprint(m)
+	if err != nil {
+		return err
+	}
+	if m.fingerprint != expected {
+		return manifestError("fingerprint", "does not match the declaration")
+	}
+	return nil
+}
+
+// MarshalJSON emits the Python-compatible Source Definition manifest shape.
+func (m DefinitionManifest) MarshalJSON() ([]byte, error) {
+	if err := m.Validate(); err != nil {
+		return nil, err
+	}
+	return json.Marshal(definitionWire(m, true))
+}
+
+// ParseDefinitionManifest strictly parses and verifies a transported manifest.
+func ParseDefinitionManifest(payload []byte) (DefinitionManifest, error) {
+	root, err := definitionManifestObject(payload)
+	if err != nil {
+		return DefinitionManifest{}, err
+	}
+	name, err := requiredString(root["name"], "name")
+	if err != nil {
+		return DefinitionManifest{}, err
+	}
+	version, err := requiredString(root["version"], "version")
+	if err != nil {
+		return DefinitionManifest{}, err
+	}
+	providedFingerprint, err := requiredString(root["fingerprint"], "fingerprint")
+	if err != nil || !validFingerprint(providedFingerprint) {
+		return DefinitionManifest{}, manifestError("fingerprint", "must use sha256 followed by lowercase hexadecimal")
+	}
+	identity, err := NewDefinitionIdentity(name, version)
+	if err != nil {
+		return DefinitionManifest{}, err
+	}
+
+	projectionValues := []jsontext.Value{}
+	if encodedProjections, exists := root["projections"]; exists {
+		projectionValues, err = requiredArray(encodedProjections, "projections")
+		if err != nil {
+			return DefinitionManifest{}, err
+		}
+	}
+	projections := make([]ProjectionManifest, len(projectionValues))
+	for index, value := range projectionValues {
+		projection, parseErr := parseProjectionManifest(value)
+		if parseErr != nil {
+			return DefinitionManifest{}, manifestError("projections", "must contain valid projection declarations")
+		}
+		projections[index] = projection
+	}
+
+	manifest, err := NewDefinitionManifest(identity, root["source_schema"], projections)
+	if err != nil {
+		return DefinitionManifest{}, err
+	}
+	if manifest.fingerprint != providedFingerprint {
+		return DefinitionManifest{}, manifestError("fingerprint", "does not match the declaration")
+	}
+	return manifest, nil
+}
+
+type projectionKeyWire struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+type projectionManifestWire struct {
+	Key    projectionKeyWire `json:"key"`
+	Schema jsontext.Value    `json:"schema"`
+}
+
+type definitionManifestWire struct {
+	Name         string                   `json:"name"`
+	Version      string                   `json:"version"`
+	Fingerprint  string                   `json:"fingerprint,omitempty"`
+	SourceSchema jsontext.Value           `json:"source_schema"`
+	Projections  []projectionManifestWire `json:"projections"`
+}
+
+func definitionWire(manifest DefinitionManifest, includeFingerprint bool) definitionManifestWire {
+	projections := make([]projectionManifestWire, len(manifest.projections))
+	for index, projection := range manifest.projections {
+		projections[index] = projectionManifestWire{
+			Key: projectionKeyWire{
+				Name:    projection.key.name,
+				Version: projection.key.version,
+			},
+			Schema: jsontext.Value(bytes.Clone(projection.schema)),
+		}
+	}
+	fingerprint := ""
+	if includeFingerprint {
+		fingerprint = manifest.fingerprint
+	}
+	return definitionManifestWire{
+		Name:         manifest.identity.name,
+		Version:      manifest.identity.version,
+		Fingerprint:  fingerprint,
+		SourceSchema: jsontext.Value(bytes.Clone(manifest.sourceSchema)),
+		Projections:  projections,
+	}
+}
+
+func definitionFingerprint(manifest DefinitionManifest) (string, error) {
+	declaration, err := json.Marshal(definitionWire(manifest, false))
+	if err != nil {
+		return "", manifestError("declaration", "must be valid JSON")
+	}
+	canonical := jsontext.Value(declaration)
+	if err := canonical.Canonicalize(); err != nil {
+		return "", manifestError("declaration", "must satisfy RFC 8785")
+	}
+	digest := sha256.Sum256(canonical)
+	return "sha256:" + hex.EncodeToString(digest[:]), nil
+}
+
+func parseProjectionManifest(payload jsontext.Value) (ProjectionManifest, error) {
+	root, err := exactObject(payload, "projection", "key", "schema")
+	if err != nil {
+		return ProjectionManifest{}, err
+	}
+	keyObject, err := exactObject(root["key"], "key", "name", "version")
+	if err != nil {
+		return ProjectionManifest{}, err
+	}
+	name, err := requiredString(keyObject["name"], "name")
+	if err != nil {
+		return ProjectionManifest{}, err
+	}
+	version, err := requiredString(keyObject["version"], "version")
+	if err != nil {
+		return ProjectionManifest{}, err
+	}
+	key, err := NewProjectionKey(name, version)
+	if err != nil {
+		return ProjectionManifest{}, err
+	}
+	return NewProjectionManifest(key, root["schema"])
+}
+
+func immutableSchema(value any, field string) (jsontext.Value, error) {
+	var encoded jsontext.Value
+	if raw, ok := value.(jsontext.Value); ok {
+		encoded = jsontext.Value(bytes.Clone(raw))
+		if err := validateJSONNumbers(encoded); err != nil {
+			return nil, manifestError(field, "must contain only interoperable JSON numbers")
+		}
+	} else {
+		// Let the standard encoder reject cycles before recursively preserving
+		// the lexical distinction between Go floating-point and integer values.
+		if _, err := json.Marshal(value); err != nil {
+			return nil, manifestError(field, "must contain only JSON-compatible values")
+		}
+		normalized, err := normalizeGoJSONValue(value)
+		if err != nil {
+			return nil, manifestError(field, "must contain only JSON-compatible values")
+		}
+		payload, err := json.Marshal(normalized)
+		if err != nil {
+			return nil, manifestError(field, "must be a JSON object")
+		}
+		encoded = jsontext.Value(payload)
+	}
+	if encoded.Kind() != '{' {
+		return nil, manifestError(field, "must be a JSON object")
+	}
+	var schema map[string]any
+	if err := json.Unmarshal(encoded, &schema); err != nil {
+		return nil, manifestError(field, "must be a valid JSON object")
+	}
+	if hasRemoteSchemaReference(schema) {
+		return nil, manifestError(field, "must not contain remote schema references")
+	}
+	return encoded, nil
+}
+
+func normalizeGoJSONValue(value any) (any, error) {
+	switch typed := value.(type) {
+	case nil, bool, string:
+		return typed, nil
+	case float32:
+		return normalizeGoFloat(float64(typed), 32)
+	case float64:
+		return normalizeGoFloat(typed, 64)
+	case int:
+		return typed, validateGoSignedInteger(int64(typed))
+	case int8:
+		return typed, nil
+	case int16:
+		return typed, nil
+	case int32:
+		return typed, nil
+	case int64:
+		return typed, validateGoSignedInteger(typed)
+	case uint:
+		return typed, validateGoUnsignedInteger(uint64(typed))
+	case uint8:
+		return typed, nil
+	case uint16:
+		return typed, nil
+	case uint32:
+		return typed, nil
+	case uint64:
+		return typed, validateGoUnsignedInteger(typed)
+	case stdjson.Number:
+		raw := jsontext.Value(typed.String())
+		if err := validateJSONNumbers(raw); err != nil {
+			return nil, err
+		}
+		return raw, nil
+	case jsontext.Value:
+		if err := validateJSONNumbers(typed); err != nil {
+			return nil, err
+		}
+		return jsontext.Value(bytes.Clone(typed)), nil
+	case map[string]any:
+		result := make(map[string]any, len(typed))
+		for name, nested := range typed {
+			normalized, err := normalizeGoJSONValue(nested)
+			if err != nil {
+				return nil, err
+			}
+			result[name] = normalized
+		}
+		return result, nil
+	case []any:
+		result := make([]any, len(typed))
+		for index, nested := range typed {
+			normalized, err := normalizeGoJSONValue(nested)
+			if err != nil {
+				return nil, err
+			}
+			result[index] = normalized
+		}
+		return result, nil
+	default:
+		return nil, manifestError("value", "must be JSON-compatible")
+	}
+}
+
+func normalizeGoFloat(value float64, bits int) (jsontext.Value, error) {
+	if math.IsNaN(value) || math.IsInf(value, 0) {
+		return nil, manifestError("number", "must be finite")
+	}
+	encoded := strconv.FormatFloat(value, 'g', -1, bits)
+	if !strings.ContainsAny(encoded, ".eE") {
+		encoded += ".0"
+	}
+	return jsontext.Value(encoded), nil
+}
+
+func validateGoSignedInteger(value int64) error {
+	if value < -9007199254740991 || value > 9007199254740991 {
+		return manifestError("number", "must be within the IEEE-754 safe integer range")
+	}
+	return nil
+}
+
+func validateGoUnsignedInteger(value uint64) error {
+	if value > 9007199254740991 {
+		return manifestError("number", "must be within the IEEE-754 safe integer range")
+	}
+	return nil
+}
+
+func validateJSONNumbers(payload jsontext.Value) error {
+	decoder := jsontext.NewDecoder(bytes.NewReader(payload))
+	for decoder.PeekKind() != 0 {
+		token, err := decoder.ReadToken()
+		if err != nil {
+			return err
+		}
+		if token.Kind() != '0' {
+			continue
+		}
+		value := token.String()
+		if strings.ContainsAny(value, ".eE") {
+			continue
+		}
+		integer, ok := new(big.Int).SetString(value, 10)
+		if !ok || new(big.Int).Abs(integer).Cmp(maxJSONSafeInteger) > 0 {
+			return manifestError("number", "must be within the IEEE-754 safe integer range")
+		}
+	}
+	return nil
+}
+
+func hasRemoteSchemaReference(value any) bool {
+	switch typed := value.(type) {
+	case map[string]any:
+		for name, nested := range typed {
+			if name == "$ref" || name == "$dynamicRef" {
+				if reference, ok := nested.(string); ok && !strings.HasPrefix(reference, "#") {
+					return true
+				}
+			}
+			if hasRemoteSchemaReference(nested) {
+				return true
+			}
+		}
+	case []any:
+		for _, nested := range typed {
+			if hasRemoteSchemaReference(nested) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func exactObject(payload []byte, field string, required ...string) (map[string]jsontext.Value, error) {
+	if jsontext.Value(payload).Kind() != '{' {
+		return nil, manifestError(field, "must be a JSON object")
+	}
+	var object map[string]jsontext.Value
+	if err := json.Unmarshal(payload, &object); err != nil {
+		return nil, manifestError(field, "must be valid JSON without duplicate members or trailing data")
+	}
+	if len(object) != len(required) {
+		return nil, manifestError(field, "must contain exactly the required members")
+	}
+	for _, name := range required {
+		if _, exists := object[name]; !exists {
+			return nil, manifestError(field, "must contain exactly the required members")
+		}
+	}
+	return object, nil
+}
+
+func definitionManifestObject(payload []byte) (map[string]jsontext.Value, error) {
+	if jsontext.Value(payload).Kind() != '{' {
+		return nil, manifestError("payload", "must be a JSON object")
+	}
+	var object map[string]jsontext.Value
+	if err := json.Unmarshal(payload, &object); err != nil {
+		return nil, manifestError("payload", "must be valid JSON without duplicate members or trailing data")
+	}
+	required := [...]string{"name", "version", "fingerprint", "source_schema"}
+	for _, name := range required {
+		if _, exists := object[name]; !exists {
+			return nil, manifestError("payload", "must contain every required member")
+		}
+	}
+	for name := range object {
+		switch name {
+		case "name", "version", "fingerprint", "source_schema", "projections":
+		default:
+			return nil, manifestError("payload", "must not contain unknown members")
+		}
+	}
+	return object, nil
+}
+
+func requiredString(payload jsontext.Value, field string) (string, error) {
+	if payload.Kind() != '"' {
+		return "", manifestError(field, "must be a string")
+	}
+	var value string
+	if err := json.Unmarshal(payload, &value); err != nil {
+		return "", manifestError(field, "must be a valid string")
+	}
+	return value, nil
+}
+
+func requiredArray(payload jsontext.Value, field string) ([]jsontext.Value, error) {
+	if payload.Kind() != '[' {
+		return nil, manifestError(field, "must be an array")
+	}
+	var values []jsontext.Value
+	if err := json.Unmarshal(payload, &values); err != nil {
+		return nil, manifestError(field, "must be a valid array")
+	}
+	return values, nil
+}
+
+func validateManifestIdentity(field, value string, maximum int) error {
+	if !utf8.ValidString(value) {
+		return manifestError(field, "must be valid UTF-8")
+	}
+	trimmed := strings.TrimFunc(value, isPythonWhitespace)
+	if trimmed == "" {
+		return manifestError(field, "must be a non-empty string")
+	}
+	if trimmed != value {
+		return manifestError(field, "must not contain leading or trailing whitespace")
+	}
+	if utf8.RuneCountInString(value) > maximum {
+		return manifestError(field, fmt.Sprintf("must not exceed %d characters", maximum))
+	}
+	return nil
+}
+
+func validFingerprint(value string) bool {
+	if len(value) != len("sha256:")+sha256.Size*2 || !strings.HasPrefix(value, "sha256:") {
+		return false
+	}
+	digest := value[len("sha256:"):]
+	for _, character := range digest {
+		if character < '0' || character > '9' && character < 'a' || character > 'f' {
+			return false
+		}
+	}
+	return true
+}
+
+func cloneProjectionManifest(value ProjectionManifest) ProjectionManifest {
+	return ProjectionManifest{key: value.key, schema: jsontext.Value(bytes.Clone(value.schema))}
+}
+
+func manifestError(field, detail string) *InvalidDefinitionManifestError {
+	return &InvalidDefinitionManifestError{Field: field, Detail: detail}
+}

--- a/source/definition_manifest_test.go
+++ b/source/definition_manifest_test.go
@@ -1,0 +1,489 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package source_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json/jsontext"
+	json "encoding/json/v2"
+	"errors"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ob-labs/powercontext-go/source"
+)
+
+func TestDefinitionManifestMatchesUpstreamFingerprint(t *testing.T) {
+	manifest := newManifest(t, "content", "1", jsontext.Value(`{"type":"object"}`), nil)
+
+	const want = "sha256:3c9c8f195eb3ba1f747db8a09a6ee4a152faf46a5ffd62f167efc0d1014f9b2f"
+	if manifest.Fingerprint() != want {
+		t.Fatalf("Fingerprint() = %q, want %q", manifest.Fingerprint(), want)
+	}
+	if err := manifest.Validate(); err != nil {
+		t.Fatal(err)
+	}
+
+	payload, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	parsed, err := source.ParseDefinitionManifest(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if parsed.Fingerprint() != want || parsed.Name() != "content" || parsed.Version() != "1" {
+		t.Fatalf("parsed manifest = name %q, version %q, fingerprint %q", parsed.Name(), parsed.Version(), parsed.Fingerprint())
+	}
+}
+
+func TestDefinitionManifestFingerprintUsesJCSWithoutUnicodeNormalization(t *testing.T) {
+	ordered := newManifest(t, "content", "1", jsontext.Value(`{"z":1,"a":{"b":2,"a":1}}`), nil)
+	reordered := newManifest(t, "content", "1", jsontext.Value(`{"a":{"a":1,"b":2},"z":1}`), nil)
+	if ordered.Fingerprint() != reordered.Fingerprint() {
+		t.Fatalf("object key order changed fingerprint: %q != %q", ordered.Fingerprint(), reordered.Fingerprint())
+	}
+
+	nfc := newManifest(t, "content", "1", jsontext.Value("{\"title\":\"\u00e9\"}"), nil)
+	nfd := newManifest(t, "content", "1", jsontext.Value("{\"title\":\"e\u0301\"}"), nil)
+	if nfc.Fingerprint() == nfd.Fingerprint() {
+		t.Fatal("NFC and NFD declarations received the same fingerprint")
+	}
+}
+
+func TestDefinitionManifestFingerprintPreservesProjectionOrder(t *testing.T) {
+	first := newProjection(t, "text", "1", jsontext.Value(`{"type":"string"}`))
+	second := newProjection(t, "tags", "1", jsontext.Value(`{"type":"array"}`))
+
+	forward := newManifest(t, "content", "1", jsontext.Value(`{"type":"object"}`), []source.ProjectionManifest{first, second})
+	reverse := newManifest(t, "content", "1", jsontext.Value(`{"type":"object"}`), []source.ProjectionManifest{second, first})
+	if forward.Fingerprint() == reverse.Fingerprint() {
+		t.Fatal("projection order did not affect the fingerprint")
+	}
+}
+
+func TestDefinitionManifestOwnsAllMutableJSON(t *testing.T) {
+	sourceSchema := jsontext.Value(`{"type":"object"}`)
+	projectionSchema := jsontext.Value(`{"type":"string"}`)
+	projection := newProjection(t, "text", "1", projectionSchema)
+	projections := []source.ProjectionManifest{projection}
+	manifest := newManifest(t, "content", "1", sourceSchema, projections)
+	fingerprint := manifest.Fingerprint()
+
+	copy(sourceSchema, `{"evil":"value"}`)
+	copy(projectionSchema, `{"evil":"value"}`)
+	projections[0] = source.ProjectionManifest{}
+	returnedSource := manifest.SourceSchema()
+	copy(returnedSource, `{"evil":"value"}`)
+	returnedProjections := manifest.Projections()
+	returnedProjectionSchema := returnedProjections[0].Schema()
+	copy(returnedProjectionSchema, `{"evil":"value"}`)
+	returnedProjections[0] = source.ProjectionManifest{}
+
+	if manifest.Fingerprint() != fingerprint {
+		t.Fatalf("mutation changed fingerprint from %q to %q", fingerprint, manifest.Fingerprint())
+	}
+	if got := string(manifest.SourceSchema()); got != `{"type":"object"}` {
+		t.Fatalf("SourceSchema() = %s", got)
+	}
+	if got := string(manifest.Projections()[0].Schema()); got != `{"type":"string"}` {
+		t.Fatalf("projection Schema() = %s", got)
+	}
+	if err := manifest.Validate(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDefinitionManifestRejectsUnsafeJSONIntegers(t *testing.T) {
+	identity := newIdentity(t, "content", "1")
+	key := newProjectionKey(t, "text", "1")
+	for _, test := range []struct {
+		name   string
+		value  jsontext.Value
+		build  func(jsontext.Value) error
+		secret string
+	}{
+		{
+			name:  "positive source integer",
+			value: jsontext.Value(`{"maximum":9007199254740992}`),
+			build: func(value jsontext.Value) error {
+				_, err := source.NewDefinitionManifest(identity, value, nil)
+				return err
+			},
+			secret: "9007199254740992",
+		},
+		{
+			name:  "negative source integer",
+			value: jsontext.Value(`{"minimum":-9007199254740992}`),
+			build: func(value jsontext.Value) error {
+				_, err := source.NewDefinitionManifest(identity, value, nil)
+				return err
+			},
+			secret: "-9007199254740992",
+		},
+		{
+			name:   "projection integer",
+			value:  jsontext.Value(`{"const":9007199254740992}`),
+			build:  func(value jsontext.Value) error { _, err := source.NewProjectionManifest(key, value); return err },
+			secret: "9007199254740992",
+		},
+		{
+			name: "Go integer",
+			build: func(jsontext.Value) error {
+				_, err := source.NewDefinitionManifest(identity, map[string]any{"maximum": int64(9007199254740992)}, nil)
+				return err
+			},
+			secret: "9007199254740992",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			err := test.build(test.value)
+			_ = assertInvalidManifest(t, err)
+			if strings.Contains(err.Error(), test.secret) {
+				t.Fatalf("error disclosed rejected JSON value: %v", err)
+			}
+		})
+	}
+
+	for _, value := range []jsontext.Value{
+		jsontext.Value(`{"minimum":-9007199254740991}`),
+		jsontext.Value(`{"maximum":9007199254740991}`),
+		jsontext.Value(`{"multipleOf":9.007199254740992e+15}`),
+	} {
+		if _, err := source.NewDefinitionManifest(identity, value, nil); err != nil {
+			t.Fatalf("safe or floating-point JSON number %s rejected: %v", value, err)
+		}
+	}
+}
+
+func TestDefinitionManifestAcceptsPythonJCSFloatBoundary(t *testing.T) {
+	const want = "sha256:034496481be1e18cc7517c80f55bc13fcaf60c2af34d8cb65a9a7145e4ee9ddf"
+	for _, schema := range []any{
+		map[string]any{"maximum": float64(9007199254740992)},
+		jsontext.Value(`{"maximum":9.007199254740992e+15}`),
+		jsontext.Value(`{"maximum":9007199254740992.0}`),
+	} {
+		manifest := newManifest(t, "content", "1", schema, nil)
+		if manifest.Fingerprint() != want {
+			t.Fatalf("Fingerprint() = %q, want %q", manifest.Fingerprint(), want)
+		}
+		if err := manifest.Validate(); err != nil {
+			t.Fatalf("Validate() rejected the constructed manifest: %v", err)
+		}
+		payload, err := json.Marshal(manifest)
+		if err != nil {
+			t.Fatalf("MarshalJSON() rejected the constructed manifest: %v", err)
+		}
+		parsed, err := source.ParseDefinitionManifest(payload)
+		if err != nil {
+			t.Fatalf("ParseDefinitionManifest() rejected marshaled output: %v", err)
+		}
+		if parsed.Fingerprint() != want {
+			t.Fatalf("round-trip Fingerprint() = %q, want %q", parsed.Fingerprint(), want)
+		}
+	}
+}
+
+func TestProjectionManifestPreservesPythonJCSFloatBoundary(t *testing.T) {
+	projection := newProjection(t, "score", "1", map[string]any{"maximum": float64(9007199254740992)})
+	if err := projection.Validate(); err != nil {
+		t.Fatalf("projection Validate() rejected its constructed value: %v", err)
+	}
+	manifest := newManifest(t, "content", "1", jsontext.Value(`{}`), []source.ProjectionManifest{projection})
+	if err := manifest.Validate(); err != nil {
+		t.Fatalf("definition Validate() rejected the projection: %v", err)
+	}
+	payload, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatalf("MarshalJSON() rejected the projection: %v", err)
+	}
+	parsed, err := source.ParseDefinitionManifest(payload)
+	if err != nil {
+		t.Fatalf("ParseDefinitionManifest() rejected the projection: %v", err)
+	}
+	if parsed.Fingerprint() != manifest.Fingerprint() || len(parsed.Projections()) != 1 {
+		t.Fatalf("round-trip manifest = fingerprint %q, projections %d", parsed.Fingerprint(), len(parsed.Projections()))
+	}
+}
+
+func TestDefinitionManifestRejectsCyclicGoValues(t *testing.T) {
+	if cycleKind := os.Getenv("POWERCONTEXT_MANIFEST_CYCLE_TEST"); cycleKind != "" {
+		var schema map[string]any
+		switch cycleKind {
+		case "map":
+			schema = map[string]any{}
+			schema["self"] = schema
+		case "slice":
+			cycle := []any{nil}
+			cycle[0] = cycle
+			schema = map[string]any{"self": cycle}
+		default:
+			t.Fatalf("unknown cycle kind %q", cycleKind)
+		}
+		_, err := source.NewDefinitionManifest(newIdentity(t, "content", "1"), schema, nil)
+		_ = assertInvalidManifest(t, err)
+		return
+	}
+
+	for _, cycleKind := range []string{"map", "slice"} {
+		t.Run(cycleKind, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+			defer cancel()
+			command := exec.CommandContext(ctx, os.Args[0], "-test.run=^TestDefinitionManifestRejectsCyclicGoValues$")
+			command.Env = append(os.Environ(), "POWERCONTEXT_MANIFEST_CYCLE_TEST="+cycleKind)
+			output, err := command.CombinedOutput()
+			if ctx.Err() != nil {
+				t.Fatalf("cycle helper exceeded its deadline: %v", ctx.Err())
+			}
+			if err != nil {
+				t.Fatalf("cycle helper failed: %v\n%s", err, output)
+			}
+		})
+	}
+}
+
+func TestDefinitionManifestRejectsRemoteSchemaReferences(t *testing.T) {
+	identity := newIdentity(t, "content", "1")
+	key := newProjectionKey(t, "text", "1")
+	for _, test := range []struct {
+		name  string
+		build func() error
+	}{
+		{
+			name: "nested source ref",
+			build: func() error {
+				_, err := source.NewDefinitionManifest(identity, jsontext.Value(`{"items":[{"$ref":"https://example.invalid/schema"}]}`), nil)
+				return err
+			},
+		},
+		{
+			name: "projection dynamic ref",
+			build: func() error {
+				_, err := source.NewProjectionManifest(key, jsontext.Value(`{"allOf":[{"$dynamicRef":"other.json"}]}`))
+				return err
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			_ = assertInvalidManifest(t, test.build())
+		})
+	}
+
+	local := newProjection(t, "text", "1", jsontext.Value(`{"$dynamicRef":"#anchor"}`))
+	if _, err := source.NewDefinitionManifest(
+		identity,
+		jsontext.Value(`{"$ref":"#/definitions/content"}`),
+		[]source.ProjectionManifest{local},
+	); err != nil {
+		t.Fatalf("local fragment references rejected: %v", err)
+	}
+}
+
+func TestDefinitionManifestRequiresJSONObjects(t *testing.T) {
+	identity := newIdentity(t, "content", "1")
+	key := newProjectionKey(t, "text", "1")
+	for _, test := range []struct {
+		name  string
+		build func() error
+	}{
+		{name: "source array", build: func() error { _, err := source.NewDefinitionManifest(identity, jsontext.Value(`[]`), nil); return err }},
+		{name: "source invalid JSON", build: func() error {
+			_, err := source.NewDefinitionManifest(identity, jsontext.Value(`{"type":`), nil)
+			return err
+		}},
+		{name: "source duplicate member", build: func() error {
+			_, err := source.NewDefinitionManifest(identity, jsontext.Value(`{"type":"object","type":"array"}`), nil)
+			return err
+		}},
+		{name: "projection null", build: func() error { _, err := source.NewProjectionManifest(key, jsontext.Value(`null`)); return err }},
+		{name: "non-JSON Go value", build: func() error {
+			_, err := source.NewDefinitionManifest(identity, map[string]any{"callback": func() {}}, nil)
+			return err
+		}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			_ = assertInvalidManifest(t, test.build())
+		})
+	}
+}
+
+func TestDefinitionAndProjectionIdentitiesAreBoundedAndRedacted(t *testing.T) {
+	maximumProjectionPart := strings.Repeat("p", source.MaxIDLength)
+	key, err := source.NewProjectionKey(maximumProjectionPart, maximumProjectionPart)
+	if err != nil {
+		t.Fatalf("256-character projection key rejected: %v", err)
+	}
+	if key.Name() != maximumProjectionPart || key.Version() != maximumProjectionPart {
+		t.Fatal("projection key did not retain its maximum-length identity")
+	}
+
+	invalidUTF8 := string([]byte{0xff})
+	for _, test := range []struct {
+		name   string
+		field  string
+		value  string
+		secret string
+		build  func(string) error
+	}{
+		{name: "empty definition name", field: "name", value: "", build: func(value string) error { _, err := source.NewDefinitionIdentity(value, "1"); return err }},
+		{name: "definition Python whitespace", field: "name", value: "\u001csecret-name", secret: "secret-name", build: func(value string) error { _, err := source.NewDefinitionIdentity(value, "1"); return err }},
+		{name: "definition invalid UTF-8", field: "version", value: invalidUTF8, build: func(value string) error { _, err := source.NewDefinitionIdentity("content", value); return err }},
+		{name: "definition oversize", field: "name", value: strings.Repeat("d", source.MaxTypeLength+1), build: func(value string) error { _, err := source.NewDefinitionIdentity(value, "1"); return err }},
+		{name: "projection name oversize", field: "name", value: strings.Repeat("p", source.MaxIDLength+1), build: func(value string) error { _, err := source.NewProjectionKey(value, "1"); return err }},
+		{name: "projection version oversize", field: "version", value: strings.Repeat("v", source.MaxIDLength+1), build: func(value string) error { _, err := source.NewProjectionKey("text", value); return err }},
+		{name: "projection trailing whitespace", field: "version", value: "1\u001f", build: func(value string) error { _, err := source.NewProjectionKey("text", value); return err }},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			err := test.build(test.value)
+			invalid := assertInvalidManifest(t, err)
+			if invalid.Field != test.field {
+				t.Fatalf("Field = %q, want %q", invalid.Field, test.field)
+			}
+			if test.secret != "" && strings.Contains(err.Error(), test.secret) {
+				t.Fatalf("error disclosed rejected identity: %v", err)
+			}
+		})
+	}
+
+	if err := (source.DefinitionIdentity{}).Validate(); err == nil {
+		t.Fatal("zero DefinitionIdentity was accepted")
+	}
+	if err := (source.ProjectionKey{}).Validate(); err == nil {
+		t.Fatal("zero ProjectionKey was accepted")
+	}
+	if err := (source.ProjectionManifest{}).Validate(); err == nil {
+		t.Fatal("zero ProjectionManifest was accepted")
+	}
+	if err := (source.DefinitionManifest{}).Validate(); err == nil {
+		t.Fatal("zero DefinitionManifest was accepted")
+	}
+}
+
+func TestDefinitionManifestLimitsProjectionCountAndRequiresUniqueKeys(t *testing.T) {
+	identity := newIdentity(t, "content", "1")
+	projection := newProjection(t, "text", "1", jsontext.Value(`{"type":"string"}`))
+	duplicate := []source.ProjectionManifest{projection, projection}
+	if _, err := source.NewDefinitionManifest(identity, jsontext.Value(`{}`), duplicate); err == nil {
+		t.Fatal("duplicate projection key was accepted")
+	} else {
+		_ = assertInvalidManifest(t, err)
+	}
+
+	projections := make([]source.ProjectionManifest, 17)
+	for index := range projections {
+		projections[index] = newProjection(t, "projection-"+string(rune('a'+index)), "1", jsontext.Value(`{}`))
+	}
+	if _, err := source.NewDefinitionManifest(identity, jsontext.Value(`{}`), projections); err == nil {
+		t.Fatal("17 projections were accepted")
+	} else {
+		_ = assertInvalidManifest(t, err)
+	}
+}
+
+func TestParseDefinitionManifestIsStrict(t *testing.T) {
+	const fingerprint = "sha256:3c9c8f195eb3ba1f747db8a09a6ee4a152faf46a5ffd62f167efc0d1014f9b2f"
+	valid := []byte(`{"name":"content","version":"1","fingerprint":"` + fingerprint + `","source_schema":{"type":"object"},"projections":[]}`)
+	if _, err := source.ParseDefinitionManifest(valid); err != nil {
+		t.Fatal(err)
+	}
+
+	invalidPayloads := map[string][]byte{
+		"unknown field":        bytes.Replace(valid, []byte(`"name":`), []byte(`"unknown":true,"name":`), 1),
+		"duplicate field":      bytes.Replace(valid, []byte(`"name":"content"`), []byte(`"name":"other","name":"content"`), 1),
+		"missing field":        bytes.Replace(valid, []byte(`,"source_schema":{"type":"object"}`), nil, 1),
+		"trailing value":       append(bytes.Clone(valid), []byte(` {}`)...),
+		"fingerprint mismatch": bytes.Replace(valid, []byte(fingerprint), []byte("sha256:"+strings.Repeat("0", 64)), 1),
+	}
+	for name, payload := range invalidPayloads {
+		t.Run(name, func(t *testing.T) {
+			_, err := source.ParseDefinitionManifest(payload)
+			_ = assertInvalidManifest(t, err)
+		})
+	}
+}
+
+func TestParseDefinitionManifestDefaultsOmittedProjectionsToEmpty(t *testing.T) {
+	const fingerprint = "sha256:3c9c8f195eb3ba1f747db8a09a6ee4a152faf46a5ffd62f167efc0d1014f9b2f"
+	payload := []byte(`{"name":"content","version":"1","fingerprint":"` + fingerprint + `","source_schema":{"type":"object"}}`)
+
+	manifest, err := source.ParseDefinitionManifest(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if projections := manifest.Projections(); len(projections) != 0 {
+		t.Fatalf("Projections() has %d entries, want 0", len(projections))
+	}
+	encoded, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(encoded, []byte(`"projections":[]`)) {
+		t.Fatalf("MarshalJSON() = %s, want explicit empty projections", encoded)
+	}
+}
+
+func newIdentity(t *testing.T, name, version string) source.DefinitionIdentity {
+	t.Helper()
+	identity, err := source.NewDefinitionIdentity(name, version)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return identity
+}
+
+func newProjectionKey(t *testing.T, name, version string) source.ProjectionKey {
+	t.Helper()
+	key, err := source.NewProjectionKey(name, version)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return key
+}
+
+func newProjection(t *testing.T, name, version string, schema any) source.ProjectionManifest {
+	t.Helper()
+	manifest, err := source.NewProjectionManifest(newProjectionKey(t, name, version), schema)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return manifest
+}
+
+func newManifest(
+	t *testing.T,
+	name, version string,
+	schema any,
+	projections []source.ProjectionManifest,
+) source.DefinitionManifest {
+	t.Helper()
+	manifest, err := source.NewDefinitionManifest(newIdentity(t, name, version), schema, projections)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return manifest
+}
+
+func assertInvalidManifest(t *testing.T, err error) *source.InvalidDefinitionManifestError {
+	t.Helper()
+	invalid, ok := errors.AsType[*source.InvalidDefinitionManifestError](err)
+	if !ok {
+		t.Fatalf("error = %T %v, want *source.InvalidDefinitionManifestError", err, err)
+	}
+	return invalid
+}


### PR DESCRIPTION
Part of #202 Phase 2. Adds only immutable, Python-compatible Source Definition Manifest domain values: strict parsing, RFC 8785 fingerprinting without NFC normalization, safe-integer rules, projection identity/limits, ref validation, and immutability. No SQLite repository, Observation, lifecycle, transport, or agent/backend expansion.