### PR TITLE
feat(source): gate observation evidence by runtime acceptance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -478,3 +478,14 @@ source / artifact / trigger / inference
   annotation mutant containing legacy `$id` and `$schema` and a nested actual
   resource with a legacy dialect, so the former is accepted and the latter is
   rejected before persistence.
+- When observation evidence becomes model-capable, source-level admission must
+  return a non-evidence staging value. Only a transaction that revalidates the
+  persisted Definition before writing the Source and its acceptance marker may
+  mint a durable evidence capability. Verify forged, unregistered, mismatched,
+  raw, pointer, or wrapper observations cannot reach model evidence or create a
+  Source, marker, or journal position. Every model-facing source window and its
+  candidate-reference set must pass only explicit durable evidence values.
+  Verify a raw-only window still advances its cursor without invoking a
+  candidate pipeline, and that accepted observations project only their
+  standard text evidence while raw observations return a typed refusal in
+  generation evidence paths.

--- a/artifact/handoff/accepted_observation_test.go
+++ b/artifact/handoff/accepted_observation_test.go
@@ -1,0 +1,104 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handoff
+
+import (
+	"encoding/json/jsontext"
+	"errors"
+	"testing"
+
+	"github.com/ob-labs/powercontext-go/source"
+)
+
+func TestHandoffEvidenceRejectsRawObservationBeforeDurableAcceptance(t *testing.T) {
+	ref, raw, admitted := handoffAcceptedObservation(t)
+	if _, isValue := any(admitted).(source.Value); isValue {
+		t.Fatal("direct source admission became Handoff evidence")
+	}
+	citation, err := NewSourceCitation(ref)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, sourceEvidenceErr := NewSourceEvidence(citation, raw); sourceEvidenceErr == nil {
+		t.Fatal("raw observation became Handoff evidence")
+	} else if _, ok := errors.AsType[*source.UnacceptedObservationError](sourceEvidenceErr); !ok {
+		t.Fatalf("raw evidence error = %T %v", sourceEvidenceErr, sourceEvidenceErr)
+	}
+	if _, sourceEvidenceErr := NewSourceEvidence(citation, &raw); sourceEvidenceErr == nil {
+		t.Fatal("raw observation pointer became Handoff evidence")
+	} else if _, ok := errors.AsType[*source.UnacceptedObservationError](sourceEvidenceErr); !ok {
+		t.Fatalf("raw pointer evidence error = %T %v", sourceEvidenceErr, sourceEvidenceErr)
+	}
+	wrapped := wrappedRawObservation{SourceObservation: raw}
+	if _, sourceEvidenceErr := NewSourceEvidence(citation, wrapped); sourceEvidenceErr == nil {
+		t.Fatal("wrapped raw observation became Handoff evidence")
+	} else if _, ok := errors.AsType[*source.UnacceptedObservationError](sourceEvidenceErr); !ok {
+		t.Fatalf("wrapped evidence error = %T %v", sourceEvidenceErr, sourceEvidenceErr)
+	}
+	if _, projectorErr := NewContentEvidenceProjector(nil).ProjectSource(wrapped); projectorErr == nil {
+		t.Fatal("wrapped raw observation reached Handoff evidence projector")
+	} else if _, ok := errors.AsType[*source.UnacceptedObservationError](projectorErr); !ok {
+		t.Fatalf("wrapped projector error = %T %v", projectorErr, projectorErr)
+	}
+	if _, projectorErr := (DefaultEvidenceProjector{}).ProjectSource(wrapped); projectorErr == nil {
+		t.Fatal("wrapped raw observation reached Handoff default evidence projector")
+	} else if _, ok := errors.AsType[*source.UnacceptedObservationError](projectorErr); !ok {
+		t.Fatalf("wrapped default projector error = %T %v", projectorErr, projectorErr)
+	}
+}
+
+type wrappedRawObservation struct{ source.SourceObservation }
+
+func (wrappedRawObservation) EvidenceSource() {}
+
+func handoffAcceptedObservation(t *testing.T) (source.Ref, source.SourceObservation, *source.AdmittedObservation) {
+	t.Helper()
+	identity, err := source.NewDefinitionIdentity("remote.handoff", "1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	projectionManifest, err := source.NewProjectionManifest(source.TextEvidenceProjectionKey(), source.TextEvidenceSchema())
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest, err := source.NewDefinitionManifest(identity,
+		jsontext.Value(`{"type":"object","properties":{"name":{"type":"string"},"definition_version":{"type":"string"},"materialization":{"const":"captured"}},"required":["name","definition_version","materialization"]}`),
+		[]source.ProjectionManifest{projectionManifest})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ref, err := source.NewRef("remote.handoff", "item-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	projection, err := source.NewSourceProjectionValue(source.TextEvidenceProjectionKey(), jsontext.Value(
+		`{"source_type":"remote.handoff","source_id":"item-1","content":"handoff evidence"}`,
+	))
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := source.NewSourceObservation(ref, manifest.Version(), manifest.Fingerprint(), nil,
+		jsontext.Value(`{"name":"item-1","definition_version":"1","materialization":"captured"}`),
+		[]source.SourceProjectionValue{projection},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	accepted, err := source.AdmitObservation(manifest, raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return ref, raw, accepted
+}

--- a/artifact/handoff/evidence.go
+++ b/artifact/handoff/evidence.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/ob-labs/powercontext-go/artifact"
 	"github.com/ob-labs/powercontext-go/artifact/memory"
+	"github.com/ob-labs/powercontext-go/internal/sourceevidence"
 	"github.com/ob-labs/powercontext-go/source"
 )
 
@@ -44,6 +45,9 @@ func (SourceEvidence) evidenceValue()         {}
 func (e SourceEvidence) Source() source.Value { return e.source }
 func (e SourceEvidence) Validate() error {
 	if err := e.citation.Validate(); err != nil {
+		return err
+	}
+	if err := sourceevidence.Require(e.source); err != nil {
 		return err
 	}
 	if isNilInterface(e.source) || e.source.SourceName() != e.citation.ref.ID() {

--- a/artifact/handoff/generation.go
+++ b/artifact/handoff/generation.go
@@ -26,6 +26,7 @@ import (
 	"github.com/ob-labs/powercontext-go/artifact/handoff/prompts"
 	"github.com/ob-labs/powercontext-go/artifact/memory"
 	"github.com/ob-labs/powercontext-go/inference"
+	"github.com/ob-labs/powercontext-go/internal/sourceevidence"
 	"github.com/ob-labs/powercontext-go/source"
 )
 
@@ -38,6 +39,9 @@ type EvidenceProjector interface {
 type DefaultEvidenceProjector struct{}
 
 func (DefaultEvidenceProjector) ProjectSource(value source.Value) (any, error) {
+	if err := sourceevidence.Require(value); err != nil {
+		return nil, err
+	}
 	description, hasDescription := value.SourceDescription()
 	var projectedDescription *string
 	if hasDescription {
@@ -79,6 +83,12 @@ func NewContentEvidenceProjector(fallback EvidenceProjector) ContentEvidenceProj
 }
 
 func (p ContentEvidenceProjector) ProjectSource(value source.Value) (any, error) {
+	if err := sourceevidence.Require(value); err != nil {
+		return nil, err
+	}
+	if accepted, ok := value.(sourceevidence.AcceptedObservation); ok {
+		return accepted.TextEvidence()
+	}
 	if content, ok := value.(source.ContentSource); ok {
 		return struct {
 			SourceType string         `json:"source_type"`

--- a/artifact/memory/accepted_observation_test.go
+++ b/artifact/memory/accepted_observation_test.go
@@ -1,0 +1,106 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package memory
+
+import (
+	"encoding/json/jsontext"
+	"errors"
+	"testing"
+
+	"github.com/ob-labs/powercontext-go/source"
+)
+
+func TestMemoryEvidenceRejectsRawObservationBeforeCandidateModelInput(t *testing.T) {
+	raw, admitted := memoryAcceptedObservation(t)
+	if _, isValue := any(admitted).(source.Value); isValue {
+		t.Fatal("direct source admission became Memory model evidence")
+	}
+	if _, err := NewCandidateRequest([]source.Value{raw}, nil, nil); err == nil {
+		t.Fatal("raw observation reached CandidateRequest")
+	} else if _, ok := errors.AsType[*source.UnacceptedObservationError](err); !ok {
+		t.Fatalf("raw CandidateRequest error = %T %v", err, err)
+	}
+	if _, err := NewContentEvidenceProjector(nil).ProjectSource(raw); err == nil {
+		t.Fatal("raw observation reached Memory evidence projector")
+	}
+	if _, err := NewCandidateRequest([]source.Value{&raw}, nil, nil); err == nil {
+		t.Fatal("raw observation pointer reached CandidateRequest")
+	} else if _, ok := errors.AsType[*source.UnacceptedObservationError](err); !ok {
+		t.Fatalf("raw pointer CandidateRequest error = %T %v", err, err)
+	}
+	if _, err := NewContentEvidenceProjector(nil).ProjectSource(&raw); err == nil {
+		t.Fatal("raw observation pointer reached Memory evidence projector")
+	}
+	wrapped := wrappedRawObservation{SourceObservation: raw}
+	if _, err := NewCandidateRequest([]source.Value{wrapped}, nil, nil); err == nil {
+		t.Fatal("wrapped raw observation reached Memory candidate input")
+	} else if _, ok := errors.AsType[*source.UnacceptedObservationError](err); !ok {
+		t.Fatalf("wrapped CandidateRequest error = %T %v", err, err)
+	}
+	if _, err := NewContentEvidenceProjector(nil).ProjectSource(wrapped); err == nil {
+		t.Fatal("wrapped raw observation reached Memory evidence projector")
+	} else if _, ok := errors.AsType[*source.UnacceptedObservationError](err); !ok {
+		t.Fatalf("wrapped projector error = %T %v", err, err)
+	}
+	if _, err := (DefaultEvidenceProjector{}).ProjectSource(wrapped); err == nil {
+		t.Fatal("wrapped raw observation reached Memory default evidence projector")
+	} else if _, ok := errors.AsType[*source.UnacceptedObservationError](err); !ok {
+		t.Fatalf("wrapped default projector error = %T %v", err, err)
+	}
+}
+
+type wrappedRawObservation struct{ source.SourceObservation }
+
+func (wrappedRawObservation) EvidenceSource() {}
+
+func memoryAcceptedObservation(t *testing.T) (source.SourceObservation, *source.AdmittedObservation) {
+	t.Helper()
+	identity, err := source.NewDefinitionIdentity("remote.note", "1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	projectionManifest, err := source.NewProjectionManifest(source.TextEvidenceProjectionKey(), source.TextEvidenceSchema())
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest, err := source.NewDefinitionManifest(identity,
+		jsontext.Value(`{"type":"object","properties":{"name":{"type":"string"},"definition_version":{"type":"string"},"materialization":{"const":"captured"}},"required":["name","definition_version","materialization"]}`),
+		[]source.ProjectionManifest{projectionManifest})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ref, err := source.NewRef("remote.note", "item-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	projection, err := source.NewSourceProjectionValue(source.TextEvidenceProjectionKey(), jsontext.Value(
+		`{"source_type":"remote.note","source_id":"item-1","content":"admitted evidence"}`,
+	))
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := source.NewSourceObservation(ref, manifest.Version(), manifest.Fingerprint(), nil,
+		jsontext.Value(`{"name":"item-1","definition_version":"1","materialization":"captured"}`),
+		[]source.SourceProjectionValue{projection},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	accepted, err := source.AdmitObservation(manifest, raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return raw, accepted
+}

--- a/artifact/memory/extraction.go
+++ b/artifact/memory/extraction.go
@@ -26,6 +26,7 @@ import (
 	"github.com/ob-labs/powercontext-go/artifact"
 	"github.com/ob-labs/powercontext-go/artifact/memory/prompts"
 	"github.com/ob-labs/powercontext-go/inference"
+	"github.com/ob-labs/powercontext-go/internal/sourceevidence"
 	"github.com/ob-labs/powercontext-go/source"
 )
 
@@ -72,6 +73,9 @@ func NewCandidateRequest(
 	for _, value := range sources {
 		if value == nil {
 			return CandidateRequest{}, fmt.Errorf("Memory candidate Source must not be nil")
+		}
+		if err := sourceevidence.Require(value); err != nil {
+			return CandidateRequest{}, err
 		}
 		if _, err := source.NewRef("source", value.SourceName()); err != nil {
 			return CandidateRequest{}, err
@@ -137,6 +141,9 @@ type EvidenceProjector interface {
 type DefaultEvidenceProjector struct{}
 
 func (DefaultEvidenceProjector) ProjectSource(value source.Value) (any, error) {
+	if err := sourceevidence.Require(value); err != nil {
+		return nil, err
+	}
 	description, hasDescription := value.SourceDescription()
 	var projectedDescription *string
 	if hasDescription {
@@ -171,6 +178,12 @@ func NewContentEvidenceProjector(fallback EvidenceProjector) ContentEvidenceProj
 }
 
 func (p ContentEvidenceProjector) ProjectSource(value source.Value) (any, error) {
+	if err := sourceevidence.Require(value); err != nil {
+		return nil, err
+	}
+	if accepted, ok := value.(sourceevidence.AcceptedObservation); ok {
+		return accepted.TextEvidence()
+	}
 	if content, ok := value.(source.ContentSource); ok {
 		return struct {
 			SourceType string         `json:"source_type"`

--- a/artifact/memory/service_plan.go
+++ b/artifact/memory/service_plan.go
@@ -20,6 +20,7 @@ import (
 	"slices"
 
 	"github.com/ob-labs/powercontext-go/artifact"
+	"github.com/ob-labs/powercontext-go/internal/sourceevidence"
 	"github.com/ob-labs/powercontext-go/source"
 )
 
@@ -101,6 +102,9 @@ func (s *Service) canonicalOperationEvidence(
 ) (operationEvidence, error) {
 	result := operationEvidence{}
 	for _, value := range sources {
+		if err := sourceevidence.Require(value); err != nil {
+			return operationEvidence{}, err
+		}
 		if s.sourceResolver == nil || isNilInterface(s.sourceResolver) {
 			return operationEvidence{}, &InvalidEvidenceError{Code: "source-resolver"}
 		}

--- a/artifact/skill/external_test.go
+++ b/artifact/skill/external_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"github.com/ob-labs/powercontext-go/artifact/skill"
+	"github.com/ob-labs/powercontext-go/internal/sourceevidence"
 )
 
 func TestCodexProviderDiscoversAndExactlyResolvesLocalPackage(t *testing.T) {
@@ -65,6 +66,30 @@ func TestAgentSkillTargetsAcceptOnlySupportedProductAgents(t *testing.T) {
 		if err == nil || strings.Contains(err.Error(), string(agent)) || !strings.Contains(err.Error(), "Codex and WorkBuddy") {
 			t.Fatalf("unsupported Agent Skill error is not stable and redacted: %v", err)
 		}
+	}
+}
+
+func TestSnapshotSourcePassesClosedProductEvidenceGate(t *testing.T) {
+	registration, err := skill.NewRegistration(
+		"codex:project:repository/evidence-skill", "codex", "codex", "workstation-1",
+		skill.ProjectScope, "/workspace/.agents/skills/evidence-skill", strings.Repeat("a", 64),
+		"evidence-skill", "Provides an immutable test snapshot.",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshot, err := skill.NewSnapshot(registration, "---\nname: evidence-skill\n---\n")
+	if err != nil {
+		t.Fatal(err)
+	}
+	value, err := (skill.SnapshotSourceAdapter{}).Resolve(t.Context(), skill.SnapshotCapture{
+		Snapshot: snapshot, Mode: skill.ImportModeImport,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := sourceevidence.Require(value); err != nil {
+		t.Fatalf("sourceevidence.Require(SnapshotSource) = %v", err)
 	}
 }
 

--- a/artifact/skill/snapshot_source.go
+++ b/artifact/skill/snapshot_source.go
@@ -51,6 +51,7 @@ func (SnapshotSource) SourceMaterialization() source.Materialization {
 func (SnapshotSource) SourceDescription() (string, bool) {
 	return "Exact external Skill snapshot captured by an explicit managed import or fork.", true
 }
+
 func (s SnapshotSource) Snapshot() Snapshot { return s.snapshot }
 func (s SnapshotSource) Mode() ImportMode   { return s.mode }
 

--- a/internal/runtime/experience_incubation.go
+++ b/internal/runtime/experience_incubation.go
@@ -143,7 +143,15 @@ func (a *ExperienceIncubationApplication) incubateWindow(
 	if previous.Sequence() == next.Sequence() {
 		return result, nil
 	}
-
+	// The durable window can contain audit-only Sources which are deliberately
+	// not evidence-capable. Consume that cursor range without invoking an
+	// arbitrary candidate pipeline with an empty input.
+	if len(values) == 0 {
+		if applyErr := backend.ApplyWindow(ctx, experience.IncubationCursorName, nil, nil, next, generation); applyErr != nil {
+			return result, applyErr
+		}
+		return result, nil
+	}
 	plans, err := a.pipeline.Incubate(ctx, values)
 	if err != nil {
 		return result, err

--- a/internal/runtime/remote_ingestion.go
+++ b/internal/runtime/remote_ingestion.go
@@ -15,13 +15,9 @@
 package runtime
 
 import (
-	"bytes"
 	"context"
-	"encoding/json/jsontext"
 	json "encoding/json/v2"
 	"errors"
-
-	jsonschema "github.com/santhosh-tekuri/jsonschema/v6"
 
 	"github.com/ob-labs/powercontext-go/source"
 )
@@ -29,8 +25,6 @@ import (
 const (
 	maxDefinitionManifestBytes = 64 * 1024
 	maxSourceObservationBytes  = 4 * 1024 * 1024
-	schemaResourceURL          = "https://powercontext.invalid/remote-source-schema"
-	draft202012SchemaURL       = "https://json-schema.org/draft/2020-12/schema"
 )
 
 // RemoteIngestionBackend is the transaction-owning persistence contract for
@@ -39,7 +33,7 @@ const (
 type RemoteIngestionBackend interface {
 	Register(context.Context, source.DefinitionManifest) (source.DefinitionManifest, error)
 	Find(context.Context, source.DefinitionIdentity) (source.DefinitionManifest, bool, error)
-	Add(context.Context, string, source.SourceObservation) (source.Ref, int64, error)
+	Add(context.Context, string, *source.AdmittedObservation) (source.Ref, int64, error)
 	HasNativeDefinition(string) bool
 }
 
@@ -104,10 +98,11 @@ func (a *RemoteIngestionApplication) Submit(
 		if a.backend.HasNativeDefinition(observation.Ref().Type()) {
 			return &source.DefinitionConflictError{}
 		}
-		if validationErr := validateRemoteObservation(manifest, observation); validationErr != nil {
-			return validationErr
+		accepted, acceptErr := source.AdmitObservation(manifest, observation)
+		if acceptErr != nil {
+			return acceptErr
 		}
-		ref, sequence, addErr := a.backend.Add(ctx, scope, observation)
+		ref, sequence, addErr := a.backend.Add(ctx, scope, accepted)
 		if addErr != nil {
 			return addErr
 		}
@@ -131,56 +126,8 @@ func validateRemoteDefinition(manifest source.DefinitionManifest, backend Remote
 	if backend.HasNativeDefinition(manifest.Name()) {
 		return definitionManifestError("name", "must not replace an active Source Definition")
 	}
-	if _, err := compileDraft202012(manifest.SourceSchema()); err != nil {
-		return definitionManifestError("schema", "must be valid JSON Schema Draft 2020-12")
-	}
-	for _, projection := range manifest.Projections() {
-		if source.IsTextEvidenceProjection(projection.Key()) {
-			if err := source.ValidateTextEvidenceSchema(projection.Schema()); err != nil {
-				return definitionManifestError("projection", "must use the standard text-evidence schema")
-			}
-		}
-		if _, err := compileDraft202012(projection.Schema()); err != nil {
-			return definitionManifestError("projection", "must use valid JSON Schema Draft 2020-12")
-		}
-	}
-	return nil
-}
-
-func validateRemoteObservation(
-	manifest source.DefinitionManifest,
-	observation source.SourceObservation,
-) error {
-	if observation.Ref().Type() != manifest.Name() || observation.DefinitionVersion() != manifest.Version() {
-		return sourceObservationError("definition", "does not match the registered manifest identity")
-	}
-	if observation.DefinitionFingerprint() != manifest.Fingerprint() {
-		return sourceObservationError("fingerprint", "does not match the registered manifest")
-	}
-	if err := validateDraft202012Value(manifest.SourceSchema(), observation.Payload()); err != nil {
-		return sourceObservationError("schema", "does not match the registered Source schema")
-	}
-	declared := make(map[source.ProjectionKey]source.ProjectionManifest, len(manifest.Projections()))
-	for _, projection := range manifest.Projections() {
-		declared[projection.Key()] = projection
-	}
-	supplied := observation.Projections()
-	if len(declared) != len(supplied) {
-		return sourceObservationError("projections", "must exactly match the registered manifest")
-	}
-	for _, projection := range supplied {
-		declaration, exists := declared[projection.Key()]
-		if !exists {
-			return sourceObservationError("projections", "must exactly match the registered manifest")
-		}
-		if err := validateDraft202012Value(declaration.Schema(), projection.Value()); err != nil {
-			return sourceObservationError("projection", "does not match the registered schema")
-		}
-		if source.IsTextEvidenceProjection(projection.Key()) {
-			if err := source.ValidateTextEvidence(projection.Value(), observation.Ref()); err != nil {
-				return sourceObservationError("text-evidence", "does not match the observation envelope")
-			}
-		}
+	if err := source.ValidateDefinitionManifestForAdmission(manifest); err != nil {
+		return err
 	}
 	return nil
 }
@@ -199,135 +146,10 @@ func validateRemoteObservationEnvelope(observation source.SourceObservation) err
 	return nil
 }
 
-func compileDraft202012(schema jsontext.Value) (*jsonschema.Schema, error) {
-	if err := requireDraft202012(schema); err != nil {
-		return nil, err
-	}
-	document, err := jsonschema.UnmarshalJSON(bytes.NewReader(schema))
-	if err != nil {
-		return nil, err
-	}
-	compiler := jsonschema.NewCompiler()
-	compiler.DefaultDraft(jsonschema.Draft2020)
-	compiler.UseLoader(localSchemaLoader{})
-	if err := compiler.AddResource(schemaResourceURL, document); err != nil {
-		return nil, err
-	}
-	return compiler.Compile(schemaResourceURL)
-}
-
-// requireDraft202012 prevents explicit dialect declarations from overriding
-// the compiler default. Embedded schema resources with their own $id may
-// independently declare a dialect, so each resource is checked before
-// compilation.
-func requireDraft202012(schema jsontext.Value) error {
-	var value any
-	if err := json.Unmarshal(schema, &value); err != nil {
-		return err
-	}
-	return requireDraft202012Value(value, true)
-}
-
-func requireDraft202012Value(value any, resourceRoot bool) error {
-	schema, ok := value.(map[string]any)
-	if !ok {
-		return nil
-	}
-	if resourceRoot {
-		if dialect, exists := schema["$schema"]; exists {
-			name, ok := dialect.(string)
-			if !ok || !isDraft202012SchemaURL(name) {
-				return errors.New("JSON Schema must use Draft 2020-12")
-			}
-		}
-	}
-
-	for keyword, nested := range schema {
-		var err error
-		switch keyword {
-		case "not", "additionalProperties", "additionalItems", "propertyNames", "contains",
-			"if", "then", "else", "unevaluatedProperties", "unevaluatedItems", "contentSchema":
-			err = requireDraft202012Subschema(nested)
-		case "definitions", "properties", "patternProperties", "dependencies", "$defs", "dependentSchemas":
-			err = requireDraft202012SubschemaMap(nested)
-		case "allOf", "anyOf", "oneOf", "prefixItems":
-			err = requireDraft202012SubschemaArray(nested)
-		case "items":
-			err = requireDraft202012Subschema(nested)
-			if err == nil {
-				err = requireDraft202012SubschemaArray(nested)
-			}
-		}
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func requireDraft202012Subschema(value any) error {
-	schema, ok := value.(map[string]any)
-	return requireDraft202012Value(value, ok && hasSchemaResourceID(schema))
-}
-
-func requireDraft202012SubschemaMap(value any) error {
-	entries, ok := value.(map[string]any)
-	if !ok {
-		return nil
-	}
-	for _, schema := range entries {
-		if err := requireDraft202012Subschema(schema); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func requireDraft202012SubschemaArray(value any) error {
-	entries, ok := value.([]any)
-	if !ok {
-		return nil
-	}
-	for _, schema := range entries {
-		if err := requireDraft202012Subschema(schema); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func hasSchemaResourceID(value map[string]any) bool {
-	id, ok := value["$id"].(string)
-	return ok && id != ""
-}
-
-func isDraft202012SchemaURL(value string) bool {
-	return value == draft202012SchemaURL ||
-		value == "http://json-schema.org/draft/2020-12/schema"
-}
-
-func validateDraft202012Value(schema, value jsontext.Value) error {
-	compiled, err := compileDraft202012(schema)
-	if err != nil {
-		return err
-	}
-	instance, err := jsonschema.UnmarshalJSON(bytes.NewReader(value))
-	if err != nil {
-		return err
-	}
-	return compiled.Validate(instance)
-}
-
-type localSchemaLoader struct{}
-
-func (localSchemaLoader) Load(string) (any, error) {
-	return nil, errors.New("remote JSON Schema loading is disabled")
+func sourceObservationError(field, detail string) *source.InvalidSourceObservationError {
+	return &source.InvalidSourceObservationError{Field: field, Detail: detail}
 }
 
 func definitionManifestError(field, detail string) *source.InvalidDefinitionManifestError {
 	return &source.InvalidDefinitionManifestError{Field: field, Detail: detail}
-}
-
-func sourceObservationError(field, detail string) *source.InvalidSourceObservationError {
-	return &source.InvalidSourceObservationError{Field: field, Detail: detail}
 }

--- a/internal/runtime/remote_ingestion_test.go
+++ b/internal/runtime/remote_ingestion_test.go
@@ -208,8 +208,8 @@ func TestRemoteIngestionApplicationValidatesObservationBeforeStore(t *testing.T)
 	if receipt.Ref != valid.Ref() || receipt.Sequence != 1 || backend.added != 1 {
 		t.Fatalf("Submit() = %#v after %d stores", receipt, backend.added)
 	}
-	if !strings.Contains(string(backend.last.Payload()), "9007199254740993") {
-		t.Fatalf("Submit() lost the large JSON integer: %s", backend.last.Payload())
+	if backend.last == nil || !strings.Contains(string(backend.last.Observation().Payload()), "9007199254740993") {
+		t.Fatalf("Submit() lost the large JSON integer: %#v", backend.last)
 	}
 
 	for _, test := range []struct {
@@ -362,7 +362,7 @@ type remoteIngestionBackend struct {
 	registered int
 	finds      int
 	added      int
-	last       source.SourceObservation
+	last       *source.AdmittedObservation
 }
 
 func newRemoteIngestionBackend() *remoteIngestionBackend {
@@ -384,10 +384,10 @@ func (b *remoteIngestionBackend) Find(_ context.Context, identity source.Definit
 	return manifest, found, nil
 }
 
-func (b *remoteIngestionBackend) Add(_ context.Context, _ string, observation source.SourceObservation) (source.Ref, int64, error) {
+func (b *remoteIngestionBackend) Add(_ context.Context, _ string, observation *source.AdmittedObservation) (source.Ref, int64, error) {
 	b.added++
 	b.last = observation
-	return observation.Ref(), int64(b.added), nil
+	return observation.Observation().Ref(), int64(b.added), nil
 }
 
 func (b *remoteIngestionBackend) HasNativeDefinition(name string) bool { return b.native[name] }

--- a/internal/sourceevidence/accepted_observation.go
+++ b/internal/sourceevidence/accepted_observation.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sourceevidence
+
+import "github.com/ob-labs/powercontext-go/source"
+
+// AcceptedObservation is the durable counterpart of a worker observation. Its
+// fields remain private so external callers cannot construct model-capable
+// evidence from source.AdmitObservation alone.
+//
+// Production construction is intentionally limited to the SQLite source
+// sidecar paths after they have re-admitted the observation against the
+// persisted Definition and established the acceptance marker in the same
+// transaction.
+type AcceptedObservation struct {
+	observation source.SourceObservation
+}
+
+// NewAcceptedObservation constructs the internal durable representation after
+// the caller has completed persisted Definition re-admission and marker work.
+// It validates the worker payload again so malformed durable data cannot gain
+// model capability through a sidecar marker alone.
+func NewAcceptedObservation(observation source.SourceObservation) (AcceptedObservation, error) {
+	if err := observation.Validate(); err != nil {
+		return AcceptedObservation{}, err
+	}
+	return AcceptedObservation{observation: observation}, nil
+}
+
+func (o AcceptedObservation) Ref() source.Ref { return o.observation.Ref() }
+
+func (o AcceptedObservation) Observation() source.SourceObservation { return o.observation }
+
+func (o AcceptedObservation) SourceName() string { return o.observation.SourceName() }
+
+func (o AcceptedObservation) SourceMaterialization() source.Materialization {
+	return o.observation.SourceMaterialization()
+}
+
+func (o AcceptedObservation) SourceDescription() (string, bool) {
+	return o.observation.SourceDescription()
+}
+
+func (o AcceptedObservation) TextEvidence() (source.TextEvidence, error) {
+	projection, err := o.observation.Projection(source.TextEvidenceProjectionKey())
+	if err != nil {
+		return source.TextEvidence{}, &source.InvalidTextEvidenceError{
+			Field: "projection", Detail: "must be supplied by an accepted observation",
+		}
+	}
+	return source.ParseTextEvidence(projection, o.observation.Ref())
+}
+
+func (o AcceptedObservation) Validate() error {
+	return o.observation.Validate()
+}
+
+var _ source.Value = AcceptedObservation{}

--- a/internal/sourceevidence/gate.go
+++ b/internal/sourceevidence/gate.go
@@ -1,0 +1,42 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package sourceevidence owns the closed product boundary for Source values
+// that may enter Artifact evidence or model input.
+package sourceevidence
+
+import (
+	"github.com/ob-labs/powercontext-go/artifact/skill"
+	"github.com/ob-labs/powercontext-go/source"
+)
+
+// Require admits only exact immutable product Source values. Unsupported
+// adapters, wrappers, raw observations, and pointer forms fail closed.
+func Require(value source.Value) error {
+	switch typed := value.(type) {
+	case source.ContentSource, skill.SnapshotSource:
+		return nil
+	case AcceptedObservation:
+		if err := typed.Validate(); err != nil {
+			return err
+		}
+		_, err := typed.TextEvidence()
+		return err
+	default:
+		return &source.UnacceptedObservationError{}
+	}
+}
+
+// Allows reports whether value passes the complete product evidence gate.
+func Allows(value source.Value) bool { return Require(value) == nil }

--- a/internal/sourceevidence/gate_test.go
+++ b/internal/sourceevidence/gate_test.go
@@ -1,0 +1,131 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sourceevidence
+
+import (
+	"encoding/json/jsontext"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/ob-labs/powercontext-go/artifact/skill"
+	"github.com/ob-labs/powercontext-go/source"
+)
+
+func TestRequireUsesClosedProductTypeAllowlist(t *testing.T) {
+	content, err := source.RestoreContentSource("content-1", source.Captured, nil, "content", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest, raw := acceptedObservation(t)
+	if _, admissionErr := source.AdmitObservation(manifest, raw); admissionErr != nil {
+		t.Fatal(admissionErr)
+	}
+	accepted, err := NewAcceptedObservation(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshot := snapshotSource(t)
+
+	for _, value := range []source.Value{content, accepted, snapshot} {
+		if err := Require(value); err != nil {
+			t.Fatalf("Require(%T) = %v", value, err)
+		}
+	}
+	for _, value := range []source.Value{raw, &raw, forgedEvidenceSource{SourceObservation: raw}, &accepted} {
+		err := Require(value)
+		if _, ok := errors.AsType[*source.UnacceptedObservationError](err); !ok {
+			t.Fatalf("Require(%T) error = %T %v", value, err, err)
+		}
+	}
+}
+
+func TestDirectAdmissionCannotMintModelEvidenceWithoutDurableAcceptance(t *testing.T) {
+	manifest, raw := acceptedObservation(t)
+	admitted, err := source.AdmitObservation(manifest, raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, isModelValue := any(admitted).(source.Value); isModelValue {
+		t.Fatal("direct source admission minted a model-capable Source without a durable acceptance marker")
+	}
+}
+
+type forgedEvidenceSource struct{ source.SourceObservation }
+
+func (forgedEvidenceSource) EvidenceSource() {}
+
+func acceptedObservation(t *testing.T) (source.DefinitionManifest, source.SourceObservation) {
+	t.Helper()
+	identity, err := source.NewDefinitionIdentity("remote.closed", "1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	projectionManifest, err := source.NewProjectionManifest(
+		source.TextEvidenceProjectionKey(), source.TextEvidenceSchema(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest, err := source.NewDefinitionManifest(
+		identity, jsontext.Value(`{"type":"object"}`), []source.ProjectionManifest{projectionManifest},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ref, err := source.NewRef(identity.Name(), "item-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	projection, err := source.NewSourceProjectionValue(
+		source.TextEvidenceProjectionKey(),
+		jsontext.Value(`{"source_type":"remote.closed","source_id":"item-1","content":"accepted"}`),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := source.NewSourceObservation(
+		ref, manifest.Version(), manifest.Fingerprint(), nil,
+		jsontext.Value(`{"name":"item-1","definition_version":"1","materialization":"captured"}`),
+		[]source.SourceProjectionValue{projection},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return manifest, raw
+}
+
+func snapshotSource(t *testing.T) skill.SnapshotSource {
+	t.Helper()
+	registration, err := skill.NewRegistration(
+		"codex:project:repository/evidence-skill", "codex", "codex", "workstation-1",
+		skill.ProjectScope, "/workspace/.agents/skills/evidence-skill", strings.Repeat("a", 64),
+		"evidence-skill", "Provides an immutable test snapshot.",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshot, err := skill.NewSnapshot(registration, "---\nname: evidence-skill\n---\n")
+	if err != nil {
+		t.Fatal(err)
+	}
+	value, err := (skill.SnapshotSourceAdapter{}).Resolve(t.Context(), skill.SnapshotCapture{
+		Snapshot: snapshot, Mode: skill.ImportModeImport,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return value
+}

--- a/internal/sqlstore/database_test.go
+++ b/internal/sqlstore/database_test.go
@@ -65,6 +65,7 @@ func TestOpenSQLiteInitializesSchemaAndEveryConnection(t *testing.T) {
 		"pc_connector_checkpoints",
 		"pc_source_definition_manifests",
 		"pc_sources",
+		"pc_source_observation_acceptances",
 		"pc_source_journal_heads",
 		"pc_artifacts",
 		"pc_artifact_heads",

--- a/internal/sqlstore/experience_incubation.go
+++ b/internal/sqlstore/experience_incubation.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/ob-labs/powercontext-go/artifact/experience"
 	"github.com/ob-labs/powercontext-go/internal/review"
+	"github.com/ob-labs/powercontext-go/internal/sourceevidence"
 	"github.com/ob-labs/powercontext-go/source"
 	"github.com/ob-labs/powercontext-go/trigger"
 )
@@ -100,11 +101,16 @@ func (s *ExperienceIncubationStore) ObserveWindow(
 		if listErr != nil {
 			return listErr
 		}
-		values = make([]source.Value, len(rows))
-		available = make([]source.Ref, len(rows))
-		for index, row := range rows {
-			values[index] = row.Value
-			available[index] = row.Ref
+		values = make([]source.Value, 0, len(rows))
+		available = make([]source.Ref, 0, len(rows))
+		for _, row := range rows {
+			// Unaccepted worker observations stay in the journal and consume the
+			// window range, but never become arbitrary pipeline input.
+			if !sourceevidence.Allows(row.Value) {
+				continue
+			}
+			values = append(values, row.Value)
+			available = append(available, row.Ref)
 		}
 		return nil
 	})
@@ -128,10 +134,14 @@ func (s *ExperienceIncubationStore) ApplyWindow(
 		for index, plan := range plans {
 			refs := plan.Sources()
 			for _, ref := range refs {
-				if _, err := s.sources.Get(ctx, tx, s.scopeID, ref); err != nil {
+				stored, err := s.sources.Get(ctx, tx, s.scopeID, ref)
+				if err != nil {
 					return &review.InvalidCandidateError{
 						Field: "evidence", Detail: "reference is not available in this scope",
 					}
+				}
+				if err := sourceevidence.Require(stored.Value); err != nil {
+					return err
 				}
 			}
 			reason := plan.Reason()

--- a/internal/sqlstore/experience_incubation_test.go
+++ b/internal/sqlstore/experience_incubation_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 
 	"github.com/ob-labs/powercontext-go/artifact/experience"
+	"github.com/ob-labs/powercontext-go/inference"
+	"github.com/ob-labs/powercontext-go/internal/runtime"
 	"github.com/ob-labs/powercontext-go/internal/sqlstore"
 	"github.com/ob-labs/powercontext-go/source"
 )
@@ -82,6 +84,182 @@ func TestExperienceCandidatesAndCursorCASAreOneTransaction(t *testing.T) {
 		t.Fatal(err)
 	}
 	assertIncubationState(t, database, 1, 1, 2)
+}
+
+func TestExperienceIncubationRejectsRawObservationCitationFromMixedWindow(t *testing.T) {
+	ctx := t.Context()
+	database := openTestDatabase(t)
+	sources, _ := repositories(t)
+	stored := addFlushSource(t, database, sources, "scope-filtered-window", "task-1", "safe task outcome")
+	raw := observationSource(t, "worker.raw", "item-1", `{"name":"item-1","definition_version":"1","materialization":"captured"}`)
+	payload, err := observationEnvelope(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, insertErr := database.SQLDB().ExecContext(ctx, `INSERT INTO pc_sources
+        (scope_id, source_type, source_id, payload, journal_position) VALUES (?, ?, ?, ?, ?)`,
+		"scope-filtered-window", raw.Ref().Type(), raw.Ref().ID(), payload, 2,
+	); insertErr != nil {
+		t.Fatal(insertErr)
+	}
+	candidates, err := sqlstore.NewCandidateRepository(sqlstore.SQLiteDialect, sqlstore.ExperienceArtifactCodec())
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := sqlstore.NewExperienceIncubationStore(database, "scope-filtered-window", sources, candidates)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var seen []source.Value
+	application, err := runtime.NewExperienceIncubationApplication(
+		runtime.New(), func(string) (runtime.ExperienceIncubationBackend, error) { return store, nil },
+		experiencePipelineFunc(func(_ context.Context, values []source.Value) ([]experience.CandidateInput, error) {
+			seen = append([]source.Value(nil), values...)
+			content, contentErr := experience.NewContent("situation", "action", "outcome", "lesson")
+			if contentErr != nil {
+				return nil, contentErr
+			}
+			plan, planErr := experience.NewCandidateInput(content, []source.Ref{raw.Ref()})
+			return []experience.CandidateInput{plan}, planErr
+		}),
+		func(string) (string, error) { return "candidate-raw", nil },
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := application.Incubate(ctx, "scope-filtered-window", experience.IncubationWindowLimit)
+	var invalid *inference.InvalidOutputError
+	if !errors.As(err, &invalid) {
+		t.Fatalf("Incubate() error = %T %v", err, err)
+	}
+	if result.CurrentCursor != 2 || result.HighWatermark != 2 || result.ProcessedSourceCount != 1 || len(seen) != 1 {
+		t.Fatalf("result=%#v pipeline values=%#v", result, seen)
+	}
+	if value, ok := seen[0].(source.ContentSource); !ok || value.SourceName() != stored.Ref.ID() {
+		t.Fatalf("pipeline received %T %#v, want captured ContentSource", seen[0], seen[0])
+	}
+	var candidateCount, cursorCount int
+	if queryErr := database.SQLDB().QueryRowContext(ctx, `SELECT
+        (SELECT COUNT(*) FROM pc_artifact_candidate_heads WHERE scope_id = ?),
+        (SELECT COUNT(*) FROM pc_source_cursors WHERE scope_id = ? AND binding_name = ?)`,
+		"scope-filtered-window", "scope-filtered-window", experience.IncubationCursorName,
+	).Scan(&candidateCount, &cursorCount); queryErr != nil {
+		t.Fatal(queryErr)
+	}
+	if candidateCount != 0 || cursorCount != 0 {
+		t.Fatalf("rejected raw citation persisted candidates=%d cursors=%d", candidateCount, cursorCount)
+	}
+}
+
+func TestExperienceIncubationConsumesRawOnlyWindowWithoutPipeline(t *testing.T) {
+	ctx := t.Context()
+	database := openTestDatabase(t)
+	sources, _ := repositories(t)
+	raw := observationSource(t, "worker.raw", "item-1", `{"name":"item-1","definition_version":"1","materialization":"captured"}`)
+	payload, err := observationEnvelope(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, insertErr := database.SQLDB().ExecContext(ctx, `INSERT INTO pc_sources
+        (scope_id, source_type, source_id, payload, journal_position) VALUES (?, ?, ?, ?, ?)`,
+		"scope-raw-only", raw.Ref().Type(), raw.Ref().ID(), payload, 1,
+	); insertErr != nil {
+		t.Fatal(insertErr)
+	}
+	candidates, err := sqlstore.NewCandidateRepository(sqlstore.SQLiteDialect, sqlstore.ExperienceArtifactCodec())
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := sqlstore.NewExperienceIncubationStore(database, "scope-raw-only", sources, candidates)
+	if err != nil {
+		t.Fatal(err)
+	}
+	application, err := runtime.NewExperienceIncubationApplication(
+		runtime.New(), func(string) (runtime.ExperienceIncubationBackend, error) { return store, nil },
+		experiencePipelineFunc(func(context.Context, []source.Value) ([]experience.CandidateInput, error) {
+			t.Fatal("raw-only window invoked the Experience candidate pipeline")
+			return nil, nil
+		}),
+		func(string) (string, error) { return "unused", nil },
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := application.Incubate(ctx, "scope-raw-only", experience.IncubationWindowLimit)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.CurrentCursor != 1 || result.HighWatermark != 1 || result.ProcessedSourceCount != 0 || result.CandidateCount != 0 {
+		t.Fatalf("result=%#v", result)
+	}
+	assertIncubationCursor(t, database, "scope-raw-only", 1)
+}
+
+func TestExperienceIncubationApplyWindowRejectsRawCitationAndRollsBack(t *testing.T) {
+	ctx := t.Context()
+	database := openTestDatabase(t)
+	sources, _ := repositories(t)
+	raw := observationSource(t, "worker.raw", "item-apply", `{"name":"item-apply","definition_version":"1","materialization":"captured"}`)
+	payload, err := observationEnvelope(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, insertErr := database.SQLDB().ExecContext(ctx, `INSERT INTO pc_sources
+        (scope_id, source_type, source_id, payload, journal_position) VALUES (?, ?, ?, ?, ?)`,
+		"scope-raw-apply", raw.Ref().Type(), raw.Ref().ID(), payload, 1,
+	); insertErr != nil {
+		t.Fatal(insertErr)
+	}
+	candidates, err := sqlstore.NewCandidateRepository(sqlstore.SQLiteDialect, sqlstore.ExperienceArtifactCodec())
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := sqlstore.NewExperienceIncubationStore(database, "scope-raw-apply", sources, candidates)
+	if err != nil {
+		t.Fatal(err)
+	}
+	content, err := experience.NewContent("situation", "action", "outcome", "lesson")
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan, err := experience.NewCandidateInput(content, []source.Ref{raw.Ref()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = store.ApplyWindow(ctx, experience.IncubationCursorName, []string{"candidate-raw"}, []experience.CandidateInput{plan}, source.NewCursor(1), nil)
+	if _, ok := errors.AsType[*source.UnacceptedObservationError](err); !ok {
+		t.Fatalf("ApplyWindow() error = %T %v", err, err)
+	}
+	var candidateCount, cursorCount int
+	if err := database.SQLDB().QueryRowContext(ctx, `SELECT
+        (SELECT COUNT(*) FROM pc_artifact_candidate_heads WHERE scope_id = ?),
+        (SELECT COUNT(*) FROM pc_source_cursors WHERE scope_id = ? AND binding_name = ?)`,
+		"scope-raw-apply", "scope-raw-apply", experience.IncubationCursorName,
+	).Scan(&candidateCount, &cursorCount); err != nil {
+		t.Fatal(err)
+	}
+	if candidateCount != 0 || cursorCount != 0 {
+		t.Fatalf("raw candidate changed state: candidates=%d cursors=%d", candidateCount, cursorCount)
+	}
+}
+
+type experiencePipelineFunc func(context.Context, []source.Value) ([]experience.CandidateInput, error)
+
+func (f experiencePipelineFunc) Incubate(ctx context.Context, values []source.Value) ([]experience.CandidateInput, error) {
+	return f(ctx, values)
+}
+
+func assertIncubationCursor(t *testing.T, database *sqlstore.Database, scopeID string, sequence int64) {
+	t.Helper()
+	var cursor []byte
+	if err := database.SQLDB().QueryRowContext(t.Context(), `SELECT cursor FROM pc_source_cursors
+        WHERE scope_id = ? AND binding_name = ?`, scopeID, experience.IncubationCursorName).Scan(&cursor); err != nil {
+		t.Fatal(err)
+	}
+	want := fmt.Sprintf(`{"sequence":%d}`, sequence)
+	if string(cursor) != want {
+		t.Fatalf("cursor=%s, want %s", cursor, want)
+	}
 }
 
 func assertIncubationState(t *testing.T, database *sqlstore.Database, candidates, sequence, generation int64) {

--- a/internal/sqlstore/generation_evidence.go
+++ b/internal/sqlstore/generation_evidence.go
@@ -16,6 +16,7 @@ package sqlstore
 
 import (
 	"context"
+	json "encoding/json/v2"
 	"errors"
 	"fmt"
 	"reflect"
@@ -23,6 +24,7 @@ import (
 
 	"github.com/ob-labs/powercontext-go/artifact"
 	"github.com/ob-labs/powercontext-go/internal/review"
+	"github.com/ob-labs/powercontext-go/internal/sourceevidence"
 	"github.com/ob-labs/powercontext-go/source"
 )
 
@@ -60,11 +62,10 @@ func (r *GenerationEvidenceReader) Read(
 			if err != nil {
 				return generationEvidenceError(err)
 			}
-			codec, ok := r.sources.bySource[sourceType(stored.Value)]
-			if !ok {
-				return &RepositoryNotFoundError{Kind: "source-adapter", Identity: sourceType(stored.Value)}
+			if evidenceErr := sourceevidence.Require(stored.Value); evidenceErr != nil {
+				return evidenceErr
 			}
-			payload, err := codec.encode(stored.Value)
+			payload, err := r.encodeSource(stored.Value)
 			if err != nil {
 				return err
 			}
@@ -104,6 +105,21 @@ func (r *GenerationEvidenceReader) Read(
 		return nil, &review.InvalidCandidateError{Field: "evidence", Detail: "at least one exact reference is required"}
 	}
 	return result, nil
+}
+
+func (r *GenerationEvidenceReader) encodeSource(value source.Value) ([]byte, error) {
+	if accepted, ok := value.(sourceevidence.AcceptedObservation); ok {
+		evidence, err := accepted.TextEvidence()
+		if err != nil {
+			return nil, err
+		}
+		return json.Marshal(evidence)
+	}
+	codec, ok := r.sources.bySource[sourceType(value)]
+	if !ok {
+		return nil, &RepositoryNotFoundError{Kind: "source-adapter", Identity: sourceType(value)}
+	}
+	return codec.encode(value)
 }
 
 func (r *GenerationEvidenceReader) encodeArtifact(value artifact.Snapshot) ([]byte, error) {

--- a/internal/sqlstore/generation_evidence_acceptance_test.go
+++ b/internal/sqlstore/generation_evidence_acceptance_test.go
@@ -1,0 +1,200 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sqlstore_test
+
+import (
+	"encoding/json/jsontext"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/ob-labs/powercontext-go/artifact"
+	"github.com/ob-labs/powercontext-go/artifact/skill"
+	"github.com/ob-labs/powercontext-go/internal/sqlstore"
+	"github.com/ob-labs/powercontext-go/source"
+)
+
+func TestGenerationEvidenceReaderProjectsAcceptedObservationTextEvidence(t *testing.T) {
+	ctx := t.Context()
+	database := openTestDatabase(t)
+	sources, artifacts := repositories(t)
+	manifest, raw := generationObservation(t, "remote.generation", "item-1", "accepted text")
+	accepted, err := source.AdmitObservation(manifest, raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if transactionErr := database.Transaction(ctx, func(tx sqlstore.DBTX) error {
+		if _, registerErr := (sqlstore.DefinitionManifestRepository{}).Register(ctx, tx, manifest); registerErr != nil {
+			return registerErr
+		}
+		_, addErr := sources.AddAccepted(ctx, tx, "scope-generation", accepted)
+		return addErr
+	}); transactionErr != nil {
+		t.Fatal(transactionErr)
+	}
+	reader, err := sqlstore.NewGenerationEvidenceReader(database, "scope-generation", sources, artifacts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	evidence, err := reader.Read(ctx, []source.Ref{raw.Ref()}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(evidence) != 1 || evidence[0].Kind != artifact.SourceEvidence || evidence[0].Truncated {
+		t.Fatalf("evidence = %#v", evidence)
+	}
+	want := `{"source_type":"remote.generation","source_id":"item-1","content":"accepted text","metadata":{"visible":true}}`
+	if evidence[0].Content != want {
+		t.Fatalf("accepted evidence content = %s, want %s", evidence[0].Content, want)
+	}
+	if strings.Contains(evidence[0].Content, "private-observation-payload") {
+		t.Fatalf("accepted evidence exposed raw observation payload: %s", evidence[0].Content)
+	}
+}
+
+func TestGenerationEvidenceReaderRejectsRawObservationWithoutDisclosure(t *testing.T) {
+	ctx := t.Context()
+	database := openTestDatabase(t)
+	sources, artifacts := repositories(t)
+	_, raw := generationObservation(t, "remote.raw-secret", "raw-id-secret", "not accepted")
+	payload, err := observationEnvelope(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, insertErr := database.SQLDB().ExecContext(ctx, `INSERT INTO pc_sources
+        (scope_id, source_type, source_id, payload, journal_position) VALUES (?, ?, ?, ?, ?)`,
+		"scope-raw-secret", raw.Ref().Type(), raw.Ref().ID(), payload, 1,
+	); insertErr != nil {
+		t.Fatal(insertErr)
+	}
+	reader, err := sqlstore.NewGenerationEvidenceReader(database, "scope-raw-secret", sources, artifacts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = reader.Read(ctx, []source.Ref{raw.Ref()}, nil)
+	if _, ok := errors.AsType[*source.UnacceptedObservationError](err); !ok {
+		t.Fatalf("Read(raw observation) error = %T %v", err, err)
+	}
+	for _, secret := range []string{"scope-raw-secret", "remote.raw-secret", "raw-id-secret", "private-observation-payload"} {
+		if strings.Contains(err.Error(), secret) {
+			t.Fatalf("raw rejection exposed %q: %v", secret, err)
+		}
+	}
+}
+
+func TestGenerationEvidenceReaderPreservesSnapshotNativePayload(t *testing.T) {
+	ctx := t.Context()
+	database := openTestDatabase(t)
+	sources, err := sqlstore.NewSourceRepository(
+		sqlstore.SQLiteDialect,
+		sqlstore.ContentSourceCodec(),
+		sqlstore.ExternalSkillSnapshotSourceCodec(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, artifacts := repositories(t)
+	registration, err := skill.NewRegistration(
+		"codex:project:repository/generation-skill", "codex", "codex", "workstation-1",
+		skill.ProjectScope, "/workspace/.agents/skills/generation-skill", strings.Repeat("a", 64),
+		"generation-skill", "Generation evidence snapshot.",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshot, err := skill.NewSnapshot(registration, "---\nname: generation-skill\n---\n\nKeep native bytes.\n")
+	if err != nil {
+		t.Fatal(err)
+	}
+	value, err := (skill.SnapshotSourceAdapter{}).Resolve(ctx, skill.SnapshotCapture{
+		Snapshot: snapshot, Mode: skill.ImportModeImport,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if transactionErr := database.Transaction(ctx, func(tx sqlstore.DBTX) error {
+		_, addErr := sources.Add(ctx, tx, "scope-snapshot", value)
+		return addErr
+	}); transactionErr != nil {
+		t.Fatal(transactionErr)
+	}
+	ref, err := sources.Ref(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	reader, err := sqlstore.NewGenerationEvidenceReader(database, "scope-snapshot", sources, artifacts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	evidence, err := reader.Read(ctx, []source.Ref{ref}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(evidence) != 1 || evidence[0].Kind != artifact.SourceEvidence || evidence[0].Truncated {
+		t.Fatalf("evidence = %#v", evidence)
+	}
+	for _, fragment := range []string{
+		`"materialization":"captured"`,
+		`"manifest":"---\nname: generation-skill\n---\n\nKeep native bytes.\n"`,
+		`"mode":"import"`,
+	} {
+		if !strings.Contains(evidence[0].Content, fragment) {
+			t.Fatalf("snapshot evidence missing %s: %s", fragment, evidence[0].Content)
+		}
+	}
+}
+
+func generationObservation(
+	t *testing.T,
+	sourceType, sourceID, content string,
+) (source.DefinitionManifest, source.SourceObservation) {
+	t.Helper()
+	identity, err := source.NewDefinitionIdentity(sourceType, "1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	projectionManifest, err := source.NewProjectionManifest(
+		source.TextEvidenceProjectionKey(), source.TextEvidenceSchema(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest, err := source.NewDefinitionManifest(
+		identity, jsontext.Value(`{"type":"object"}`), []source.ProjectionManifest{projectionManifest},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ref, err := source.NewRef(sourceType, sourceID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	projection, err := source.NewSourceProjectionValue(
+		source.TextEvidenceProjectionKey(),
+		jsontext.Value(`{"source_type":"`+sourceType+`","source_id":"`+sourceID+`","content":"`+content+`","metadata":{"visible":true}}`),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	observation, err := source.NewSourceObservation(
+		ref, manifest.Version(), manifest.Fingerprint(), nil,
+		jsontext.Value(`{"name":"`+sourceID+`","definition_version":"1","materialization":"captured","private":"private-observation-payload"}`),
+		[]source.SourceProjectionValue{projection},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return manifest, observation
+}

--- a/internal/sqlstore/handoff_evidence.go
+++ b/internal/sqlstore/handoff_evidence.go
@@ -22,6 +22,7 @@ import (
 	"github.com/ob-labs/powercontext-go/artifact"
 	"github.com/ob-labs/powercontext-go/artifact/handoff"
 	"github.com/ob-labs/powercontext-go/artifact/memory"
+	"github.com/ob-labs/powercontext-go/source"
 )
 
 // HandoffEvidenceResolver resolves exact immutable citations inside one Scope.
@@ -109,8 +110,11 @@ func unavailableHandoffEvidence(err error) bool {
 	var artifactMissing *artifact.NotFoundError
 	var invalidMemory *memory.InvalidCitationError
 	var entryMissing *memory.EntryNotFoundError
+	var rawObservation *source.UnacceptedObservationError
+	var invalidTextEvidence *source.InvalidTextEvidenceError
 	return errors.As(err, &repositoryMissing) || errors.As(err, &artifactMissing) ||
-		errors.As(err, &invalidMemory) || errors.As(err, &entryMissing)
+		errors.As(err, &invalidMemory) || errors.As(err, &entryMissing) ||
+		errors.As(err, &rawObservation) || errors.As(err, &invalidTextEvidence)
 }
 
 var _ handoff.EvidenceResolver = (*HandoffEvidenceResolver)(nil)

--- a/internal/sqlstore/handoff_evidence_acceptance_test.go
+++ b/internal/sqlstore/handoff_evidence_acceptance_test.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sqlstore_test
+
+import (
+	"context"
+	"encoding/json/jsontext"
+	"errors"
+	"testing"
+
+	"github.com/ob-labs/powercontext-go/artifact/handoff"
+	"github.com/ob-labs/powercontext-go/artifact/memory"
+	"github.com/ob-labs/powercontext-go/internal/sqlstore"
+	"github.com/ob-labs/powercontext-go/source"
+)
+
+func TestHandoffEvidenceResolverMapsLegacyRawObservationToUnavailable(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	database := openTestDatabase(t)
+	sources, artifacts := repositories(t)
+	ref, err := source.NewRef("worker.legacy", "item-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := source.NewSourceObservation(ref, "1", "fingerprint", nil,
+		jsontext.Value(`{"name":"item-1","definition_version":"1","materialization":"captured"}`), nil,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload, err := observationEnvelope(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, insertErr := database.SQLDB().ExecContext(ctx, `INSERT INTO pc_sources
+        (scope_id, source_type, source_id, payload, journal_position) VALUES (?, ?, ?, ?, ?)`,
+		"scope-handoff-raw", ref.Type(), ref.ID(), payload, 1,
+	); insertErr != nil {
+		t.Fatal(insertErr)
+	}
+	memoryRepository, err := sqlstore.NewMemoryRepository(database, "scope-handoff-raw", artifacts, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	memoryService, err := memory.NewService(memoryRepository, memory.ServiceOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolver, err := sqlstore.NewHandoffEvidenceResolver(database, "scope-handoff-raw", sources, artifacts, memoryService)
+	if err != nil {
+		t.Fatal(err)
+	}
+	citation, err := handoff.NewSourceCitation(ref)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = resolver.Resolve(ctx, citation)
+	if _, ok := errors.AsType[*handoff.EvidenceUnavailableError](err); !ok {
+		t.Fatalf("legacy raw Handoff resolution = %T %v", err, err)
+	}
+}

--- a/internal/sqlstore/memory_flush.go
+++ b/internal/sqlstore/memory_flush.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 
 	"github.com/ob-labs/powercontext-go/artifact/memory"
+	"github.com/ob-labs/powercontext-go/internal/sourceevidence"
 	"github.com/ob-labs/powercontext-go/source"
 	"github.com/ob-labs/powercontext-go/trigger"
 )
@@ -103,6 +104,17 @@ func (s *MemoryFlushStore) ObserveWindow(
 		for _, row := range rows {
 			if row.JournalPosition > actions[0].Through() {
 				break
+			}
+			// Legacy raw observations remain auditable journal rows, but their
+			// cursor range is consumed without exposing their worker payload to
+			// Memory extraction.
+			if _, raw := row.Value.(source.SourceObservation); raw {
+				continue
+			}
+			if accepted, ok := row.Value.(sourceevidence.AcceptedObservation); ok {
+				if _, evidenceErr := accepted.TextEvidence(); evidenceErr != nil {
+					continue
+				}
 			}
 			values = append(values, row.Value)
 		}

--- a/internal/sqlstore/memory_flush_test.go
+++ b/internal/sqlstore/memory_flush_test.go
@@ -153,6 +153,72 @@ func TestMemoryFlushPlanningDoesNotHoldDatabaseTransaction(t *testing.T) {
 	}
 }
 
+func TestMemoryFlushSkipsLegacyRawObservationsAndAdvancesTheirCursor(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	database := openTestDatabase(t)
+	sources, artifacts := repositories(t)
+	addFlushSource(t, database, sources, "scope-raw-window", "native-1", "accepted native evidence")
+	raw := observationSource(t, "worker.legacy", "raw-1", `{"name":"raw-1","definition_version":"1","materialization":"captured"}`)
+	payload, err := observationEnvelope(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, insertErr := database.SQLDB().ExecContext(ctx, `INSERT INTO pc_sources
+        (scope_id, source_type, source_id, payload, journal_position) VALUES (?, ?, ?, ?, ?)`,
+		"scope-raw-window", raw.Ref().Type(), raw.Ref().ID(), payload, 2,
+	); insertErr != nil {
+		t.Fatal(insertErr)
+	}
+	repository, err := sqlstore.NewMemoryRepository(database, "scope-raw-window", artifacts, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolver, err := sqlstore.NewMemorySourceResolver(database, "scope-raw-window", sources)
+	if err != nil {
+		t.Fatal(err)
+	}
+	service, err := memory.NewService(repository, memory.ServiceOptions{
+		CandidatePipeline: echoMemoryPipeline{}, SourceResolver: resolver, IDFactory: sequentialMemoryIDs(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := sqlstore.NewMemoryFlushStore(database, "scope-raw-window", sources, repository)
+	if err != nil {
+		t.Fatal(err)
+	}
+	previous, next, generation, high, values, err := store.ObserveWindow(ctx, trigger.SourceWindowName, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if previous.Sequence() != 0 || next.Sequence() != 2 || high != 2 || generation != nil {
+		t.Fatalf("raw window = previous:%d next:%d high:%d generation:%v", previous.Sequence(), next.Sequence(), high, generation)
+	}
+	if len(values) != 1 {
+		t.Fatalf("window values = %d, want only the accepted native Source", len(values))
+	}
+	if _, raw := values[0].(source.SourceObservation); raw {
+		t.Fatalf("raw observation reached Memory planning: %#v", values[0])
+	}
+	plan, err := service.PlanRemember(ctx, nil, values, nil, nil, memory.RememberExtract)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.ApplyWindow(ctx, trigger.SourceWindowName, plan, next, generation); err != nil {
+		t.Fatal(err)
+	}
+	var cursor []byte
+	if err := database.SQLDB().QueryRowContext(ctx, `SELECT cursor FROM pc_source_cursors WHERE scope_id = ? AND binding_name = ?`,
+		"scope-raw-window", trigger.SourceWindowName,
+	).Scan(&cursor); err != nil {
+		t.Fatal(err)
+	}
+	if string(cursor) != `{"sequence":2}` {
+		t.Fatalf("raw observation did not advance Memory cursor: %s", cursor)
+	}
+}
+
 type echoMemoryPipeline struct{}
 
 func (echoMemoryPipeline) Extract(_ context.Context, request memory.CandidateRequest) ([]memory.EntryInput, error) {

--- a/internal/sqlstore/recall_tokens.go
+++ b/internal/sqlstore/recall_tokens.go
@@ -26,6 +26,7 @@ import (
 	"github.com/ob-labs/powercontext-go/artifact/skill"
 	"github.com/ob-labs/powercontext-go/inference"
 	"github.com/ob-labs/powercontext-go/internal/contextpack"
+	"github.com/ob-labs/powercontext-go/internal/sourceevidence"
 	"github.com/ob-labs/powercontext-go/internal/stats"
 	"github.com/ob-labs/powercontext-go/source"
 )
@@ -250,6 +251,14 @@ func (e *RelationalRecallTokenEstimator) memoryEntry(
 
 func recallSourceText(ref source.Ref, value source.Value) (string, error) {
 	switch typed := value.(type) {
+	case sourceevidence.AcceptedObservation:
+		evidence, err := typed.TextEvidence()
+		if err != nil {
+			return "", &RecallTokenProjectionError{SourceType: ref.Type()}
+		}
+		return evidence.Content(), nil
+	case source.SourceObservation:
+		return "", &RecallTokenProjectionError{SourceType: ref.Type()}
 	case source.ContentSource:
 		return typed.Content(), nil
 	case skill.SnapshotSource:

--- a/internal/sqlstore/recall_tokens_acceptance_test.go
+++ b/internal/sqlstore/recall_tokens_acceptance_test.go
@@ -1,0 +1,62 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sqlstore
+
+import (
+	"encoding/json/jsontext"
+	"errors"
+	"testing"
+
+	"github.com/ob-labs/powercontext-go/source"
+)
+
+func TestRecallSourceTextRejectsRawStandardTextEvidence(t *testing.T) {
+	identity, err := source.NewDefinitionIdentity("remote.note", "1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	projectionManifest, err := source.NewProjectionManifest(source.TextEvidenceProjectionKey(), source.TextEvidenceSchema())
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest, err := source.NewDefinitionManifest(identity,
+		jsontext.Value(`{"type":"object","properties":{"name":{"type":"string"},"definition_version":{"type":"string"},"materialization":{"const":"captured"}},"required":["name","definition_version","materialization"]}`),
+		[]source.ProjectionManifest{projectionManifest})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ref, err := source.NewRef("remote.note", "item-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	projection, err := source.NewSourceProjectionValue(source.TextEvidenceProjectionKey(), jsontext.Value(
+		`{"source_type":"remote.note","source_id":"item-1","content":"recall this"}`,
+	))
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := source.NewSourceObservation(ref, manifest.Version(), manifest.Fingerprint(), nil,
+		jsontext.Value(`{"name":"item-1","definition_version":"1","materialization":"captured"}`),
+		[]source.SourceProjectionValue{projection},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, recallErr := recallSourceText(ref, raw); recallErr == nil {
+		t.Fatal("raw worker observation became recall text")
+	} else if _, ok := errors.AsType[*RecallTokenProjectionError](recallErr); !ok {
+		t.Fatalf("raw recall error = %T %v", recallErr, recallErr)
+	}
+}

--- a/internal/sqlstore/remote_ingestion.go
+++ b/internal/sqlstore/remote_ingestion.go
@@ -82,10 +82,10 @@ func (b *RuntimeRemoteIngestionBackend) Find(
 func (b *RuntimeRemoteIngestionBackend) Add(
 	ctx context.Context,
 	scopeID string,
-	observation source.SourceObservation,
+	observation *source.AdmittedObservation,
 ) (ref source.Ref, sequence int64, err error) {
 	err = b.database.Transaction(ctx, func(tx DBTX) error {
-		stored, addErr := b.sources.Add(ctx, tx, scopeID, observation)
+		stored, addErr := b.sources.AddAccepted(ctx, tx, scopeID, observation)
 		if addErr != nil {
 			return addErr
 		}

--- a/internal/sqlstore/remote_ingestion_test.go
+++ b/internal/sqlstore/remote_ingestion_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	pcruntime "github.com/ob-labs/powercontext-go/internal/runtime"
+	"github.com/ob-labs/powercontext-go/internal/sourceevidence"
 	"github.com/ob-labs/powercontext-go/internal/sqlstore"
 	"github.com/ob-labs/powercontext-go/source"
 )
@@ -48,7 +49,7 @@ func TestRuntimeRemoteIngestionBackendOwnsSQLiteTransactions(t *testing.T) {
 		t.Fatalf("Find() = %#v, %t, %v", found, exists, err)
 	}
 	observation := remoteStoredObservation(t, manifest, `{"name":"item-1","definition_version":"1","materialization":"captured","large":9007199254740993}`)
-	ref, sequence, err := backend.Add(t.Context(), "scope-remote", observation)
+	ref, sequence, err := backend.Add(t.Context(), "scope-remote", acceptedStoredObservation(t, manifest, observation))
 	if err != nil || ref != observation.Ref() || sequence != 1 {
 		t.Fatalf("Add() = %s, %d, %v", ref, sequence, err)
 	}
@@ -77,14 +78,57 @@ func TestRuntimeRemoteIngestionBackendReturnsTypedRedactedConflicts(t *testing.T
 
 	firstObservation := remoteStoredObservation(t, first, `{"name":"item-1","definition_version":"1","materialization":"captured","large":1}`)
 	secondObservation := remoteStoredObservation(t, first, `{"name":"item-1","definition_version":"1","materialization":"captured","large":2}`)
-	if _, _, addErr := backend.Add(t.Context(), "scope-remote", firstObservation); addErr != nil {
+	if _, _, addErr := backend.Add(t.Context(), "scope-remote", acceptedStoredObservation(t, first, firstObservation)); addErr != nil {
 		t.Fatal(addErr)
 	}
-	_, _, err = backend.Add(t.Context(), "scope-remote", secondObservation)
+	_, _, err = backend.Add(t.Context(), "scope-remote", acceptedStoredObservation(t, first, secondObservation))
 	if _, ok := errors.AsType[*source.ObservationConflictError](err); !ok {
 		t.Fatalf("observation conflict = %T %v", err, err)
 	}
 	assertRemoteIngestionErrorRedacted(t, err, "remote.secret", "item-1", first.Fingerprint())
+}
+
+func TestRuntimeRemoteIngestionBackendRequiresPersistedManifestForAcceptedMarker(t *testing.T) {
+	database := openTestDatabase(t)
+	repository, err := sqlstore.NewSourceRepository(sqlstore.SQLiteDialect, sqlstore.ContentSourceCodec())
+	if err != nil {
+		t.Fatal(err)
+	}
+	backend, err := sqlstore.NewRuntimeRemoteIngestionBackend(database, sqlstore.DefinitionManifestRepository{}, repository)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fake := remoteStoredManifest(t, "remote.unregistered", jsontext.Value(`{"type":"object"}`))
+	observation := remoteStoredObservation(t, fake, `{"name":"item-1","definition_version":"1","materialization":"captured","large":1}`)
+	accepted := acceptedStoredObservation(t, fake, observation)
+
+	_, _, err = backend.Add(t.Context(), "scope-unregistered", accepted)
+	if _, ok := errors.AsType[*source.DefinitionNotFoundError](err); !ok {
+		t.Fatalf("unregistered accepted Add() error = %T %v", err, err)
+	}
+	assertAcceptedObservationRows(t, database, "scope-unregistered", 0, 0)
+	if transactionErr := database.Transaction(t.Context(), func(tx sqlstore.DBTX) error {
+		position, positionErr := repository.JournalPosition(t.Context(), tx, "scope-unregistered")
+		if positionErr != nil {
+			return positionErr
+		}
+		if position != 0 {
+			t.Fatalf("unregistered accepted journal position = %d, want 0", position)
+		}
+		return nil
+	}); transactionErr != nil {
+		t.Fatal(transactionErr)
+	}
+
+	persisted := remoteStoredManifest(t, "remote.unregistered", jsontext.Value(`{"type":"object","properties":{"large":{"type":"integer"}}}`))
+	if _, registerErr := backend.Register(t.Context(), persisted); registerErr != nil {
+		t.Fatal(registerErr)
+	}
+	_, _, err = backend.Add(t.Context(), "scope-unregistered", accepted)
+	if _, ok := errors.AsType[*source.InvalidSourceObservationError](err); !ok {
+		t.Fatalf("mismatched accepted Add() error = %T %v", err, err)
+	}
+	assertAcceptedObservationRows(t, database, "scope-unregistered", 0, 0)
 }
 
 func TestRemoteIngestionApplicationUsesSQLiteAdapterAfterValidation(t *testing.T) {
@@ -143,9 +187,9 @@ func TestRemoteIngestionApplicationUsesSQLiteAdapterAfterValidation(t *testing.T
 		if stored.JournalPosition != receipt.Sequence {
 			t.Fatalf("stored sequence = %d, want %d", stored.JournalPosition, receipt.Sequence)
 		}
-		_, ok := stored.Value.(source.SourceObservation)
+		_, ok := stored.Value.(sourceevidence.AcceptedObservation)
 		if !ok {
-			t.Fatalf("stored value = %T, want SourceObservation", stored.Value)
+			t.Fatalf("stored value = %T, want sourceevidence.AcceptedObservation", stored.Value)
 		}
 		return nil
 	}); transactionErr != nil {
@@ -209,6 +253,19 @@ func remoteStoredObservation(t *testing.T, manifest source.DefinitionManifest, p
 		t.Fatal(err)
 	}
 	return observation
+}
+
+func acceptedStoredObservation(
+	t *testing.T,
+	manifest source.DefinitionManifest,
+	observation source.SourceObservation,
+) *source.AdmittedObservation {
+	t.Helper()
+	accepted, err := source.AdmitObservation(manifest, observation)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return accepted
 }
 
 func assertRemoteIngestionErrorRedacted(t *testing.T, err error, secrets ...string) {

--- a/internal/sqlstore/schema.go
+++ b/internal/sqlstore/schema.go
@@ -133,6 +133,15 @@ var builtinSchema = []string{
         PRIMARY KEY (scope_id, source_type, source_id),
         CONSTRAINT uq_pc_sources_scope_journal_position UNIQUE (scope_id, journal_position)
     )`,
+	`CREATE TABLE IF NOT EXISTS pc_source_observation_acceptances (
+	    scope_id VARCHAR(256) NOT NULL,
+	    source_type VARCHAR(128) NOT NULL,
+	    source_id VARCHAR(256) NOT NULL,
+	    PRIMARY KEY (scope_id, source_type, source_id),
+	    CONSTRAINT fk_pc_source_observation_acceptances_source
+	        FOREIGN KEY (scope_id, source_type, source_id)
+	        REFERENCES pc_sources (scope_id, source_type, source_id) ON DELETE RESTRICT
+	)`,
 	`CREATE TABLE IF NOT EXISTS pc_artifacts (
         scope_id VARCHAR(256) NOT NULL,
         family VARCHAR(128) NOT NULL,

--- a/internal/sqlstore/sources.go
+++ b/internal/sqlstore/sources.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 	"unicode/utf8"
 
+	"github.com/ob-labs/powercontext-go/internal/sourceevidence"
 	"github.com/ob-labs/powercontext-go/source"
 )
 
@@ -64,6 +65,12 @@ func (r *SourceRepository) Ref(value source.Value) (source.Ref, error) {
 			return source.Ref{}, err
 		}
 		return observation.Ref(), nil
+	}
+	if accepted, ok := value.(sourceevidence.AcceptedObservation); ok {
+		if err := accepted.Validate(); err != nil {
+			return source.Ref{}, err
+		}
+		return accepted.Ref(), nil
 	}
 	codec, ok := r.bySource[reflect.TypeOf(value)]
 	if !ok {
@@ -110,7 +117,7 @@ func (r *SourceRepository) Add(
 	if err := requireScope(scopeID); err != nil {
 		return StoredSource{}, err
 	}
-	ref, payload, observation, err := r.encode(value)
+	ref, payload, err := r.encode(value)
 	if err != nil {
 		return StoredSource{}, err
 	}
@@ -122,17 +129,14 @@ func (r *SourceRepository) Add(
 		return StoredSource{}, err
 	}
 	if found {
-		equal, equalErr := sameStoredSourcePayload(existing.payload, payload, observation)
+		equal, equalErr := sameStoredSourcePayload(existing.payload, payload, false)
 		if equalErr != nil {
 			return StoredSource{}, invalidStoredSourceObservation()
 		}
 		if !equal {
-			if observation {
-				return StoredSource{}, sourceObservationConflict()
-			}
 			return StoredSource{}, &StoredPayloadConflictError{Kind: "source", Identity: sourceIdentity(scopeID, ref)}
 		}
-		return r.decode(existing)
+		return r.decode(ctx, db, existing)
 	}
 
 	position, err := nextJournalPosition(ctx, db, scopeID)
@@ -150,45 +154,138 @@ func (r *SourceRepository) Add(
 		if !found {
 			return StoredSource{}, err
 		}
-		equal, equalErr := sameStoredSourcePayload(existing.payload, payload, observation)
+		equal, equalErr := sameStoredSourcePayload(existing.payload, payload, false)
 		if equalErr != nil {
 			return StoredSource{}, invalidStoredSourceObservation()
 		}
 		if !equal {
-			if observation {
-				return StoredSource{}, sourceObservationConflict()
-			}
 			return StoredSource{}, &StoredPayloadConflictError{Kind: "source", Identity: sourceIdentity(scopeID, ref)}
 		}
-		return r.decode(existing)
+		return r.decode(ctx, db, existing)
 	}
 	return StoredSource{Ref: ref, Value: value, JournalPosition: position}, nil
 }
 
-func (r *SourceRepository) encode(value source.Value) (source.Ref, []byte, bool, error) {
-	if observation, ok := value.(source.SourceObservation); ok {
-		if err := observation.Validate(); err != nil {
-			return source.Ref{}, nil, true, err
+// AddAccepted persists an already schema-admitted worker observation. It
+// repeats Definition admission against the Definition visible in this write
+// transaction, then writes the Source and durable acceptance marker atomically
+// before exposing an evidence-capable value.
+func (r *SourceRepository) AddAccepted(
+	ctx context.Context,
+	db DBTX,
+	scopeID string,
+	admitted *source.AdmittedObservation,
+) (StoredSource, error) {
+	if err := requireScope(scopeID); err != nil {
+		return StoredSource{}, err
+	}
+	if err := admitted.Validate(); err != nil {
+		return StoredSource{}, err
+	}
+	persisted, err := r.admitPersistedObservation(ctx, db, admitted.Observation())
+	if err != nil {
+		return StoredSource{}, err
+	}
+	observation := persisted.Observation()
+	payload, err := encodeSourceObservation(observation)
+	if err != nil {
+		return StoredSource{}, err
+	}
+	ref := observation.Ref()
+	if lockErr := r.lockJournalHead(ctx, db, scopeID); lockErr != nil {
+		return StoredSource{}, lockErr
+	}
+	existing, found, err := r.find(ctx, db, scopeID, ref)
+	if err != nil {
+		return StoredSource{}, err
+	}
+	if found {
+		equal, equalErr := sameStoredSourcePayload(existing.payload, payload, true)
+		if equalErr != nil {
+			return StoredSource{}, invalidStoredSourceObservation()
 		}
-		payload, err := encodeSourceObservation(observation)
-		if err != nil {
-			return source.Ref{}, nil, true, err
+		if !equal || !existing.accepted {
+			return StoredSource{}, sourceObservationConflict()
 		}
-		return observation.Ref(), payload, true, nil
+		return r.decode(ctx, db, existing)
+	}
+	position, err := nextJournalPosition(ctx, db, scopeID)
+	if err != nil {
+		return StoredSource{}, err
+	}
+	if _, insertErr := db.ExecContext(ctx, `INSERT INTO pc_sources
+        (scope_id, source_type, source_id, payload, journal_position)
+		VALUES (?, ?, ?, ?, ?)`, scopeID, ref.Type(), ref.ID(), payload, position); insertErr != nil {
+		existing, found, findErr := r.find(ctx, db, scopeID, ref)
+		if findErr != nil {
+			return StoredSource{}, errors.Join(insertErr, findErr)
+		}
+		if !found {
+			return StoredSource{}, insertErr
+		}
+		equal, equalErr := sameStoredSourcePayload(existing.payload, payload, true)
+		if equalErr != nil {
+			return StoredSource{}, invalidStoredSourceObservation()
+		}
+		if !equal || !existing.accepted {
+			return StoredSource{}, sourceObservationConflict()
+		}
+		return r.decode(ctx, db, existing)
+	}
+	if markErr := markAcceptedObservation(ctx, db, scopeID, ref); markErr != nil {
+		return StoredSource{}, markErr
+	}
+	value, err := sourceevidence.NewAcceptedObservation(observation)
+	if err != nil {
+		return StoredSource{}, err
+	}
+	return StoredSource{Ref: ref, Value: value, JournalPosition: position}, nil
+}
+
+func (r *SourceRepository) encode(value source.Value) (source.Ref, []byte, error) {
+	if _, raw := value.(source.SourceObservation); raw {
+		return source.Ref{}, nil, &source.UnacceptedObservationError{}
 	}
 	codec, ok := r.bySource[reflect.TypeOf(value)]
 	if !ok {
-		return source.Ref{}, nil, false, &RepositoryNotFoundError{Kind: "source-adapter", Identity: reflect.TypeOf(value)}
+		return source.Ref{}, nil, &RepositoryNotFoundError{Kind: "source-adapter", Identity: reflect.TypeOf(value)}
 	}
 	ref, err := r.Ref(value)
 	if err != nil {
-		return source.Ref{}, nil, false, err
+		return source.Ref{}, nil, err
 	}
 	payload, err := codec.encode(value)
 	if err != nil {
-		return source.Ref{}, nil, false, &InvalidStoredPayloadError{Kind: "source", Name: codec.name, Issue: "value is not JSON serializable"}
+		return source.Ref{}, nil, &InvalidStoredPayloadError{Kind: "source", Name: codec.name, Issue: "value is not JSON serializable"}
 	}
-	return ref, payload, false, nil
+	return ref, payload, nil
+}
+
+// admitPersistedObservation rechecks a worker observation against the
+// Definition stored in this transaction. An in-memory Definition is not
+// sufficient because this method guards the durable acceptance marker.
+func (*SourceRepository) admitPersistedObservation(
+	ctx context.Context,
+	db DBTX,
+	observation source.SourceObservation,
+) (*source.AdmittedObservation, error) {
+	if err := observation.Validate(); err != nil {
+		return nil, err
+	}
+	identity, err := source.NewDefinitionIdentity(observation.Ref().Type(), observation.DefinitionVersion())
+	if err != nil {
+		return nil, &source.InvalidSourceObservationError{
+			Field: "definition", Detail: "must identify a valid Source Definition",
+		}
+	}
+	manifest, found, err := (DefinitionManifestRepository{}).Find(ctx, db, identity.Name(), identity.Version())
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return nil, &source.DefinitionNotFoundError{}
+	}
+	return source.AdmitObservation(manifest, observation)
 }
 
 func (r *SourceRepository) Get(
@@ -210,7 +307,7 @@ func (r *SourceRepository) Get(
 	if !found {
 		return StoredSource{}, &RepositoryNotFoundError{Kind: "source", Identity: sourceIdentity(scopeID, ref)}
 	}
-	return r.decode(row)
+	return r.decode(ctx, db, row)
 }
 
 func (r *SourceRepository) List(
@@ -229,8 +326,12 @@ func (r *SourceRepository) List(
 	if limit != nil && *limit < 1 {
 		return nil, &InvalidRepositoryArgumentError{Field: "limit", Detail: "must be positive"}
 	}
-	query := `SELECT scope_id, source_type, source_id, payload, journal_position
-        FROM pc_sources WHERE scope_id = ? AND journal_position > ? ORDER BY journal_position`
+	query := `SELECT s.scope_id, s.source_type, s.source_id, s.payload, s.journal_position,
+        a.source_id IS NOT NULL
+        FROM pc_sources AS s
+        LEFT JOIN pc_source_observation_acceptances AS a
+          ON a.scope_id = s.scope_id AND a.source_type = s.source_type AND a.source_id = s.source_id
+        WHERE s.scope_id = ? AND s.journal_position > ? ORDER BY s.journal_position`
 	arguments := []any{scopeID, after}
 	if limit != nil {
 		query += " LIMIT ?"
@@ -240,21 +341,34 @@ func (r *SourceRepository) List(
 	if err != nil {
 		return nil, err
 	}
-	defer func() { returnErr = errors.Join(returnErr, rows.Close()) }()
-	result = make([]StoredSource, 0)
+	rowsClosed := false
+	defer func() {
+		if !rowsClosed {
+			returnErr = errors.Join(returnErr, rows.Close())
+		}
+	}()
+	stored := make([]storedSourceRow, 0)
 	for rows.Next() {
 		row, err := scanSource(rows)
 		if err != nil {
 			return nil, err
 		}
-		decoded, err := r.decode(row)
+		stored = append(stored, row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	rowsClosed = true
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	result = make([]StoredSource, 0, len(stored))
+	for _, row := range stored {
+		decoded, err := r.decode(ctx, db, row)
 		if err != nil {
 			return nil, err
 		}
 		result = append(result, decoded)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
 	}
 	return result, nil
 }
@@ -286,6 +400,7 @@ type storedSourceRow struct {
 	sourceID string
 	payload  []byte
 	position int64
+	accepted bool
 }
 
 func (r *SourceRepository) find(
@@ -294,8 +409,12 @@ func (r *SourceRepository) find(
 	scopeID string,
 	ref source.Ref,
 ) (storedSourceRow, bool, error) {
-	row, err := scanSource(db.QueryRowContext(ctx, `SELECT scope_id, source_type, source_id, payload, journal_position
-        FROM pc_sources WHERE scope_id = ? AND source_type = ? AND source_id = ?`,
+	row, err := scanSource(db.QueryRowContext(ctx, `SELECT s.scope_id, s.source_type, s.source_id, s.payload, s.journal_position,
+        a.source_id IS NOT NULL
+        FROM pc_sources AS s
+        LEFT JOIN pc_source_observation_acceptances AS a
+          ON a.scope_id = s.scope_id AND a.source_type = s.source_type AND a.source_id = s.source_id
+        WHERE s.scope_id = ? AND s.source_type = ? AND s.source_id = ?`,
 		scopeID, ref.Type(), ref.ID()))
 	if errors.Is(err, sql.ErrNoRows) {
 		return storedSourceRow{}, false, nil
@@ -309,7 +428,8 @@ func scanSource(value scanner) (storedSourceRow, error) {
 	var row storedSourceRow
 	var payload any
 	var position any
-	if err := value.Scan(&row.scopeID, &row.typeName, &row.sourceID, &payload, &position); err != nil {
+	var accepted any
+	if err := value.Scan(&row.scopeID, &row.typeName, &row.sourceID, &payload, &position, &accepted); err != nil {
 		return storedSourceRow{}, err
 	}
 	decodedPayload, err := storedBytes(payload, "payload")
@@ -322,10 +442,15 @@ func scanSource(value scanner) (storedSourceRow, error) {
 	}
 	row.payload = decodedPayload
 	row.position = decodedPosition
+	acceptedValue, ok := integer(accepted)
+	if !ok || acceptedValue < 0 || acceptedValue > 1 {
+		return storedSourceRow{}, &InvalidStoredColumnError{Column: "observation_acceptance", Expected: "a boolean join marker"}
+	}
+	row.accepted = acceptedValue == 1
 	return row, nil
 }
 
-func (r *SourceRepository) decode(row storedSourceRow) (StoredSource, error) {
+func (r *SourceRepository) decode(ctx context.Context, db DBTX, row storedSourceRow) (StoredSource, error) {
 	envelope, recognized, envelopeErr := parseSourceEnvelope(row.payload)
 	if recognized {
 		if envelopeErr != nil {
@@ -340,6 +465,17 @@ func (r *SourceRepository) decode(row storedSourceRow) (StoredSource, error) {
 			if indexed != envelope.observation.Ref() {
 				return StoredSource{}, sourceObservationIdentityMismatch()
 			}
+			if row.accepted {
+				admitted, admittedErr := r.admitPersistedObservation(ctx, db, envelope.observation)
+				if admittedErr != nil {
+					return StoredSource{}, invalidStoredSourceObservation()
+				}
+				accepted, acceptedErr := sourceevidence.NewAcceptedObservation(admitted.Observation())
+				if acceptedErr != nil {
+					return StoredSource{}, invalidStoredSourceObservation()
+				}
+				return StoredSource{Ref: indexed, Value: accepted, JournalPosition: row.position}, nil
+			}
 			return StoredSource{Ref: indexed, Value: envelope.observation, JournalPosition: row.position}, nil
 		case sourceNativeRepresentation:
 			return r.decodeNative(row, envelope.value)
@@ -349,6 +485,9 @@ func (r *SourceRepository) decode(row storedSourceRow) (StoredSource, error) {
 }
 
 func (r *SourceRepository) decodeNative(row storedSourceRow, payload []byte) (StoredSource, error) {
+	if row.accepted {
+		return StoredSource{}, invalidStoredSourceObservation()
+	}
 	codec, ok := r.byName[row.typeName]
 	if !ok {
 		return StoredSource{}, &RepositoryNotFoundError{Kind: "source-adapter", Identity: row.typeName}
@@ -369,6 +508,22 @@ func (r *SourceRepository) decodeNative(row storedSourceRow, payload []byte) (St
 		return StoredSource{}, &IdentityMismatchError{Kind: "source", Indexed: indexed, Decoded: decoded}
 	}
 	return StoredSource{Ref: indexed, Value: value, JournalPosition: row.position}, nil
+}
+
+func markAcceptedObservation(ctx context.Context, db DBTX, scopeID string, ref source.Ref) error {
+	result, err := db.ExecContext(ctx, `INSERT INTO pc_source_observation_acceptances
+        (scope_id, source_type, source_id) VALUES (?, ?, ?)`, scopeID, ref.Type(), ref.ID())
+	if err != nil {
+		return err
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affected != 1 {
+		return &InvalidStoredColumnError{Column: "observation_acceptance", Expected: "one durable admission marker"}
+	}
+	return nil
 }
 
 func sameStoredSourcePayload(stored, expected []byte, observation bool) (bool, error) {

--- a/internal/sqlstore/sources_test.go
+++ b/internal/sqlstore/sources_test.go
@@ -27,6 +27,7 @@ import (
 	"testing"
 
 	"github.com/ob-labs/powercontext-go/artifact/skill"
+	"github.com/ob-labs/powercontext-go/internal/sourceevidence"
 	"github.com/ob-labs/powercontext-go/internal/sqlstore"
 	"github.com/ob-labs/powercontext-go/source"
 )
@@ -365,6 +366,8 @@ func TestSourceRepositoryPersistsObservationEnvelopeAlongsideNativeSources(t *te
 		t.Fatal(err)
 	}
 	observation := observationSource(t, "worker.capture", "worker-item", `{"name":"worker-item","definition_version":"1","materialization":"captured","payload":{"nested":true}}`)
+	accepted := acceptedObservationSource(t, observation)
+	registerObservationDefinition(t, database, observation)
 
 	ref, err := repository.Ref(observation)
 	if err != nil {
@@ -381,7 +384,7 @@ func TestSourceRepositoryPersistsObservationEnvelopeAlongsideNativeSources(t *te
 		if addErr != nil {
 			return addErr
 		}
-		stored, addErr = repository.Add(ctx, tx, "scope-observation", observation)
+		stored, addErr = repository.AddAccepted(ctx, tx, "scope-observation", accepted)
 		return addErr
 	}); err != nil {
 		t.Fatal(err)
@@ -389,8 +392,8 @@ func TestSourceRepositoryPersistsObservationEnvelopeAlongsideNativeSources(t *te
 	if native.JournalPosition != 1 || stored.JournalPosition != 2 {
 		t.Fatalf("journal positions = %d/%d, want 1/2", native.JournalPosition, stored.JournalPosition)
 	}
-	decoded, ok := stored.Value.(source.SourceObservation)
-	if !ok || decoded.Ref() != observation.Ref() || string(decoded.Payload()) != string(observation.Payload()) {
+	decoded, ok := stored.Value.(sourceevidence.AcceptedObservation)
+	if !ok || decoded.Ref() != observation.Ref() || string(decoded.Observation().Payload()) != string(observation.Payload()) {
 		t.Fatalf("stored observation = %#v", stored.Value)
 	}
 
@@ -435,9 +438,107 @@ func TestSourceRepositoryPersistsObservationEnvelopeAlongsideNativeSources(t *te
 		if len(listed) != 2 {
 			t.Fatalf("List() returned %d Sources, want 2", len(listed))
 		}
-		_, observationFound := listed[1].Value.(source.SourceObservation)
+		_, observationFound := listed[1].Value.(sourceevidence.AcceptedObservation)
 		if !observationFound {
 			t.Fatalf("List() observation type = %T", listed[1].Value)
+		}
+		return nil
+	}); transactionErr != nil {
+		t.Fatal(transactionErr)
+	}
+}
+
+func TestSourceRepositoryAcceptsOnlyRuntimeAdmittedObservations(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	database := openTestDatabase(t)
+	repository, err := sqlstore.NewSourceRepository(sqlstore.SQLiteDialect, sqlstore.ContentSourceCodec())
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw := observationSource(t, "worker.audit", "item-1", `{"name":"item-1","definition_version":"1","materialization":"captured"}`)
+	registerObservationDefinition(t, database, raw)
+
+	err = database.Transaction(ctx, func(tx sqlstore.DBTX) error {
+		_, addErr := repository.Add(ctx, tx, "scope-admission", raw)
+		return addErr
+	})
+	if _, ok := errors.AsType[*source.UnacceptedObservationError](err); !ok {
+		t.Fatalf("raw Add() error = %T %v", err, err)
+	}
+	assertAcceptedObservationRows(t, database, "scope-admission", 0, 0)
+
+	accepted := acceptedObservationSource(t, raw)
+	if transactionErr := database.Transaction(ctx, func(tx sqlstore.DBTX) error {
+		_, addErr := repository.AddAccepted(ctx, tx, "scope-admission", accepted)
+		return addErr
+	}); transactionErr != nil {
+		t.Fatal(transactionErr)
+	}
+	assertAcceptedObservationRows(t, database, "scope-admission", 1, 1)
+
+	legacy := observationSource(t, "worker.audit", "legacy", `{"name":"legacy","definition_version":"1","materialization":"captured"}`)
+	payload, err := observationEnvelope(legacy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, insertErr := database.SQLDB().ExecContext(ctx, `INSERT INTO pc_sources
+        (scope_id, source_type, source_id, payload, journal_position) VALUES (?, ?, ?, ?, ?)`,
+		"scope-admission", legacy.Ref().Type(), legacy.Ref().ID(), payload, 2,
+	); insertErr != nil {
+		t.Fatal(insertErr)
+	}
+	if transactionErr := database.Transaction(ctx, func(tx sqlstore.DBTX) error {
+		stored, getErr := repository.Get(ctx, tx, "scope-admission", legacy.Ref())
+		if getErr != nil {
+			return getErr
+		}
+		if _, raw := stored.Value.(source.SourceObservation); !raw {
+			t.Fatalf("legacy value = %T, want raw SourceObservation", stored.Value)
+		}
+		return nil
+	}); transactionErr != nil {
+		t.Fatal(transactionErr)
+	}
+	err = database.Transaction(ctx, func(tx sqlstore.DBTX) error {
+		_, addErr := repository.AddAccepted(ctx, tx, "scope-admission", acceptedObservationSource(t, legacy))
+		return addErr
+	})
+	if _, ok := errors.AsType[*sqlstore.StoredPayloadConflictError](err); !ok {
+		t.Fatalf("legacy admission replay error = %T %v", err, err)
+	}
+	assertAcceptedObservationRows(t, database, "scope-admission", 2, 1)
+}
+
+func TestSourceRepositoryRollsBackObservationWhenAcceptanceMarkerFails(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	database := openTestDatabase(t)
+	repository, err := sqlstore.NewSourceRepository(sqlstore.SQLiteDialect, sqlstore.ContentSourceCodec())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, triggerErr := database.SQLDB().ExecContext(ctx, `CREATE TRIGGER reject_observation_acceptance
+	        BEFORE INSERT ON pc_source_observation_acceptances BEGIN SELECT RAISE(ABORT, 'rejected'); END`); triggerErr != nil {
+		t.Fatal(triggerErr)
+	}
+	raw := observationSource(t, "worker.atomic", "item-1", `{"name":"item-1","definition_version":"1","materialization":"captured"}`)
+	registerObservationDefinition(t, database, raw)
+	err = database.Transaction(ctx, func(tx sqlstore.DBTX) error {
+		_, addErr := repository.AddAccepted(ctx, tx, "scope-atomic", acceptedObservationSource(t, raw))
+		return addErr
+	})
+	if err == nil {
+		t.Fatal("accepted Add() succeeded despite marker trigger")
+	}
+	assertAcceptedObservationRows(t, database, "scope-atomic", 0, 0)
+	if transactionErr := database.Transaction(ctx, func(tx sqlstore.DBTX) error {
+		position, positionErr := repository.JournalPosition(ctx, tx, "scope-atomic")
+		if positionErr != nil {
+			return positionErr
+		}
+		if position != 0 {
+			t.Fatalf("rolled-back journal position = %d, want 0", position)
 		}
 		return nil
 	}); transactionErr != nil {
@@ -454,17 +555,19 @@ func TestSourceRepositoryObservationEnvelopeWinsOverCollidingContentCodec(t *tes
 		t.Fatal(err)
 	}
 	observation := observationSource(t, source.ContentType, "observation-item", `{"name":"observation-item","definition_version":"1","materialization":"captured","payload":{"content":"worker-owned"}}`)
+	accepted := acceptedObservationSource(t, observation)
+	registerObservationDefinition(t, database, observation)
 
 	var added sqlstore.StoredSource
 	if err := database.Transaction(ctx, func(tx sqlstore.DBTX) error {
 		var addErr error
-		added, addErr = repository.Add(ctx, tx, "scope-observation-content", observation)
+		added, addErr = repository.AddAccepted(ctx, tx, "scope-observation-content", accepted)
 		return addErr
 	}); err != nil {
 		t.Fatal(err)
 	}
-	if _, ok := added.Value.(source.SourceObservation); !ok {
-		t.Fatalf("Add() value type = %T, want source.SourceObservation", added.Value)
+	if _, ok := added.Value.(sourceevidence.AcceptedObservation); !ok {
+		t.Fatalf("AddAccepted() value type = %T, want sourceevidence.AcceptedObservation", added.Value)
 	}
 
 	var payload []byte
@@ -489,8 +592,8 @@ func TestSourceRepositoryObservationEnvelopeWinsOverCollidingContentCodec(t *tes
 		if getErr != nil {
 			return getErr
 		}
-		if _, ok := stored.Value.(source.SourceObservation); !ok {
-			t.Fatalf("Get() value type = %T, want source.SourceObservation", stored.Value)
+		if _, ok := stored.Value.(sourceevidence.AcceptedObservation); !ok {
+			t.Fatalf("Get() value type = %T, want sourceevidence.AcceptedObservation", stored.Value)
 		}
 		listed, listErr := repository.List(ctx, tx, "scope-observation-content", 0, nil)
 		if listErr != nil {
@@ -499,8 +602,8 @@ func TestSourceRepositoryObservationEnvelopeWinsOverCollidingContentCodec(t *tes
 		if len(listed) != 1 {
 			t.Fatalf("List() returned %d Sources, want 1", len(listed))
 		}
-		if _, ok := listed[0].Value.(source.SourceObservation); !ok {
-			t.Fatalf("List() value type = %T, want source.SourceObservation", listed[0].Value)
+		if _, ok := listed[0].Value.(sourceevidence.AcceptedObservation); !ok {
+			t.Fatalf("List() value type = %T, want sourceevidence.AcceptedObservation", listed[0].Value)
 		}
 		return nil
 	}); err != nil {
@@ -519,15 +622,16 @@ func TestSourceRepositoryObservationUsesJSONSemanticIdempotence(t *testing.T) {
 	first := observationSource(t, "worker.capture", "item", `{"name":"item","definition_version":"1","materialization":"captured","payload":{"\u0061":1.0,"b":[true,null],"large":123456789012345678901234567890}}`)
 	reordered := observationSource(t, "worker.capture", "item", `{"payload":{"large":123456789012345678901234567890,"b":[true,null],"a":1e0},"materialization":"captured","definition_version":"1","name":"item"}`)
 	conflicting := observationSource(t, "worker.capture", "item", `{"name":"item","definition_version":"1","materialization":"captured","payload":{"a":2,"b":[true,null],"large":123456789012345678901234567890}}`)
+	registerObservationDefinition(t, database, first)
 
 	var initial, replay sqlstore.StoredSource
 	if initialTransactionErr := database.Transaction(ctx, func(tx sqlstore.DBTX) error {
 		var addErr error
-		initial, addErr = repository.Add(ctx, tx, "scope-observation", first)
+		initial, addErr = repository.AddAccepted(ctx, tx, "scope-observation", acceptedObservationSource(t, first))
 		if addErr != nil {
 			return addErr
 		}
-		replay, addErr = repository.Add(ctx, tx, "scope-observation", reordered)
+		replay, addErr = repository.AddAccepted(ctx, tx, "scope-observation", acceptedObservationSource(t, reordered))
 		return addErr
 	}); initialTransactionErr != nil {
 		t.Fatal(initialTransactionErr)
@@ -537,7 +641,7 @@ func TestSourceRepositoryObservationUsesJSONSemanticIdempotence(t *testing.T) {
 	}
 	largeIntegerConflict := observationSource(t, "worker.capture", "item", `{"name":"item","definition_version":"1","materialization":"captured","payload":{"a":1e0,"b":[true,null],"large":123456789012345678901234567891}}`)
 	err = database.Transaction(ctx, func(tx sqlstore.DBTX) error {
-		_, addErr := repository.Add(ctx, tx, "scope-observation", largeIntegerConflict)
+		_, addErr := repository.AddAccepted(ctx, tx, "scope-observation", acceptedObservationSource(t, largeIntegerConflict))
 		return addErr
 	})
 	if _, ok := errors.AsType[*sqlstore.StoredPayloadConflictError](err); !ok {
@@ -545,7 +649,7 @@ func TestSourceRepositoryObservationUsesJSONSemanticIdempotence(t *testing.T) {
 	}
 	assertObservationRepositoryErrorRedacted(t, err, "worker.capture", "item", "fingerprint-secret")
 	err = database.Transaction(ctx, func(tx sqlstore.DBTX) error {
-		_, addErr := repository.Add(ctx, tx, "scope-observation", conflicting)
+		_, addErr := repository.AddAccepted(ctx, tx, "scope-observation", acceptedObservationSource(t, conflicting))
 		return addErr
 	})
 	if _, ok := errors.AsType[*sqlstore.StoredPayloadConflictError](err); !ok {
@@ -780,15 +884,49 @@ func contentSource(t *testing.T, id, content string, metadata map[string]any) so
 
 func observationSource(t *testing.T, sourceType, sourceID, payload string) source.SourceObservation {
 	t.Helper()
+	manifest := observationManifest(t, sourceType)
 	ref, err := source.NewRef(sourceType, sourceID)
 	if err != nil {
 		t.Fatal(err)
 	}
-	observation, err := source.NewSourceObservation(ref, "1", "fingerprint-secret", nil, jsontext.Value(payload), nil)
+	observation, err := source.NewSourceObservation(ref, manifest.Version(), manifest.Fingerprint(), nil, jsontext.Value(payload), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 	return observation
+}
+
+func acceptedObservationSource(t *testing.T, observation source.SourceObservation) *source.AdmittedObservation {
+	t.Helper()
+	accepted, err := source.AdmitObservation(observationManifest(t, observation.Ref().Type()), observation)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return accepted
+}
+
+func observationManifest(t *testing.T, name string) source.DefinitionManifest {
+	t.Helper()
+	identity, err := source.NewDefinitionIdentity(name, "1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest, err := source.NewDefinitionManifest(identity, jsontext.Value(`{"type":"object"}`), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return manifest
+}
+
+func registerObservationDefinition(t *testing.T, database *sqlstore.Database, observation source.SourceObservation) {
+	t.Helper()
+	manifest := observationManifest(t, observation.Ref().Type())
+	if transactionErr := database.Transaction(t.Context(), func(tx sqlstore.DBTX) error {
+		_, err := (sqlstore.DefinitionManifestRepository{}).Register(t.Context(), tx, manifest)
+		return err
+	}); transactionErr != nil {
+		t.Fatal(transactionErr)
+	}
 }
 
 func observationEnvelope(observation source.SourceObservation) ([]byte, error) {
@@ -808,5 +946,19 @@ func assertObservationRepositoryErrorRedacted(t *testing.T, err error, secrets .
 		if strings.Contains(err.Error(), secret) {
 			t.Fatalf("observation repository error exposed %q: %v", secret, err)
 		}
+	}
+}
+
+func assertAcceptedObservationRows(t *testing.T, database *sqlstore.Database, scopeID string, sources, acceptances int) {
+	t.Helper()
+	var sourceCount, acceptanceCount int
+	if err := database.SQLDB().QueryRowContext(t.Context(), `SELECT COUNT(*) FROM pc_sources WHERE scope_id = ?`, scopeID).Scan(&sourceCount); err != nil {
+		t.Fatal(err)
+	}
+	if err := database.SQLDB().QueryRowContext(t.Context(), `SELECT COUNT(*) FROM pc_source_observation_acceptances WHERE scope_id = ?`, scopeID).Scan(&acceptanceCount); err != nil {
+		t.Fatal(err)
+	}
+	if sourceCount != sources || acceptanceCount != acceptances {
+		t.Fatalf("acceptance rows = sources:%d markers:%d, want %d/%d", sourceCount, acceptanceCount, sources, acceptances)
 	}
 }

--- a/source/accepted_observation.go
+++ b/source/accepted_observation.go
@@ -1,0 +1,261 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package source
+
+import (
+	"bytes"
+	"encoding/json/jsontext"
+	json "encoding/json/v2"
+	"errors"
+
+	jsonschema "github.com/santhosh-tekuri/jsonschema/v6"
+)
+
+const (
+	admissionSchemaResourceURL = "https://powercontext.invalid/source-admission-schema"
+	draft202012SchemaURL       = "https://json-schema.org/draft/2020-12/schema"
+)
+
+// AdmittedObservation is a worker observation which has passed the
+// definition, schema, and projection checks at an owning runtime boundary.
+// It deliberately does not implement Value. A persistence adapter must
+// re-admit it against the Definition stored in its write transaction and write
+// a durable acceptance marker before it can become model evidence.
+type AdmittedObservation struct{ observation SourceObservation }
+
+// AdmitObservation validates a worker result against its exact immutable
+// Definition before making it eligible for durable evidence admission. The
+// returned value still requires a persistence adapter to verify the same
+// Definition inside the transaction that writes its acceptance marker.
+func AdmitObservation(manifest DefinitionManifest, observation SourceObservation) (*AdmittedObservation, error) {
+	compiled, err := compileAdmissionManifest(manifest)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateAdmissionObservation(manifest, compiled, observation); err != nil {
+		return nil, err
+	}
+	return &AdmittedObservation{observation: observation}, nil
+}
+
+// ValidateDefinitionManifestForAdmission verifies that a Definition can be
+// used to admit worker data under the supported JSON Schema dialect. Durable
+// registries use this before storing a remote Definition.
+func ValidateDefinitionManifestForAdmission(manifest DefinitionManifest) error {
+	_, err := compileAdmissionManifest(manifest)
+	return err
+}
+
+// Observation returns the immutable worker payload which was admitted.
+func (o *AdmittedObservation) Observation() SourceObservation {
+	if o == nil {
+		return SourceObservation{}
+	}
+	return o.observation
+}
+
+// Validate checks the wrapped raw observation. It does not repeat Definition
+// admission, which belongs to the current runtime boundary.
+func (o *AdmittedObservation) Validate() error {
+	if o == nil {
+		return observationError("admission", "must not be nil")
+	}
+	return o.observation.Validate()
+}
+
+type admissionManifest struct {
+	source      *jsonschema.Schema
+	projections map[ProjectionKey]*jsonschema.Schema
+}
+
+func compileAdmissionManifest(manifest DefinitionManifest) (admissionManifest, error) {
+	if err := manifest.Validate(); err != nil {
+		return admissionManifest{}, err
+	}
+	sourceSchema, err := compileAdmissionDraft202012(manifest.SourceSchema())
+	if err != nil {
+		return admissionManifest{}, manifestError("schema", "must use valid JSON Schema Draft 2020-12")
+	}
+	projections := make(map[ProjectionKey]*jsonschema.Schema, len(manifest.Projections()))
+	for _, projection := range manifest.Projections() {
+		if IsTextEvidenceProjection(projection.Key()) {
+			if err := ValidateTextEvidenceSchema(projection.Schema()); err != nil {
+				return admissionManifest{}, manifestError("projection", "must use the standard text-evidence schema")
+			}
+		}
+		compiled, compileErr := compileAdmissionDraft202012(projection.Schema())
+		if compileErr != nil {
+			return admissionManifest{}, manifestError("projection", "must use valid JSON Schema Draft 2020-12")
+		}
+		projections[projection.Key()] = compiled
+	}
+	return admissionManifest{source: sourceSchema, projections: projections}, nil
+}
+
+func validateAdmissionObservation(
+	manifest DefinitionManifest,
+	compiled admissionManifest,
+	observation SourceObservation,
+) error {
+	if err := observation.Validate(); err != nil {
+		return err
+	}
+	if observation.Ref().Type() != manifest.Name() || observation.DefinitionVersion() != manifest.Version() {
+		return observationError("definition", "does not match the registered manifest identity")
+	}
+	if observation.DefinitionFingerprint() != manifest.Fingerprint() {
+		return observationError("fingerprint", "does not match the registered manifest")
+	}
+	if err := validateAdmissionValue(compiled.source, observation.Payload()); err != nil {
+		return observationError("schema", "does not match the registered Source schema")
+	}
+	projections := observation.Projections()
+	if len(compiled.projections) != len(projections) {
+		return observationError("projections", "must exactly match the registered manifest")
+	}
+	for _, projection := range projections {
+		schema, found := compiled.projections[projection.Key()]
+		if !found {
+			return observationError("projections", "must exactly match the registered manifest")
+		}
+		if err := validateAdmissionValue(schema, projection.Value()); err != nil {
+			return observationError("projection", "does not match the registered schema")
+		}
+		if IsTextEvidenceProjection(projection.Key()) {
+			if err := ValidateTextEvidence(projection.Value(), observation.Ref()); err != nil {
+				return observationError("text-evidence", "does not match the observation envelope")
+			}
+		}
+	}
+	return nil
+}
+
+func compileAdmissionDraft202012(schema jsontext.Value) (*jsonschema.Schema, error) {
+	if err := requireAdmissionDraft202012(schema); err != nil {
+		return nil, err
+	}
+	document, err := jsonschema.UnmarshalJSON(bytes.NewReader(schema))
+	if err != nil {
+		return nil, err
+	}
+	compiler := jsonschema.NewCompiler()
+	compiler.DefaultDraft(jsonschema.Draft2020)
+	compiler.UseLoader(admissionSchemaLoader{})
+	if err := compiler.AddResource(admissionSchemaResourceURL, document); err != nil {
+		return nil, err
+	}
+	return compiler.Compile(admissionSchemaResourceURL)
+}
+
+func validateAdmissionValue(schema *jsonschema.Schema, value jsontext.Value) error {
+	instance, err := jsonschema.UnmarshalJSON(bytes.NewReader(value))
+	if err != nil {
+		return err
+	}
+	return schema.Validate(instance)
+}
+
+// requireAdmissionDraft202012 prevents a nested schema resource from changing
+// the Draft selected by the manifest admission contract. Annotation payloads
+// remain ordinary data and are not recursively treated as schemas.
+func requireAdmissionDraft202012(schema jsontext.Value) error {
+	var value any
+	if err := json.Unmarshal(schema, &value); err != nil {
+		return err
+	}
+	return requireAdmissionDraft202012Value(value, true)
+}
+
+func requireAdmissionDraft202012Value(value any, resourceRoot bool) error {
+	schema, ok := value.(map[string]any)
+	if !ok {
+		return nil
+	}
+	if resourceRoot {
+		if dialect, exists := schema["$schema"]; exists {
+			name, stringValue := dialect.(string)
+			if !stringValue || !isAdmissionDraft202012SchemaURL(name) {
+				return errors.New("JSON Schema must use Draft 2020-12")
+			}
+		}
+	}
+	for keyword, nested := range schema {
+		var err error
+		switch keyword {
+		case "not", "additionalProperties", "additionalItems", "propertyNames", "contains",
+			"if", "then", "else", "unevaluatedProperties", "unevaluatedItems", "contentSchema":
+			err = requireAdmissionDraft202012Subschema(nested)
+		case "definitions", "properties", "patternProperties", "dependencies", "$defs", "dependentSchemas":
+			err = requireAdmissionDraft202012SubschemaMap(nested)
+		case "allOf", "anyOf", "oneOf", "prefixItems":
+			err = requireAdmissionDraft202012SubschemaArray(nested)
+		case "items":
+			err = requireAdmissionDraft202012Subschema(nested)
+			if err == nil {
+				err = requireAdmissionDraft202012SubschemaArray(nested)
+			}
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func requireAdmissionDraft202012Subschema(value any) error {
+	schema, ok := value.(map[string]any)
+	return requireAdmissionDraft202012Value(value, ok && hasAdmissionSchemaResourceID(schema))
+}
+
+func requireAdmissionDraft202012SubschemaMap(value any) error {
+	entries, ok := value.(map[string]any)
+	if !ok {
+		return nil
+	}
+	for _, schema := range entries {
+		if err := requireAdmissionDraft202012Subschema(schema); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func requireAdmissionDraft202012SubschemaArray(value any) error {
+	entries, ok := value.([]any)
+	if !ok {
+		return nil
+	}
+	for _, schema := range entries {
+		if err := requireAdmissionDraft202012Subschema(schema); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func hasAdmissionSchemaResourceID(value map[string]any) bool {
+	id, ok := value["$id"].(string)
+	return ok && id != ""
+}
+
+func isAdmissionDraft202012SchemaURL(value string) bool {
+	return value == draft202012SchemaURL || value == "http://json-schema.org/draft/2020-12/schema"
+}
+
+type admissionSchemaLoader struct{}
+
+func (admissionSchemaLoader) Load(string) (any, error) {
+	return nil, errors.New("remote JSON Schema loading is disabled")
+}

--- a/source/accepted_observation_test.go
+++ b/source/accepted_observation_test.go
@@ -1,0 +1,239 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package source_test
+
+import (
+	"encoding/json/jsontext"
+	"errors"
+	"testing"
+
+	"github.com/ob-labs/powercontext-go/source"
+)
+
+func TestAdmittedObservationRetainsValidatedWorkerPayloadWithoutModelCapability(t *testing.T) {
+	manifest := acceptedObservationManifest(t, "remote.note")
+	ref, err := source.NewRef("remote.note", "item-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	projection, err := source.NewSourceProjectionValue(
+		source.TextEvidenceProjectionKey(),
+		jsontext.Value(`{"source_type":"remote.note","source_id":"item-1","content":"admitted","metadata":{"stable":true}}`),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := source.NewSourceObservation(
+		ref, manifest.Version(), manifest.Fingerprint(), nil,
+		jsontext.Value(`{"name":"item-1","definition_version":"1","materialization":"captured","priority":1}`),
+		[]source.SourceProjectionValue{projection},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	admitted, err := source.AdmitObservation(manifest, raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := admitted.Observation(); got.Ref() != raw.Ref() || string(got.Payload()) != string(raw.Payload()) {
+		t.Fatalf("Observation() = %#v, want equivalent worker payload", got)
+	}
+	if _, isValue := any(admitted).(source.Value); isValue {
+		t.Fatal("admitted worker value implements source.Value")
+	}
+}
+
+func TestAdmitObservationRejectsForgedDefinitionAndWorkerValues(t *testing.T) {
+	manifest := acceptedObservationManifest(t, "remote.note")
+	valid := acceptedObservationValue(t, manifest, "item-1", `{"name":"item-1","definition_version":"1","materialization":"captured","priority":1}`,
+		`{"source_type":"remote.note","source_id":"item-1","content":"admitted"}`)
+
+	for _, test := range []struct {
+		name        string
+		manifest    source.DefinitionManifest
+		observation source.SourceObservation
+	}{
+		{
+			name:        "wrong fingerprint",
+			manifest:    manifest,
+			observation: acceptedObservationValue(t, manifest, "item-1", `{"name":"item-1","definition_version":"1","materialization":"captured","priority":1}`, `{"source_type":"remote.note","source_id":"item-1","content":"admitted"}`, "wrong"),
+		},
+		{
+			name:        "payload schema",
+			manifest:    manifest,
+			observation: acceptedObservationValue(t, manifest, "item-1", `{"name":"item-1","definition_version":"1","materialization":"captured","priority":"wrong"}`, `{"source_type":"remote.note","source_id":"item-1","content":"admitted"}`),
+		},
+		{
+			name:        "text evidence identity",
+			manifest:    manifest,
+			observation: acceptedObservationValue(t, manifest, "item-1", `{"name":"item-1","definition_version":"1","materialization":"captured","priority":1}`, `{"source_type":"remote.note","source_id":"other","content":"admitted"}`),
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if _, err := source.AdmitObservation(test.manifest, test.observation); err == nil {
+				t.Fatal("forged observation was admitted")
+			} else if _, ok := errors.AsType[*source.InvalidSourceObservationError](err); !ok {
+				t.Fatalf("AdmitObservation() error = %T %v", err, err)
+			}
+		})
+	}
+
+	if _, err := source.AdmitObservation(manifest, valid); err != nil {
+		t.Fatalf("AdmitObservation(valid) = %v", err)
+	}
+	ref, err := source.NewRef(manifest.Name(), "item-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	withoutProjection, err := source.NewSourceObservation(ref, manifest.Version(), manifest.Fingerprint(), nil,
+		jsontext.Value(`{"name":"item-1","definition_version":"1","materialization":"captured","priority":1}`), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, admissionErr := source.AdmitObservation(manifest, withoutProjection); admissionErr == nil {
+		t.Fatal("observation missing a declared projection was admitted")
+	}
+	wrongVersion, err := source.NewSourceObservation(ref, "2", manifest.Fingerprint(), nil,
+		jsontext.Value(`{"name":"item-1","definition_version":"2","materialization":"captured","priority":1}`), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, admissionErr := source.AdmitObservation(manifest, wrongVersion); admissionErr == nil {
+		t.Fatal("observation with a mismatched definition version was admitted")
+	}
+	undeclaredKey, err := source.NewProjectionKey("remote.undeclared", "1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	undeclaredProjection, err := source.NewSourceProjectionValue(undeclaredKey, jsontext.Value(`true`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	undeclaredProjectionObservation, err := source.NewSourceObservation(ref, manifest.Version(), manifest.Fingerprint(), nil,
+		jsontext.Value(`{"name":"item-1","definition_version":"1","materialization":"captured","priority":1}`),
+		[]source.SourceProjectionValue{undeclaredProjection})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, admissionErr := source.AdmitObservation(manifest, undeclaredProjectionObservation); admissionErr == nil {
+		t.Fatal("observation with an undeclared projection was admitted")
+	}
+
+	projectionKey, err := source.NewProjectionKey("remote.priority", "1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	customProjection, err := source.NewProjectionManifest(projectionKey, jsontext.Value(`{"type":"integer"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifestWithCustom, err := source.NewDefinitionManifest(manifest.Identity(), manifest.SourceSchema(), append(manifest.Projections(), customProjection))
+	if err != nil {
+		t.Fatal(err)
+	}
+	textProjection, err := source.NewSourceProjectionValue(source.TextEvidenceProjectionKey(), jsontext.Value(`{"source_type":"remote.note","source_id":"item-1","content":"admitted"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	wrongProjection, err := source.NewSourceProjectionValue(projectionKey, jsontext.Value(`"wrong"`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	projectionSchemaMismatch, err := source.NewSourceObservation(ref, manifestWithCustom.Version(), manifestWithCustom.Fingerprint(), nil,
+		jsontext.Value(`{"name":"item-1","definition_version":"1","materialization":"captured","priority":1}`),
+		[]source.SourceProjectionValue{textProjection, wrongProjection})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := source.AdmitObservation(manifestWithCustom, projectionSchemaMismatch); err == nil {
+		t.Fatal("observation with a schema-invalid projection was admitted")
+	}
+}
+
+func TestAdmitObservationRejectsNonstandardTextEvidenceManifest(t *testing.T) {
+	identity, err := source.NewDefinitionIdentity("remote.text", "1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	projection, err := source.NewProjectionManifest(source.TextEvidenceProjectionKey(), jsontext.Value(`{"type":"object"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest, err := source.NewDefinitionManifest(identity, jsontext.Value(`{"type":"object"}`), []source.ProjectionManifest{projection})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ref, err := source.NewRef(manifest.Name(), "item-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	value, err := source.NewSourceProjectionValue(source.TextEvidenceProjectionKey(), jsontext.Value(`{"source_type":"remote.text","source_id":"item-1","content":"admitted"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	observation, err := source.NewSourceObservation(ref, manifest.Version(), manifest.Fingerprint(), nil,
+		jsontext.Value(`{"name":"item-1","definition_version":"1","materialization":"captured"}`), []source.SourceProjectionValue{value})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := source.AdmitObservation(manifest, observation); err == nil {
+		t.Fatal("nonstandard text-evidence manifest admitted an observation")
+	} else if _, ok := errors.AsType[*source.InvalidDefinitionManifestError](err); !ok {
+		t.Fatalf("AdmitObservation() error = %T %v", err, err)
+	}
+}
+
+func acceptedObservationManifest(t *testing.T, name string) source.DefinitionManifest {
+	t.Helper()
+	identity, err := source.NewDefinitionIdentity(name, "1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	projection, err := source.NewProjectionManifest(source.TextEvidenceProjectionKey(), source.TextEvidenceSchema())
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest, err := source.NewDefinitionManifest(identity, jsontext.Value(`{"type":"object","properties":{"name":{"type":"string"},"definition_version":{"type":"string"},"materialization":{"const":"captured"},"priority":{"type":"integer"}},"required":["name","definition_version","materialization","priority"]}`), []source.ProjectionManifest{projection})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return manifest
+}
+
+func acceptedObservationValue(
+	t *testing.T,
+	manifest source.DefinitionManifest,
+	id, payload, evidence string,
+	fingerprint ...string,
+) source.SourceObservation {
+	t.Helper()
+	ref, err := source.NewRef(manifest.Name(), id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	projection, err := source.NewSourceProjectionValue(source.TextEvidenceProjectionKey(), jsontext.Value(evidence))
+	if err != nil {
+		t.Fatal(err)
+	}
+	valueFingerprint := manifest.Fingerprint()
+	if len(fingerprint) != 0 {
+		valueFingerprint = fingerprint[0]
+	}
+	observation, err := source.NewSourceObservation(ref, manifest.Version(), valueFingerprint, nil, jsontext.Value(payload), []source.SourceProjectionValue{projection})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return observation
+}

--- a/source/content.go
+++ b/source/content.go
@@ -70,6 +70,7 @@ func (s ContentSource) SourceDescription() (string, bool) {
 	}
 	return *s.description, true
 }
+
 func (s ContentSource) Content() string { return s.content }
 func (s ContentSource) Metadata() map[string]any {
 	value, _ := cloneJSONObject(s.metadata)

--- a/source/ingestion_errors.go
+++ b/source/ingestion_errors.go
@@ -35,3 +35,12 @@ type ObservationConflictError struct{}
 func (*ObservationConflictError) Error() string {
 	return "Source observation already stores a different payload"
 }
+
+// UnacceptedObservationError reports a worker payload which has not passed
+// durable runtime admission. It deliberately contains no Source identity or
+// worker content because callers may surface it at public evidence boundaries.
+type UnacceptedObservationError struct{}
+
+func (*UnacceptedObservationError) Error() string {
+	return "Source observation has not been accepted as evidence"
+}

--- a/source/text_evidence.go
+++ b/source/text_evidence.go
@@ -32,6 +32,59 @@ type InvalidTextEvidenceError struct {
 	Detail string
 }
 
+// TextEvidence is the stable standard projection consumed by textual evidence
+// projectors. It owns immutable copies of the declared source identity and
+// metadata without coercing worker JSON numbers.
+type TextEvidence struct {
+	ref      Ref
+	content  string
+	metadata jsontext.Value
+}
+
+// ParseTextEvidence validates and freezes one standard projection value.
+func ParseTextEvidence(value jsontext.Value, ref Ref) (TextEvidence, error) {
+	if err := ValidateTextEvidence(value, ref); err != nil {
+		return TextEvidence{}, err
+	}
+	var fields map[string]jsontext.Value
+	if err := json.Unmarshal(value, &fields); err != nil {
+		return TextEvidence{}, textEvidenceError("value", "must be valid JSON")
+	}
+	content, _ := textEvidenceString(fields["content"])
+	metadata := jsontext.Value(`{}`)
+	if value, exists := fields["metadata"]; exists {
+		metadata = value.Clone()
+	}
+	return TextEvidence{ref: ref, content: content, metadata: metadata}, nil
+}
+
+func (e TextEvidence) SourceRef() Ref           { return e.ref }
+func (e TextEvidence) Content() string          { return e.content }
+func (e TextEvidence) Metadata() jsontext.Value { return e.metadata.Clone() }
+
+// MarshalJSON emits the Python-compatible standard projection shape.
+func (e TextEvidence) MarshalJSON() ([]byte, error) {
+	if _, err := NewRef(e.ref.Type(), e.ref.ID()); err != nil {
+		return nil, textEvidenceError("source", "must have a valid observation identity")
+	}
+	if !e.metadata.IsValid() || e.metadata.Kind() != '{' {
+		return nil, textEvidenceError("metadata", "must be a JSON object")
+	}
+	payload, err := json.Marshal(struct {
+		SourceType string         `json:"source_type"`
+		SourceID   string         `json:"source_id"`
+		Content    string         `json:"content"`
+		Metadata   jsontext.Value `json:"metadata"`
+	}{e.ref.Type(), e.ref.ID(), e.content, e.metadata})
+	if err != nil {
+		return nil, err
+	}
+	if err := ValidateTextEvidence(jsontext.Value(payload), e.ref); err != nil {
+		return nil, err
+	}
+	return payload, nil
+}
+
 func (e *InvalidTextEvidenceError) Error() string {
 	return "invalid Source text evidence " + e.Field + ": " + e.Detail
 }


### PR DESCRIPTION
Part of #202 Phase 2. Adds durable AcceptedObservation provenance: schema admission yields a non-evidence staging value; only a same-transaction persisted Definition, Source and acceptance marker mint model evidence. Memory/Handoff/Experience/Generation consume the closed durable capability, legacy raw observations remain audit-only. No OpenAPI/host/connector changes.