### PR TITLE
feat(scope): validate hierarchy and bootstrap default atomically

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -465,3 +465,9 @@ source / artifact / trigger / inference
   unique key decide an initial-create race. Verify real multi-connection
   contention and that cancellation or non-constraint storage failures remain
   distinguishable from a typed checkpoint conflict.
+- When a hierarchy mutation validates graph relationships, acquire the database
+  write lock before reading its hierarchy snapshot and commit that validation
+  with metadata CAS in one transaction. Verify two independent SQLite Database
+  and Runtime instances cannot commit opposite parent edges or duplicate an
+  idempotent default bootstrap, and prove that an injected default-setting
+  failure rolls the Scope and its creation key back together.

--- a/internal/runtime/scope_application.go
+++ b/internal/runtime/scope_application.go
@@ -15,16 +15,22 @@
 package runtime
 
 import (
+	"cmp"
 	"context"
 	"errors"
+	"slices"
 
 	"github.com/ob-labs/powercontext-go/internal/scope"
 )
 
-// ScopeStore is the transaction-owning persistence boundary consumed by ScopeApplication.
+// ScopeStore owns transactions. Create and Update run validation against the
+// hierarchy after acquiring its database write lock and before committing.
 type ScopeStore interface {
-	Create(context.Context, string, scope.Draft) (scope.Descriptor, error)
+	Create(context.Context, string, scope.Draft, func([]scope.Descriptor) error) (scope.Descriptor, error)
+	Update(context.Context, string, scope.Mutation, func([]scope.Descriptor) error) (scope.Descriptor, error)
+	BootstrapDefault(context.Context, string, scope.Draft) (scope.Descriptor, error)
 	Get(context.Context, string) (scope.Descriptor, bool, error)
+	List(context.Context) ([]scope.Descriptor, error)
 	SetDefault(context.Context, string) (scope.Descriptor, error)
 	Default(context.Context) (scope.Descriptor, bool, error)
 	SetBinding(context.Context, scope.BindingKey, string) (scope.Binding, error)
@@ -47,9 +53,59 @@ func NewScopeApplication(runtime *Runtime, store ScopeStore, newID func() string
 
 func (a *ScopeApplication) Create(ctx context.Context, draft scope.Draft) (result scope.Descriptor, err error) {
 	err = a.runtime.Operation(ctx, func(ctx context.Context) error {
-		created, createErr := a.store.Create(ctx, a.newID(), draft)
+		if _, validationErr := scope.NewDraft(draft.Title(), draft.Summary(), draft.ParentScopeID(), draft.ContextReferences(), draft.ExternalReferences(), draft.IdempotencyKey()); validationErr != nil {
+			return &scope.ValidationError{}
+		}
+		id := a.newID()
+		created, createErr := a.store.Create(ctx, id, draft, func(scopes []scope.Descriptor) error {
+			return validateScopeRelationships(scopes, id, draft.ParentScopeID(), draft.ContextReferences())
+		})
 		result = created
 		return createErr
+	})
+	return result, err
+}
+
+func (a *ScopeApplication) Update(ctx context.Context, id string, mutation scope.Mutation) (result scope.Descriptor, err error) {
+	err = a.runtime.Operation(ctx, func(ctx context.Context) error {
+		if _, validationErr := scope.NewMutation(mutation.ExpectedVersion(), mutation.Title(), mutation.Summary(), mutation.ParentScopeID(), mutation.ContextReferences(), mutation.ExternalReferences()); validationErr != nil {
+			return &scope.ValidationError{}
+		}
+		updated, updateErr := a.store.Update(ctx, id, mutation, func(scopes []scope.Descriptor) error {
+			return validateScopeRelationships(scopes, id, mutation.ParentScopeID(), mutation.ContextReferences())
+		})
+		result = updated
+		return updateErr
+	})
+	return result, err
+}
+
+// BootstrapDefault preserves an existing default and otherwise creates an ordinary
+// Scope with a stable creation key in the same transaction as the default setting.
+func (a *ScopeApplication) BootstrapDefault(ctx context.Context) (result scope.Descriptor, err error) {
+	err = a.runtime.Operation(ctx, func(ctx context.Context) error {
+		draft, draftErr := scope.NewDraft("Default", "Default context", "", nil, nil, "powercontext.default-scope.v1")
+		if draftErr != nil {
+			return draftErr
+		}
+		created, bootstrapErr := a.store.BootstrapDefault(ctx, a.newID(), draft)
+		result = created
+		return bootstrapErr
+	})
+	return result, err
+}
+
+func (a *ScopeApplication) Get(ctx context.Context, id string) (result scope.Descriptor, err error) {
+	err = a.runtime.Operation(ctx, func(ctx context.Context) error {
+		value, found, getErr := a.store.Get(ctx, id)
+		if getErr != nil {
+			return getErr
+		}
+		if !found {
+			return &scope.NotFoundError{}
+		}
+		result = value
+		return nil
 	})
 	return result, err
 }
@@ -72,15 +128,17 @@ func (a *ScopeApplication) Bind(ctx context.Context, key scope.BindingKey, id st
 	return result, err
 }
 
-func (a *ScopeApplication) Resolve(ctx context.Context, explicitID string, keys []scope.BindingKey) (result scope.Descriptor, err error) {
+// Resolve treats nil as omitted and every explicit value, including an empty
+// string, as an exact Scope request that must not fall back to a binding.
+func (a *ScopeApplication) Resolve(ctx context.Context, explicitID *string, keys []scope.BindingKey) (result scope.Descriptor, err error) {
 	err = a.runtime.Operation(ctx, func(ctx context.Context) error {
-		if explicitID != "" {
-			value, found, getErr := a.store.Get(ctx, explicitID)
+		if explicitID != nil {
+			value, found, getErr := a.store.Get(ctx, *explicitID)
 			if getErr != nil {
 				return getErr
 			}
 			if !found {
-				return errors.New("runtime: requested Scope was not found")
+				return &scope.NotFoundError{}
 			}
 			result = value
 			return nil
@@ -98,7 +156,7 @@ func (a *ScopeApplication) Resolve(ctx context.Context, explicitID string, keys 
 				return getErr
 			}
 			if !scopeFound {
-				return errors.New("runtime: bound Scope was not found")
+				return &scope.NotFoundError{}
 			}
 			result = value
 			return nil
@@ -108,10 +166,95 @@ func (a *ScopeApplication) Resolve(ctx context.Context, explicitID string, keys 
 			return defaultErr
 		}
 		if !found {
-			return errors.New("runtime: no Scope binding is available")
+			return &scope.BindingNotFoundError{}
 		}
 		result = value
 		return nil
 	})
 	return result, err
+}
+
+// ResolveSelection uses parent edges only for subtree organization. A parent
+// never becomes a Context Reference or an implicit member of an exact selection.
+func (a *ScopeApplication) ResolveSelection(ctx context.Context, selection scope.Selection) (result []scope.Descriptor, err error) {
+	err = a.runtime.Operation(ctx, func(ctx context.Context) error {
+		if selection.Mode() != scope.SelectionAll && selection.Mode() != scope.SelectionExact && selection.Mode() != scope.SelectionSubtree {
+			return &scope.ValidationError{}
+		}
+		scopes, listErr := a.store.List(ctx)
+		if listErr != nil {
+			return listErr
+		}
+		slices.SortFunc(scopes, func(a, b scope.Descriptor) int { return cmp.Compare(a.ID(), b.ID()) })
+		byID := scopeIndex(scopes)
+		switch selection.Mode() {
+		case scope.SelectionAll:
+			result = scopes
+		case scope.SelectionExact:
+			for _, id := range selection.ScopeIDs() {
+				value, found := byID[id]
+				if !found {
+					return &scope.NotFoundError{}
+				}
+				result = append(result, value)
+			}
+		case scope.SelectionSubtree:
+			root, found := byID[selection.RootScopeID()]
+			if !found {
+				return &scope.NotFoundError{}
+			}
+			children := make(map[string][]scope.Descriptor)
+			for _, value := range scopes {
+				children[value.ParentScopeID()] = append(children[value.ParentScopeID()], value)
+			}
+			result = []scope.Descriptor{root}
+			visited := map[string]bool{root.ID(): true}
+			for index := 0; index < len(result); index++ {
+				for _, child := range children[result[index].ID()] {
+					if !visited[child.ID()] {
+						visited[child.ID()] = true
+						result = append(result, child)
+					}
+				}
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func validateScopeRelationships(scopes []scope.Descriptor, id, parentID string, references []string) error {
+	byID := scopeIndex(scopes)
+	visited := map[string]bool{id: true}
+	for parentID != "" {
+		if visited[parentID] {
+			return &scope.RelationshipError{}
+		}
+		visited[parentID] = true
+		parent, found := byID[parentID]
+		if !found {
+			return &scope.NotFoundError{}
+		}
+		parentID = parent.ParentScopeID()
+	}
+	for _, reference := range references {
+		if reference == id {
+			return &scope.RelationshipError{}
+		}
+		if _, found := byID[reference]; !found {
+			return &scope.NotFoundError{}
+		}
+	}
+	return nil
+}
+
+func scopeIndex(scopes []scope.Descriptor) map[string]scope.Descriptor {
+	byID := make(map[string]scope.Descriptor, len(scopes))
+	for _, value := range scopes {
+		byID[value.ID()] = value
+	}
+	return byID
 }

--- a/internal/runtime/scope_application_test.go
+++ b/internal/runtime/scope_application_test.go
@@ -47,10 +47,10 @@ func TestScopeApplicationResolvesExplicitBindingAndDefaultInOrder(t *testing.T) 
 	}
 	for _, test := range []struct {
 		name     string
-		explicit string
+		explicit *string
 		keys     []scope.BindingKey
 	}{
-		{name: "explicit", explicit: created.ID()},
+		{name: "explicit", explicit: new(created.ID())},
 		{name: "binding", keys: []scope.BindingKey{key}},
 		{name: "default"},
 	} {
@@ -63,18 +63,91 @@ func TestScopeApplicationResolvesExplicitBindingAndDefaultInOrder(t *testing.T) 
 	}
 }
 
+func TestScopeApplicationRejectsInvalidRelationships(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		parent     string
+		references []string
+	}{
+		{name: "missing parent", parent: "missing-secret"},
+		{name: "self parent", parent: "scope-created"},
+		{name: "missing reference", references: []string{"missing-secret"}},
+		{name: "self reference", references: []string{"scope-created"}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			store := &memoryScopeStore{scopes: map[string]scope.Descriptor{}}
+			application, err := NewScopeApplication(New(), store, func() string { return "scope-created" })
+			if err != nil {
+				t.Fatal(err)
+			}
+			draft, err := scope.NewDraft("title", "summary", test.parent, test.references, nil, "create")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, createErr := application.Create(t.Context(), draft); createErr == nil {
+				t.Fatal("invalid relationship was accepted")
+			}
+			if len(store.scopes) != 0 {
+				t.Fatal("rejected creation persisted a Scope")
+			}
+		})
+	}
+}
+
 type memoryScopeStore struct {
 	scopes    map[string]scope.Descriptor
 	defaultID string
 	bindings  map[scope.BindingKey]scope.Binding
 }
 
-func (s *memoryScopeStore) Create(_ context.Context, id string, draft scope.Draft) (scope.Descriptor, error) {
+func (s *memoryScopeStore) Create(ctx context.Context, id string, draft scope.Draft, validate func([]scope.Descriptor) error) (scope.Descriptor, error) {
+	scopes, _ := s.List(ctx)
+	if err := validate(scopes); err != nil {
+		return scope.Descriptor{}, err
+	}
 	created, err := scope.NewDescriptor(id, draft.Title(), draft.Summary(), draft.ParentScopeID(), draft.ContextReferences(), draft.ExternalReferences(), 1)
 	if err == nil {
 		s.scopes[id] = created
 	}
 	return created, err
+}
+
+func (s *memoryScopeStore) Update(ctx context.Context, id string, mutation scope.Mutation, validate func([]scope.Descriptor) error) (scope.Descriptor, error) {
+	current, found := s.scopes[id]
+	if !found {
+		return scope.Descriptor{}, &scope.NotFoundError{}
+	}
+	if current.Version() != mutation.ExpectedVersion() {
+		return scope.Descriptor{}, &scope.VersionConflictError{Expected: mutation.ExpectedVersion(), Actual: current.Version()}
+	}
+	scopes, _ := s.List(ctx)
+	if err := validate(scopes); err != nil {
+		return scope.Descriptor{}, err
+	}
+	updated, err := scope.NewDescriptor(id, mutation.Title(), mutation.Summary(), mutation.ParentScopeID(), mutation.ContextReferences(), mutation.ExternalReferences(), current.Version()+1)
+	if err == nil {
+		s.scopes[id] = updated
+	}
+	return updated, err
+}
+
+func (s *memoryScopeStore) BootstrapDefault(ctx context.Context, id string, draft scope.Draft) (scope.Descriptor, error) {
+	if existing, found := s.scopes[s.defaultID]; found {
+		return existing, nil
+	}
+	created, err := s.Create(ctx, id, draft, func([]scope.Descriptor) error { return nil })
+	if err == nil {
+		s.defaultID = created.ID()
+	}
+	return created, err
+}
+
+func (s *memoryScopeStore) List(_ context.Context) ([]scope.Descriptor, error) {
+	result := make([]scope.Descriptor, 0, len(s.scopes))
+	for _, value := range s.scopes {
+		result = append(result, value)
+	}
+	return result, nil
 }
 
 func (s *memoryScopeStore) Get(_ context.Context, id string) (scope.Descriptor, bool, error) {

--- a/internal/scope/models.go
+++ b/internal/scope/models.go
@@ -35,6 +35,26 @@ const (
 	MaxBindingExternalIDLength      = 256
 )
 
+// NotFoundError reports a missing Scope without disclosing its identity.
+type NotFoundError struct{}
+
+func (*NotFoundError) Error() string { return "Scope was not found" }
+
+// BindingNotFoundError reports that no explicit, durable, or default Scope exists.
+type BindingNotFoundError struct{}
+
+func (*BindingNotFoundError) Error() string { return "no Scope binding is available" }
+
+// RelationshipError reports a self reference or a cyclic parent relationship.
+type RelationshipError struct{}
+
+func (*RelationshipError) Error() string { return "invalid Scope relationship" }
+
+// ValidationError reports invalid application input without retaining its value.
+type ValidationError struct{}
+
+func (*ValidationError) Error() string { return "invalid Scope input" }
+
 // IdempotencyConflictError reports a Scope creation key reused with different input.
 type IdempotencyConflictError struct{}
 

--- a/internal/sqlstore/runtime_scopes.go
+++ b/internal/sqlstore/runtime_scopes.go
@@ -35,11 +35,94 @@ func NewRuntimeScopeStore(database *Database, repository ScopeRepository) (*Runt
 	return &RuntimeScopeStore{database: database, repository: repository}, nil
 }
 
-func (s *RuntimeScopeStore) Create(ctx context.Context, id string, draft scope.Draft) (result scope.Descriptor, err error) {
+func (s *RuntimeScopeStore) Create(ctx context.Context, id string, draft scope.Draft, validate func([]scope.Descriptor) error) (result scope.Descriptor, err error) {
+	if validate == nil {
+		return scope.Descriptor{}, &scope.ValidationError{}
+	}
 	err = s.database.Transaction(ctx, func(tx DBTX) error {
+		if lockErr := s.repository.LockHierarchy(ctx, tx); lockErr != nil {
+			return lockErr
+		}
+		digest, digestErr := draftDigest(draft)
+		if digestErr != nil {
+			return digestErr
+		}
+		existing, found, findErr := findScopeCreation(ctx, tx, draft.IdempotencyKey(), digest)
+		if findErr != nil || found {
+			result = existing
+			return findErr
+		}
+		scopes, listErr := s.repository.List(ctx, tx)
+		if listErr != nil {
+			return listErr
+		}
+		if validationErr := validate(scopes); validationErr != nil {
+			return validationErr
+		}
 		created, createErr := s.repository.Create(ctx, tx, id, draft)
 		result = created
 		return createErr
+	})
+	return result, err
+}
+
+func (s *RuntimeScopeStore) Update(ctx context.Context, id string, mutation scope.Mutation, validate func([]scope.Descriptor) error) (result scope.Descriptor, err error) {
+	if validate == nil {
+		return scope.Descriptor{}, &scope.ValidationError{}
+	}
+	err = s.database.Transaction(ctx, func(tx DBTX) error {
+		if lockErr := s.repository.LockHierarchy(ctx, tx); lockErr != nil {
+			return lockErr
+		}
+		current, getErr := s.repository.Get(ctx, tx, id)
+		if getErr != nil {
+			return requiredScopeError(getErr)
+		}
+		if current.Version() != mutation.ExpectedVersion() {
+			return &scope.VersionConflictError{Expected: mutation.ExpectedVersion(), Actual: current.Version()}
+		}
+		scopes, listErr := s.repository.List(ctx, tx)
+		if listErr != nil {
+			return listErr
+		}
+		if validationErr := validate(scopes); validationErr != nil {
+			return validationErr
+		}
+		updated, updateErr := s.repository.Update(ctx, tx, id, mutation)
+		result = updated
+		return updateErr
+	})
+	return result, err
+}
+
+func (s *RuntimeScopeStore) BootstrapDefault(ctx context.Context, id string, draft scope.Draft) (result scope.Descriptor, err error) {
+	err = s.database.Transaction(ctx, func(tx DBTX) error {
+		if lockErr := s.repository.LockHierarchy(ctx, tx); lockErr != nil {
+			return lockErr
+		}
+		existing, found, defaultErr := s.repository.Default(ctx, tx)
+		if defaultErr != nil || found {
+			result = existing
+			return requiredScopeError(defaultErr)
+		}
+		created, createErr := s.repository.Create(ctx, tx, id, draft)
+		if createErr != nil {
+			return createErr
+		}
+		if setErr := s.repository.SetDefault(ctx, tx, created.ID()); setErr != nil {
+			return setErr
+		}
+		result = created
+		return nil
+	})
+	return result, err
+}
+
+func (s *RuntimeScopeStore) List(ctx context.Context) (result []scope.Descriptor, err error) {
+	err = s.database.Transaction(ctx, func(tx DBTX) error {
+		var listErr error
+		result, listErr = s.repository.List(ctx, tx)
+		return listErr
 	})
 	return result, err
 }
@@ -59,9 +142,12 @@ func (s *RuntimeScopeStore) Get(ctx context.Context, id string) (scope.Descripto
 
 func (s *RuntimeScopeStore) SetDefault(ctx context.Context, id string) (result scope.Descriptor, err error) {
 	err = s.database.Transaction(ctx, func(tx DBTX) error {
+		if lockErr := s.repository.LockHierarchy(ctx, tx); lockErr != nil {
+			return lockErr
+		}
 		value, getErr := s.repository.Get(ctx, tx, id)
 		if getErr != nil {
-			return getErr
+			return requiredScopeError(getErr)
 		}
 		if setErr := s.repository.SetDefault(ctx, tx, id); setErr != nil {
 			return setErr
@@ -78,21 +164,31 @@ func (s *RuntimeScopeStore) Default(ctx context.Context) (scope.Descriptor, bool
 	err := s.database.Transaction(ctx, func(tx DBTX) error {
 		value, defaultFound, defaultErr := s.repository.Default(ctx, tx)
 		result, found = value, defaultFound
-		return defaultErr
+		return requiredScopeError(defaultErr)
 	})
 	return result, found, err
 }
 
 func (s *RuntimeScopeStore) SetBinding(ctx context.Context, key scope.BindingKey, id string) (result scope.Binding, err error) {
 	err = s.database.Transaction(ctx, func(tx DBTX) error {
+		if lockErr := s.repository.LockHierarchy(ctx, tx); lockErr != nil {
+			return lockErr
+		}
 		if _, getErr := s.repository.Get(ctx, tx, id); getErr != nil {
-			return getErr
+			return requiredScopeError(getErr)
 		}
 		binding, bindErr := s.repository.SetBinding(ctx, tx, key, id)
 		result = binding
 		return bindErr
 	})
 	return result, err
+}
+
+func requiredScopeError(err error) error {
+	if errors.Is(err, sql.ErrNoRows) {
+		return &scope.NotFoundError{}
+	}
+	return err
 }
 
 func (s *RuntimeScopeStore) Binding(ctx context.Context, key scope.BindingKey) (scope.Binding, bool, error) {

--- a/internal/sqlstore/runtime_scopes_test.go
+++ b/internal/sqlstore/runtime_scopes_test.go
@@ -15,8 +15,18 @@
 package sqlstore_test
 
 import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"reflect"
+	"slices"
+	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 
+	"github.com/ob-labs/powercontext-go/internal/runtime"
 	"github.com/ob-labs/powercontext-go/internal/scope"
 	"github.com/ob-labs/powercontext-go/internal/sqlstore"
 )
@@ -30,7 +40,7 @@ func TestRuntimeScopeStoreOwnsScopeTransactions(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	created, err := store.Create(t.Context(), "scope-runtime", draft)
+	created, err := store.Create(t.Context(), "scope-runtime", draft, func([]scope.Descriptor) error { return nil })
 	if err != nil || created.ID() != "scope-runtime" {
 		t.Fatalf("created Scope = %#v, %v", created, err)
 	}
@@ -56,4 +66,399 @@ func TestRuntimeScopeStoreOwnsScopeTransactions(t *testing.T) {
 	if err != nil || !bindingFound || binding.ScopeID() != created.ID() {
 		t.Fatalf("binding = %#v, %t, %v", binding, bindingFound, err)
 	}
+}
+
+func TestScopeApplicationSQLiteValidatesRelationshipsBeforeMetadataCAS(t *testing.T) {
+	application := scopeApplication(t, openTestDatabase(t), "scope")
+	root := createScope(t, application, "root", "", nil)
+	child := createScope(t, application, "child", root.ID(), nil)
+	for _, test := range []struct {
+		name       string
+		parent     string
+		references []string
+		notFound   bool
+	}{
+		{name: "self parent", parent: root.ID()},
+		{name: "parent cycle", parent: child.ID()},
+		{name: "missing parent", parent: "missing-secret", notFound: true},
+		{name: "self reference", references: []string{root.ID()}},
+		{name: "missing reference", references: []string{"missing-secret"}, notFound: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			mutation := scopeMutation(t, root.Version(), test.parent, test.references)
+			_, updateErr := application.Update(t.Context(), root.ID(), mutation)
+			if test.notFound {
+				if _, found := errors.AsType[*scope.NotFoundError](updateErr); !found {
+					t.Fatalf("missing relationship error = %T %v", updateErr, updateErr)
+				}
+			} else if _, relationship := errors.AsType[*scope.RelationshipError](updateErr); !relationship {
+				t.Fatalf("relationship error = %T %v", updateErr, updateErr)
+			}
+			if strings.Contains(fmt.Sprintf("%v %#v", updateErr, updateErr), "missing-secret") {
+				t.Fatal("relationship error exposed Scope identity")
+			}
+			loaded, getErr := application.Get(t.Context(), root.ID())
+			if getErr != nil || !reflect.DeepEqual(loaded, root) {
+				t.Fatalf("rejected mutation changed Scope: %#v, %v", loaded, getErr)
+			}
+		})
+	}
+	updated, err := application.Update(t.Context(), child.ID(), scopeMutation(t, child.Version(), "", []string{root.ID()}))
+	if err != nil || updated.Version() != 2 || updated.ParentScopeID() != "" || !slices.Equal(updated.ContextReferences(), []string{root.ID()}) {
+		t.Fatalf("valid metadata replacement = %#v, %v", updated, err)
+	}
+	_, err = application.Update(t.Context(), child.ID(), scopeMutation(t, child.Version(), "missing-secret", nil))
+	conflict, stale := errors.AsType[*scope.VersionConflictError](err)
+	if !stale || conflict.Expected != 1 || conflict.Actual != 2 {
+		t.Fatalf("stale metadata error = %T %v", err, err)
+	}
+}
+
+func TestScopeApplicationSQLiteSelectsHierarchyWithoutImplicitSharing(t *testing.T) {
+	application := scopeApplication(t, openTestDatabase(t), "scope")
+	root := createScope(t, application, "root", "", nil)
+	referenced := createScope(t, application, "referenced", "", nil)
+	child := createScope(t, application, "child", root.ID(), []string{referenced.ID()})
+	grandchild := createScope(t, application, "grandchild", child.ID(), nil)
+	sibling := createScope(t, application, "sibling", root.ID(), nil)
+	exact, err := scope.NewExactSelection([]string{sibling.ID(), child.ID()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	subtree, err := scope.NewSubtreeSelection(root.ID())
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, test := range []struct {
+		name      string
+		selection scope.Selection
+		want      []string
+	}{
+		{name: "all", selection: scope.AllSelection(), want: []string{root.ID(), referenced.ID(), child.ID(), grandchild.ID(), sibling.ID()}},
+		{name: "exact", selection: exact, want: []string{child.ID(), sibling.ID()}},
+		{name: "subtree breadth first", selection: subtree, want: []string{root.ID(), child.ID(), sibling.ID(), grandchild.ID()}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			selected, selectionErr := application.ResolveSelection(t.Context(), test.selection)
+			if selectionErr != nil || !slices.Equal(scopeIDs(selected), test.want) {
+				t.Fatalf("selection = %v, %v", scopeIDs(selected), selectionErr)
+			}
+		})
+	}
+	if !slices.Equal(child.ContextReferences(), []string{referenced.ID()}) || len(sibling.ContextReferences()) != 0 {
+		t.Fatal("parent relationship implicitly shared context")
+	}
+	missingExact, err := scope.NewExactSelection([]string{root.ID(), "unknown"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	missingSubtree, err := scope.NewSubtreeSelection("unknown")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, selection := range []scope.Selection{missingExact, missingSubtree} {
+		selected, selectionErr := application.ResolveSelection(t.Context(), selection)
+		if _, missing := errors.AsType[*scope.NotFoundError](selectionErr); !missing || selected != nil {
+			t.Fatalf("partial or missing selection = %v, %v", selected, selectionErr)
+		}
+	}
+	if _, selectionErr := application.ResolveSelection(t.Context(), scope.Selection{}); selectionErr == nil {
+		t.Fatal("zero selection was accepted")
+	}
+}
+
+func TestScopeApplicationSQLiteResolveHonorsExplicitPresenceAndCase(t *testing.T) {
+	application := scopeApplication(t, openTestDatabase(t), "Scope")
+	defaultScope, err := application.BootstrapDefault(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	bound := createScope(t, application, "bound", "", nil)
+	explicit := createScope(t, application, "explicit", "", nil)
+	key, err := scope.NewBindingKey("codex", "project", "repository")
+	if err != nil {
+		t.Fatal(err)
+	}
+	missingKey, err := scope.NewBindingKey("workbuddy", "project", "unbound")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, bindErr := application.Bind(t.Context(), key, bound.ID()); bindErr != nil {
+		t.Fatal(bindErr)
+	}
+	for _, test := range []struct {
+		name     string
+		explicit *string
+		keys     []scope.BindingKey
+		want     string
+	}{
+		{name: "explicit wins", explicit: new(explicit.ID()), keys: []scope.BindingKey{key}, want: explicit.ID()},
+		{name: "first existing binding", keys: []scope.BindingKey{missingKey, key}, want: bound.ID()},
+		{name: "default fallback", keys: []scope.BindingKey{missingKey}, want: defaultScope.ID()},
+		{name: "explicit blank", explicit: new(""), keys: []scope.BindingKey{key}},
+		{name: "explicit missing", explicit: new("missing-secret"), keys: []scope.BindingKey{key}},
+		{name: "case distinct", explicit: new(strings.ToLower(explicit.ID())), keys: []scope.BindingKey{key}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			value, resolveErr := application.Resolve(t.Context(), test.explicit, test.keys)
+			if test.want != "" {
+				if resolveErr != nil || value.ID() != test.want {
+					t.Fatalf("resolved Scope = %#v, %v", value, resolveErr)
+				}
+			} else if _, missing := errors.AsType[*scope.NotFoundError](resolveErr); !missing {
+				t.Fatalf("explicit Scope silently fell back: %#v, %v", value, resolveErr)
+			}
+		})
+	}
+}
+
+func TestScopeApplicationSQLiteConcurrentParentUpdatesRemainAcyclic(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "hierarchy.db")
+	first := scopeApplication(t, openScopeDatabase(t, path), "first")
+	second := scopeApplication(t, openScopeDatabase(t, path), "second")
+	left := createScope(t, first, "left", "", nil)
+	right := createScope(t, second, "right", "", nil)
+	mutations := []scope.Mutation{scopeMutation(t, 1, right.ID(), nil), scopeMutation(t, 1, left.ID(), nil)}
+	applications := []*runtime.ScopeApplication{first, second}
+	ids := []string{left.ID(), right.ID()}
+	results := make([]error, 2)
+	start := make(chan struct{})
+	var group sync.WaitGroup
+	ctx := t.Context()
+	for index, application := range applications {
+		group.Go(func() {
+			<-start
+			_, results[index] = application.Update(ctx, ids[index], mutations[index])
+		})
+	}
+	close(start)
+	group.Wait()
+	var succeeded, rejected int
+	for _, err := range results {
+		if err == nil {
+			succeeded++
+			continue
+		}
+		if _, relationship := errors.AsType[*scope.RelationshipError](err); !relationship {
+			t.Fatalf("concurrent parent error = %T %v", err, err)
+		}
+		rejected++
+	}
+	if succeeded != 1 || rejected != 1 {
+		t.Fatalf("parent update results = success:%d rejected:%d", succeeded, rejected)
+	}
+	currentLeft, err := first.Get(t.Context(), left.ID())
+	if err != nil {
+		t.Fatal(err)
+	}
+	currentRight, err := second.Get(t.Context(), right.ID())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if currentLeft.ParentScopeID() == right.ID() && currentRight.ParentScopeID() == left.ID() {
+		t.Fatal("concurrent writes persisted a parent cycle")
+	}
+}
+
+func TestScopeApplicationSQLiteConcurrentCreateAndBootstrap(t *testing.T) {
+	for _, operation := range []string{"same draft", "conflicting draft", "bootstrap"} {
+		t.Run(operation, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "creation.db")
+			applications := []*runtime.ScopeApplication{
+				scopeApplication(t, openScopeDatabase(t, path), "first"),
+				scopeApplication(t, openScopeDatabase(t, path), "second"),
+			}
+			drafts := make([]scope.Draft, 2)
+			for index := range drafts {
+				title := "same"
+				if operation == "conflicting draft" {
+					title = fmt.Sprintf("title-%d", index)
+				}
+				var draftErr error
+				drafts[index], draftErr = scope.NewDraft(title, "summary", "", nil, nil, "shared-key")
+				if draftErr != nil {
+					t.Fatal(draftErr)
+				}
+			}
+			values := make([]scope.Descriptor, 2)
+			results := make([]error, 2)
+			start := make(chan struct{})
+			var group sync.WaitGroup
+			ctx := t.Context()
+			for index, application := range applications {
+				group.Go(func() {
+					<-start
+					if operation == "bootstrap" {
+						values[index], results[index] = application.BootstrapDefault(ctx)
+					} else {
+						values[index], results[index] = application.Create(ctx, drafts[index])
+					}
+				})
+			}
+			close(start)
+			group.Wait()
+			var succeeded, conflicts int
+			for _, result := range results {
+				if result == nil {
+					succeeded++
+					continue
+				}
+				if _, conflict := errors.AsType[*scope.IdempotencyConflictError](result); !conflict {
+					t.Fatalf("concurrent creation error = %T %v", result, result)
+				}
+				conflicts++
+			}
+			if operation == "conflicting draft" {
+				if succeeded != 1 || conflicts != 1 {
+					t.Fatalf("conflicting create results = success:%d conflict:%d", succeeded, conflicts)
+				}
+			} else if succeeded != 2 || values[0].ID() != values[1].ID() {
+				t.Fatalf("idempotent create results = %#v, %v", values, results)
+			}
+			all, listErr := applications[0].ResolveSelection(t.Context(), scope.AllSelection())
+			if listErr != nil || len(all) != 1 {
+				t.Fatalf("creation produced duplicate Scopes = %#v, %v", all, listErr)
+			}
+			if operation == "bootstrap" {
+				resolved, resolveErr := applications[1].Resolve(t.Context(), nil, nil)
+				if resolveErr != nil || resolved.ID() != all[0].ID() || resolved.Title() != "Default" || resolved.Summary() != "Default context" {
+					t.Fatalf("bootstrapped default = %#v, %v", resolved, resolveErr)
+				}
+			}
+		})
+	}
+}
+
+func TestScopeApplicationSQLiteBootstrapPreservesDefaultAndStableCreationKey(t *testing.T) {
+	application := scopeApplication(t, openTestDatabase(t), "scope")
+	if _, err := application.Resolve(t.Context(), nil, nil); err == nil {
+		t.Fatal("empty database resolved a Scope")
+	} else if _, missing := errors.AsType[*scope.BindingNotFoundError](err); !missing {
+		t.Fatalf("no default error = %T %v", err, err)
+	}
+	draft, err := scope.NewDraft("Custom", "Customized context", "", nil, nil, "powercontext.default-scope.v1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	custom, err := application.Create(t.Context(), draft)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, bootstrapErr := application.BootstrapDefault(t.Context()); bootstrapErr == nil {
+		t.Fatal("bootstrap overwrote a conflicting reserved creation key")
+	} else if _, conflict := errors.AsType[*scope.IdempotencyConflictError](bootstrapErr); !conflict {
+		t.Fatalf("bootstrap conflict = %T %v", bootstrapErr, bootstrapErr)
+	}
+	if _, resolveErr := application.Resolve(t.Context(), nil, nil); resolveErr == nil {
+		t.Fatal("conflicting bootstrap assigned a default")
+	}
+	if _, setErr := application.SetDefault(t.Context(), custom.ID()); setErr != nil {
+		t.Fatal(setErr)
+	}
+	existing, err := application.BootstrapDefault(t.Context())
+	if err != nil || !reflect.DeepEqual(existing, custom) {
+		t.Fatalf("bootstrap replaced the existing default = %#v, %v", existing, err)
+	}
+	all, err := application.ResolveSelection(t.Context(), scope.AllSelection())
+	if err != nil || len(all) != 1 {
+		t.Fatalf("bootstrap created another Scope = %#v, %v", all, err)
+	}
+}
+
+func TestScopeApplicationSQLiteBootstrapRollsBackCreationWhenDefaultWriteFails(t *testing.T) {
+	database := openTestDatabase(t)
+	application := scopeApplication(t, database, "scope")
+	if _, err := database.SQLDB().ExecContext(t.Context(), `CREATE TRIGGER reject_scope_default
+        BEFORE INSERT ON pc_scope_settings BEGIN SELECT RAISE(ABORT, 'injected failure'); END`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := application.BootstrapDefault(t.Context()); err == nil {
+		t.Fatal("bootstrap ignored a failed default write")
+	}
+	all, err := application.ResolveSelection(t.Context(), scope.AllSelection())
+	if err != nil || len(all) != 0 {
+		t.Fatalf("failed bootstrap left its Scope behind = %#v, %v", all, err)
+	}
+	if _, dropErr := database.SQLDB().ExecContext(t.Context(), `DROP TRIGGER reject_scope_default`); dropErr != nil {
+		t.Fatal(dropErr)
+	}
+	created, err := application.BootstrapDefault(t.Context())
+	if err != nil {
+		t.Fatalf("retry could not recover the creation key: %v", err)
+	}
+	resolved, err := application.Resolve(t.Context(), nil, nil)
+	if err != nil || resolved.ID() != created.ID() {
+		t.Fatalf("retried bootstrap = %#v, %v", resolved, err)
+	}
+}
+
+func TestScopeApplicationSQLiteCancellationPreservesState(t *testing.T) {
+	application := scopeApplication(t, openTestDatabase(t), "scope")
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	if _, err := application.BootstrapDefault(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("canceled bootstrap error = %T %v", err, err)
+	}
+	all, err := application.ResolveSelection(t.Context(), scope.AllSelection())
+	if err != nil || len(all) != 0 {
+		t.Fatalf("canceled bootstrap changed state = %#v, %v", all, err)
+	}
+}
+
+func scopeApplication(t *testing.T, database *sqlstore.Database, prefix string) *runtime.ScopeApplication {
+	t.Helper()
+	store, err := sqlstore.NewRuntimeScopeStore(database, sqlstore.ScopeRepository{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var sequence atomic.Int64
+	application, err := runtime.NewScopeApplication(runtime.New(), store, func() string { return fmt.Sprintf("%s-%d", prefix, sequence.Add(1)) })
+	if err != nil {
+		t.Fatal(err)
+	}
+	return application
+}
+
+func createScope(t *testing.T, application *runtime.ScopeApplication, key, parent string, references []string) scope.Descriptor {
+	t.Helper()
+	draft, err := scope.NewDraft(key, "summary", parent, references, nil, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	created, err := application.Create(t.Context(), draft)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return created
+}
+
+func scopeMutation(t *testing.T, version int64, parent string, references []string) scope.Mutation {
+	t.Helper()
+	mutation, err := scope.NewMutation(version, "Updated", "Updated summary", parent, references, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return mutation
+}
+
+func scopeIDs(values []scope.Descriptor) []string {
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		result = append(result, value.ID())
+	}
+	return result
+}
+
+func openScopeDatabase(t *testing.T, path string) *sqlstore.Database {
+	t.Helper()
+	database, err := sqlstore.OpenSQLite(t.Context(), sqlstore.DefaultSQLiteConfig(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if closeErr := database.Close(context.Background()); closeErr != nil {
+			t.Error(closeErr)
+		}
+	})
+	return database
 }

--- a/internal/sqlstore/scopes.go
+++ b/internal/sqlstore/scopes.go
@@ -29,25 +29,26 @@ import (
 // ScopeRepository persists Scope metadata and durable external bindings.
 type ScopeRepository struct{}
 
+// LockHierarchy obtains SQLite's write lock before any hierarchy snapshot is
+// read, including an empty hierarchy. The caller must own the transaction.
+func (ScopeRepository) LockHierarchy(ctx context.Context, db DBTX) error {
+	_, err := db.ExecContext(ctx, `UPDATE pc_scopes SET version = version WHERE 1 = 0`)
+	return err
+}
+
 func (ScopeRepository) Create(ctx context.Context, db DBTX, id string, draft scope.Draft) (scope.Descriptor, error) {
 	if _, err := scope.NewDescriptor(id, draft.Title(), draft.Summary(), draft.ParentScopeID(), draft.ContextReferences(), draft.ExternalReferences(), 1); err != nil {
 		return scope.Descriptor{}, err
+	}
+	if _, err := scope.NewDraft(draft.Title(), draft.Summary(), draft.ParentScopeID(), draft.ContextReferences(), draft.ExternalReferences(), draft.IdempotencyKey()); err != nil {
+		return scope.Descriptor{}, &scope.ValidationError{}
 	}
 	digest, err := draftDigest(draft)
 	if err != nil {
 		return scope.Descriptor{}, err
 	}
-	var existingDigest, existingID string
-	err = db.QueryRowContext(ctx, `SELECT request_digest, scope_id FROM pc_scope_creation_requests
-        WHERE idempotency_key = ?`, draft.IdempotencyKey()).Scan(&existingDigest, &existingID)
-	if err == nil {
-		if existingDigest != digest {
-			return scope.Descriptor{}, &scope.IdempotencyConflictError{}
-		}
-		return ScopeRepository{}.Get(ctx, db, existingID)
-	}
-	if !errors.Is(err, sql.ErrNoRows) {
-		return scope.Descriptor{}, err
+	if existing, found, findErr := findScopeCreation(ctx, db, draft.IdempotencyKey(), digest); findErr != nil || found {
+		return existing, findErr
 	}
 	if _, err := db.ExecContext(ctx, `INSERT INTO pc_scopes (scope_id, title, summary, parent_scope_id, version)
         VALUES (?, ?, ?, NULLIF(?, ''), 1)`, id, draft.Title(), draft.Summary(), draft.ParentScopeID()); err != nil {
@@ -61,6 +62,23 @@ func (ScopeRepository) Create(ctx context.Context, db DBTX, id string, draft sco
 		return scope.Descriptor{}, err
 	}
 	return ScopeRepository{}.Get(ctx, db, id)
+}
+
+func findScopeCreation(ctx context.Context, db DBTX, key, digest string) (scope.Descriptor, bool, error) {
+	var existingDigest, existingID string
+	err := db.QueryRowContext(ctx, `SELECT request_digest, scope_id FROM pc_scope_creation_requests
+        WHERE idempotency_key = ?`, key).Scan(&existingDigest, &existingID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return scope.Descriptor{}, false, nil
+	}
+	if err != nil {
+		return scope.Descriptor{}, false, err
+	}
+	if existingDigest != digest {
+		return scope.Descriptor{}, false, &scope.IdempotencyConflictError{}
+	}
+	value, getErr := ScopeRepository{}.Get(ctx, db, existingID)
+	return value, true, getErr
 }
 
 func (ScopeRepository) Update(ctx context.Context, db DBTX, id string, mutation scope.Mutation) (scope.Descriptor, error) {


### PR DESCRIPTION
Part of #202 Phase 2. Adds SQLite-atomic Scope hierarchy validation, selection, default bootstrap and presence-aware resolution. Includes the learned transaction invariant. Does not add Server composition, HTTP/MCP Scope APIs, host binding, or admission enforcement.