### PR TITLE
feat(sqlite): persist worker source observations

### DIFF
--- a/internal/sqlstore/source_codec.go
+++ b/internal/sqlstore/source_codec.go
@@ -15,12 +15,41 @@
 package sqlstore
 
 import (
+	"bytes"
 	"encoding/json"
+	"encoding/json/jsontext"
+	jsonv2 "encoding/json/v2"
 	"fmt"
 	"reflect"
 
 	"github.com/ob-labs/powercontext-go/source"
 )
+
+const (
+	sourceEnvelopeEncoding            = "powercontext-source-v1"
+	sourceNativeRepresentation        = "native"
+	sourceObservationRepresentation   = "observation"
+	redactedSourceObservationIdentity = "<redacted>"
+	sourceObservationPayloadKind      = "source"
+)
+
+type sourceObservationEnvelope struct {
+	Encoding       string         `json:"encoding"`
+	Representation string         `json:"representation"`
+	Value          jsontext.Value `json:"value"`
+}
+
+type sourceEnvelope struct {
+	Encoding       string         `json:"encoding"`
+	Representation string         `json:"representation"`
+	Value          jsontext.Value `json:"value"`
+}
+
+type parsedSourceEnvelope struct {
+	representation string
+	value          jsontext.Value
+	observation    source.SourceObservation
+}
 
 // SourceCodec is an exact concrete Source type route for the Python storage
 // payload. It is immutable after construction.
@@ -140,4 +169,104 @@ func decodeContentSource(payload []byte) (source.ContentSource, error) {
 		}
 	}
 	return source.RestoreContentSource(name, materialization, description, content, metadata)
+}
+
+func encodeSourceObservation(value source.SourceObservation) ([]byte, error) {
+	observation, err := jsonv2.Marshal(value)
+	if err != nil {
+		return nil, err
+	}
+	return jsonv2.Marshal(sourceObservationEnvelope{
+		Encoding:       sourceEnvelopeEncoding,
+		Representation: sourceObservationRepresentation,
+		Value:          jsontext.Value(observation),
+	})
+}
+
+// parseSourceEnvelope recognizes the current durable Source envelope. A
+// legacy native payload with only an incidental encoding member remains owned
+// by its exact codec; current envelopes require both the encoding and
+// representation members.
+func parseSourceEnvelope(payload []byte) (parsedSourceEnvelope, bool, error) {
+	var marker map[string]jsontext.Value
+	if err := jsonv2.Unmarshal(payload, &marker); err != nil {
+		if looksLikeCurrentSourceEnvelope(payload) {
+			return parsedSourceEnvelope{}, true, err
+		}
+		return parsedSourceEnvelope{}, false, nil
+	}
+	encoding, exists := marker["encoding"]
+	if !exists {
+		return parsedSourceEnvelope{}, false, nil
+	}
+	var encodingValue string
+	if err := jsonv2.Unmarshal(encoding, &encodingValue); err != nil || encodingValue != sourceEnvelopeEncoding {
+		return parsedSourceEnvelope{}, false, nil
+	}
+	if _, exists := marker["representation"]; !exists {
+		return parsedSourceEnvelope{}, false, nil
+	}
+	var envelope sourceEnvelope
+	if err := jsonv2.Unmarshal(payload, &envelope, jsonv2.RejectUnknownMembers(true)); err != nil {
+		return parsedSourceEnvelope{}, true, err
+	}
+	if envelope.Value == nil {
+		return parsedSourceEnvelope{}, true, fmt.Errorf("invalid Source envelope")
+	}
+	parsed := parsedSourceEnvelope{
+		representation: envelope.Representation,
+		value:          envelope.Value.Clone(),
+	}
+	switch envelope.Representation {
+	case sourceNativeRepresentation:
+		return parsed, true, nil
+	case sourceObservationRepresentation:
+		observation, err := source.ParseSourceObservation(envelope.Value)
+		if err != nil {
+			return parsedSourceEnvelope{}, true, err
+		}
+		parsed.observation = observation
+		return parsed, true, nil
+	default:
+		return parsedSourceEnvelope{}, true, fmt.Errorf("invalid Source envelope representation")
+	}
+}
+
+// looksLikeCurrentSourceEnvelope permits damaged and duplicate current
+// envelopes to be classified before codec lookup while deliberately leaving a
+// legacy native payload with only an encoding member to its registered codec.
+func looksLikeCurrentSourceEnvelope(payload []byte) bool {
+	decoder := jsontext.NewDecoder(bytes.NewReader(payload), jsontext.AllowDuplicateNames(true))
+	start, err := decoder.ReadToken()
+	if err != nil || start.Kind() != '{' {
+		return false
+	}
+	var matchingEncoding, representation bool
+	for decoder.PeekKind() != '}' {
+		name, err := decoder.ReadToken()
+		if err != nil || name.Kind() != '"' {
+			return matchingEncoding && representation
+		}
+		switch name.String() {
+		case "encoding":
+			value, readErr := decoder.ReadValue()
+			if readErr != nil {
+				return matchingEncoding && representation
+			}
+			var encoding string
+			if jsonv2.Unmarshal(value, &encoding) == nil && encoding == sourceEnvelopeEncoding {
+				matchingEncoding = true
+			}
+		case "representation":
+			representation = true
+			if err := decoder.SkipValue(); err != nil {
+				return matchingEncoding && representation
+			}
+		default:
+			if err := decoder.SkipValue(); err != nil {
+				return matchingEncoding && representation
+			}
+		}
+	}
+	return matchingEncoding && representation
 }

