### PR TITLE
feat(runtime): validate remote source ingestion

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -471,3 +471,10 @@ source / artifact / trigger / inference
   and Runtime instances cannot commit opposite parent edges or duplicate an
   idempotent default bootstrap, and prove that an injected default-setting
   failure rolls the Scope and its creation key back together.
+
+- When a remote manifest restricts JSON Schema dialects, walk only the pinned
+  draft's schema-bearing keyword paths when finding nested resource roots.
+  Treat `examples` and unknown annotation values as opaque data. Verify both an
+  annotation mutant containing legacy `` and `` and a nested actual
+  resource with a legacy dialect, so the former is accepted and the latter is
+  rejected before persistence.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -475,6 +475,6 @@ source / artifact / trigger / inference
 - When a remote manifest restricts JSON Schema dialects, walk only the pinned
   draft's schema-bearing keyword paths when finding nested resource roots.
   Treat `examples` and unknown annotation values as opaque data. Verify both an
-  annotation mutant containing legacy `` and `` and a nested actual
+  annotation mutant containing legacy `$id` and `$schema` and a nested actual
   resource with a legacy dialect, so the former is accepted and the latter is
   rejected before persistence.

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/ogen-go/ogen v1.23.0
 	github.com/openai/openai-go/v3 v3.51.0
 	github.com/prometheus/client_golang v1.24.1
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.3
 	github.com/spf13/cobra v1.10.2
 	go.opentelemetry.io/otel v1.44.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.44.0

--- a/go.sum
+++ b/go.sum
@@ -241,6 +241,8 @@ github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUc
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.3 h1:1EYB5IzjZawrrnELUi78f9fPu57HuXjmddZPjrls/28=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.3/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 github.com/schollz/progressbar/v3 v3.19.0 h1:Ea18xuIRQXLAUidVDox3AbwfUhD0/1IvohyTutOIFoc=
 github.com/schollz/progressbar/v3 v3.19.0/go.mod h1:IsO3lpbaGuzh8zIMzgY3+J8l4C8GjO0Y9S69eFvNsec=
 github.com/segmentio/asm v1.2.1 h1:DTNbBqs57ioxAD4PrArqftgypG4/qNpXoJx8TVXxPR0=