--- a/internal/sqlstore/sources.go
+++ b/internal/sqlstore/sources.go
@@ -18,8 +18,10 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
+	"encoding/json/jsontext"
 	"errors"
 	"fmt"
+	"math/big"
 	"reflect"
 	"strings"
 	"unicode/utf8"
@@ -56,6 +58,12 @@ type SourceRepository struct {
 func (r *SourceRepository) Ref(value source.Value) (source.Ref, error) {
 	if value == nil {
 		return source.Ref{}, &source.InvalidEntryError{}
+	}
+	if observation, ok := value.(source.SourceObservation); ok {
+		if err := observation.Validate(); err != nil {
+			return source.Ref{}, err
+		}
+		return observation.Ref(), nil
 	}
 	codec, ok := r.bySource[reflect.TypeOf(value)]
 	if !ok {
@@ -95,17 +103,9 @@ func (r *SourceRepository) Add(
 	if err := requireScope(scopeID); err != nil {
 		return StoredSource{}, err
 	}
-	codec, ok := r.bySource[reflect.TypeOf(value)]
-	if !ok {
-		return StoredSource{}, &RepositoryNotFoundError{Kind: "source-adapter", Identity: reflect.TypeOf(value)}
-	}
-	ref, err := r.Ref(value)
+	ref, payload, observation, err := r.encode(value)
 	if err != nil {
 		return StoredSource{}, err
-	}
-	payload, err := codec.encode(value)
-	if err != nil {
-		return StoredSource{}, &InvalidStoredPayloadError{Kind: "source", Name: codec.name, Issue: "value is not JSON serializable"}
 	}
 	if lockErr := r.lockJournalHead(ctx, db, scopeID); lockErr != nil {
 		return StoredSource{}, lockErr
@@ -115,7 +115,14 @@ func (r *SourceRepository) Add(
 		return StoredSource{}, err
 	}
 	if found {
-		if !bytes.Equal(existing.payload, payload) {
+		equal, equalErr := sameStoredSourcePayload(existing.payload, payload, observation)
+		if equalErr != nil {
+			return StoredSource{}, invalidStoredSourceObservation()
+		}
+		if !equal {
+			if observation {
+				return StoredSource{}, sourceObservationConflict()
+			}
 			return StoredSource{}, &StoredPayloadConflictError{Kind: "source", Identity: sourceIdentity(scopeID, ref)}
 		}
 		return r.decode(existing)
@@ -136,12 +143,45 @@ func (r *SourceRepository) Add(
 		if !found {
 			return StoredSource{}, err
 		}
-		if !bytes.Equal(existing.payload, payload) {
+		equal, equalErr := sameStoredSourcePayload(existing.payload, payload, observation)
+		if equalErr != nil {
+			return StoredSource{}, invalidStoredSourceObservation()
+		}
+		if !equal {
+			if observation {
+				return StoredSource{}, sourceObservationConflict()
+			}
 			return StoredSource{}, &StoredPayloadConflictError{Kind: "source", Identity: sourceIdentity(scopeID, ref)}
 		}
 		return r.decode(existing)
 	}
 	return StoredSource{Ref: ref, Value: value, JournalPosition: position}, nil
+}
+
+func (r *SourceRepository) encode(value source.Value) (source.Ref, []byte, bool, error) {
+	if observation, ok := value.(source.SourceObservation); ok {
+		if err := observation.Validate(); err != nil {
+			return source.Ref{}, nil, true, err
+		}
+		payload, err := encodeSourceObservation(observation)
+		if err != nil {
+			return source.Ref{}, nil, true, err
+		}
+		return observation.Ref(), payload, true, nil
+	}
+	codec, ok := r.bySource[reflect.TypeOf(value)]
+	if !ok {
+		return source.Ref{}, nil, false, &RepositoryNotFoundError{Kind: "source-adapter", Identity: reflect.TypeOf(value)}
+	}
+	ref, err := r.Ref(value)
+	if err != nil {
+		return source.Ref{}, nil, false, err
+	}
+	payload, err := codec.encode(value)
+	if err != nil {
+		return source.Ref{}, nil, false, &InvalidStoredPayloadError{Kind: "source", Name: codec.name, Issue: "value is not JSON serializable"}
+	}
+	return ref, payload, false, nil
 }
 
 func (r *SourceRepository) Get(
@@ -279,11 +319,34 @@ func scanSource(value scanner) (storedSourceRow, error) {
 }
 
 func (r *SourceRepository) decode(row storedSourceRow) (StoredSource, error) {
+	envelope, recognized, envelopeErr := parseSourceEnvelope(row.payload)
+	if recognized {
+		if envelopeErr != nil {
+			return StoredSource{}, invalidStoredSourceObservation()
+		}
+		switch envelope.representation {
+		case sourceObservationRepresentation:
+			indexed, err := source.NewRef(row.typeName, row.sourceID)
+			if err != nil {
+				return StoredSource{}, err
+			}
+			if indexed != envelope.observation.Ref() {
+				return StoredSource{}, sourceObservationIdentityMismatch()
+			}
+			return StoredSource{Ref: indexed, Value: envelope.observation, JournalPosition: row.position}, nil
+		case sourceNativeRepresentation:
+			return r.decodeNative(row, envelope.value)
+		}
+	}
+	return r.decodeNative(row, row.payload)
+}
+
+func (r *SourceRepository) decodeNative(row storedSourceRow, payload []byte) (StoredSource, error) {
 	codec, ok := r.byName[row.typeName]
 	if !ok {
 		return StoredSource{}, &RepositoryNotFoundError{Kind: "source-adapter", Identity: row.typeName}
 	}
-	value, err := codec.decode(row.payload)
+	value, err := codec.decode(payload)
 	if err != nil {
 		return StoredSource{}, &InvalidStoredPayloadError{Kind: "source", Name: row.typeName, Issue: "payload does not match the model"}
 	}
@@ -299,6 +362,233 @@ func (r *SourceRepository) decode(row storedSourceRow) (StoredSource, error) {
 		return StoredSource{}, &IdentityMismatchError{Kind: "source", Indexed: indexed, Decoded: decoded}
 	}
 	return StoredSource{Ref: indexed, Value: value, JournalPosition: row.position}, nil
+}
+
+func sameStoredSourcePayload(stored, expected []byte, observation bool) (bool, error) {
+	if !observation {
+		return bytes.Equal(stored, expected), nil
+	}
+	envelope, recognized, err := parseSourceEnvelope(stored)
+	if err != nil {
+		return false, err
+	}
+	if !recognized || envelope.representation != sourceObservationRepresentation {
+		return false, nil
+	}
+	return equalJSONValues(jsontext.Value(stored), jsontext.Value(expected))
+}
+
+func equalJSONValues(left, right jsontext.Value) (bool, error) {
+	if !left.IsValid() || !right.IsValid() {
+		return false, fmt.Errorf("invalid JSON value")
+	}
+	leftKind, rightKind := left.Kind(), right.Kind()
+	if leftKind != rightKind {
+		return false, nil
+	}
+	switch leftKind {
+	case '{':
+		return equalJSONObjects(left, right)
+	case '[':
+		return equalJSONArrays(left, right)
+	case '"':
+		return equalJSONStrings(left, right)
+	case '0':
+		return equalJSONNumbers(left, right)
+	default:
+		return bytes.Equal(bytes.TrimSpace(left), bytes.TrimSpace(right)), nil
+	}
+}
+
+func equalJSONObjects(left, right jsontext.Value) (bool, error) {
+	leftMembers, err := jsonObjectMembers(left)
+	if err != nil {
+		return false, err
+	}
+	rightMembers, err := jsonObjectMembers(right)
+	if err != nil {
+		return false, err
+	}
+	if len(leftMembers) != len(rightMembers) {
+		return false, nil
+	}
+	for name, leftValue := range leftMembers {
+		rightValue, ok := rightMembers[name]
+		if !ok {
+			return false, nil
+		}
+		equal, err := equalJSONValues(leftValue, rightValue)
+		if err != nil || !equal {
+			return equal, err
+		}
+	}
+	return true, nil
+}
+
+func jsonObjectMembers(value jsontext.Value) (map[string]jsontext.Value, error) {
+	decoder := jsontext.NewDecoder(bytes.NewReader(value))
+	start, err := decoder.ReadToken()
+	if err != nil || start.Kind() != '{' {
+		return nil, fmt.Errorf("invalid JSON object")
+	}
+	members := make(map[string]jsontext.Value)
+	for decoder.PeekKind() != '}' {
+		name, err := decoder.ReadToken()
+		if err != nil || name.Kind() != '"' {
+			return nil, fmt.Errorf("invalid JSON object member")
+		}
+		memberName := name.Clone().String()
+		member, err := decoder.ReadValue()
+		if err != nil {
+			return nil, err
+		}
+		members[memberName] = member.Clone()
+	}
+	if _, err := decoder.ReadToken(); err != nil {
+		return nil, err
+	}
+	return members, nil
+}
+
+func equalJSONArrays(left, right jsontext.Value) (bool, error) {
+	leftValues, err := jsonArrayValues(left)
+	if err != nil {
+		return false, err
+	}
+	rightValues, err := jsonArrayValues(right)
+	if err != nil {
+		return false, err
+	}
+	if len(leftValues) != len(rightValues) {
+		return false, nil
+	}
+	for index := range leftValues {
+		equal, err := equalJSONValues(leftValues[index], rightValues[index])
+		if err != nil || !equal {
+			return equal, err
+		}
+	}
+	return true, nil
+}
+
+func jsonArrayValues(value jsontext.Value) ([]jsontext.Value, error) {
+	decoder := jsontext.NewDecoder(bytes.NewReader(value))
+	start, err := decoder.ReadToken()
+	if err != nil || start.Kind() != '[' {
+		return nil, fmt.Errorf("invalid JSON array")
+	}
+	values := make([]jsontext.Value, 0)
+	for decoder.PeekKind() != ']' {
+		entry, err := decoder.ReadValue()
+		if err != nil {
+			return nil, err
+		}
+		values = append(values, entry.Clone())
+	}
+	if _, err := decoder.ReadToken(); err != nil {
+		return nil, err
+	}
+	return values, nil
+}
+
+func equalJSONStrings(left, right jsontext.Value) (bool, error) {
+	var leftString, rightString string
+	if err := unmarshalJSON(left, &leftString); err != nil {
+		return false, err
+	}
+	if err := unmarshalJSON(right, &rightString); err != nil {
+		return false, err
+	}
+	return leftString == rightString, nil
+}
+
+func equalJSONNumbers(left, right jsontext.Value) (bool, error) {
+	leftNumber, err := parseJSONNumber(left)
+	if err != nil {
+		return false, err
+	}
+	rightNumber, err := parseJSONNumber(right)
+	if err != nil {
+		return false, err
+	}
+	if leftNumber.zero || rightNumber.zero {
+		return leftNumber.zero == rightNumber.zero, nil
+	}
+	return leftNumber.negative == rightNumber.negative &&
+		leftNumber.significand == rightNumber.significand &&
+		leftNumber.exponent.Cmp(rightNumber.exponent) == 0, nil
+}
+
+type jsonNumber struct {
+	negative    bool
+	zero        bool
+	significand string
+	exponent    *big.Int
+}
+
+func parseJSONNumber(value jsontext.Value) (jsonNumber, error) {
+	raw := bytes.TrimSpace(value)
+	negative := false
+	if raw[0] == '-' {
+		negative = true
+		raw = raw[1:]
+	}
+	exponentIndex := bytes.IndexAny(raw, "eE")
+	mantissa, exponentText := raw, []byte(nil)
+	if exponentIndex >= 0 {
+		mantissa, exponentText = raw[:exponentIndex], raw[exponentIndex+1:]
+	}
+	fractionDigits := 0
+	if decimalIndex := bytes.IndexByte(mantissa, '.'); decimalIndex >= 0 {
+		fractionDigits = len(mantissa) - decimalIndex - 1
+		mantissa = append(bytes.Clone(mantissa[:decimalIndex]), mantissa[decimalIndex+1:]...)
+	}
+	mantissa = bytes.TrimLeft(mantissa, "0")
+	if len(mantissa) == 0 {
+		return jsonNumber{zero: true}, nil
+	}
+	trailingZeros := len(mantissa) - len(bytes.TrimRight(mantissa, "0"))
+	mantissa = mantissa[:len(mantissa)-trailingZeros]
+	exponent := new(big.Int).Neg(big.NewInt(int64(fractionDigits)))
+	if len(exponentText) > 0 {
+		if exponentText[0] == '+' {
+			exponentText = exponentText[1:]
+		}
+		parsedExponent, ok := new(big.Int).SetString(string(exponentText), 10)
+		if !ok {
+			return jsonNumber{}, fmt.Errorf("invalid JSON number")
+		}
+		exponent.Add(exponent, parsedExponent)
+	}
+	exponent.Add(exponent, big.NewInt(int64(trailingZeros)))
+	return jsonNumber{
+		negative:    negative,
+		significand: string(mantissa),
+		exponent:    exponent,
+	}, nil
+}
+
+func invalidStoredSourceObservation() error {
+	return &InvalidStoredPayloadError{
+		Kind:  sourceObservationPayloadKind,
+		Name:  redactedSourceObservationIdentity,
+		Issue: "payload does not match the observation envelope",
+	}
+}
+
+func sourceObservationIdentityMismatch() error {
+	return &IdentityMismatchError{
+		Kind:    sourceObservationPayloadKind,
+		Indexed: redactedSourceObservationIdentity,
+		Decoded: redactedSourceObservationIdentity,
+	}
+}
+
+func sourceObservationConflict() error {
+	return &StoredPayloadConflictError{
+		Kind:     sourceObservationPayloadKind,
+		Identity: redactedSourceObservationIdentity,
+	}
 }
 
 func (r *SourceRepository) lockJournalHead(ctx context.Context, db DBTX, scopeID string) error {

--- a/internal/sqlstore/sources_test.go
+++ b/internal/sqlstore/sources_test.go
@@ -15,7 +15,9 @@
 package sqlstore_test
 
 import (
+	"bytes"
 	"context"
+	"encoding/json/jsontext"
 	"errors"
 	"fmt"
 	"path/filepath"
@@ -354,6 +356,400 @@ func TestSourceRepositoryRejectsIndexedIdentityMismatch(t *testing.T) {
 	}
 }
 
+func TestSourceRepositoryPersistsObservationEnvelopeAlongsideNativeSources(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	database := openTestDatabase(t)
+	repository, err := sqlstore.NewSourceRepository(sqlstore.SQLiteDialect, sqlstore.ContentSourceCodec())
+	if err != nil {
+		t.Fatal(err)
+	}
+	observation := observationSource(t, "worker.capture", "worker-item", `{"name":"worker-item","definition_version":"1","materialization":"captured","payload":{"nested":true}}`)
+
+	ref, err := repository.Ref(observation)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ref != observation.Ref() {
+		t.Fatalf("observation Ref() = %s, want %s", ref, observation.Ref())
+	}
+
+	var native, stored sqlstore.StoredSource
+	if err := database.Transaction(ctx, func(tx sqlstore.DBTX) error {
+		var addErr error
+		native, addErr = repository.Add(ctx, tx, "scope-observation", contentSource(t, "native-item", "native", nil))
+		if addErr != nil {
+			return addErr
+		}
+		stored, addErr = repository.Add(ctx, tx, "scope-observation", observation)
+		return addErr
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if native.JournalPosition != 1 || stored.JournalPosition != 2 {
+		t.Fatalf("journal positions = %d/%d, want 1/2", native.JournalPosition, stored.JournalPosition)
+	}
+	decoded, ok := stored.Value.(source.SourceObservation)
+	if !ok || decoded.Ref() != observation.Ref() || string(decoded.Payload()) != string(observation.Payload()) {
+		t.Fatalf("stored observation = %#v", stored.Value)
+	}
+
+	var nativePayload, observationPayload []byte
+	if err := database.SQLDB().QueryRowContext(ctx, `SELECT payload FROM pc_sources
+        WHERE scope_id = ? AND source_type = ? AND source_id = ?`,
+		"scope-observation", "content", "native-item",
+	).Scan(&nativePayload); err != nil {
+		t.Fatal(err)
+	}
+	if err := database.SQLDB().QueryRowContext(ctx, `SELECT payload FROM pc_sources
+        WHERE scope_id = ? AND source_type = ? AND source_id = ?`,
+		"scope-observation", observation.Ref().Type(), observation.Ref().ID(),
+	).Scan(&observationPayload); err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(nativePayload, []byte(`"encoding":"powercontext-source-v1"`)) {
+		t.Fatalf("native payload changed to an envelope: %s", nativePayload)
+	}
+	for _, member := range []string{
+		`"encoding":"powercontext-source-v1"`,
+		`"representation":"observation"`,
+		`"source_type":"worker.capture"`,
+	} {
+		if !bytes.Contains(observationPayload, []byte(member)) {
+			t.Fatalf("observation envelope %s does not contain %s", observationPayload, member)
+		}
+	}
+
+	if transactionErr := database.Transaction(ctx, func(tx sqlstore.DBTX) error {
+		got, getErr := repository.Get(ctx, tx, "scope-observation", observation.Ref())
+		if getErr != nil {
+			return getErr
+		}
+		if got.JournalPosition != 2 {
+			t.Fatalf("observation Get() position = %d, want 2", got.JournalPosition)
+		}
+		listed, listErr := repository.List(ctx, tx, "scope-observation", 0, nil)
+		if listErr != nil {
+			return listErr
+		}
+		if len(listed) != 2 {
+			t.Fatalf("List() returned %d Sources, want 2", len(listed))
+		}
+		_, observationFound := listed[1].Value.(source.SourceObservation)
+		if !observationFound {
+			t.Fatalf("List() observation type = %T", listed[1].Value)
+		}
+		return nil
+	}); transactionErr != nil {
+		t.Fatal(transactionErr)
+	}
+}
+
+func TestSourceRepositoryObservationEnvelopeWinsOverCollidingContentCodec(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	database := openTestDatabase(t)
+	repository, err := sqlstore.NewSourceRepository(sqlstore.SQLiteDialect, sqlstore.ContentSourceCodec())
+	if err != nil {
+		t.Fatal(err)
+	}
+	observation := observationSource(t, source.ContentType, "observation-item", `{"name":"observation-item","definition_version":"1","materialization":"captured","payload":{"content":"worker-owned"}}`)
+
+	var added sqlstore.StoredSource
+	if err := database.Transaction(ctx, func(tx sqlstore.DBTX) error {
+		var addErr error
+		added, addErr = repository.Add(ctx, tx, "scope-observation-content", observation)
+		return addErr
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := added.Value.(source.SourceObservation); !ok {
+		t.Fatalf("Add() value type = %T, want source.SourceObservation", added.Value)
+	}
+
+	var payload []byte
+	if err := database.SQLDB().QueryRowContext(ctx, `SELECT payload FROM pc_sources
+        WHERE scope_id = ? AND source_type = ? AND source_id = ?`,
+		"scope-observation-content", source.ContentType, observation.Ref().ID(),
+	).Scan(&payload); err != nil {
+		t.Fatal(err)
+	}
+	for _, member := range []string{
+		`"encoding":"powercontext-source-v1"`,
+		`"representation":"observation"`,
+		`"source_type":"content"`,
+	} {
+		if !bytes.Contains(payload, []byte(member)) {
+			t.Fatalf("observation payload %s does not contain %s", payload, member)
+		}
+	}
+
+	if err := database.Transaction(ctx, func(tx sqlstore.DBTX) error {
+		stored, getErr := repository.Get(ctx, tx, "scope-observation-content", observation.Ref())
+		if getErr != nil {
+			return getErr
+		}
+		if _, ok := stored.Value.(source.SourceObservation); !ok {
+			t.Fatalf("Get() value type = %T, want source.SourceObservation", stored.Value)
+		}
+		listed, listErr := repository.List(ctx, tx, "scope-observation-content", 0, nil)
+		if listErr != nil {
+			return listErr
+		}
+		if len(listed) != 1 {
+			t.Fatalf("List() returned %d Sources, want 1", len(listed))
+		}
+		if _, ok := listed[0].Value.(source.SourceObservation); !ok {
+			t.Fatalf("List() value type = %T, want source.SourceObservation", listed[0].Value)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSourceRepositoryObservationUsesJSONSemanticIdempotence(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	database := openTestDatabase(t)
+	repository, err := sqlstore.NewSourceRepository(sqlstore.SQLiteDialect, sqlstore.ContentSourceCodec())
+	if err != nil {
+		t.Fatal(err)
+	}
+	first := observationSource(t, "worker.capture", "item", `{"name":"item","definition_version":"1","materialization":"captured","payload":{"\u0061":1.0,"b":[true,null],"large":123456789012345678901234567890}}`)
+	reordered := observationSource(t, "worker.capture", "item", `{"payload":{"large":123456789012345678901234567890,"b":[true,null],"a":1e0},"materialization":"captured","definition_version":"1","name":"item"}`)
+	conflicting := observationSource(t, "worker.capture", "item", `{"name":"item","definition_version":"1","materialization":"captured","payload":{"a":2,"b":[true,null],"large":123456789012345678901234567890}}`)
+
+	var initial, replay sqlstore.StoredSource
+	if initialTransactionErr := database.Transaction(ctx, func(tx sqlstore.DBTX) error {
+		var addErr error
+		initial, addErr = repository.Add(ctx, tx, "scope-observation", first)
+		if addErr != nil {
+			return addErr
+		}
+		replay, addErr = repository.Add(ctx, tx, "scope-observation", reordered)
+		return addErr
+	}); initialTransactionErr != nil {
+		t.Fatal(initialTransactionErr)
+	}
+	if initial.JournalPosition != 1 || replay.JournalPosition != 1 {
+		t.Fatalf("replayed positions = %d/%d, want 1/1", initial.JournalPosition, replay.JournalPosition)
+	}
+	largeIntegerConflict := observationSource(t, "worker.capture", "item", `{"name":"item","definition_version":"1","materialization":"captured","payload":{"a":1e0,"b":[true,null],"large":123456789012345678901234567891}}`)
+	err = database.Transaction(ctx, func(tx sqlstore.DBTX) error {
+		_, addErr := repository.Add(ctx, tx, "scope-observation", largeIntegerConflict)
+		return addErr
+	})
+	if _, ok := errors.AsType[*sqlstore.StoredPayloadConflictError](err); !ok {
+		t.Fatalf("large integer conflict = %T %v", err, err)
+	}
+	assertObservationRepositoryErrorRedacted(t, err, "worker.capture", "item", "fingerprint-secret")
+	err = database.Transaction(ctx, func(tx sqlstore.DBTX) error {
+		_, addErr := repository.Add(ctx, tx, "scope-observation", conflicting)
+		return addErr
+	})
+	if _, ok := errors.AsType[*sqlstore.StoredPayloadConflictError](err); !ok {
+		t.Fatalf("conflicting observation = %T %v", err, err)
+	}
+	assertObservationRepositoryErrorRedacted(t, err, "worker.capture", "item", "fingerprint-secret")
+	var position int64
+	if positionTransactionErr := database.Transaction(ctx, func(tx sqlstore.DBTX) error {
+		var positionErr error
+		position, positionErr = repository.JournalPosition(ctx, tx, "scope-observation")
+		return positionErr
+	}); positionTransactionErr != nil {
+		t.Fatal(positionTransactionErr)
+	}
+	if position != 1 {
+		t.Fatalf("journal position after conflicting replay = %d, want 1", position)
+	}
+}
+
+func TestSourceRepositoryDecodesCurrentNativeEnvelopeWithoutHijackingLegacyEncoding(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	database := openTestDatabase(t)
+	repository, err := sqlstore.NewSourceRepository(sqlstore.SQLiteDialect, sqlstore.ContentSourceCodec())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	current := contentSource(t, "current-v1-native", "current native source", nil)
+	legacy := contentSource(t, "legacy-encoding", "legacy native source", nil)
+	if transactionErr := database.Transaction(ctx, func(tx sqlstore.DBTX) error {
+		if _, addErr := repository.Add(ctx, tx, "seed-native-envelope", current); addErr != nil {
+			return addErr
+		}
+		_, addErr := repository.Add(ctx, tx, "seed-native-envelope", legacy)
+		return addErr
+	}); transactionErr != nil {
+		t.Fatal(transactionErr)
+	}
+
+	var currentPayload, legacyPayload []byte
+	currentRef, err := source.NewRef(source.ContentType, current.SourceName())
+	if err != nil {
+		t.Fatal(err)
+	}
+	legacyRef, err := source.NewRef(source.ContentType, legacy.SourceName())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := database.SQLDB().QueryRowContext(ctx, `SELECT payload FROM pc_sources
+        WHERE scope_id = ? AND source_type = ? AND source_id = ?`,
+		"seed-native-envelope", currentRef.Type(), currentRef.ID(),
+	).Scan(&currentPayload); err != nil {
+		t.Fatal(err)
+	}
+	if err := database.SQLDB().QueryRowContext(ctx, `SELECT payload FROM pc_sources
+        WHERE scope_id = ? AND source_type = ? AND source_id = ?`,
+		"seed-native-envelope", legacyRef.Type(), legacyRef.ID(),
+	).Scan(&legacyPayload); err != nil {
+		t.Fatal(err)
+	}
+	currentPayload = []byte(`{"encoding":"powercontext-source-v1","representation":"native","value":` + string(currentPayload) + `}`)
+	legacyPayload = append(legacyPayload[:len(legacyPayload)-1], []byte(`,"encoding":"powercontext-source-v1"}`)...)
+
+	for _, entry := range []struct {
+		name     string
+		ref      source.Ref
+		payload  []byte
+		position int
+	}{
+		{name: "current native envelope", ref: currentRef, payload: currentPayload, position: 1},
+		{name: "legacy native encoding field", ref: legacyRef, payload: legacyPayload, position: 2},
+	} {
+		t.Run(entry.name, func(t *testing.T) {
+			t.Parallel()
+			if _, execErr := database.SQLDB().ExecContext(ctx, `INSERT INTO pc_sources
+                (scope_id, source_type, source_id, payload, journal_position) VALUES (?, ?, ?, ?, ?)`,
+				"native-envelope", entry.ref.Type(), entry.ref.ID(), entry.payload, entry.position,
+			); execErr != nil {
+				t.Fatal(execErr)
+			}
+			err := database.Transaction(ctx, func(tx sqlstore.DBTX) error {
+				stored, getErr := repository.Get(ctx, tx, "native-envelope", entry.ref)
+				if getErr != nil {
+					return getErr
+				}
+				if stored.Value.SourceName() != entry.ref.ID() {
+					t.Fatalf("decoded native SourceName() = %q, want %q", stored.Value.SourceName(), entry.ref.ID())
+				}
+				return nil
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestSourceRepositoryRejectsDamagedCurrentV1EnvelopeBeforeCodecLookup(t *testing.T) {
+	for _, scenario := range []struct {
+		name    string
+		payload []byte
+	}{
+		{
+			name:    "malformed outer envelope",
+			payload: []byte(`{"encoding":"powercontext-source-v1","representation":"observation","value":`),
+		},
+		{
+			name:    "damaged outer envelope",
+			payload: []byte(`{"encoding":"powercontext-source-v1","representation":"observation"}`),
+		},
+		{
+			name:    "duplicate outer marker",
+			payload: []byte(`{"encoding":"powercontext-source-v1","encoding":"powercontext-source-v1","representation":"observation","value":{}}`),
+		},
+	} {
+		t.Run(scenario.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := t.Context()
+			database := openTestDatabase(t)
+			repository, err := sqlstore.NewSourceRepository(sqlstore.SQLiteDialect, sqlstore.ContentSourceCodec())
+			if err != nil {
+				t.Fatal(err)
+			}
+			const typeName = "dynamic-type-secret"
+			const sourceID = "dynamic-id-secret"
+			if _, execErr := database.SQLDB().ExecContext(ctx, `INSERT INTO pc_sources
+                (scope_id, source_type, source_id, payload, journal_position) VALUES (?, ?, ?, ?, ?)`,
+				"scope-dynamic-envelope", typeName, sourceID, scenario.payload, 1,
+			); execErr != nil {
+				t.Fatal(execErr)
+			}
+			ref, err := source.NewRef(typeName, sourceID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = database.Transaction(ctx, func(tx sqlstore.DBTX) error {
+				_, getErr := repository.Get(ctx, tx, "scope-dynamic-envelope", ref)
+				return getErr
+			})
+			if _, ok := errors.AsType[*sqlstore.InvalidStoredPayloadError](err); !ok {
+				t.Fatalf("damaged dynamic envelope = %T %v", err, err)
+			}
+			assertObservationRepositoryErrorRedacted(t, err, typeName, sourceID, "powercontext-source-v1")
+		})
+	}
+}
+
+func TestSourceRepositoryClassifiesObservationStorageCorruptionBeforeCodecLookup(t *testing.T) {
+	for _, scenario := range []string{"malformed envelope", "unknown envelope member", "indexed identity mismatch"} {
+		t.Run(scenario, func(t *testing.T) {
+			t.Parallel()
+			ctx := t.Context()
+			database := openTestDatabase(t)
+			repository, err := sqlstore.NewSourceRepository(sqlstore.SQLiteDialect, sqlstore.ContentSourceCodec())
+			if err != nil {
+				t.Fatal(err)
+			}
+			observation := observationSource(t, "decoded-type-secret", "decoded-id-secret", `{"name":"decoded-id-secret","definition_version":"1","materialization":"captured"}`)
+			payload, err := observationEnvelope(observation)
+			if err != nil {
+				t.Fatal(err)
+			}
+			indexedType, indexedID := observation.Ref().Type(), observation.Ref().ID()
+			switch scenario {
+			case "malformed envelope":
+				payload = []byte(`{"encoding":"powercontext-source-v1","representation":"observation","value":{"source_type":"stored-secret"}}`)
+			case "unknown envelope member":
+				payload = append(payload[:len(payload)-1], []byte(`,"stored-secret":true}`)...)
+			case "indexed identity mismatch":
+				indexedType = "indexed-type-secret"
+				indexedID = "indexed-id-secret"
+			}
+			if _, execErr := database.SQLDB().ExecContext(ctx, `INSERT INTO pc_sources
+                (scope_id, source_type, source_id, payload, journal_position) VALUES (?, ?, ?, ?, ?)`,
+				"scope-observation", indexedType, indexedID, payload, 1,
+			); execErr != nil {
+				t.Fatal(execErr)
+			}
+			ref, err := source.NewRef(indexedType, indexedID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = database.Transaction(ctx, func(tx sqlstore.DBTX) error {
+				_, getErr := repository.Get(ctx, tx, "scope-observation", ref)
+				return getErr
+			})
+			switch scenario {
+			case "malformed envelope", "unknown envelope member":
+				if _, ok := errors.AsType[*sqlstore.InvalidStoredPayloadError](err); !ok {
+					t.Fatalf("malformed observation error = %T %v", err, err)
+				}
+			case "indexed identity mismatch":
+				if _, ok := errors.AsType[*sqlstore.IdentityMismatchError](err); !ok {
+					t.Fatalf("indexed observation error = %T %v", err, err)
+				}
+			}
+			assertObservationRepositoryErrorRedacted(t, err,
+				"decoded-type-secret", "decoded-id-secret", "indexed-type-secret", "indexed-id-secret", "stored-secret", "fingerprint-secret",
+			)
+		})
+	}
+}
+
 func openTestDatabase(t *testing.T) *sqlstore.Database {
 	t.Helper()
 	config := sqlstore.DefaultSQLiteConfig(filepath.Join(t.TempDir(), "powercontext.db"))
@@ -380,4 +776,37 @@ func contentSource(t *testing.T, id, content string, metadata map[string]any) so
 		t.Fatal(err)
 	}
 	return value
+}
+
+func observationSource(t *testing.T, sourceType, sourceID, payload string) source.SourceObservation {
+	t.Helper()
+	ref, err := source.NewRef(sourceType, sourceID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	observation, err := source.NewSourceObservation(ref, "1", "fingerprint-secret", nil, jsontext.Value(payload), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return observation
+}
+
+func observationEnvelope(observation source.SourceObservation) ([]byte, error) {
+	value, err := observation.MarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return []byte(`{"encoding":"powercontext-source-v1","representation":"observation","value":` + string(value) + `}`), nil
+}
+
+func assertObservationRepositoryErrorRedacted(t *testing.T, err error, secrets ...string) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected an observation repository error")
+	}
+	for _, secret := range secrets {
+		if strings.Contains(err.Error(), secret) {
+			t.Fatalf("observation repository error exposed %q: %v", secret, err)
+		}
+	}
 }


### PR DESCRIPTION
Part of #202 Phase 2. Extends SQLite SourceRepository with strict v1 Observation/native envelopes, dynamic Observation routing, lossless JSON semantic idempotence, native legacy compatibility and typed redacted corruption errors. Does not perform manifest/schema validation, connector lifecycle, HTTP or host integration.