--- a/internal/runtime/remote_ingestion.go
+++ b/internal/runtime/remote_ingestion.go
@@ -1,0 +1,333 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtime
+
+import (
+	"bytes"
+	"context"
+	"encoding/json/jsontext"
+	json "encoding/json/v2"
+	"errors"
+
+	jsonschema "github.com/santhosh-tekuri/jsonschema/v6"
+
+	"github.com/ob-labs/powercontext-go/source"
+)
+
+const (
+	maxDefinitionManifestBytes = 64 * 1024
+	maxSourceObservationBytes  = 4 * 1024 * 1024
+	schemaResourceURL          = "https://powercontext.invalid/remote-source-schema"
+	draft202012SchemaURL       = "https://json-schema.org/draft/2020-12/schema"
+)
+
+// RemoteIngestionBackend is the transaction-owning persistence contract for
+// declarative worker Source ingestion. Implementations must not hold a SQL
+// transaction while RemoteIngestionApplication validates a manifest or value.
+type RemoteIngestionBackend interface {
+	Register(context.Context, source.DefinitionManifest) (source.DefinitionManifest, error)
+	Find(context.Context, source.DefinitionIdentity) (source.DefinitionManifest, bool, error)
+	Add(context.Context, string, source.SourceObservation) (source.Ref, int64, error)
+	HasNativeDefinition(string) bool
+}
+
+// RemoteIngestionApplication validates remote Source declarations and
+// observations before delegating their short durable writes to a backend.
+type RemoteIngestionApplication struct {
+	runtime *Runtime
+	backend RemoteIngestionBackend
+}
+
+// NewRemoteIngestionApplication binds remote Source ingestion to Runtime
+// lifecycle admission and per-Scope serialization.
+func NewRemoteIngestionApplication(
+	runtime *Runtime,
+	backend RemoteIngestionBackend,
+) (*RemoteIngestionApplication, error) {
+	if runtime == nil || backend == nil {
+		return nil, errors.New("runtime: Remote ingestion dependencies must not be nil")
+	}
+	return &RemoteIngestionApplication{runtime: runtime, backend: backend}, nil
+}
+
+// Register validates one immutable worker Definition before beginning its
+// backend-owned transaction.
+func (a *RemoteIngestionApplication) Register(
+	ctx context.Context,
+	manifest source.DefinitionManifest,
+) (result source.DefinitionManifest, err error) {
+	err = a.runtime.Operation(ctx, func(ctx context.Context) error {
+		if validationErr := validateRemoteDefinition(manifest, a.backend); validationErr != nil {
+			return validationErr
+		}
+		var registerErr error
+		result, registerErr = a.backend.Register(ctx, manifest)
+		return registerErr
+	})
+	return result, err
+}
+
+// Submit validates a worker observation against its durable Definition before
+// asking the backend to append it in a short transaction.
+func (a *RemoteIngestionApplication) Submit(
+	ctx context.Context,
+	scopeID string,
+	observation source.SourceObservation,
+) (result SourceReceipt, err error) {
+	err = a.runtime.ScopedWrite(ctx, scopeID, func(ctx context.Context, scope string) error {
+		if validationErr := validateRemoteObservationEnvelope(observation); validationErr != nil {
+			return validationErr
+		}
+		identity, identityErr := source.NewDefinitionIdentity(observation.Ref().Type(), observation.DefinitionVersion())
+		if identityErr != nil {
+			return sourceObservationError("definition", "must identify a valid Source Definition")
+		}
+		manifest, found, findErr := a.backend.Find(ctx, identity)
+		if findErr != nil {
+			return findErr
+		}
+		if !found {
+			return &source.DefinitionNotFoundError{}
+		}
+		if a.backend.HasNativeDefinition(observation.Ref().Type()) {
+			return &source.DefinitionConflictError{}
+		}
+		if validationErr := validateRemoteObservation(manifest, observation); validationErr != nil {
+			return validationErr
+		}
+		ref, sequence, addErr := a.backend.Add(ctx, scope, observation)
+		if addErr != nil {
+			return addErr
+		}
+		result = SourceReceipt{Ref: ref, Sequence: sequence}
+		return nil
+	})
+	return result, err
+}
+
+func validateRemoteDefinition(manifest source.DefinitionManifest, backend RemoteIngestionBackend) error {
+	if err := manifest.Validate(); err != nil {
+		return err
+	}
+	payload, err := json.Marshal(manifest)
+	if err != nil {
+		return definitionManifestError("manifest", "must be serializable")
+	}
+	if len(payload) > maxDefinitionManifestBytes {
+		return definitionManifestError("manifest", "must not exceed 64 KiB")
+	}
+	if backend.HasNativeDefinition(manifest.Name()) {
+		return definitionManifestError("name", "must not replace an active Source Definition")
+	}
+	if _, err := compileDraft202012(manifest.SourceSchema()); err != nil {
+		return definitionManifestError("schema", "must be valid JSON Schema Draft 2020-12")
+	}
+	for _, projection := range manifest.Projections() {
+		if source.IsTextEvidenceProjection(projection.Key()) {
+			if err := source.ValidateTextEvidenceSchema(projection.Schema()); err != nil {
+				return definitionManifestError("projection", "must use the standard text-evidence schema")
+			}
+		}
+		if _, err := compileDraft202012(projection.Schema()); err != nil {
+			return definitionManifestError("projection", "must use valid JSON Schema Draft 2020-12")
+		}
+	}
+	return nil
+}
+
+func validateRemoteObservation(
+	manifest source.DefinitionManifest,
+	observation source.SourceObservation,
+) error {
+	if observation.Ref().Type() != manifest.Name() || observation.DefinitionVersion() != manifest.Version() {
+		return sourceObservationError("definition", "does not match the registered manifest identity")
+	}
+	if observation.DefinitionFingerprint() != manifest.Fingerprint() {
+		return sourceObservationError("fingerprint", "does not match the registered manifest")
+	}
+	if err := validateDraft202012Value(manifest.SourceSchema(), observation.Payload()); err != nil {
+		return sourceObservationError("schema", "does not match the registered Source schema")
+	}
+	declared := make(map[source.ProjectionKey]source.ProjectionManifest, len(manifest.Projections()))
+	for _, projection := range manifest.Projections() {
+		declared[projection.Key()] = projection
+	}
+	supplied := observation.Projections()
+	if len(declared) != len(supplied) {
+		return sourceObservationError("projections", "must exactly match the registered manifest")
+	}
+	for _, projection := range supplied {
+		declaration, exists := declared[projection.Key()]
+		if !exists {
+			return sourceObservationError("projections", "must exactly match the registered manifest")
+		}
+		if err := validateDraft202012Value(declaration.Schema(), projection.Value()); err != nil {
+			return sourceObservationError("projection", "does not match the registered schema")
+		}
+		if source.IsTextEvidenceProjection(projection.Key()) {
+			if err := source.ValidateTextEvidence(projection.Value(), observation.Ref()); err != nil {
+				return sourceObservationError("text-evidence", "does not match the observation envelope")
+			}
+		}
+	}
+	return nil
+}
+
+func validateRemoteObservationEnvelope(observation source.SourceObservation) error {
+	if err := observation.Validate(); err != nil {
+		return err
+	}
+	payload, err := json.Marshal(observation)
+	if err != nil {
+		return sourceObservationError("value", "must be serializable")
+	}
+	if len(payload) > maxSourceObservationBytes {
+		return sourceObservationError("size", "must not exceed 4 MiB")
+	}
+	return nil
+}
+
+func compileDraft202012(schema jsontext.Value) (*jsonschema.Schema, error) {
+	if err := requireDraft202012(schema); err != nil {
+		return nil, err
+	}
+	document, err := jsonschema.UnmarshalJSON(bytes.NewReader(schema))
+	if err != nil {
+		return nil, err
+	}
+	compiler := jsonschema.NewCompiler()
+	compiler.DefaultDraft(jsonschema.Draft2020)
+	compiler.UseLoader(localSchemaLoader{})
+	if err := compiler.AddResource(schemaResourceURL, document); err != nil {
+		return nil, err
+	}
+	return compiler.Compile(schemaResourceURL)
+}
+
+// requireDraft202012 prevents explicit dialect declarations from overriding
+// the compiler default. Embedded schema resources with their own $id may
+// independently declare a dialect, so each resource is checked before
+// compilation.
+func requireDraft202012(schema jsontext.Value) error {
+	var value any
+	if err := json.Unmarshal(schema, &value); err != nil {
+		return err
+	}
+	return requireDraft202012Value(value, true)
+}
+
+func requireDraft202012Value(value any, resourceRoot bool) error {
+	schema, ok := value.(map[string]any)
+	if !ok {
+		return nil
+	}
+	if resourceRoot {
+		if dialect, exists := schema["$schema"]; exists {
+			name, ok := dialect.(string)
+			if !ok || !isDraft202012SchemaURL(name) {
+				return errors.New("JSON Schema must use Draft 2020-12")
+			}
+		}
+	}
+
+	for keyword, nested := range schema {
+		var err error
+		switch keyword {
+		case "not", "additionalProperties", "additionalItems", "propertyNames", "contains",
+			"if", "then", "else", "unevaluatedProperties", "unevaluatedItems", "contentSchema":
+			err = requireDraft202012Subschema(nested)
+		case "definitions", "properties", "patternProperties", "dependencies", "$defs", "dependentSchemas":
+			err = requireDraft202012SubschemaMap(nested)
+		case "allOf", "anyOf", "oneOf", "prefixItems":
+			err = requireDraft202012SubschemaArray(nested)
+		case "items":
+			err = requireDraft202012Subschema(nested)
+			if err == nil {
+				err = requireDraft202012SubschemaArray(nested)
+			}
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func requireDraft202012Subschema(value any) error {
+	schema, ok := value.(map[string]any)
+	return requireDraft202012Value(value, ok && hasSchemaResourceID(schema))
+}
+
+func requireDraft202012SubschemaMap(value any) error {
+	entries, ok := value.(map[string]any)
+	if !ok {
+		return nil
+	}
+	for _, schema := range entries {
+		if err := requireDraft202012Subschema(schema); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func requireDraft202012SubschemaArray(value any) error {
+	entries, ok := value.([]any)
+	if !ok {
+		return nil
+	}
+	for _, schema := range entries {
+		if err := requireDraft202012Subschema(schema); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func hasSchemaResourceID(value map[string]any) bool {
+	id, ok := value["$id"].(string)
+	return ok && id != ""
+}
+
+func isDraft202012SchemaURL(value string) bool {
+	return value == draft202012SchemaURL ||
+		value == "http://json-schema.org/draft/2020-12/schema"
+}
+
+func validateDraft202012Value(schema, value jsontext.Value) error {
+	compiled, err := compileDraft202012(schema)
+	if err != nil {
+		return err
+	}
+	instance, err := jsonschema.UnmarshalJSON(bytes.NewReader(value))
+	if err != nil {
+		return err
+	}
+	return compiled.Validate(instance)
+}
+
+type localSchemaLoader struct{}
+
+func (localSchemaLoader) Load(string) (any, error) {
+	return nil, errors.New("remote JSON Schema loading is disabled")
+}
+
+func definitionManifestError(field, detail string) *source.InvalidDefinitionManifestError {
+	return &source.InvalidDefinitionManifestError{Field: field, Detail: detail}
+}
+
+func sourceObservationError(field, detail string) *source.InvalidSourceObservationError {
+	return &source.InvalidSourceObservationError{Field: field, Detail: detail}
+}

--- a/internal/runtime/remote_ingestion_test.go
+++ b/internal/runtime/remote_ingestion_test.go
@@ -1,0 +1,451 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtime
+
+import (
+	"context"
+	"encoding/json/jsontext"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/ob-labs/powercontext-go/source"
+)
+
+func TestRemoteIngestionApplicationRegistersOnlyValidatedNonNativeDefinitions(t *testing.T) {
+	valid := remoteManifest(t, "remote.note", jsontext.Value(`{"type":"object"}`), nil)
+	for _, test := range []struct {
+		name     string
+		manifest source.DefinitionManifest
+		native   bool
+	}{
+		{name: "native definition shadow", manifest: valid, native: true},
+		{name: "invalid Draft 2020-12 schema", manifest: remoteManifest(t, "remote.invalid-schema", jsontext.Value(`{"type":5}`), nil)},
+		{name: "different text evidence schema", manifest: remoteManifest(t, "remote.invalid-evidence", jsontext.Value(`{"type":"object"}`), []source.ProjectionManifest{
+			remoteProjection(t, source.TextEvidenceProjectionKey(), jsontext.Value(`{"type":"object"}`)),
+		})},
+		{name: "manifest over 64 KiB", manifest: remoteManifest(t, "remote.large", jsontext.Value(`{"description":"`+strings.Repeat("x", 64*1024)+`"}`), nil)},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			backend := newRemoteIngestionBackend()
+			backend.native[test.manifest.Name()] = test.native
+			application, err := NewRemoteIngestionApplication(New(), backend)
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, err = application.Register(t.Context(), test.manifest)
+			if _, ok := errors.AsType[*source.InvalidDefinitionManifestError](err); !ok {
+				t.Fatalf("Register() error = %T %v", err, err)
+			}
+			if backend.registered != 0 {
+				t.Fatalf("Register() reached storage %d times", backend.registered)
+			}
+			for _, secret := range []string{test.manifest.Name(), "remote", "xxxxx"} {
+				if strings.Contains(err.Error(), secret) {
+					t.Fatalf("Register() error exposed %q: %v", secret, err)
+				}
+			}
+		})
+	}
+
+	backend := newRemoteIngestionBackend()
+	application, err := NewRemoteIngestionApplication(New(), backend)
+	if err != nil {
+		t.Fatal(err)
+	}
+	registered, err := application.Register(t.Context(), valid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if backend.registered != 1 || registered.Fingerprint() != valid.Fingerprint() {
+		t.Fatalf("Register() = %#v after %d store calls", registered, backend.registered)
+	}
+}
+
+func TestRemoteIngestionApplicationEnforcesDraft202012OnlyAtSchemaResourceRoots(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		schema jsontext.Value
+		secret string
+	}{
+		{
+			name:   "Draft 7 root",
+			schema: jsontext.Value(`{"$schema":"http://json-schema.org/draft-07/schema","type":"object"}`),
+			secret: "draft-07",
+		},
+		{
+			name:   "Draft 2019 root",
+			schema: jsontext.Value(`{"$schema":"https://json-schema.org/draft/2019-09/schema","type":"object"}`),
+			secret: "2019-09",
+		},
+		{
+			name: "Draft 2019 nested resource",
+			schema: jsontext.Value(`{
+				"$schema":"https://json-schema.org/draft/2020-12/schema",
+				"$defs":{"embedded":{"$id":"https://powercontext.invalid/embedded","$schema":"https://json-schema.org/draft/2019-09/schema","type":"object"}}
+			}`),
+			secret: "embedded",
+		},
+		{
+			name: "Draft 7 nested property resource",
+			schema: jsontext.Value(`{
+				"$schema":"https://json-schema.org/draft/2020-12/schema",
+				"properties":{"embedded":{"$id":"https://powercontext.invalid/property","$schema":"http://json-schema.org/draft-07/schema","type":"string"}}
+			}`),
+			secret: "property",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			manifest := remoteManifest(t, "remote.dialect", test.schema, nil)
+			backend := newRemoteIngestionBackend()
+			application, err := NewRemoteIngestionApplication(New(), backend)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			_, err = application.Register(t.Context(), manifest)
+			if _, ok := errors.AsType[*source.InvalidDefinitionManifestError](err); !ok {
+				t.Fatalf("Register() error = %T %v", err, err)
+			}
+			if backend.registered != 0 {
+				t.Fatalf("Register() reached storage %d times", backend.registered)
+			}
+			for _, secret := range []string{"remote.dialect", test.secret, "json-schema.org"} {
+				if strings.Contains(err.Error(), secret) {
+					t.Fatalf("Register() error exposed %q: %v", secret, err)
+				}
+			}
+		})
+	}
+
+	manifest := remoteManifest(t, "remote.explicit-dialect", jsontext.Value(`{"$schema":"https://json-schema.org/draft/2020-12/schema","type":"object"}`), nil)
+	backend := newRemoteIngestionBackend()
+	application, err := NewRemoteIngestionApplication(New(), backend)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, registerErr := application.Register(t.Context(), manifest); registerErr != nil {
+		t.Fatalf("explicit Draft 2020-12 Register() = %v", registerErr)
+	}
+	if backend.registered != 1 {
+		t.Fatalf("explicit Draft 2020-12 Register() reached storage %d times", backend.registered)
+	}
+
+	for _, test := range []struct {
+		name   string
+		schema jsontext.Value
+	}{
+		{
+			name: "inline non-resource dialect",
+			schema: jsontext.Value(`{
+				"$schema":"https://json-schema.org/draft/2020-12/schema",
+				"$defs":{"inline":{"$schema":"https://json-schema.org/draft/2019-09/schema","type":"object"}}
+			}`),
+		},
+		{
+			name: "examples annotation",
+			schema: jsontext.Value(`{
+				"$schema":"https://json-schema.org/draft/2020-12/schema",
+				"type":"object",
+				"properties":{"value":{"examples":[{"$id":"example-record","$schema":"http://json-schema.org/draft-07/schema"}]}}
+			}`),
+		},
+		{
+			name: "custom annotation",
+			schema: jsontext.Value(`{
+				"$schema":"https://json-schema.org/draft/2020-12/schema",
+				"type":"object",
+				"properties":{"value":{"x-powercontext":{"$id":"custom-record","$schema":"https://json-schema.org/draft/2019-09/schema"}}}
+			}`),
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			candidateBackend := newRemoteIngestionBackend()
+			candidate, candidateErr := NewRemoteIngestionApplication(New(), candidateBackend)
+			if candidateErr != nil {
+				t.Fatal(candidateErr)
+			}
+			candidateManifest := remoteManifest(t, "remote.annotation", test.schema, nil)
+
+			if _, registerErr := candidate.Register(t.Context(), candidateManifest); registerErr != nil {
+				t.Fatalf("annotation Register() = %v", registerErr)
+			}
+			if candidateBackend.registered != 1 {
+				t.Fatalf("annotation Register() reached storage %d times", candidateBackend.registered)
+			}
+		})
+	}
+}
+
+func TestRemoteIngestionApplicationValidatesObservationBeforeStore(t *testing.T) {
+	manifest := remoteManifest(t, "remote.note", remoteObservationSchema, []source.ProjectionManifest{
+		remoteProjection(t, source.TextEvidenceProjectionKey(), source.TextEvidenceSchema()),
+	})
+	valid := remoteObservation(t, manifest, `{"name":"item-1","definition_version":"1","materialization":"captured","large":9007199254740993}`, `{"source_type":"remote.note","source_id":"item-1","content":"preserve this","metadata":{"large":9007199254740993}}`, true)
+
+	backend := newRemoteIngestionBackend()
+	backend.manifests[manifest.Identity()] = manifest
+	application, err := NewRemoteIngestionApplication(New(), backend)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := application.Submit(t.Context(), "scope-remote", valid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if receipt.Ref != valid.Ref() || receipt.Sequence != 1 || backend.added != 1 {
+		t.Fatalf("Submit() = %#v after %d stores", receipt, backend.added)
+	}
+	if !strings.Contains(string(backend.last.Payload()), "9007199254740993") {
+		t.Fatalf("Submit() lost the large JSON integer: %s", backend.last.Payload())
+	}
+
+	for _, test := range []struct {
+		name        string
+		observation source.SourceObservation
+		missing     bool
+	}{
+		{name: "missing manifest", observation: valid, missing: true},
+		{name: "mismatched fingerprint", observation: remoteObservation(t, manifest, `{"name":"item-1","definition_version":"1","materialization":"captured","large":1}`, `{"source_type":"remote.note","source_id":"item-1","content":"preserve this"}`, true, "wrong-fingerprint")},
+		{name: "schema mismatch", observation: remoteObservation(t, manifest, `{"name":"item-1","definition_version":"1","materialization":"captured","large":"wrong"}`, `{"source_type":"remote.note","source_id":"item-1","content":"preserve this"}`, true)},
+		{name: "projection set mismatch", observation: remoteObservation(t, manifest, `{"name":"item-1","definition_version":"1","materialization":"captured","large":1}`, "", false)},
+		{name: "text evidence identity mismatch", observation: remoteObservation(t, manifest, `{"name":"item-1","definition_version":"1","materialization":"captured","large":1}`, `{"source_type":"remote.note","source_id":"other","content":"preserve this"}`, true)},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			candidateBackend := newRemoteIngestionBackend()
+			if !test.missing {
+				candidateBackend.manifests[manifest.Identity()] = manifest
+			}
+			candidate, newErr := NewRemoteIngestionApplication(New(), candidateBackend)
+			if newErr != nil {
+				t.Fatal(newErr)
+			}
+			_, submitErr := candidate.Submit(t.Context(), "scope-remote", test.observation)
+			if test.missing {
+				if _, ok := errors.AsType[*source.DefinitionNotFoundError](submitErr); !ok {
+					t.Fatalf("missing manifest error = %T %v", submitErr, submitErr)
+				}
+			} else if _, ok := errors.AsType[*source.InvalidSourceObservationError](submitErr); !ok {
+				t.Fatalf("Submit() error = %T %v", submitErr, submitErr)
+			}
+			if candidateBackend.added != 0 {
+				t.Fatalf("Submit() stored invalid observation %d times", candidateBackend.added)
+			}
+			for _, secret := range []string{"remote.note", "item-1", "wrong-fingerprint", "preserve this", "other"} {
+				if strings.Contains(submitErr.Error(), secret) {
+					t.Fatalf("Submit() error exposed %q: %v", secret, submitErr)
+				}
+			}
+		})
+	}
+}
+
+func TestRemoteIngestionApplicationRejectsPersistedManifestShadowedByNativeDefinition(t *testing.T) {
+	manifest := remoteManifest(t, source.ContentType, remoteObservationSchema, []source.ProjectionManifest{
+		remoteProjection(t, source.TextEvidenceProjectionKey(), source.TextEvidenceSchema()),
+	})
+	observation := remoteObservation(t, manifest,
+		`{"name":"item-1","definition_version":"1","materialization":"captured","large":1}`,
+		`{"source_type":"content","source_id":"item-1","content":"durable text"}`,
+		true,
+	)
+	backend := newRemoteIngestionBackend()
+	// Model a remote manifest which was persisted before the local content codec
+	// became active. Submit must not route that state through the native codec.
+	backend.manifests[manifest.Identity()] = manifest
+	backend.native[source.ContentType] = true
+	application, err := NewRemoteIngestionApplication(New(), backend)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = application.Submit(t.Context(), "scope-remote", observation)
+	if _, ok := errors.AsType[*source.DefinitionConflictError](err); !ok {
+		t.Fatalf("Submit() error = %T %v", err, err)
+	}
+	if backend.finds != 1 || backend.added != 0 {
+		t.Fatalf("Submit() performed %d manifest reads and %d Source writes", backend.finds, backend.added)
+	}
+	for _, secret := range []string{source.ContentType, "item-1", manifest.Fingerprint(), "durable text"} {
+		if strings.Contains(err.Error(), secret) {
+			t.Fatalf("Submit() error exposed %q: %v", secret, err)
+		}
+	}
+}
+
+func TestRemoteIngestionApplicationPreCanceledContextSkipsBackend(t *testing.T) {
+	manifest := remoteManifest(t, "remote.canceled", remoteObservationSchema, nil)
+	observation := remoteObservation(t, manifest,
+		`{"name":"item-1","definition_version":"1","materialization":"captured","large":1}`,
+		"",
+		false,
+	)
+
+	t.Run("Register", func(t *testing.T) {
+		backend := newRemoteIngestionBackend()
+		application, err := NewRemoteIngestionApplication(New(), backend)
+		if err != nil {
+			t.Fatal(err)
+		}
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+
+		_, err = application.Register(ctx, manifest)
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("canceled Register() = %T %v", err, err)
+		}
+		if backend.registered != 0 {
+			t.Fatalf("canceled Register() reached storage %d times", backend.registered)
+		}
+	})
+
+	t.Run("Submit", func(t *testing.T) {
+		backend := newRemoteIngestionBackend()
+		backend.manifests[manifest.Identity()] = manifest
+		application, err := NewRemoteIngestionApplication(New(), backend)
+		if err != nil {
+			t.Fatal(err)
+		}
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+
+		_, err = application.Submit(ctx, "scope-remote", observation)
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("canceled Submit() = %T %v", err, err)
+		}
+		if backend.finds != 0 || backend.added != 0 {
+			t.Fatalf("canceled Submit() performed %d manifest reads and %d Source writes", backend.finds, backend.added)
+		}
+	})
+}
+
+func TestRemoteIngestionApplicationRejectsObservationOverFourMiBBeforeStore(t *testing.T) {
+	manifest := remoteManifest(t, "remote.large", remoteObservationSchema, []source.ProjectionManifest{
+		remoteProjection(t, source.TextEvidenceProjectionKey(), source.TextEvidenceSchema()),
+	})
+	observation := remoteObservation(t, manifest,
+		`{"name":"item-1","definition_version":"1","materialization":"captured","large":1,"extra":"`+strings.Repeat("x", 4*1024*1024)+`"}`,
+		`{"source_type":"remote.large","source_id":"item-1","content":"bounded"}`, true,
+	)
+	backend := newRemoteIngestionBackend()
+	backend.manifests[manifest.Identity()] = manifest
+	application, err := NewRemoteIngestionApplication(New(), backend)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = application.Submit(t.Context(), "scope-large", observation)
+	if _, ok := errors.AsType[*source.InvalidSourceObservationError](err); !ok {
+		t.Fatalf("large observation error = %T %v", err, err)
+	}
+	if backend.finds != 0 || backend.added != 0 {
+		t.Fatalf("large observation reached storage %d reads and %d writes", backend.finds, backend.added)
+	}
+}
+
+var remoteObservationSchema = jsontext.Value(`{"type":"object","properties":{"name":{"type":"string"},"definition_version":{"type":"string"},"materialization":{"const":"captured"},"large":{"type":"integer"}},"required":["name","definition_version","materialization","large"]}`)
+
+type remoteIngestionBackend struct {
+	manifests  map[source.DefinitionIdentity]source.DefinitionManifest
+	native     map[string]bool
+	registered int
+	finds      int
+	added      int
+	last       source.SourceObservation
+}
+
+func newRemoteIngestionBackend() *remoteIngestionBackend {
+	return &remoteIngestionBackend{
+		manifests: make(map[source.DefinitionIdentity]source.DefinitionManifest),
+		native:    make(map[string]bool),
+	}
+}
+
+func (b *remoteIngestionBackend) Register(_ context.Context, manifest source.DefinitionManifest) (source.DefinitionManifest, error) {
+	b.registered++
+	b.manifests[manifest.Identity()] = manifest
+	return manifest, nil
+}
+
+func (b *remoteIngestionBackend) Find(_ context.Context, identity source.DefinitionIdentity) (source.DefinitionManifest, bool, error) {
+	b.finds++
+	manifest, found := b.manifests[identity]
+	return manifest, found, nil
+}
+
+func (b *remoteIngestionBackend) Add(_ context.Context, _ string, observation source.SourceObservation) (source.Ref, int64, error) {
+	b.added++
+	b.last = observation
+	return observation.Ref(), int64(b.added), nil
+}
+
+func (b *remoteIngestionBackend) HasNativeDefinition(name string) bool { return b.native[name] }
+
+func remoteManifest(
+	t *testing.T,
+	name string,
+	schema jsontext.Value,
+	projections []source.ProjectionManifest,
+) source.DefinitionManifest {
+	t.Helper()
+	identity, err := source.NewDefinitionIdentity(name, "1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest, err := source.NewDefinitionManifest(identity, schema, projections)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return manifest
+}
+
+func remoteProjection(t *testing.T, key source.ProjectionKey, schema jsontext.Value) source.ProjectionManifest {
+	t.Helper()
+	projection, err := source.NewProjectionManifest(key, schema)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return projection
+}
+
+func remoteObservation(
+	t *testing.T,
+	manifest source.DefinitionManifest,
+	payload, evidence string,
+	withProjection bool,
+	fingerprint ...string,
+) source.SourceObservation {
+	t.Helper()
+	valueFingerprint := manifest.Fingerprint()
+	if len(fingerprint) > 0 {
+		valueFingerprint = fingerprint[0]
+	}
+	ref, err := source.NewRef(manifest.Name(), "item-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	projections := []source.SourceProjectionValue(nil)
+	if withProjection {
+		projection, projectionErr := source.NewSourceProjectionValue(source.TextEvidenceProjectionKey(), jsontext.Value(evidence))
+		if projectionErr != nil {
+			t.Fatal(projectionErr)
+		}
+		projections = []source.SourceProjectionValue{projection}
+	}
+	observation, err := source.NewSourceObservation(ref, manifest.Version(), valueFingerprint, nil, jsontext.Value(payload), projections)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return observation
+}

--- a/internal/sqlstore/remote_ingestion.go
+++ b/internal/sqlstore/remote_ingestion.go
@@ -1,0 +1,105 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sqlstore
+
+import (
+	"context"
+	"errors"
+
+	"github.com/ob-labs/powercontext-go/source"
+)
+
+// RuntimeRemoteIngestionBackend is the transaction-owning SQLite adapter for
+// runtime.RemoteIngestionApplication. Runtime performs all Schema validation
+// before calling Add, leaving this adapter with only durable registry/journal
+// operations.
+type RuntimeRemoteIngestionBackend struct {
+	database    *Database
+	definitions DefinitionManifestRepository
+	sources     *SourceRepository
+}
+
+// NewRuntimeRemoteIngestionBackend constructs the remote-ingestion persistence
+// adapter from the existing immutable Definition and Source repositories.
+func NewRuntimeRemoteIngestionBackend(
+	database *Database,
+	definitions DefinitionManifestRepository,
+	sources *SourceRepository,
+) (*RuntimeRemoteIngestionBackend, error) {
+	if database == nil || sources == nil {
+		return nil, errors.New("sqlstore: Runtime remote ingestion dependencies must not be nil")
+	}
+	return &RuntimeRemoteIngestionBackend{
+		database: database, definitions: definitions, sources: sources,
+	}, nil
+}
+
+// Register persists a Definition in one short transaction.
+func (b *RuntimeRemoteIngestionBackend) Register(
+	ctx context.Context,
+	manifest source.DefinitionManifest,
+) (result source.DefinitionManifest, err error) {
+	err = b.database.Transaction(ctx, func(tx DBTX) error {
+		var registerErr error
+		result, registerErr = b.definitions.Register(ctx, tx, manifest)
+		return registerErr
+	})
+	if _, ok := errors.AsType[*StoredPayloadConflictError](err); ok {
+		return source.DefinitionManifest{}, &source.DefinitionConflictError{}
+	}
+	return result, err
+}
+
+// Find loads one Definition in a standalone read transaction.
+func (b *RuntimeRemoteIngestionBackend) Find(
+	ctx context.Context,
+	identity source.DefinitionIdentity,
+) (result source.DefinitionManifest, found bool, err error) {
+	if validationErr := identity.Validate(); validationErr != nil {
+		return source.DefinitionManifest{}, false, validationErr
+	}
+	err = b.database.Transaction(ctx, func(tx DBTX) error {
+		var findErr error
+		result, found, findErr = b.definitions.Find(ctx, tx, identity.Name(), identity.Version())
+		return findErr
+	})
+	return result, found, err
+}
+
+// Add appends a pre-validated observation in one short transaction.
+func (b *RuntimeRemoteIngestionBackend) Add(
+	ctx context.Context,
+	scopeID string,
+	observation source.SourceObservation,
+) (ref source.Ref, sequence int64, err error) {
+	err = b.database.Transaction(ctx, func(tx DBTX) error {
+		stored, addErr := b.sources.Add(ctx, tx, scopeID, observation)
+		if addErr != nil {
+			return addErr
+		}
+		ref, sequence = stored.Ref, stored.JournalPosition
+		return nil
+	})
+	if _, ok := errors.AsType[*StoredPayloadConflictError](err); ok {
+		return source.Ref{}, 0, &source.ObservationConflictError{}
+	}
+	return ref, sequence, err
+}
+
+// HasNativeDefinition reports definitions that are already owned by concrete
+// local Source codecs.
+func (b *RuntimeRemoteIngestionBackend) HasNativeDefinition(name string) bool {
+	return b.sources.HasNativeDefinition(name)
+}

--- a/internal/sqlstore/remote_ingestion_test.go
+++ b/internal/sqlstore/remote_ingestion_test.go
@@ -1,0 +1,224 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sqlstore_test
+
+import (
+	"encoding/json/jsontext"
+	"errors"
+	"strings"
+	"testing"
+
+	pcruntime "github.com/ob-labs/powercontext-go/internal/runtime"
+	"github.com/ob-labs/powercontext-go/internal/sqlstore"
+	"github.com/ob-labs/powercontext-go/source"
+)
+
+func TestRuntimeRemoteIngestionBackendOwnsSQLiteTransactions(t *testing.T) {
+	database := openTestDatabase(t)
+	repository, err := sqlstore.NewSourceRepository(sqlstore.SQLiteDialect, sqlstore.ContentSourceCodec())
+	if err != nil {
+		t.Fatal(err)
+	}
+	backend, err := sqlstore.NewRuntimeRemoteIngestionBackend(database, sqlstore.DefinitionManifestRepository{}, repository)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !backend.HasNativeDefinition(source.ContentType) || backend.HasNativeDefinition("remote.note") {
+		t.Fatal("native definition lookup did not use the Source codec registry")
+	}
+	manifest := remoteStoredManifest(t, "remote.note", jsontext.Value(`{"type":"object"}`))
+	registered, err := backend.Register(t.Context(), manifest)
+	if err != nil || registered.Fingerprint() != manifest.Fingerprint() {
+		t.Fatalf("Register() = %#v, %v", registered, err)
+	}
+	found, exists, err := backend.Find(t.Context(), manifest.Identity())
+	if err != nil || !exists || found.Fingerprint() != manifest.Fingerprint() {
+		t.Fatalf("Find() = %#v, %t, %v", found, exists, err)
+	}
+	observation := remoteStoredObservation(t, manifest, `{"name":"item-1","definition_version":"1","materialization":"captured","large":9007199254740993}`)
+	ref, sequence, err := backend.Add(t.Context(), "scope-remote", observation)
+	if err != nil || ref != observation.Ref() || sequence != 1 {
+		t.Fatalf("Add() = %s, %d, %v", ref, sequence, err)
+	}
+}
+
+func TestRuntimeRemoteIngestionBackendReturnsTypedRedactedConflicts(t *testing.T) {
+	database := openTestDatabase(t)
+	repository, err := sqlstore.NewSourceRepository(sqlstore.SQLiteDialect, sqlstore.ContentSourceCodec())
+	if err != nil {
+		t.Fatal(err)
+	}
+	backend, err := sqlstore.NewRuntimeRemoteIngestionBackend(database, sqlstore.DefinitionManifestRepository{}, repository)
+	if err != nil {
+		t.Fatal(err)
+	}
+	first := remoteStoredManifest(t, "remote.secret", jsontext.Value(`{"type":"object"}`))
+	second := remoteStoredManifest(t, "remote.secret", jsontext.Value(`{"type":"string"}`))
+	if _, registerErr := backend.Register(t.Context(), first); registerErr != nil {
+		t.Fatal(registerErr)
+	}
+	_, err = backend.Register(t.Context(), second)
+	if _, ok := errors.AsType[*source.DefinitionConflictError](err); !ok {
+		t.Fatalf("definition conflict = %T %v", err, err)
+	}
+	assertRemoteIngestionErrorRedacted(t, err, "remote.secret", first.Fingerprint(), second.Fingerprint())
+
+	firstObservation := remoteStoredObservation(t, first, `{"name":"item-1","definition_version":"1","materialization":"captured","large":1}`)
+	secondObservation := remoteStoredObservation(t, first, `{"name":"item-1","definition_version":"1","materialization":"captured","large":2}`)
+	if _, _, addErr := backend.Add(t.Context(), "scope-remote", firstObservation); addErr != nil {
+		t.Fatal(addErr)
+	}
+	_, _, err = backend.Add(t.Context(), "scope-remote", secondObservation)
+	if _, ok := errors.AsType[*source.ObservationConflictError](err); !ok {
+		t.Fatalf("observation conflict = %T %v", err, err)
+	}
+	assertRemoteIngestionErrorRedacted(t, err, "remote.secret", "item-1", first.Fingerprint())
+}
+
+func TestRemoteIngestionApplicationUsesSQLiteAdapterAfterValidation(t *testing.T) {
+	database := openTestDatabase(t)
+	repository, err := sqlstore.NewSourceRepository(sqlstore.SQLiteDialect, sqlstore.ContentSourceCodec())
+	if err != nil {
+		t.Fatal(err)
+	}
+	backend, err := sqlstore.NewRuntimeRemoteIngestionBackend(database, sqlstore.DefinitionManifestRepository{}, repository)
+	if err != nil {
+		t.Fatal(err)
+	}
+	application, err := pcruntime.NewRemoteIngestionApplication(pcruntime.New(), backend)
+	if err != nil {
+		t.Fatal(err)
+	}
+	identity, err := source.NewDefinitionIdentity("remote.note", "1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	projection, err := source.NewProjectionManifest(source.TextEvidenceProjectionKey(), source.TextEvidenceSchema())
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest, err := source.NewDefinitionManifest(identity, jsontext.Value(`{"type":"object","properties":{"name":{"type":"string"},"definition_version":{"type":"string"},"materialization":{"const":"captured"}},"required":["name","definition_version","materialization"]}`), []source.ProjectionManifest{projection})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, registerErr := application.Register(t.Context(), manifest); registerErr != nil {
+		t.Fatal(registerErr)
+	}
+	ref, err := source.NewRef("remote.note", "item-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	evidence, err := source.NewSourceProjectionValue(source.TextEvidenceProjectionKey(), jsontext.Value(`{"source_type":"remote.note","source_id":"item-1","content":"durable text"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	observation, err := source.NewSourceObservation(ref, "1", manifest.Fingerprint(), nil,
+		jsontext.Value(`{"name":"item-1","definition_version":"1","materialization":"captured"}`),
+		[]source.SourceProjectionValue{evidence},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := application.Submit(t.Context(), "scope-remote", observation)
+	if err != nil || receipt.Ref != ref || receipt.Sequence != 1 {
+		t.Fatalf("Submit() = %#v, %v", receipt, err)
+	}
+	if transactionErr := database.Transaction(t.Context(), func(tx sqlstore.DBTX) error {
+		stored, getErr := repository.Get(t.Context(), tx, "scope-remote", ref)
+		if getErr != nil {
+			return getErr
+		}
+		if stored.JournalPosition != receipt.Sequence {
+			t.Fatalf("stored sequence = %d, want %d", stored.JournalPosition, receipt.Sequence)
+		}
+		_, ok := stored.Value.(source.SourceObservation)
+		if !ok {
+			t.Fatalf("stored value = %T, want SourceObservation", stored.Value)
+		}
+		return nil
+	}); transactionErr != nil {
+		t.Fatal(transactionErr)
+	}
+
+	wrongFingerprint, err := source.NewSourceObservation(ref, "1", "wrong", nil,
+		jsontext.Value(`{"name":"item-1","definition_version":"1","materialization":"captured"}`),
+		[]source.SourceProjectionValue{evidence},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = application.Submit(t.Context(), "scope-remote", wrongFingerprint)
+	if _, ok := errors.AsType[*source.InvalidSourceObservationError](err); !ok {
+		t.Fatalf("invalid observation error = %T %v", err, err)
+	}
+	var count int
+	if err := database.SQLDB().QueryRowContext(t.Context(), "SELECT count(*) FROM pc_sources WHERE scope_id = ?", "scope-remote").Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 {
+		t.Fatalf("invalid observation changed stored Source count to %d", count)
+	}
+}
+
+func TestRuntimeRemoteIngestionBackendRejectsNilDependencies(t *testing.T) {
+	repository, err := sqlstore.NewSourceRepository(sqlstore.SQLiteDialect, sqlstore.ContentSourceCodec())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqlstore.NewRuntimeRemoteIngestionBackend(nil, sqlstore.DefinitionManifestRepository{}, repository); err == nil {
+		t.Fatal("nil database was accepted")
+	}
+	if _, err := sqlstore.NewRuntimeRemoteIngestionBackend(openTestDatabase(t), sqlstore.DefinitionManifestRepository{}, nil); err == nil {
+		t.Fatal("nil Source repository was accepted")
+	}
+}
+
+func remoteStoredManifest(t *testing.T, name string, schema jsontext.Value) source.DefinitionManifest {
+	t.Helper()
+	identity, err := source.NewDefinitionIdentity(name, "1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest, err := source.NewDefinitionManifest(identity, schema, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return manifest
+}
+
+func remoteStoredObservation(t *testing.T, manifest source.DefinitionManifest, payload string) source.SourceObservation {
+	t.Helper()
+	ref, err := source.NewRef(manifest.Name(), "item-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	observation, err := source.NewSourceObservation(ref, manifest.Version(), manifest.Fingerprint(), nil, jsontext.Value(payload), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return observation
+}
+
+func assertRemoteIngestionErrorRedacted(t *testing.T, err error, secrets ...string) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected a remote-ingestion error")
+	}
+	for _, secret := range secrets {
+		if strings.Contains(err.Error(), secret) {
+			t.Fatalf("remote-ingestion error exposed %q: %v", secret, err)
+		}
+	}
+}

--- a/internal/sqlstore/sources.go
+++ b/internal/sqlstore/sources.go
@@ -94,6 +94,13 @@ func NewSourceRepository(dialect Dialect, codecs ...SourceCodec) (*SourceReposit
 	return repository, nil
 }
 
+// HasNativeDefinition reports whether name is owned by a concrete Source codec.
+// Remote Definition manifests must not replace these local runtime contracts.
+func (r *SourceRepository) HasNativeDefinition(name string) bool {
+	_, exists := r.byName[name]
+	return exists
+}
+
 func (r *SourceRepository) Add(
 	ctx context.Context,
 	db DBTX,

--- a/source/ingestion_errors.go
+++ b/source/ingestion_errors.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package source
+
+// DefinitionNotFoundError reports a missing registered Source Definition
+// without exposing its worker-owned identity.
+type DefinitionNotFoundError struct{}
+
+func (*DefinitionNotFoundError) Error() string { return "Source Definition was not found" }
+
+// DefinitionConflictError reports an immutable Definition identity reused for
+// a different declaration without exposing either declaration.
+type DefinitionConflictError struct{}
+
+func (*DefinitionConflictError) Error() string {
+	return "Source Definition already stores a different declaration"
+}
+
+// ObservationConflictError reports a stable observation identity reused for a
+// different payload without exposing either captured value.
+type ObservationConflictError struct{}
+
+func (*ObservationConflictError) Error() string {
+	return "Source observation already stores a different payload"
+}

--- a/source/text_evidence.go
+++ b/source/text_evidence.go
@@ -1,0 +1,115 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package source
+
+import (
+	"bytes"
+	"encoding/json/jsontext"
+	json "encoding/json/v2"
+)
+
+var (
+	textEvidenceProjectionKey = ProjectionKey{name: "powercontext.text-evidence", version: "1"}
+	textEvidenceSchema        = jsontext.Value(`{"$defs":{"JsonValue":{}},"description":"Canonical JSON shape consumed as textual Artifact evidence.","properties":{"content":{"title":"Content","type":"string"},"metadata":{"additionalProperties":{"$ref":"#/$defs/JsonValue"},"title":"Metadata","type":"object"},"source_id":{"title":"Source Id","type":"string"},"source_type":{"title":"Source Type","type":"string"}},"required":["source_type","source_id","content"],"title":"TextEvidence","type":"object"}`)
+)
+
+// InvalidTextEvidenceError reports a malformed standard text-evidence
+// declaration or value without disclosing its source identity or content.
+type InvalidTextEvidenceError struct {
+	Field  string
+	Detail string
+}
+
+func (e *InvalidTextEvidenceError) Error() string {
+	return "invalid Source text evidence " + e.Field + ": " + e.Detail
+}
+
+// TextEvidenceProjectionKey identifies the stable standard projection consumed
+// as textual Artifact evidence.
+func TextEvidenceProjectionKey() ProjectionKey { return textEvidenceProjectionKey }
+
+// TextEvidenceSchema returns the exact Python-compatible JSON Schema for the
+// standard text-evidence projection.
+func TextEvidenceSchema() jsontext.Value { return textEvidenceSchema.Clone() }
+
+// IsTextEvidenceProjection reports whether key is the standard text-evidence
+// projection without accepting an unversioned or similarly named projection.
+func IsTextEvidenceProjection(key ProjectionKey) bool { return key == textEvidenceProjectionKey }
+
+// ValidateTextEvidenceSchema requires the exact standard schema declaration.
+// Object member order and whitespace do not affect equality.
+func ValidateTextEvidenceSchema(schema jsontext.Value) error {
+	if !schema.IsValid() || schema.Kind() != '{' {
+		return textEvidenceError("schema", "must be the standard JSON object schema")
+	}
+	actual := schema.Clone()
+	expected := textEvidenceSchema.Clone()
+	if err := actual.Canonicalize(); err != nil {
+		return textEvidenceError("schema", "must be valid JSON")
+	}
+	if err := expected.Canonicalize(); err != nil {
+		panic("invalid built-in TextEvidence schema")
+	}
+	if !bytes.Equal(actual, expected) {
+		return textEvidenceError("schema", "must be the standard schema")
+	}
+	return nil
+}
+
+// ValidateTextEvidence verifies a standard projection value belongs to ref.
+// Extra fields are retained for Python compatibility; required fields and
+// metadata retain the standard model's JSON shape.
+func ValidateTextEvidence(value jsontext.Value, ref Ref) error {
+	if _, err := NewRef(ref.Type(), ref.ID()); err != nil {
+		return textEvidenceError("source", "must have a valid observation identity")
+	}
+	if !value.IsValid() || value.Kind() != '{' {
+		return textEvidenceError("value", "must be a JSON object")
+	}
+	var fields map[string]jsontext.Value
+	if err := json.Unmarshal(value, &fields); err != nil {
+		return textEvidenceError("value", "must be valid JSON")
+	}
+	sourceType, ok := textEvidenceString(fields["source_type"])
+	if !ok || sourceType != ref.Type() {
+		return textEvidenceError("source_type", "must match the observation")
+	}
+	sourceID, ok := textEvidenceString(fields["source_id"])
+	if !ok || sourceID != ref.ID() {
+		return textEvidenceError("source_id", "must match the observation")
+	}
+	if _, ok := textEvidenceString(fields["content"]); !ok {
+		return textEvidenceError("content", "must be a string")
+	}
+	if metadata, exists := fields["metadata"]; exists && metadata.Kind() != '{' {
+		return textEvidenceError("metadata", "must be a JSON object")
+	}
+	return nil
+}
+
+func textEvidenceString(value jsontext.Value) (string, bool) {
+	if value.Kind() != '"' {
+		return "", false
+	}
+	var result string
+	if err := json.Unmarshal(value, &result); err != nil {
+		return "", false
+	}
+	return result, true
+}
+
+func textEvidenceError(field, detail string) *InvalidTextEvidenceError {
+	return &InvalidTextEvidenceError{Field: field, Detail: detail}
+}

--- a/source/text_evidence_test.go
+++ b/source/text_evidence_test.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package source_test
+
+import (
+	"encoding/json/jsontext"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/ob-labs/powercontext-go/source"
+)
+
+func TestTextEvidenceContractRequiresTheStandardSchemaAndMatchingSource(t *testing.T) {
+	key := source.TextEvidenceProjectionKey()
+	if key.Name() != "powercontext.text-evidence" || key.Version() != "1" {
+		t.Fatalf("TextEvidenceProjectionKey() = %s@%s", key.Name(), key.Version())
+	}
+	if err := source.ValidateTextEvidenceSchema(source.TextEvidenceSchema()); err != nil {
+		t.Fatalf("standard TextEvidence schema rejected: %v", err)
+	}
+	if err := source.ValidateTextEvidenceSchema(jsontext.Value(`{"type":"object"}`)); err == nil {
+		t.Fatal("schema drift was accepted")
+	} else if _, ok := errors.AsType[*source.InvalidTextEvidenceError](err); !ok {
+		t.Fatalf("schema drift error = %T %v", err, err)
+	}
+
+	ref, err := source.NewRef("remote.note", "item-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	valid := jsontext.Value(`{"source_type":"remote.note","source_id":"item-1","content":"bounded evidence","metadata":{"large":9007199254740993}}`)
+	if err := source.ValidateTextEvidence(valid, ref); err != nil {
+		t.Fatalf("valid TextEvidence rejected: %v", err)
+	}
+	for name, value := range map[string]jsontext.Value{
+		"missing required text":  jsontext.Value(`{"source_type":"remote.note","source_id":"item-1"}`),
+		"wrong source identity":  jsontext.Value(`{"source_type":"remote.note","source_id":"other","content":"bounded evidence"}`),
+		"metadata is not object": jsontext.Value(`{"source_type":"remote.note","source_id":"item-1","content":"bounded evidence","metadata":[]}`),
+	} {
+		t.Run(name, func(t *testing.T) {
+			err := source.ValidateTextEvidence(value, ref)
+			if _, ok := errors.AsType[*source.InvalidTextEvidenceError](err); !ok {
+				t.Fatalf("ValidateTextEvidence() error = %T %v", err, err)
+			}
+			for _, secret := range []string{"remote.note", "item-1", "other", "bounded evidence"} {
+				if strings.Contains(err.Error(), secret) {
+					t.Fatalf("TextEvidence error exposed %q: %v", secret, err)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Part of #202 Phase 2. Adds Draft 2020-12 remote Definition registration and Observation validation/durable acceptance through short SQLite transactions. Enforces manifest and observation limits, native definition ownership, standard text-evidence contract, schema/projection/fingerprint checks, and dialect resource safety. Deliberately excludes accepted-observation provenance/projectors, Connector checkpoint lifecycle, HTTP/OpenAPI and host wiring.