### PR TITLE
feat(source): add connector lifecycle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -489,3 +489,21 @@ source / artifact / trigger / inference
   candidate pipeline, and that accepted observations project only their
   standard text evidence while raw observations return a typed refusal in
   generation evidence paths.
+- When a Connector lifecycle decides whether to CAS a checkpoint, name the
+  equality result explicitly and advance only when values differ. Verify
+  equivalent JSON, stored JSON null versus an absent checkpoint, a large
+  integer change, rejected or failed outcomes, cancellation, and a real stale
+  CAS conflict so no accepted Source is lost or checkpoint is advanced early.
+  Apply native Definition ownership checks to every accepted submission path
+  before persistence. When a public Connector session permits concurrent calls,
+  reserve each item under synchronization, perform external sink I/O outside
+  that lock, and snapshot outcomes by reservation order. Verify a shadowed
+  Definition writes no Source, marker, journal, or checkpoint and concurrent
+  duplicate submissions write once without a race or lock-held I/O deadlock.
+  Finalize a session and drain every claimed submission before evaluating
+  outcomes or a checkpoint; verify a Connector that returns while a submission
+  is blocked cannot write a checkpoint until that submission has settled.
+  After an external Connector returns without an error, make an in-flight
+  cancellation dominate any no-op or successful completion before producing a
+  result or saving a checkpoint; verify a connector that ignores cancellation
+  cannot report success or advance state.

--- a/internal/runtime/connector_lifecycle.go
+++ b/internal/runtime/connector_lifecycle.go
@@ -1,0 +1,201 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtime
+
+import (
+	"context"
+	"errors"
+
+	"github.com/ob-labs/powercontext-go/source"
+)
+
+// AcceptedObservationSubmitter is the narrow durable Source path a Connector
+// session consumes. It only accepts observations already validated against the
+// Connector's declared Definition.
+type AcceptedObservationSubmitter interface {
+	SubmitAccepted(context.Context, string, *source.AdmittedObservation) (SourceReceipt, error)
+}
+
+// ConnectorCheckpointStore owns short, optimistic durable checkpoint writes.
+// Load preserves the distinction between an absent row and JSON null.
+type ConnectorCheckpointStore interface {
+	Load(context.Context, source.ConnectorBinding) (source.ConnectorCheckpoint, error)
+	Save(context.Context, source.ConnectorBinding, source.ConnectorCheckpoint, source.ConnectorCheckpoint) error
+}
+
+// ConnectorLifecycleApplication runs external Connectors without holding a
+// database transaction or a per-Scope Runtime lock across provider work. Each
+// item submit independently takes the RemoteIngestion scoped durable path.
+type ConnectorLifecycleApplication struct {
+	runtime     *Runtime
+	ingestion   AcceptedObservationSubmitter
+	checkpoints ConnectorCheckpointStore
+}
+
+func NewConnectorLifecycleApplication(
+	runtime *Runtime,
+	ingestion AcceptedObservationSubmitter,
+	checkpoints ConnectorCheckpointStore,
+) (*ConnectorLifecycleApplication, error) {
+	if runtime == nil || ingestion == nil || checkpoints == nil {
+		return nil, errors.New("runtime: Connector lifecycle dependencies must not be nil")
+	}
+	return &ConnectorLifecycleApplication{
+		runtime: runtime, ingestion: ingestion, checkpoints: checkpoints,
+	}, nil
+}
+
+// Run executes provider work outside SQL and scope-lock ownership. Accepted
+// Source writes happen before their accepted item outcomes, and a checkpoint
+// advances only after a complete run with no rejected or failed item.
+func (a *ConnectorLifecycleApplication) Run(
+	ctx context.Context,
+	connector source.Connector,
+	binding source.ConnectorBinding,
+) (result source.ConnectorRunResult, err error) {
+	err = a.runtime.Operation(ctx, func(ctx context.Context) error {
+		definitions, validationErr := source.ValidateConnector(connector, binding)
+		if validationErr != nil {
+			return validationErr
+		}
+		previous, loadErr := a.checkpoints.Load(ctx, binding)
+		if loadErr != nil {
+			return loadErr
+		}
+		session, sessionErr := source.NewConnectorRunSession(
+			binding, previous, definitions, connectorIngestionSink{ingestion: a.ingestion},
+		)
+		if sessionErr != nil {
+			return sessionErr
+		}
+		completion, runErr := connector.Run(ctx, session)
+		drainErr := session.Finalize(ctx)
+		if runErr != nil {
+			return runErr
+		}
+		if drainErr != nil {
+			return drainErr
+		}
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
+		if submissionErr := session.Failure(); submissionErr != nil {
+			return submissionErr
+		}
+		if completionErr := completion.Validate(); completionErr != nil {
+			return completionErr
+		}
+
+		proposed, checkpointErr := source.NewConnectorCheckpoint(completion.Checkpoint())
+		if checkpointErr != nil {
+			return checkpointErr
+		}
+		items := session.Outcomes()
+		unsafe := false
+		for _, item := range items {
+			if item.Status() == source.ConnectorSubmissionRejected || item.Status() == source.ConnectorSubmissionFailed {
+				unsafe = true
+				break
+			}
+		}
+		status := completion.Status()
+		committed := previous
+		if unsafe {
+			status = source.ConnectorRunIncomplete
+		} else if status == source.ConnectorRunComplete {
+			equal, compareErr := source.EqualConnectorCheckpoints(previous, proposed)
+			if compareErr != nil {
+				return compareErr
+			}
+			if !equal {
+				if saveErr := a.checkpoints.Save(ctx, binding, proposed, previous); saveErr != nil {
+					return saveErr
+				}
+				committed = proposed
+			}
+		}
+		built, resultErr := source.NewConnectorRunResult(binding, status, previous, proposed, committed, items)
+		if resultErr != nil {
+			return resultErr
+		}
+		result = built
+		return nil
+	})
+	return result, err
+}
+
+// connectorIngestionSink is the only bridge from Connector code to Runtime.
+// It turns well-formed but inadmissible worker observations into visible
+// rejections while preserving cancellation and infrastructure errors.
+type connectorIngestionSink struct{ ingestion AcceptedObservationSubmitter }
+
+func (s connectorIngestionSink) Submit(
+	ctx context.Context,
+	binding source.ConnectorBinding,
+	_ string,
+	definitionName string,
+	observation *source.AdmittedObservation,
+) (source.Ref, error) {
+	if err := binding.Validate(); err != nil {
+		return source.Ref{}, err
+	}
+	if validationErr := observation.Validate(); validationErr != nil {
+		return source.Ref{}, validationErr
+	}
+	if observation.Observation().Ref().Type() != definitionName {
+		return source.Ref{}, &source.InvalidConnectorRunError{
+			Field: "source_ref", Detail: "must match the declared Source Definition",
+		}
+	}
+	receipt, err := s.ingestion.SubmitAccepted(ctx, binding.ScopeID(), observation)
+	if err != nil {
+		if isConnectorSubmissionRejection(err) {
+			rejection, rejectionErr := source.NewConnectorSubmissionRejectedError("durable Source acceptance rejected")
+			if rejectionErr != nil {
+				return source.Ref{}, rejectionErr
+			}
+			return source.Ref{}, rejection
+		}
+		return source.Ref{}, err
+	}
+	if receipt.Ref != observation.Observation().Ref() {
+		return source.Ref{}, &source.InvalidConnectorRunError{
+			Field: "source_ref", Detail: "durable acceptance returned a different Source reference",
+		}
+	}
+	return receipt.Ref, nil
+}
+
+func isConnectorSubmissionRejection(err error) bool {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+	if _, ok := errors.AsType[*source.InvalidSourceObservationError](err); ok {
+		return true
+	}
+	if _, ok := errors.AsType[*source.DefinitionNotFoundError](err); ok {
+		return true
+	}
+	if _, ok := errors.AsType[*source.DefinitionConflictError](err); ok {
+		return true
+	}
+	if _, ok := errors.AsType[*source.ObservationConflictError](err); ok {
+		return true
+	}
+	if _, ok := errors.AsType[*source.UnacceptedObservationError](err); ok {
+		return true
+	}
+	return false
+}

--- a/internal/runtime/connector_lifecycle_test.go
+++ b/internal/runtime/connector_lifecycle_test.go
@@ -1,0 +1,481 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtime
+
+import (
+	"context"
+	"encoding/json/jsontext"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/ob-labs/powercontext-go/source"
+)
+
+func TestConnectorLifecycleCommitsOnlyAfterDurableAcceptedSource(t *testing.T) {
+	binding := lifecycleBinding(t)
+	accepted := lifecycleAcceptedObservation(t, "remote.note", "item-1")
+	previous, err := source.NewConnectorCheckpoint(jsontext.Value(`{"offset":1}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	store := &lifecycleCheckpointStore{value: previous}
+	ingestion := &lifecycleIngestion{receipt: SourceReceipt{Ref: accepted.Observation().Ref(), Sequence: 4}}
+	application, err := NewConnectorLifecycleApplication(New(), ingestion, store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	connector := lifecycleConnector{
+		name: "connector", version: "v1", definitions: []string{"remote.note"},
+		run: func(ctx context.Context, session *source.ConnectorRunSession) (source.ConnectorRunCompletion, error) {
+			if _, submitErr := session.Submit(ctx, "provider-item", "remote.note", accepted); submitErr != nil {
+				return source.ConnectorRunCompletion{}, submitErr
+			}
+			return source.NewConnectorRunCompletion(source.ConnectorRunComplete, jsontext.Value(`{"offset":2}`))
+		},
+	}
+	result, err := application.Run(t.Context(), connector, binding)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ingestion.calls != 1 || store.saves != 1 {
+		t.Fatalf("ingestion calls=%d checkpoint saves=%d", ingestion.calls, store.saves)
+	}
+	if len(store.events) != 2 || store.events[0] != "load" || store.events[1] != "save" {
+		t.Fatalf("checkpoint events = %#v", store.events)
+	}
+	if result.Status() != source.ConnectorRunComplete || len(result.Items()) != 1 || result.Items()[0].Status() != source.ConnectorSubmissionAccepted {
+		t.Fatalf("result = %#v", result)
+	}
+	committed, found := result.CommittedCheckpoint().Value()
+	if !found || string(committed) != `{"offset":2}` {
+		t.Fatalf("committed checkpoint = %q, found=%t", committed, found)
+	}
+}
+
+func TestConnectorLifecycleNeverAdvancesUnsafeOrUnchangedCheckpoint(t *testing.T) {
+	binding := lifecycleBinding(t)
+	accepted := lifecycleAcceptedObservation(t, "remote.note", "item-1")
+	previous, err := source.NewConnectorCheckpoint(jsontext.Value(`{"offset":9007199254740993,"tag":"same"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	rejection, err := source.NewConnectorSubmissionRejectedError("provider rejected item")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, test := range []struct {
+		name       string
+		completion source.ConnectorRunStatus
+		checkpoint jsontext.Value
+		run        func(context.Context, *source.ConnectorRunSession) error
+		wantStatus source.ConnectorRunStatus
+		wantSaves  int
+	}{
+		{
+			name: "value equivalent checkpoint", completion: source.ConnectorRunComplete,
+			checkpoint: jsontext.Value(`{"tag":"same","offset":9007199254740993.0}`), wantStatus: source.ConnectorRunComplete,
+		},
+		{
+			name: "incomplete run", completion: source.ConnectorRunIncomplete,
+			checkpoint: jsontext.Value(`{"offset":2}`), wantStatus: source.ConnectorRunIncomplete,
+		},
+		{
+			name: "provider rejection", completion: source.ConnectorRunComplete,
+			checkpoint: jsontext.Value(`{"offset":2}`), wantStatus: source.ConnectorRunIncomplete,
+			run: func(_ context.Context, session *source.ConnectorRunSession) error {
+				_, runErr := session.Reject("provider-item", "remote.note", "provider rejected item")
+				return runErr
+			},
+		},
+		{
+			name: "provider failure", completion: source.ConnectorRunComplete,
+			checkpoint: jsontext.Value(`{"offset":2}`), wantStatus: source.ConnectorRunIncomplete,
+			run: func(_ context.Context, session *source.ConnectorRunSession) error {
+				_, runErr := session.Fail("provider-item", "remote.note", "provider unavailable")
+				return runErr
+			},
+		},
+		{
+			name: "typed durable rejection", completion: source.ConnectorRunComplete,
+			checkpoint: jsontext.Value(`{"offset":2}`), wantStatus: source.ConnectorRunIncomplete,
+			run: func(ctx context.Context, session *source.ConnectorRunSession) error {
+				_, runErr := session.Submit(ctx, "provider-item", "remote.note", accepted)
+				return runErr
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			store := &lifecycleCheckpointStore{value: previous}
+			ingestion := &lifecycleIngestion{receipt: SourceReceipt{Ref: accepted.Observation().Ref(), Sequence: 1}}
+			if test.name == "typed durable rejection" {
+				ingestion.err = rejection
+			}
+			application, newErr := NewConnectorLifecycleApplication(New(), ingestion, store)
+			if newErr != nil {
+				t.Fatal(newErr)
+			}
+			connector := lifecycleConnector{
+				name: "connector", version: "v1", definitions: []string{"remote.note"},
+				run: func(ctx context.Context, session *source.ConnectorRunSession) (source.ConnectorRunCompletion, error) {
+					if test.run != nil {
+						if runErr := test.run(ctx, session); runErr != nil {
+							return source.ConnectorRunCompletion{}, runErr
+						}
+					}
+					return source.NewConnectorRunCompletion(test.completion, test.checkpoint)
+				},
+			}
+			result, runErr := application.Run(t.Context(), connector, binding)
+			if runErr != nil {
+				t.Fatal(runErr)
+			}
+			if result.Status() != test.wantStatus || store.saves != test.wantSaves {
+				t.Fatalf("status=%q saves=%d", result.Status(), store.saves)
+			}
+			committed, found := result.CommittedCheckpoint().Value()
+			before, beforeFound := previous.Value()
+			if !found || !beforeFound || string(committed) != string(before) {
+				t.Fatalf("unsafe result committed=%q found=%t, want previous=%q", committed, found, before)
+			}
+		})
+	}
+}
+
+func TestConnectorLifecyclePreservesSourceWhenCheckpointConflictsOrRunFails(t *testing.T) {
+	binding := lifecycleBinding(t)
+	accepted := lifecycleAcceptedObservation(t, "remote.note", "item-1")
+	previous := source.NoConnectorCheckpoint()
+	for _, test := range []struct {
+		name     string
+		storeErr error
+		runErr   error
+		wantErr  error
+	}{
+		{name: "checkpoint conflict", storeErr: errors.New("checkpoint conflict")},
+		{name: "canceled provider", runErr: context.Canceled, wantErr: context.Canceled},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			store := &lifecycleCheckpointStore{value: previous, saveErr: test.storeErr}
+			ingestion := &lifecycleIngestion{receipt: SourceReceipt{Ref: accepted.Observation().Ref(), Sequence: 3}}
+			application, err := NewConnectorLifecycleApplication(New(), ingestion, store)
+			if err != nil {
+				t.Fatal(err)
+			}
+			connector := lifecycleConnector{
+				name: "connector", version: "v1", definitions: []string{"remote.note"},
+				run: func(ctx context.Context, session *source.ConnectorRunSession) (source.ConnectorRunCompletion, error) {
+					if _, submitErr := session.Submit(ctx, "provider-item", "remote.note", accepted); submitErr != nil {
+						return source.ConnectorRunCompletion{}, submitErr
+					}
+					if test.runErr != nil {
+						return source.ConnectorRunCompletion{}, test.runErr
+					}
+					return source.NewConnectorRunCompletion(source.ConnectorRunComplete, jsontext.Value(`{"offset":1}`))
+				},
+			}
+			_, runErr := application.Run(t.Context(), connector, binding)
+			if runErr == nil {
+				t.Fatal("unsafe lifecycle error was swallowed")
+			}
+			if test.wantErr != nil && !errors.Is(runErr, test.wantErr) {
+				t.Fatalf("Run() error = %T %v, want %v", runErr, runErr, test.wantErr)
+			}
+			if ingestion.calls != 1 {
+				t.Fatalf("durable source was not submitted before lifecycle failure: %d", ingestion.calls)
+			}
+			if test.storeErr != nil && store.saves != 1 {
+				t.Fatalf("checkpoint save attempts = %d", store.saves)
+			}
+			if test.runErr != nil && store.saves != 0 {
+				t.Fatalf("checkpoint save attempts after provider failure = %d", store.saves)
+			}
+		})
+	}
+}
+
+func TestConnectorLifecycleRejectsWrongDurableSourceReference(t *testing.T) {
+	binding := lifecycleBinding(t)
+	accepted := lifecycleAcceptedObservation(t, "remote.note", "item-1")
+	wrongRef, err := source.NewRef("remote.note", "other")
+	if err != nil {
+		t.Fatal(err)
+	}
+	store := &lifecycleCheckpointStore{value: source.NoConnectorCheckpoint()}
+	ingestion := &lifecycleIngestion{receipt: SourceReceipt{Ref: wrongRef, Sequence: 1}}
+	application, err := NewConnectorLifecycleApplication(New(), ingestion, store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	connector := lifecycleConnector{
+		name: "connector", version: "v1", definitions: []string{"remote.note"},
+		run: func(ctx context.Context, session *source.ConnectorRunSession) (source.ConnectorRunCompletion, error) {
+			if _, submitErr := session.Submit(ctx, "provider-item", "remote.note", accepted); submitErr != nil {
+				return source.ConnectorRunCompletion{}, submitErr
+			}
+			return source.NewConnectorRunCompletion(source.ConnectorRunComplete, jsontext.Value("null"))
+		},
+	}
+	_, err = application.Run(t.Context(), connector, binding)
+	if _, ok := errors.AsType[*source.InvalidConnectorRunError](err); !ok {
+		t.Fatalf("wrong Source reference error = %T %v", err, err)
+	}
+	if store.saves != 0 {
+		t.Fatalf("checkpoint advanced after wrong Source reference: %d", store.saves)
+	}
+}
+
+func TestConnectorLifecycleDoesNotAdvanceWhenConnectorSwallowsGenericSubmissionError(t *testing.T) {
+	binding := lifecycleBinding(t)
+	accepted := lifecycleAcceptedObservation(t, "remote.note", "item-1")
+	submissionErr := errors.New("durable database unavailable")
+	store := &lifecycleCheckpointStore{value: source.NoConnectorCheckpoint()}
+	ingestion := &lifecycleIngestion{err: submissionErr}
+	application, err := NewConnectorLifecycleApplication(New(), ingestion, store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	connector := lifecycleConnector{
+		name: "connector", version: "v1", definitions: []string{"remote.note"},
+		run: func(ctx context.Context, session *source.ConnectorRunSession) (source.ConnectorRunCompletion, error) {
+			_, _ = session.Submit(ctx, "provider-item", "remote.note", accepted)
+			return source.NewConnectorRunCompletion(source.ConnectorRunComplete, jsontext.Value(`{"offset":1}`))
+		},
+	}
+	_, err = application.Run(t.Context(), connector, binding)
+	if !errors.Is(err, submissionErr) {
+		t.Fatalf("Run() error = %T %v, want submission error", err, err)
+	}
+	if store.saves != 0 {
+		t.Fatalf("checkpoint advanced after swallowed generic submission error: %d", store.saves)
+	}
+}
+
+func TestConnectorLifecycleCancellationAfterIgnoredRunStopsSuccessfulResult(t *testing.T) {
+	binding := lifecycleBinding(t)
+	previous, err := source.NewConnectorCheckpoint(jsontext.Value(`{"offset":1}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	store := &lifecycleCheckpointStore{value: previous}
+	application, err := NewConnectorLifecycleApplication(New(), &lifecycleIngestion{}, store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	connector := lifecycleConnector{
+		name: "connector", version: "v1", definitions: []string{"remote.note"},
+		run: func(_ context.Context, _ *source.ConnectorRunSession) (source.ConnectorRunCompletion, error) {
+			cancel()
+			return source.NewConnectorRunCompletion(source.ConnectorRunComplete, jsontext.Value(`{"offset":1}`))
+		},
+	}
+
+	result, runErr := application.Run(ctx, connector, binding)
+	if !errors.Is(runErr, context.Canceled) {
+		t.Fatalf("Run() error = %T %v, want context cancellation", runErr, runErr)
+	}
+	if result.Status() == source.ConnectorRunComplete {
+		t.Fatalf("Run() returned successful result after cancellation: %#v", result)
+	}
+	if store.saves != 0 {
+		t.Fatalf("checkpoint save attempts after ignored cancellation = %d", store.saves)
+	}
+}
+
+func TestConnectorLifecycleCancellationWhileDrainingDoesNotAdvanceCheckpoint(t *testing.T) {
+	binding := lifecycleBinding(t)
+	accepted := lifecycleAcceptedObservation(t, "remote.note", "item-1")
+	store := &lifecycleCheckpointStore{value: source.NoConnectorCheckpoint()}
+	entered := make(chan struct{})
+	drainIngestion := &lifecycleDrainIngestion{
+		receipt: SourceReceipt{Ref: accepted.Observation().Ref(), Sequence: 1},
+		entered: entered,
+	}
+	application, err := NewConnectorLifecycleApplication(New(), drainIngestion, store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	submitted := make(chan error, 1)
+	connectorReturned := make(chan struct{})
+	connector := lifecycleConnector{
+		name: "connector", version: "v1", definitions: []string{"remote.note"},
+		run: func(runContext context.Context, session *source.ConnectorRunSession) (source.ConnectorRunCompletion, error) {
+			go func() {
+				_, submitErr := session.Submit(runContext, "provider-item", "remote.note", accepted)
+				submitted <- submitErr
+			}()
+			<-entered
+			close(connectorReturned)
+			return source.NewConnectorRunCompletion(source.ConnectorRunComplete, jsontext.Value(`{"offset":1}`))
+		},
+	}
+	finished := make(chan error, 1)
+	go func() {
+		_, runErr := application.Run(ctx, connector, binding)
+		finished <- runErr
+	}()
+	<-connectorReturned
+	cancel()
+	if runErr := <-finished; !errors.Is(runErr, context.Canceled) {
+		t.Fatalf("Run() error = %T %v, want context cancellation", runErr, runErr)
+	}
+	if submitErr := <-submitted; !errors.Is(submitErr, context.Canceled) {
+		t.Fatalf("in-flight Submit() error = %T %v, want context cancellation", submitErr, submitErr)
+	}
+	if store.saves != 0 {
+		t.Fatalf("checkpoint save attempts after cancellation while draining = %d", store.saves)
+	}
+}
+
+func TestConnectorLifecyclePreservesConnectorErrorAfterCancellation(t *testing.T) {
+	binding := lifecycleBinding(t)
+	store := &lifecycleCheckpointStore{value: source.NoConnectorCheckpoint()}
+	application, err := NewConnectorLifecycleApplication(New(), &lifecycleIngestion{}, store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	providerErr := errors.New("provider failed")
+	connector := lifecycleConnector{
+		name: "connector", version: "v1", definitions: []string{"remote.note"},
+		run: func(_ context.Context, _ *source.ConnectorRunSession) (source.ConnectorRunCompletion, error) {
+			cancel()
+			return source.ConnectorRunCompletion{}, providerErr
+		},
+	}
+
+	_, runErr := application.Run(ctx, connector, binding)
+	if !errors.Is(runErr, providerErr) {
+		t.Fatalf("Run() error = %T %v, want provider error", runErr, runErr)
+	}
+	if errors.Is(runErr, context.Canceled) {
+		t.Fatalf("Run() replaced connector error with cancellation: %v", runErr)
+	}
+	if store.saves != 0 {
+		t.Fatalf("checkpoint save attempts after connector error = %d", store.saves)
+	}
+}
+
+type lifecycleCheckpointStore struct {
+	value   source.ConnectorCheckpoint
+	events  []string
+	saves   int
+	saveErr error
+}
+
+func (s *lifecycleCheckpointStore) Load(_ context.Context, _ source.ConnectorBinding) (source.ConnectorCheckpoint, error) {
+	s.events = append(s.events, "load")
+	return s.value, nil
+}
+
+func (s *lifecycleCheckpointStore) Save(
+	_ context.Context,
+	_ source.ConnectorBinding,
+	next, _ source.ConnectorCheckpoint,
+) error {
+	s.events = append(s.events, "save")
+	s.saves++
+	if s.saveErr != nil {
+		return s.saveErr
+	}
+	s.value = next
+	return nil
+}
+
+type lifecycleIngestion struct {
+	receipt SourceReceipt
+	err     error
+	calls   int
+}
+
+func (i *lifecycleIngestion) SubmitAccepted(
+	_ context.Context,
+	_ string,
+	_ *source.AdmittedObservation,
+) (SourceReceipt, error) {
+	i.calls++
+	return i.receipt, i.err
+}
+
+type lifecycleDrainIngestion struct {
+	receipt SourceReceipt
+	entered chan<- struct{}
+	once    sync.Once
+}
+
+func (i *lifecycleDrainIngestion) SubmitAccepted(
+	ctx context.Context,
+	_ string,
+	_ *source.AdmittedObservation,
+) (SourceReceipt, error) {
+	i.once.Do(func() { close(i.entered) })
+	<-ctx.Done()
+	return i.receipt, ctx.Err()
+}
+
+type lifecycleConnector struct {
+	name        string
+	version     string
+	definitions []string
+	run         func(context.Context, *source.ConnectorRunSession) (source.ConnectorRunCompletion, error)
+}
+
+func (c lifecycleConnector) Name() string                { return c.name }
+func (c lifecycleConnector) Version() string             { return c.version }
+func (c lifecycleConnector) SourceDefinitions() []string { return c.definitions }
+func (c lifecycleConnector) Run(ctx context.Context, session *source.ConnectorRunSession) (source.ConnectorRunCompletion, error) {
+	return c.run(ctx, session)
+}
+
+func lifecycleBinding(t *testing.T) source.ConnectorBinding {
+	t.Helper()
+	binding, err := source.NewConnectorBinding("scope", "binding", "connector", "v1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return binding
+}
+
+func lifecycleAcceptedObservation(t *testing.T, definition, identifier string) *source.AdmittedObservation {
+	t.Helper()
+	identity, err := source.NewDefinitionIdentity(definition, "1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest, err := source.NewDefinitionManifest(identity, jsontext.Value(`{"type":"object","required":["name","definition_version","materialization"],"properties":{"name":{"type":"string"},"definition_version":{"type":"string"},"materialization":{"const":"captured"}}}`), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ref, err := source.NewRef(definition, identifier)
+	if err != nil {
+		t.Fatal(err)
+	}
+	observation, err := source.NewSourceObservation(ref, "1", manifest.Fingerprint(), nil,
+		jsontext.Value(`{"name":"`+identifier+`","definition_version":"1","materialization":"captured"}`), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	accepted, err := source.AdmitObservation(manifest, observation)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return accepted
+}

--- a/internal/runtime/remote_ingestion.go
+++ b/internal/runtime/remote_ingestion.go
@@ -112,6 +112,49 @@ func (a *RemoteIngestionApplication) Submit(
 	return result, err
 }
 
+// SubmitAccepted persists an observation already admitted by the Connector
+// boundary. The persistence adapter repeats durable Definition admission in
+// its own short transaction before writing the evidence marker. This method
+// checks durable Definition existence and native ownership, but does not
+// repeat schema admission while a Connector is running; that happens in the
+// persistence transaction before the immutable AdmittedObservation is stored.
+func (a *RemoteIngestionApplication) SubmitAccepted(
+	ctx context.Context,
+	scopeID string,
+	accepted *source.AdmittedObservation,
+) (result SourceReceipt, err error) {
+	err = a.runtime.ScopedWrite(ctx, scopeID, func(ctx context.Context, scope string) error {
+		if validationErr := accepted.Validate(); validationErr != nil {
+			return validationErr
+		}
+		if envelopeErr := validateRemoteObservationEnvelope(accepted.Observation()); envelopeErr != nil {
+			return envelopeErr
+		}
+		observation := accepted.Observation()
+		identity, identityErr := source.NewDefinitionIdentity(observation.Ref().Type(), observation.DefinitionVersion())
+		if identityErr != nil {
+			return sourceObservationError("definition", "must identify a valid Source Definition")
+		}
+		_, found, findErr := a.backend.Find(ctx, identity)
+		if findErr != nil {
+			return findErr
+		}
+		if !found {
+			return &source.DefinitionNotFoundError{}
+		}
+		if a.backend.HasNativeDefinition(observation.Ref().Type()) {
+			return &source.DefinitionConflictError{}
+		}
+		ref, sequence, addErr := a.backend.Add(ctx, scope, accepted)
+		if addErr != nil {
+			return addErr
+		}
+		result = SourceReceipt{Ref: ref, Sequence: sequence}
+		return nil
+	})
+	return result, err
+}
+
 func validateRemoteDefinition(manifest source.DefinitionManifest, backend RemoteIngestionBackend) error {
 	if err := manifest.Validate(); err != nil {
 		return err

--- a/internal/runtime/remote_ingestion_test.go
+++ b/internal/runtime/remote_ingestion_test.go
@@ -252,6 +252,74 @@ func TestRemoteIngestionApplicationValidatesObservationBeforeStore(t *testing.T)
 	}
 }
 
+func TestRemoteIngestionApplicationSubmitAcceptedUsesDurableDefinitionBeforeAdd(t *testing.T) {
+	manifest := remoteManifest(t, "remote.connector", remoteObservationSchema, nil)
+	observation := remoteObservation(t, manifest,
+		`{"name":"item-1","definition_version":"1","materialization":"captured","large":1}`,
+		"", false,
+	)
+	accepted, err := source.AdmitObservation(manifest, observation)
+	if err != nil {
+		t.Fatal(err)
+	}
+	backend := newRemoteIngestionBackend()
+	backend.manifests[manifest.Identity()] = manifest
+	application, err := NewRemoteIngestionApplication(New(), backend)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := application.SubmitAccepted(t.Context(), "scope-connector", accepted)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if receipt.Ref != observation.Ref() || receipt.Sequence != 1 || backend.added != 1 || backend.finds != 1 {
+		t.Fatalf("SubmitAccepted() = %#v after added=%d finds=%d", receipt, backend.added, backend.finds)
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	_, err = application.SubmitAccepted(ctx, "scope-connector", accepted)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("canceled SubmitAccepted() = %T %v", err, err)
+	}
+	if backend.added != 1 {
+		t.Fatalf("canceled SubmitAccepted() reached storage %d times", backend.added)
+	}
+}
+
+func TestRemoteIngestionApplicationSubmitAcceptedRejectsPersistedManifestShadowedByNativeDefinition(t *testing.T) {
+	manifest := remoteManifest(t, source.ContentType, remoteObservationSchema, nil)
+	observation := remoteObservation(t, manifest,
+		`{"name":"item-1","definition_version":"1","materialization":"captured","large":1}`,
+		"", false,
+	)
+	accepted, err := source.AdmitObservation(manifest, observation)
+	if err != nil {
+		t.Fatal(err)
+	}
+	backend := newRemoteIngestionBackend()
+	// Model a remote manifest persisted before a local codec acquired this name.
+	backend.manifests[manifest.Identity()] = manifest
+	backend.native[source.ContentType] = true
+	application, err := NewRemoteIngestionApplication(New(), backend)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = application.SubmitAccepted(t.Context(), "scope-connector", accepted)
+	if _, ok := errors.AsType[*source.DefinitionConflictError](err); !ok {
+		t.Fatalf("SubmitAccepted() error = %T %v", err, err)
+	}
+	if backend.finds != 1 || backend.added != 0 {
+		t.Fatalf("SubmitAccepted() performed %d manifest reads and %d Source writes", backend.finds, backend.added)
+	}
+	for _, secret := range []string{source.ContentType, "item-1", manifest.Fingerprint()} {
+		if strings.Contains(err.Error(), secret) {
+			t.Fatalf("SubmitAccepted() error exposed %q: %v", secret, err)
+		}
+	}
+}
+
 func TestRemoteIngestionApplicationRejectsPersistedManifestShadowedByNativeDefinition(t *testing.T) {
 	manifest := remoteManifest(t, source.ContentType, remoteObservationSchema, []source.ProjectionManifest{
 		remoteProjection(t, source.TextEvidenceProjectionKey(), source.TextEvidenceSchema()),

--- a/internal/sqlstore/remote_ingestion_test.go
+++ b/internal/sqlstore/remote_ingestion_test.go
@@ -131,6 +131,48 @@ func TestRuntimeRemoteIngestionBackendRequiresPersistedManifestForAcceptedMarker
 	assertAcceptedObservationRows(t, database, "scope-unregistered", 0, 0)
 }
 
+func TestRuntimeRemoteIngestionApplicationSubmitAcceptedRejectsNativeDefinitionBeforeSQLiteWrite(t *testing.T) {
+	database := openTestDatabase(t)
+	repository, err := sqlstore.NewSourceRepository(sqlstore.SQLiteDialect, sqlstore.ContentSourceCodec())
+	if err != nil {
+		t.Fatal(err)
+	}
+	backend, err := sqlstore.NewRuntimeRemoteIngestionBackend(database, sqlstore.DefinitionManifestRepository{}, repository)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Model an old remote registration that predated the active content codec.
+	manifest := remoteStoredManifest(t, source.ContentType, jsontext.Value(`{"type":"object"}`))
+	if _, registerErr := backend.Register(t.Context(), manifest); registerErr != nil {
+		t.Fatal(registerErr)
+	}
+	accepted := acceptedStoredObservation(t, manifest, remoteStoredObservation(t, manifest,
+		`{"name":"item-1","definition_version":"1","materialization":"captured"}`))
+	application, err := pcruntime.NewRemoteIngestionApplication(pcruntime.New(), backend)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = application.SubmitAccepted(t.Context(), "scope-shadowed-native", accepted)
+	if _, ok := errors.AsType[*source.DefinitionConflictError](err); !ok {
+		t.Fatalf("SubmitAccepted() error = %T %v", err, err)
+	}
+	assertRemoteIngestionErrorRedacted(t, err, source.ContentType, "item-1", manifest.Fingerprint())
+	assertAcceptedObservationRows(t, database, "scope-shadowed-native", 0, 0)
+	if transactionErr := database.Transaction(t.Context(), func(tx sqlstore.DBTX) error {
+		position, positionErr := repository.JournalPosition(t.Context(), tx, "scope-shadowed-native")
+		if positionErr != nil {
+			return positionErr
+		}
+		if position != 0 {
+			t.Fatalf("shadowed SubmitAccepted() journal position = %d, want 0", position)
+		}
+		return nil
+	}); transactionErr != nil {
+		t.Fatal(transactionErr)
+	}
+}
+
 func TestRemoteIngestionApplicationUsesSQLiteAdapterAfterValidation(t *testing.T) {
 	database := openTestDatabase(t)
 	repository, err := sqlstore.NewSourceRepository(sqlstore.SQLiteDialect, sqlstore.ContentSourceCodec())

--- a/internal/sqlstore/runtime_connector_checkpoints.go
+++ b/internal/sqlstore/runtime_connector_checkpoints.go
@@ -1,0 +1,97 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sqlstore
+
+import (
+	"context"
+	"encoding/json/jsontext"
+	"errors"
+
+	"github.com/ob-labs/powercontext-go/source"
+)
+
+// RuntimeConnectorCheckpointStore is the transaction-owning SQLite adapter
+// for Runtime connector lifecycle orchestration. It intentionally relies on
+// method-set compatibility instead of importing internal/runtime.
+type RuntimeConnectorCheckpointStore struct {
+	database   *Database
+	repository ConnectorCheckpointRepository
+}
+
+// NewRuntimeConnectorCheckpointStore constructs short transaction ownership
+// around the immutable checkpoint repository.
+func NewRuntimeConnectorCheckpointStore(
+	database *Database,
+	repository ConnectorCheckpointRepository,
+) (*RuntimeConnectorCheckpointStore, error) {
+	if database == nil {
+		return nil, errors.New("sqlstore: Runtime Connector checkpoint database must not be nil")
+	}
+	return &RuntimeConnectorCheckpointStore{database: database, repository: repository}, nil
+}
+
+// Load preserves absence separately from a JSON null row.
+func (s *RuntimeConnectorCheckpointStore) Load(
+	ctx context.Context,
+	binding source.ConnectorBinding,
+) (result source.ConnectorCheckpoint, err error) {
+	if bindingErr := binding.Validate(); bindingErr != nil {
+		return source.NoConnectorCheckpoint(), bindingErr
+	}
+	result = source.NoConnectorCheckpoint()
+	err = s.database.Transaction(ctx, func(tx DBTX) error {
+		value, found, loadErr := s.repository.Load(ctx, tx, binding)
+		if loadErr != nil {
+			return loadErr
+		}
+		if !found {
+			return nil
+		}
+		checkpoint, checkpointErr := source.NewConnectorCheckpoint(jsontext.Value(value))
+		if checkpointErr != nil {
+			return checkpointErr
+		}
+		result = checkpoint
+		return nil
+	})
+	return result, err
+}
+
+// Save delegates the final optimistic raw-row comparison to
+// ConnectorCheckpointRepository, whose value-based JSON CAS preserves large
+// integers. The lifecycle compares values before opening this short write.
+func (s *RuntimeConnectorCheckpointStore) Save(
+	ctx context.Context,
+	binding source.ConnectorBinding,
+	next, expected source.ConnectorCheckpoint,
+) error {
+	if bindingErr := binding.Validate(); bindingErr != nil {
+		return bindingErr
+	}
+	if nextErr := next.Validate(); nextErr != nil {
+		return nextErr
+	}
+	if !next.Found() {
+		return &InvalidRepositoryArgumentError{Field: "checkpoint", Detail: "must contain a JSON value"}
+	}
+	if expectedErr := expected.Validate(); expectedErr != nil {
+		return expectedErr
+	}
+	nextValue, _ := next.Value()
+	expectedValue, expectedFound := expected.Value()
+	return s.database.Transaction(ctx, func(tx DBTX) error {
+		return s.repository.Save(ctx, tx, binding, nextValue, expectedValue, expectedFound)
+	})
+}

--- a/internal/sqlstore/runtime_connector_checkpoints_test.go
+++ b/internal/sqlstore/runtime_connector_checkpoints_test.go
@@ -1,0 +1,594 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sqlstore_test
+
+import (
+	"context"
+	"encoding/json/jsontext"
+	"errors"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	pcruntime "github.com/ob-labs/powercontext-go/internal/runtime"
+	"github.com/ob-labs/powercontext-go/internal/sqlstore"
+	"github.com/ob-labs/powercontext-go/source"
+)
+
+func TestRuntimeConnectorCheckpointStoreDistinguishesAbsentNullAndTwoDatabaseCAS(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "connector-lifecycle.db")
+	firstDatabase := openCheckpointDatabase(t, path)
+	secondDatabase := openCheckpointDatabase(t, path)
+	first, err := sqlstore.NewRuntimeConnectorCheckpointStore(firstDatabase, sqlstore.ConnectorCheckpointRepository{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := sqlstore.NewRuntimeConnectorCheckpointStore(secondDatabase, sqlstore.ConnectorCheckpointRepository{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	binding := checkpointBinding(t, "runtime-store")
+	missing, err := first.Load(t.Context(), binding)
+	if err != nil || missing.Found() {
+		t.Fatalf("missing checkpoint = %#v, %v", missing, err)
+	}
+	nullCheckpoint, err := source.NewConnectorCheckpoint(jsontext.Value("null"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if saveErr := first.Save(t.Context(), binding, nullCheckpoint, missing); saveErr != nil {
+		t.Fatal(saveErr)
+	}
+	loaded, err := first.Load(t.Context(), binding)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if value, found := loaded.Value(); !found || string(value) != "null" {
+		t.Fatalf("stored null = %q, found=%t", value, found)
+	}
+
+	stale, err := second.Load(t.Context(), binding)
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstNext, err := source.NewConnectorCheckpoint(jsontext.Value(`{"offset":9007199254740993}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if saveErr := first.Save(t.Context(), binding, firstNext, loaded); saveErr != nil {
+		t.Fatal(saveErr)
+	}
+	secondNext, err := source.NewConnectorCheckpoint(jsontext.Value(`{"offset":9007199254740994}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = second.Save(t.Context(), binding, secondNext, stale)
+	if _, ok := errors.AsType[*sqlstore.CheckpointConflictError](err); !ok {
+		t.Fatalf("stale two-database save error = %T %v", err, err)
+	}
+	final, err := first.Load(t.Context(), binding)
+	if err != nil {
+		t.Fatal(err)
+	}
+	value, found := final.Value()
+	if !found || string(value) != `{"offset":9007199254740993}` {
+		t.Fatalf("final checkpoint = %q, found=%t", value, found)
+	}
+}
+
+func TestConnectorLifecycleSQLiteCommitsSourceBeforeCheckpointAndRetriesIdempotently(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "connector-source-before-checkpoint.db")
+	database := openCheckpointDatabase(t, path)
+	secondDatabase := openCheckpointDatabase(t, path)
+	sources, err := sqlstore.NewSourceRepository(sqlstore.SQLiteDialect)
+	if err != nil {
+		t.Fatal(err)
+	}
+	backend, err := sqlstore.NewRuntimeRemoteIngestionBackend(database, sqlstore.DefinitionManifestRepository{}, sources)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runtime := pcruntime.New()
+	ingestion, err := pcruntime.NewRemoteIngestionApplication(runtime, backend)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := sqlstore.NewRuntimeConnectorCheckpointStore(database, sqlstore.ConnectorCheckpointRepository{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondStore, err := sqlstore.NewRuntimeConnectorCheckpointStore(secondDatabase, sqlstore.ConnectorCheckpointRepository{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	lifecycle, err := pcruntime.NewConnectorLifecycleApplication(runtime, ingestion, store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest := lifecycleStoredManifest(t, "remote.connector")
+	if _, registerErr := ingestion.Register(t.Context(), manifest); registerErr != nil {
+		t.Fatal(registerErr)
+	}
+	accepted := lifecycleStoredObservation(t, manifest, "item-1", "one")
+	binding, err := source.NewConnectorBinding("scope-connector", "binding-connector", "connector", "v1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	connector := sqliteLifecycleConnector{
+		name: "connector", version: "v1", definitions: []string{manifest.Name()},
+		run: func(ctx context.Context, session *source.ConnectorRunSession) (source.ConnectorRunCompletion, error) {
+			if _, submitErr := session.Submit(ctx, "provider-item", manifest.Name(), accepted); submitErr != nil {
+				return source.ConnectorRunCompletion{}, submitErr
+			}
+			return source.NewConnectorRunCompletion(source.ConnectorRunComplete, jsontext.Value(`{"offset":1}`))
+		},
+	}
+	if _, triggerErr := database.SQLDB().ExecContext(t.Context(), `CREATE TRIGGER fail_connector_checkpoint
+        BEFORE INSERT ON pc_connector_checkpoints BEGIN SELECT RAISE(ABORT, 'checkpoint write blocked'); END`); triggerErr != nil {
+		t.Fatal(triggerErr)
+	}
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+	if _, runErr := lifecycle.Run(ctx, connector, binding); runErr == nil {
+		t.Fatal("checkpoint trigger failure was swallowed")
+	}
+	assertConnectorStoredSources(t, database, binding.ScopeID(), 1, 1)
+	assertConnectorCheckpointRows(t, database, binding, 0)
+	if _, dropErr := database.SQLDB().ExecContext(t.Context(), "DROP TRIGGER fail_connector_checkpoint"); dropErr != nil {
+		t.Fatal(dropErr)
+	}
+
+	result, err := lifecycle.Run(t.Context(), connector, binding)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Status() != source.ConnectorRunComplete || len(result.Items()) != 1 || result.Items()[0].Status() != source.ConnectorSubmissionAccepted {
+		t.Fatalf("retry result = %#v", result)
+	}
+	assertConnectorStoredSources(t, database, binding.ScopeID(), 1, 1)
+	assertConnectorCheckpointRows(t, database, binding, 1)
+	checkpoint, err := store.Load(t.Context(), binding)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if value, found := checkpoint.Value(); !found || string(value) != `{"offset":1}` {
+		t.Fatalf("retry checkpoint = %q, found=%t", value, found)
+	}
+
+	conflictSource := lifecycleStoredObservation(t, manifest, "item-2", "two")
+	competingCheckpoint, err := source.NewConnectorCheckpoint(jsontext.Value(`{"offset":3}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	conflictingStore := sqliteCheckpointConflictStore{
+		primary: store, competing: secondStore, next: competingCheckpoint,
+	}
+	conflictLifecycle, err := pcruntime.NewConnectorLifecycleApplication(runtime, ingestion, &conflictingStore)
+	if err != nil {
+		t.Fatal(err)
+	}
+	casConflictConnector := sqliteLifecycleConnector{
+		name: "connector", version: "v1", definitions: []string{manifest.Name()},
+		run: func(ctx context.Context, session *source.ConnectorRunSession) (source.ConnectorRunCompletion, error) {
+			if _, submitErr := session.Submit(ctx, "provider-cas-conflict", manifest.Name(), conflictSource); submitErr != nil {
+				return source.ConnectorRunCompletion{}, submitErr
+			}
+			return source.NewConnectorRunCompletion(source.ConnectorRunComplete, jsontext.Value(`{"offset":2}`))
+		},
+	}
+	_, err = conflictLifecycle.Run(t.Context(), casConflictConnector, binding)
+	if _, ok := errors.AsType[*sqlstore.CheckpointConflictError](err); !ok {
+		t.Fatalf("lifecycle CAS conflict = %T %v", err, err)
+	}
+	assertConnectorStoredSources(t, database, binding.ScopeID(), 2, 2)
+	checkpoint, err = store.Load(t.Context(), binding)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if value, found := checkpoint.Value(); !found || string(value) != `{"offset":3}` {
+		t.Fatalf("CAS conflict checkpoint = %q, found=%t", value, found)
+	}
+
+	conflicting := lifecycleStoredObservation(t, manifest, "item-1", "different")
+	conflictConnector := sqliteLifecycleConnector{
+		name: "connector", version: "v1", definitions: []string{manifest.Name()},
+		run: func(ctx context.Context, session *source.ConnectorRunSession) (source.ConnectorRunCompletion, error) {
+			if _, submitErr := session.Submit(ctx, "provider-conflict", manifest.Name(), conflicting); submitErr != nil {
+				return source.ConnectorRunCompletion{}, submitErr
+			}
+			return source.NewConnectorRunCompletion(source.ConnectorRunComplete, jsontext.Value(`{"offset":2}`))
+		},
+	}
+	conflictResult, err := lifecycle.Run(t.Context(), conflictConnector, binding)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if conflictResult.Status() != source.ConnectorRunIncomplete || len(conflictResult.Items()) != 1 || conflictResult.Items()[0].Status() != source.ConnectorSubmissionRejected {
+		t.Fatalf("conflict result = %#v", conflictResult)
+	}
+	checkpoint, err = store.Load(t.Context(), binding)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if value, found := checkpoint.Value(); !found || string(value) != `{"offset":3}` {
+		t.Fatalf("rejected item advanced checkpoint to %q, found=%t", value, found)
+	}
+}
+
+func TestConnectorLifecycleSQLiteDrainsInFlightSubmitBeforeCheckpoint(t *testing.T) {
+	genericSubmissionError := errors.New("durable source write failed")
+	for _, test := range []struct {
+		name              string
+		submissionError   error
+		wantRunError      error
+		wantStatus        source.ConnectorRunStatus
+		wantSources       int
+		wantCheckpointRow int
+	}{
+		{
+			name:              "accepted source settles before checkpoint",
+			wantStatus:        source.ConnectorRunComplete,
+			wantSources:       1,
+			wantCheckpointRow: 1,
+		},
+		{
+			name:              "typed rejection after drain leaves checkpoint absent",
+			submissionError:   &source.ObservationConflictError{},
+			wantStatus:        source.ConnectorRunIncomplete,
+			wantSources:       0,
+			wantCheckpointRow: 0,
+		},
+		{
+			name:              "generic failure after drain leaves checkpoint absent",
+			submissionError:   genericSubmissionError,
+			wantRunError:      genericSubmissionError,
+			wantSources:       0,
+			wantCheckpointRow: 0,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			database := openCheckpointDatabase(t, filepath.Join(t.TempDir(), "connector-drain.db"))
+			sources, err := sqlstore.NewSourceRepository(sqlstore.SQLiteDialect)
+			if err != nil {
+				t.Fatal(err)
+			}
+			backend, err := sqlstore.NewRuntimeRemoteIngestionBackend(database, sqlstore.DefinitionManifestRepository{}, sources)
+			if err != nil {
+				t.Fatal(err)
+			}
+			runtime := pcruntime.New()
+			ingestion, err := pcruntime.NewRemoteIngestionApplication(runtime, backend)
+			if err != nil {
+				t.Fatal(err)
+			}
+			manifest := lifecycleStoredManifest(t, "remote.connector.drain")
+			if _, registerErr := ingestion.Register(t.Context(), manifest); registerErr != nil {
+				t.Fatal(registerErr)
+			}
+			store, err := sqlstore.NewRuntimeConnectorCheckpointStore(database, sqlstore.ConnectorCheckpointRepository{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			entered := make(chan struct{})
+			release := make(chan struct{})
+			releaseSubmit := sync.OnceFunc(func() { close(release) })
+			t.Cleanup(releaseSubmit)
+			gatedIngestion := &checkpointDrainIngestion{
+				delegate: ingestion, entered: entered, release: release, err: test.submissionError,
+			}
+			observedStore := &checkpointDrainStore{delegate: store, saveStarted: make(chan struct{})}
+			lifecycle, err := pcruntime.NewConnectorLifecycleApplication(runtime, gatedIngestion, observedStore)
+			if err != nil {
+				t.Fatal(err)
+			}
+			binding, err := source.NewConnectorBinding("scope-connector-drain", "binding-connector-drain", "connector", "v1")
+			if err != nil {
+				t.Fatal(err)
+			}
+			accepted := lifecycleStoredObservation(t, manifest, "item-1", "one")
+			submitted := make(chan error, 1)
+			connectorReturned := make(chan struct{})
+			connector := sqliteLifecycleConnector{
+				name: "connector", version: "v1", definitions: []string{manifest.Name()},
+				run: func(ctx context.Context, session *source.ConnectorRunSession) (source.ConnectorRunCompletion, error) {
+					go func() {
+						_, submitErr := session.Submit(ctx, "provider-item", manifest.Name(), accepted)
+						submitted <- submitErr
+					}()
+					<-entered
+					close(connectorReturned)
+					return source.NewConnectorRunCompletion(source.ConnectorRunComplete, jsontext.Value(`{"offset":1}`))
+				},
+			}
+			type lifecycleResult struct {
+				result source.ConnectorRunResult
+				err    error
+			}
+			finished := make(chan lifecycleResult, 1)
+			go func() {
+				result, runErr := lifecycle.Run(t.Context(), connector, binding)
+				finished <- lifecycleResult{result: result, err: runErr}
+			}()
+			<-connectorReturned
+
+			select {
+			case completed := <-finished:
+				t.Fatalf("lifecycle completed before blocked Submit settled: result=%#v err=%v", completed.result, completed.err)
+			case <-time.After(100 * time.Millisecond):
+			}
+			assertConnectorCheckpointRows(t, database, binding, 0)
+			select {
+			case <-observedStore.saveStarted:
+				t.Fatal("checkpoint Save began before blocked Submit settled")
+			default:
+			}
+
+			releaseSubmit()
+			completed := <-finished
+			submitErr := <-submitted
+			if test.wantRunError != nil {
+				if !errors.Is(completed.err, test.wantRunError) {
+					t.Fatalf("Run() error = %T %v, want %v", completed.err, completed.err, test.wantRunError)
+				}
+				if !errors.Is(submitErr, test.wantRunError) {
+					t.Fatalf("Submit() error = %T %v, want %v", submitErr, submitErr, test.wantRunError)
+				}
+			} else {
+				if completed.err != nil {
+					t.Fatal(completed.err)
+				}
+				if submitErr != nil {
+					t.Fatal(submitErr)
+				}
+				if completed.result.Status() != test.wantStatus {
+					t.Fatalf("status = %q, want %q", completed.result.Status(), test.wantStatus)
+				}
+			}
+			assertConnectorStoredSources(t, database, binding.ScopeID(), test.wantSources, test.wantSources)
+			assertConnectorCheckpointRows(t, database, binding, test.wantCheckpointRow)
+			if test.wantCheckpointRow == 1 {
+				select {
+				case <-observedStore.saveStarted:
+				default:
+					t.Fatal("accepted Source settlement did not lead to checkpoint Save")
+				}
+			} else {
+				select {
+				case <-observedStore.saveStarted:
+					t.Fatal("unsafe settled Submit began checkpoint Save")
+				default:
+				}
+			}
+		})
+	}
+}
+
+func TestConnectorLifecycleSQLiteRejectsShadowedNativeDefinitionWithoutAdvancingCheckpoint(t *testing.T) {
+	database := openCheckpointDatabase(t, filepath.Join(t.TempDir(), "connector-shadowed-native.db"))
+	sources, err := sqlstore.NewSourceRepository(sqlstore.SQLiteDialect, sqlstore.ContentSourceCodec())
+	if err != nil {
+		t.Fatal(err)
+	}
+	backend, err := sqlstore.NewRuntimeRemoteIngestionBackend(database, sqlstore.DefinitionManifestRepository{}, sources)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Persist directly to model a remote Definition that predates the native codec.
+	manifest := lifecycleStoredManifest(t, source.ContentType)
+	if _, registerErr := backend.Register(t.Context(), manifest); registerErr != nil {
+		t.Fatal(registerErr)
+	}
+	ingestion, err := pcruntime.NewRemoteIngestionApplication(pcruntime.New(), backend)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := sqlstore.NewRuntimeConnectorCheckpointStore(database, sqlstore.ConnectorCheckpointRepository{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	lifecycle, err := pcruntime.NewConnectorLifecycleApplication(pcruntime.New(), ingestion, store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	binding, err := source.NewConnectorBinding("scope-shadowed-native", "binding-shadowed-native", "connector", "v1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	accepted := lifecycleStoredObservation(t, manifest, "item-1", "value")
+	connector := sqliteLifecycleConnector{
+		name: "connector", version: "v1", definitions: []string{source.ContentType},
+		run: func(ctx context.Context, session *source.ConnectorRunSession) (source.ConnectorRunCompletion, error) {
+			if _, submitErr := session.Submit(ctx, "provider-item", source.ContentType, accepted); submitErr != nil {
+				return source.ConnectorRunCompletion{}, submitErr
+			}
+			return source.NewConnectorRunCompletion(source.ConnectorRunComplete, jsontext.Value(`{"offset":1}`))
+		},
+	}
+
+	result, err := lifecycle.Run(t.Context(), connector, binding)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Status() != source.ConnectorRunIncomplete || len(result.Items()) != 1 || result.Items()[0].Status() != source.ConnectorSubmissionRejected {
+		t.Fatalf("shadowed native lifecycle result = %#v", result)
+	}
+	assertConnectorStoredSources(t, database, binding.ScopeID(), 0, 0)
+	assertConnectorCheckpointRows(t, database, binding, 0)
+	if transactionErr := database.Transaction(t.Context(), func(tx sqlstore.DBTX) error {
+		position, positionErr := sources.JournalPosition(t.Context(), tx, binding.ScopeID())
+		if positionErr != nil {
+			return positionErr
+		}
+		if position != 0 {
+			t.Fatalf("shadowed lifecycle journal position = %d, want 0", position)
+		}
+		return nil
+	}); transactionErr != nil {
+		t.Fatal(transactionErr)
+	}
+}
+
+type sqliteCheckpointConflictStore struct {
+	primary   *sqlstore.RuntimeConnectorCheckpointStore
+	competing *sqlstore.RuntimeConnectorCheckpointStore
+	next      source.ConnectorCheckpoint
+}
+
+func (s *sqliteCheckpointConflictStore) Load(
+	ctx context.Context,
+	binding source.ConnectorBinding,
+) (source.ConnectorCheckpoint, error) {
+	return s.primary.Load(ctx, binding)
+}
+
+func (s *sqliteCheckpointConflictStore) Save(
+	ctx context.Context,
+	binding source.ConnectorBinding,
+	next, expected source.ConnectorCheckpoint,
+) error {
+	if err := s.competing.Save(ctx, binding, s.next, expected); err != nil {
+		return err
+	}
+	return s.primary.Save(ctx, binding, next, expected)
+}
+
+type checkpointDrainIngestion struct {
+	delegate *pcruntime.RemoteIngestionApplication
+	entered  chan<- struct{}
+	release  <-chan struct{}
+	err      error
+	once     sync.Once
+}
+
+func (s *checkpointDrainIngestion) SubmitAccepted(
+	ctx context.Context,
+	scopeID string,
+	accepted *source.AdmittedObservation,
+) (pcruntime.SourceReceipt, error) {
+	s.once.Do(func() { close(s.entered) })
+	select {
+	case <-s.release:
+	case <-ctx.Done():
+		return pcruntime.SourceReceipt{}, ctx.Err()
+	}
+	if s.err != nil {
+		return pcruntime.SourceReceipt{}, s.err
+	}
+	return s.delegate.SubmitAccepted(ctx, scopeID, accepted)
+}
+
+type checkpointDrainStore struct {
+	delegate    *sqlstore.RuntimeConnectorCheckpointStore
+	saveStarted chan struct{}
+	once        sync.Once
+}
+
+func (s *checkpointDrainStore) Load(
+	ctx context.Context,
+	binding source.ConnectorBinding,
+) (source.ConnectorCheckpoint, error) {
+	return s.delegate.Load(ctx, binding)
+}
+
+func (s *checkpointDrainStore) Save(
+	ctx context.Context,
+	binding source.ConnectorBinding,
+	next, expected source.ConnectorCheckpoint,
+) error {
+	s.once.Do(func() { close(s.saveStarted) })
+	return s.delegate.Save(ctx, binding, next, expected)
+}
+
+type sqliteLifecycleConnector struct {
+	name        string
+	version     string
+	definitions []string
+	run         func(context.Context, *source.ConnectorRunSession) (source.ConnectorRunCompletion, error)
+}
+
+func (c sqliteLifecycleConnector) Name() string                { return c.name }
+func (c sqliteLifecycleConnector) Version() string             { return c.version }
+func (c sqliteLifecycleConnector) SourceDefinitions() []string { return c.definitions }
+func (c sqliteLifecycleConnector) Run(ctx context.Context, session *source.ConnectorRunSession) (source.ConnectorRunCompletion, error) {
+	return c.run(ctx, session)
+}
+
+func lifecycleStoredManifest(t *testing.T, name string) source.DefinitionManifest {
+	t.Helper()
+	identity, err := source.NewDefinitionIdentity(name, "1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest, err := source.NewDefinitionManifest(identity, jsontext.Value(`{"type":"object","required":["name","definition_version","materialization","value"],"properties":{"name":{"type":"string"},"definition_version":{"type":"string"},"materialization":{"const":"captured"},"value":{"type":"string"}}}`), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return manifest
+}
+
+func lifecycleStoredObservation(
+	t *testing.T,
+	manifest source.DefinitionManifest,
+	identifier, value string,
+) *source.AdmittedObservation {
+	t.Helper()
+	ref, err := source.NewRef(manifest.Name(), identifier)
+	if err != nil {
+		t.Fatal(err)
+	}
+	observation, err := source.NewSourceObservation(ref, manifest.Version(), manifest.Fingerprint(), nil,
+		jsontext.Value(`{"name":"`+identifier+`","definition_version":"1","materialization":"captured","value":"`+value+`"}`), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	accepted, err := source.AdmitObservation(manifest, observation)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return accepted
+}
+
+func assertConnectorStoredSources(t *testing.T, database *sqlstore.Database, scopeID string, sources, acceptances int) {
+	t.Helper()
+	var sourceCount, acceptanceCount, highestPosition int
+	if err := database.SQLDB().QueryRowContext(t.Context(), "SELECT count(*) FROM pc_sources WHERE scope_id = ?", scopeID).Scan(&sourceCount); err != nil {
+		t.Fatal(err)
+	}
+	if err := database.SQLDB().QueryRowContext(t.Context(), "SELECT count(*) FROM pc_source_observation_acceptances WHERE scope_id = ?", scopeID).Scan(&acceptanceCount); err != nil {
+		t.Fatal(err)
+	}
+	if err := database.SQLDB().QueryRowContext(t.Context(), "SELECT COALESCE(MAX(journal_position), 0) FROM pc_sources WHERE scope_id = ?", scopeID).Scan(&highestPosition); err != nil {
+		t.Fatal(err)
+	}
+	if sourceCount != sources || acceptanceCount != acceptances {
+		t.Fatalf("stored sources=%d accepted=%d, want sources=%d accepted=%d", sourceCount, acceptanceCount, sources, acceptances)
+	}
+	if highestPosition != sources {
+		t.Fatalf("highest journal position=%d, want %d after idempotent source writes", highestPosition, sources)
+	}
+}
+
+func assertConnectorCheckpointRows(t *testing.T, database *sqlstore.Database, binding source.ConnectorBinding, want int) {
+	t.Helper()
+	var count int
+	if err := database.SQLDB().QueryRowContext(t.Context(), `SELECT count(*) FROM pc_connector_checkpoints
+        WHERE scope_id = ? AND binding_id = ?`, binding.ScopeID(), binding.ID()).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != want {
+		t.Fatalf("checkpoint rows=%d, want %d", count, want)
+	}
+}

--- a/source/connector_lifecycle.go
+++ b/source/connector_lifecycle.go
@@ -1,0 +1,875 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package source
+
+import (
+	"bytes"
+	"context"
+	"encoding/json/jsontext"
+	json "encoding/json/v2"
+	"errors"
+	"fmt"
+	"maps"
+	"math/big"
+	"slices"
+	"strings"
+	"sync"
+)
+
+// ConnectorRunStatus reports whether a Connector exhausted the provider work
+// represented by a run. Only complete runs without unsafe item outcomes may
+// advance a durable checkpoint.
+type ConnectorRunStatus string
+
+const (
+	ConnectorRunComplete   ConnectorRunStatus = "complete"
+	ConnectorRunIncomplete ConnectorRunStatus = "incomplete"
+)
+
+// ConnectorSubmissionStatus is the visible durable outcome for one provider
+// item. Rejected and failed outcomes make a complete run unsafe to checkpoint.
+type ConnectorSubmissionStatus string
+
+const (
+	ConnectorSubmissionAccepted ConnectorSubmissionStatus = "accepted"
+	ConnectorSubmissionRejected ConnectorSubmissionStatus = "rejected"
+	ConnectorSubmissionFailed   ConnectorSubmissionStatus = "failed"
+)
+
+// InvalidConnectorError reports an invalid Connector declaration without
+// exposing provider-owned values.
+type InvalidConnectorError struct {
+	Field  string
+	Detail string
+}
+
+func (e *InvalidConnectorError) Error() string {
+	return fmt.Sprintf("invalid Connector %s: %s", e.Field, e.Detail)
+}
+
+// InvalidConnectorRunError reports an invalid Connector lifecycle action
+// without exposing provider item content or stable Source identities.
+type InvalidConnectorRunError struct {
+	Field  string
+	Detail string
+}
+
+func (e *InvalidConnectorRunError) Error() string {
+	return fmt.Sprintf("invalid Connector run %s: %s", e.Field, e.Detail)
+}
+
+// ConnectorSubmissionRejectedError is returned by a durable ingestion sink
+// when one item is rejected as a normal, visible lifecycle outcome. Other
+// errors abort the Connector run and never advance its checkpoint.
+type ConnectorSubmissionRejectedError struct{ detail string }
+
+func (e *ConnectorSubmissionRejectedError) Error() string {
+	if e == nil {
+		return "Connector submission was rejected"
+	}
+	return "Connector submission was rejected: " + e.detail
+}
+
+// NewConnectorSubmissionRejectedError constructs a bounded, display-safe
+// rejection detail. Callers must not put captured Source payloads in detail.
+func NewConnectorSubmissionRejectedError(detail string) (*ConnectorSubmissionRejectedError, error) {
+	if err := validateConnectorRunText("detail", detail, MaxIDLength); err != nil {
+		return nil, err
+	}
+	return &ConnectorSubmissionRejectedError{detail: detail}, nil
+}
+
+// Detail returns the bounded reason suitable for a visible rejected outcome.
+func (e *ConnectorSubmissionRejectedError) Detail() string {
+	if e == nil {
+		return ""
+	}
+	return e.detail
+}
+
+// ConnectorCheckpoint distinguishes an absent checkpoint row from a stored
+// JSON null. Value returns false only for an absent row.
+type ConnectorCheckpoint struct {
+	found bool
+	value jsontext.Value
+}
+
+// NoConnectorCheckpoint represents a binding with no durable checkpoint row.
+func NoConnectorCheckpoint() ConnectorCheckpoint { return ConnectorCheckpoint{} }
+
+// NewConnectorCheckpoint freezes one stored or proposed checkpoint. The value
+// must be complete valid JSON; JSON null is a valid stored checkpoint.
+func NewConnectorCheckpoint(value jsontext.Value) (ConnectorCheckpoint, error) {
+	cloned, err := immutableConnectorCheckpoint(value)
+	if err != nil {
+		return ConnectorCheckpoint{}, err
+	}
+	return ConnectorCheckpoint{found: true, value: cloned}, nil
+}
+
+// Found reports whether a durable checkpoint row exists.
+func (c ConnectorCheckpoint) Found() bool { return c.found }
+
+// Value returns an immutable JSON checkpoint and whether a durable row exists.
+func (c ConnectorCheckpoint) Value() (jsontext.Value, bool) {
+	if !c.found {
+		return nil, false
+	}
+	return jsontext.Value(bytes.Clone(c.value)), true
+}
+
+// Validate rejects malformed zero-value mutations at persistence boundaries.
+func (c ConnectorCheckpoint) Validate() error {
+	if !c.found {
+		if len(c.value) != 0 {
+			return connectorRunError("checkpoint", "must not carry a value when absent")
+		}
+		return nil
+	}
+	_, err := immutableConnectorCheckpoint(c.value)
+	return err
+}
+
+// EqualConnectorCheckpoints compares checkpoint JSON by value, including
+// arbitrary-size integers. It does not parse JSON numbers through float64.
+func EqualConnectorCheckpoints(left, right ConnectorCheckpoint) (bool, error) {
+	if err := left.Validate(); err != nil {
+		return false, err
+	}
+	if err := right.Validate(); err != nil {
+		return false, err
+	}
+	if left.found != right.found {
+		return false, nil
+	}
+	if !left.found {
+		return true, nil
+	}
+	return equalConnectorJSON(left.value, right.value)
+}
+
+// ConnectorItemOutcome records exactly one claimed provider item.
+type ConnectorItemOutcome struct {
+	itemID         string
+	definitionName string
+	status         ConnectorSubmissionStatus
+	sourceRef      *Ref
+	detail         *string
+}
+
+func (o ConnectorItemOutcome) ItemID() string                    { return o.itemID }
+func (o ConnectorItemOutcome) DefinitionName() string            { return o.definitionName }
+func (o ConnectorItemOutcome) Status() ConnectorSubmissionStatus { return o.status }
+
+// SourceRef returns the durable Source accepted for this item.
+func (o ConnectorItemOutcome) SourceRef() (Ref, bool) {
+	if o.sourceRef == nil {
+		return Ref{}, false
+	}
+	return *o.sourceRef, true
+}
+
+// Detail returns provider or admission detail for an unsafe item outcome.
+func (o ConnectorItemOutcome) Detail() (string, bool) {
+	if o.detail == nil {
+		return "", false
+	}
+	return *o.detail, true
+}
+
+// ConnectorRunCompletion is the Connector-owned terminal provider signal and
+// proposed next checkpoint. A complete status alone is insufficient to commit.
+type ConnectorRunCompletion struct {
+	status     ConnectorRunStatus
+	checkpoint ConnectorCheckpoint
+}
+
+func NewConnectorRunCompletion(status ConnectorRunStatus, checkpoint jsontext.Value) (ConnectorRunCompletion, error) {
+	if !validConnectorRunStatus(status) {
+		return ConnectorRunCompletion{}, connectorRunError("status", "must be complete or incomplete")
+	}
+	value, err := NewConnectorCheckpoint(checkpoint)
+	if err != nil {
+		return ConnectorRunCompletion{}, err
+	}
+	return ConnectorRunCompletion{status: status, checkpoint: value}, nil
+}
+
+func (c ConnectorRunCompletion) Status() ConnectorRunStatus { return c.status }
+
+// Checkpoint is valid JSON even when it is JSON null.
+func (c ConnectorRunCompletion) Checkpoint() jsontext.Value {
+	value, _ := c.checkpoint.Value()
+	return value
+}
+
+func (c ConnectorRunCompletion) Validate() error {
+	if !validConnectorRunStatus(c.status) {
+		return connectorRunError("status", "must be complete or incomplete")
+	}
+	if !c.checkpoint.Found() {
+		return connectorRunError("checkpoint", "must contain a JSON value")
+	}
+	return c.checkpoint.Validate()
+}
+
+// ConnectorRunResult exposes the outcome after any permitted checkpoint CAS.
+type ConnectorRunResult struct {
+	binding   ConnectorBinding
+	status    ConnectorRunStatus
+	previous  ConnectorCheckpoint
+	proposed  ConnectorCheckpoint
+	committed ConnectorCheckpoint
+	items     []ConnectorItemOutcome
+}
+
+func NewConnectorRunResult(
+	binding ConnectorBinding,
+	status ConnectorRunStatus,
+	previous, proposed, committed ConnectorCheckpoint,
+	items []ConnectorItemOutcome,
+) (ConnectorRunResult, error) {
+	if err := binding.Validate(); err != nil {
+		return ConnectorRunResult{}, err
+	}
+	if !validConnectorRunStatus(status) {
+		return ConnectorRunResult{}, connectorRunError("status", "must be complete or incomplete")
+	}
+	for _, checkpoint := range []ConnectorCheckpoint{previous, proposed, committed} {
+		if err := checkpoint.Validate(); err != nil {
+			return ConnectorRunResult{}, err
+		}
+	}
+	if !proposed.Found() {
+		return ConnectorRunResult{}, connectorRunError("proposed_checkpoint", "must contain a JSON value")
+	}
+	cloned := make([]ConnectorItemOutcome, len(items))
+	seen := make(map[string]struct{}, len(items))
+	for index, item := range items {
+		if err := item.validate(); err != nil {
+			return ConnectorRunResult{}, err
+		}
+		if _, exists := seen[item.itemID]; exists {
+			return ConnectorRunResult{}, connectorRunError("items", "must not contain duplicate item identifiers")
+		}
+		seen[item.itemID] = struct{}{}
+		cloned[index] = cloneConnectorOutcome(item)
+	}
+	return ConnectorRunResult{
+		binding: binding, status: status, previous: cloneConnectorCheckpoint(previous),
+		proposed: cloneConnectorCheckpoint(proposed), committed: cloneConnectorCheckpoint(committed), items: cloned,
+	}, nil
+}
+
+func (r ConnectorRunResult) Binding() ConnectorBinding  { return r.binding }
+func (r ConnectorRunResult) Status() ConnectorRunStatus { return r.status }
+
+func (r ConnectorRunResult) PreviousCheckpoint() ConnectorCheckpoint {
+	return cloneConnectorCheckpoint(r.previous)
+}
+
+func (r ConnectorRunResult) ProposedCheckpoint() ConnectorCheckpoint {
+	return cloneConnectorCheckpoint(r.proposed)
+}
+
+func (r ConnectorRunResult) CommittedCheckpoint() ConnectorCheckpoint {
+	return cloneConnectorCheckpoint(r.committed)
+}
+
+// Items returns immutable, ordered item outcomes.
+func (r ConnectorRunResult) Items() []ConnectorItemOutcome {
+	result := make([]ConnectorItemOutcome, len(r.items))
+	for index, item := range r.items {
+		result[index] = cloneConnectorOutcome(item)
+	}
+	return result
+}
+
+// Connector is the provider-neutral external boundary. Its Run implementation
+// is deliberately invoked outside SQL transactions and Runtime scope locks.
+type Connector interface {
+	Name() string
+	Version() string
+	SourceDefinitions() []string
+	Run(context.Context, *ConnectorRunSession) (ConnectorRunCompletion, error)
+}
+
+// ConnectorSourceSink durably accepts already-admitted worker observations.
+// ConnectorRunSession translates only ConnectorSubmissionRejectedError into a
+// visible item result; every other error aborts the run.
+type ConnectorSourceSink interface {
+	Submit(context.Context, ConnectorBinding, string, string, *AdmittedObservation) (Ref, error)
+}
+
+// ConnectorRunSession constrains one external Connector run to its declared
+// Definitions and records each item exactly once.
+type ConnectorRunSession struct {
+	binding     ConnectorBinding
+	checkpoint  ConnectorCheckpoint
+	definitions map[string]struct{}
+	sink        ConnectorSourceSink
+
+	mu           sync.Mutex
+	outcomes     map[uint64]ConnectorItemOutcome
+	itemIDs      map[string]uint64
+	nextSequence uint64
+	failure      error
+	closed       bool
+	inFlight     int
+	drained      chan struct{}
+	drainClosed  bool
+}
+
+func NewConnectorRunSession(
+	binding ConnectorBinding,
+	checkpoint ConnectorCheckpoint,
+	definitions []string,
+	sink ConnectorSourceSink,
+) (*ConnectorRunSession, error) {
+	if err := binding.Validate(); err != nil {
+		return nil, err
+	}
+	if err := checkpoint.Validate(); err != nil {
+		return nil, err
+	}
+	if sink == nil || isNil(sink) {
+		return nil, connectorRunError("sink", "must not be nil")
+	}
+	declared, err := declaredConnectorDefinitions(definitions)
+	if err != nil {
+		return nil, err
+	}
+	return &ConnectorRunSession{
+		binding: binding, checkpoint: cloneConnectorCheckpoint(checkpoint), definitions: declared,
+		sink: sink, outcomes: make(map[uint64]ConnectorItemOutcome), itemIDs: make(map[string]uint64),
+		drained: make(chan struct{}),
+	}, nil
+}
+
+func (s *ConnectorRunSession) Binding() ConnectorBinding {
+	if s == nil {
+		return ConnectorBinding{}
+	}
+	return s.binding
+}
+
+func (s *ConnectorRunSession) Checkpoint() ConnectorCheckpoint {
+	if s == nil {
+		return NoConnectorCheckpoint()
+	}
+	return cloneConnectorCheckpoint(s.checkpoint)
+}
+
+// Outcomes returns immutable results in item-claim order.
+func (s *ConnectorRunSession) Outcomes() []ConnectorItemOutcome {
+	if s == nil {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	sequences := slices.Sorted(maps.Keys(s.outcomes))
+	result := make([]ConnectorItemOutcome, len(sequences))
+	for index, sequence := range sequences {
+		result[index] = cloneConnectorOutcome(s.outcomes[sequence])
+	}
+	return result
+}
+
+// Failure returns the first generic submission failure. Connectors may choose
+// to observe and recover from an error, but the owning lifecycle must still
+// prevent checkpoint advancement for that run.
+func (s *ConnectorRunSession) Failure() error {
+	if s == nil {
+		return connectorRunError("session", "must not be nil")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.failure
+}
+
+// Finalize prevents further item claims and waits for every previously
+// claimed Submit call to settle its durable sink I/O. It never holds the
+// session lock while waiting. A canceled Context closes the session before
+// returning its cancellation error; callers may call Finalize again to wait
+// for settlement with a live Context.
+func (s *ConnectorRunSession) Finalize(ctx context.Context) error {
+	if s == nil {
+		return connectorRunError("session", "must not be nil")
+	}
+	s.mu.Lock()
+	s.closed = true
+	s.finishDrainLocked()
+	drained := s.drained
+	s.mu.Unlock()
+
+	if contextErr := context.Cause(ctx); contextErr != nil {
+		return contextErr
+	}
+	select {
+	case <-drained:
+		if contextErr := context.Cause(ctx); contextErr != nil {
+			return contextErr
+		}
+		return nil
+	case <-ctx.Done():
+		return context.Cause(ctx)
+	}
+}
+
+// Submit durably accepts one pre-admitted observation before recording an
+// accepted outcome. A typed rejection remains visible; a generic failure is
+// returned to the Connector and prevents completion/checkpoint handling.
+func (s *ConnectorRunSession) Submit(
+	ctx context.Context,
+	itemID, definitionName string,
+	observation *AdmittedObservation,
+) (ConnectorItemOutcome, error) {
+	if s == nil {
+		return ConnectorItemOutcome{}, connectorRunError("session", "must not be nil")
+	}
+	sequence, claimErr := s.claim(itemID, definitionName, true)
+	if claimErr != nil {
+		return ConnectorItemOutcome{}, s.recordFailure(claimErr)
+	}
+	defer s.settleSubmission()
+	if err := observation.Validate(); err != nil {
+		return ConnectorItemOutcome{}, s.recordFailure(connectorRunError("observation", "must be admitted and valid"))
+	}
+	accepted := observation.Observation()
+	if accepted.Ref().Type() != definitionName {
+		return ConnectorItemOutcome{}, s.recordFailure(connectorRunError("source_ref", "must match the declared Source Definition"))
+	}
+	ref, err := s.sink.Submit(ctx, s.binding, itemID, definitionName, observation)
+	if rejected, ok := errors.AsType[*ConnectorSubmissionRejectedError](err); ok {
+		outcome := rejectedConnectorOutcome(itemID, definitionName, rejected.Detail())
+		s.recordOutcome(sequence, outcome)
+		return cloneConnectorOutcome(outcome), nil
+	}
+	if err != nil {
+		return ConnectorItemOutcome{}, s.recordFailure(err)
+	}
+	if validateErr := validateConnectorReturnedRef(ref, accepted.Ref(), definitionName); validateErr != nil {
+		return ConnectorItemOutcome{}, s.recordFailure(validateErr)
+	}
+	outcome := acceptedConnectorOutcome(itemID, definitionName, ref)
+	s.recordOutcome(sequence, outcome)
+	return cloneConnectorOutcome(outcome), nil
+}
+
+// Reject records one provider item that cannot satisfy its Source Definition.
+func (s *ConnectorRunSession) Reject(itemID, definitionName, detail string) (ConnectorItemOutcome, error) {
+	return s.recordUnsafe(itemID, definitionName, ConnectorSubmissionRejected, detail)
+}
+
+// Fail records one provider item that could not be acquired safely.
+func (s *ConnectorRunSession) Fail(itemID, definitionName, detail string) (ConnectorItemOutcome, error) {
+	return s.recordUnsafe(itemID, definitionName, ConnectorSubmissionFailed, detail)
+}
+
+func (s *ConnectorRunSession) recordUnsafe(
+	itemID, definitionName string,
+	status ConnectorSubmissionStatus,
+	detail string,
+) (ConnectorItemOutcome, error) {
+	if s == nil {
+		return ConnectorItemOutcome{}, connectorRunError("session", "must not be nil")
+	}
+	if status != ConnectorSubmissionRejected && status != ConnectorSubmissionFailed {
+		return ConnectorItemOutcome{}, connectorRunError("status", "must be rejected or failed")
+	}
+	sequence, claimErr := s.claim(itemID, definitionName, false)
+	if claimErr != nil {
+		return ConnectorItemOutcome{}, s.recordFailure(claimErr)
+	}
+	if err := validateConnectorRunText("detail", detail, MaxIDLength); err != nil {
+		return ConnectorItemOutcome{}, s.recordFailure(err)
+	}
+	outcome := unsafeConnectorOutcome(itemID, definitionName, status, detail)
+	s.recordOutcome(sequence, outcome)
+	return cloneConnectorOutcome(outcome), nil
+}
+
+func (s *ConnectorRunSession) recordFailure(err error) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.failure == nil {
+		s.failure = err
+	}
+	return err
+}
+
+func (s *ConnectorRunSession) recordOutcome(sequence uint64, outcome ConnectorItemOutcome) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.outcomes[sequence] = cloneConnectorOutcome(outcome)
+}
+
+func (s *ConnectorRunSession) claim(itemID, definitionName string, tracksSettlement bool) (uint64, error) {
+	if err := validateConnectorRunText("item_id", itemID, MaxIDLength); err != nil {
+		return 0, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return 0, connectorRunError("session", "is closed")
+	}
+	if _, exists := s.itemIDs[itemID]; exists {
+		return 0, connectorRunError("duplicate_item", "must not be submitted more than once")
+	}
+	if _, exists := s.definitions[definitionName]; !exists {
+		return 0, connectorRunError("definition", "was not declared by the Connector")
+	}
+	sequence := s.nextSequence
+	s.nextSequence++
+	s.itemIDs[itemID] = sequence
+	if tracksSettlement {
+		s.inFlight++
+	}
+	return sequence, nil
+}
+
+func (s *ConnectorRunSession) settleSubmission() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.inFlight--
+	s.finishDrainLocked()
+}
+
+func (s *ConnectorRunSession) finishDrainLocked() {
+	if s.closed && s.inFlight == 0 && !s.drainClosed {
+		close(s.drained)
+		s.drainClosed = true
+	}
+}
+
+// ValidateConnector binds one Connector declaration to the exact durable
+// binding it will execute and returns an immutable declaration snapshot.
+func ValidateConnector(connector Connector, binding ConnectorBinding) ([]string, error) {
+	if err := binding.Validate(); err != nil {
+		return nil, err
+	}
+	if connector == nil || isNil(connector) {
+		return nil, &InvalidConnectorError{Field: "connector", Detail: "must not be nil"}
+	}
+	if connector.Name() != binding.ConnectorName() {
+		return nil, &InvalidConnectorError{Field: "name", Detail: "must match the binding"}
+	}
+	if connector.Version() != binding.ConnectorVersion() {
+		return nil, &InvalidConnectorError{Field: "version", Detail: "must match the binding"}
+	}
+	definitions := connector.SourceDefinitions()
+	if _, err := declaredConnectorDefinitions(definitions); err != nil {
+		return nil, &InvalidConnectorError{Field: "source_definitions", Detail: "must contain unique, non-empty trimmed names"}
+	}
+	return slices.Clone(definitions), nil
+}
+
+func declaredConnectorDefinitions(values []string) (map[string]struct{}, error) {
+	if len(values) == 0 {
+		return nil, connectorRunError("source_definitions", "must not be empty")
+	}
+	result := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		if err := validateConnectorRunText("definition", value, MaxTypeLength); err != nil {
+			return nil, err
+		}
+		if _, exists := result[value]; exists {
+			return nil, connectorRunError("source_definitions", "must not contain duplicates")
+		}
+		result[value] = struct{}{}
+	}
+	return result, nil
+}
+
+func validConnectorRunStatus(status ConnectorRunStatus) bool {
+	return status == ConnectorRunComplete || status == ConnectorRunIncomplete
+}
+
+func validateConnectorRunText(field, value string, maximum int) error {
+	if err := connectorIdentity(field, value, maximum); err != nil {
+		return connectorRunError(field, "must be a non-empty trimmed valid UTF-8 string")
+	}
+	return nil
+}
+
+func immutableConnectorCheckpoint(value jsontext.Value) (jsontext.Value, error) {
+	cloned := jsontext.Value(bytes.Clone(value))
+	if len(cloned) == 0 || !cloned.IsValid() {
+		return nil, connectorRunError("checkpoint", "must be valid JSON")
+	}
+	return cloned, nil
+}
+
+func cloneConnectorCheckpoint(value ConnectorCheckpoint) ConnectorCheckpoint {
+	if !value.found {
+		return ConnectorCheckpoint{}
+	}
+	return ConnectorCheckpoint{found: true, value: jsontext.Value(bytes.Clone(value.value))}
+}
+
+func acceptedConnectorOutcome(itemID, definitionName string, ref Ref) ConnectorItemOutcome {
+	cloned := ref
+	return ConnectorItemOutcome{itemID: itemID, definitionName: definitionName, status: ConnectorSubmissionAccepted, sourceRef: &cloned}
+}
+
+func rejectedConnectorOutcome(itemID, definitionName, detail string) ConnectorItemOutcome {
+	return unsafeConnectorOutcome(itemID, definitionName, ConnectorSubmissionRejected, detail)
+}
+
+func unsafeConnectorOutcome(itemID, definitionName string, status ConnectorSubmissionStatus, detail string) ConnectorItemOutcome {
+	cloned := strings.Clone(detail)
+	return ConnectorItemOutcome{itemID: itemID, definitionName: definitionName, status: status, detail: &cloned}
+}
+
+func cloneConnectorOutcome(value ConnectorItemOutcome) ConnectorItemOutcome {
+	result := value
+	if value.sourceRef != nil {
+		ref := *value.sourceRef
+		result.sourceRef = &ref
+	}
+	if value.detail != nil {
+		detail := strings.Clone(*value.detail)
+		result.detail = &detail
+	}
+	return result
+}
+
+func (o ConnectorItemOutcome) validate() error {
+	if err := validateConnectorRunText("item_id", o.itemID, MaxIDLength); err != nil {
+		return err
+	}
+	if err := validateConnectorRunText("definition", o.definitionName, MaxTypeLength); err != nil {
+		return err
+	}
+	switch o.status {
+	case ConnectorSubmissionAccepted:
+		if o.sourceRef == nil || o.detail != nil {
+			return connectorRunError("item", "accepted outcomes must contain exactly one Source reference")
+		}
+		if _, err := NewRef(o.sourceRef.Type(), o.sourceRef.ID()); err != nil {
+			return connectorRunError("source_ref", "must be valid")
+		}
+		if o.sourceRef.Type() != o.definitionName {
+			return connectorRunError("source_ref", "must match the declared Source Definition")
+		}
+	case ConnectorSubmissionRejected, ConnectorSubmissionFailed:
+		if o.sourceRef != nil || o.detail == nil {
+			return connectorRunError("item", "unsafe outcomes must contain one detail and no Source reference")
+		}
+		if err := validateConnectorRunText("detail", *o.detail, MaxIDLength); err != nil {
+			return err
+		}
+	default:
+		return connectorRunError("status", "must be accepted, rejected, or failed")
+	}
+	return nil
+}
+
+func validateConnectorReturnedRef(actual, expected Ref, definitionName string) error {
+	if _, err := NewRef(actual.Type(), actual.ID()); err != nil || actual.Type() != definitionName || actual != expected {
+		return connectorRunError("source_ref", "must match the accepted observation")
+	}
+	return nil
+}
+
+func connectorRunError(field, detail string) *InvalidConnectorRunError {
+	return &InvalidConnectorRunError{Field: field, Detail: detail}
+}
+
+func equalConnectorJSON(left, right jsontext.Value) (bool, error) {
+	if !left.IsValid() || !right.IsValid() {
+		return false, connectorRunError("checkpoint", "must be valid JSON")
+	}
+	if left.Kind() != right.Kind() {
+		return false, nil
+	}
+	switch left.Kind() {
+	case '{':
+		return equalConnectorObjects(left, right)
+	case '[':
+		return equalConnectorArrays(left, right)
+	case '"':
+		var leftString, rightString string
+		if err := json.Unmarshal(left, &leftString); err != nil {
+			return false, connectorRunError("checkpoint", "must be valid JSON")
+		}
+		if err := json.Unmarshal(right, &rightString); err != nil {
+			return false, connectorRunError("checkpoint", "must be valid JSON")
+		}
+		return leftString == rightString, nil
+	case '0':
+		return equalConnectorNumbers(left, right)
+	default:
+		return bytes.Equal(bytes.TrimSpace(left), bytes.TrimSpace(right)), nil
+	}
+}
+
+func equalConnectorObjects(left, right jsontext.Value) (bool, error) {
+	leftMembers, err := connectorObjectMembers(left)
+	if err != nil {
+		return false, err
+	}
+	rightMembers, err := connectorObjectMembers(right)
+	if err != nil {
+		return false, err
+	}
+	if len(leftMembers) != len(rightMembers) {
+		return false, nil
+	}
+	for name, leftValue := range leftMembers {
+		rightValue, found := rightMembers[name]
+		if !found {
+			return false, nil
+		}
+		equal, compareErr := equalConnectorJSON(leftValue, rightValue)
+		if compareErr != nil || !equal {
+			return equal, compareErr
+		}
+	}
+	return true, nil
+}
+
+func equalConnectorArrays(left, right jsontext.Value) (bool, error) {
+	leftValues, err := connectorArrayValues(left)
+	if err != nil {
+		return false, err
+	}
+	rightValues, err := connectorArrayValues(right)
+	if err != nil {
+		return false, err
+	}
+	if len(leftValues) != len(rightValues) {
+		return false, nil
+	}
+	for index := range leftValues {
+		equal, compareErr := equalConnectorJSON(leftValues[index], rightValues[index])
+		if compareErr != nil || !equal {
+			return equal, compareErr
+		}
+	}
+	return true, nil
+}
+
+func connectorObjectMembers(value jsontext.Value) (map[string]jsontext.Value, error) {
+	decoder := jsontext.NewDecoder(bytes.NewReader(value))
+	start, err := decoder.ReadToken()
+	if err != nil || start.Kind() != '{' {
+		return nil, connectorRunError("checkpoint", "must be valid JSON")
+	}
+	members := make(map[string]jsontext.Value)
+	for decoder.PeekKind() != '}' {
+		name, tokenErr := decoder.ReadToken()
+		if tokenErr != nil || name.Kind() != '"' {
+			return nil, connectorRunError("checkpoint", "must be valid JSON")
+		}
+		memberName := name.Clone().String()
+		member, valueErr := decoder.ReadValue()
+		if valueErr != nil {
+			return nil, connectorRunError("checkpoint", "must be valid JSON")
+		}
+		if _, exists := members[memberName]; exists {
+			return nil, connectorRunError("checkpoint", "must not contain duplicate object members")
+		}
+		members[memberName] = member.Clone()
+	}
+	if _, err := decoder.ReadToken(); err != nil {
+		return nil, connectorRunError("checkpoint", "must be valid JSON")
+	}
+	return members, nil
+}
+
+func connectorArrayValues(value jsontext.Value) ([]jsontext.Value, error) {
+	decoder := jsontext.NewDecoder(bytes.NewReader(value))
+	start, err := decoder.ReadToken()
+	if err != nil || start.Kind() != '[' {
+		return nil, connectorRunError("checkpoint", "must be valid JSON")
+	}
+	values := make([]jsontext.Value, 0)
+	for decoder.PeekKind() != ']' {
+		entry, valueErr := decoder.ReadValue()
+		if valueErr != nil {
+			return nil, connectorRunError("checkpoint", "must be valid JSON")
+		}
+		values = append(values, entry.Clone())
+	}
+	if _, err := decoder.ReadToken(); err != nil {
+		return nil, connectorRunError("checkpoint", "must be valid JSON")
+	}
+	return values, nil
+}
+
+func equalConnectorNumbers(left, right jsontext.Value) (bool, error) {
+	leftNumber, err := parseConnectorNumber(left)
+	if err != nil {
+		return false, err
+	}
+	rightNumber, err := parseConnectorNumber(right)
+	if err != nil {
+		return false, err
+	}
+	if leftNumber.zero || rightNumber.zero {
+		return leftNumber.zero == rightNumber.zero, nil
+	}
+	return leftNumber.negative == rightNumber.negative &&
+		leftNumber.significand == rightNumber.significand &&
+		leftNumber.exponent.Cmp(rightNumber.exponent) == 0, nil
+}
+
+type connectorNumber struct {
+	negative    bool
+	zero        bool
+	significand string
+	exponent    *big.Int
+}
+
+func parseConnectorNumber(value jsontext.Value) (connectorNumber, error) {
+	raw := bytes.TrimSpace(value)
+	if len(raw) == 0 {
+		return connectorNumber{}, connectorRunError("checkpoint", "must be valid JSON")
+	}
+	negative := false
+	if raw[0] == '-' {
+		negative = true
+		raw = raw[1:]
+	}
+	mantissa, exponentText, hasExponent := bytes.Cut(raw, []byte("e"))
+	if !hasExponent {
+		mantissa, exponentText, _ = bytes.Cut(raw, []byte("E"))
+	}
+	fractionDigits := 0
+	if whole, fraction, found := bytes.Cut(mantissa, []byte(".")); found {
+		fractionDigits = len(fraction)
+		mantissa = append(bytes.Clone(whole), fraction...)
+	}
+	mantissa = bytes.TrimLeft(mantissa, "0")
+	if len(mantissa) == 0 {
+		return connectorNumber{zero: true}, nil
+	}
+	trailingZeros := len(mantissa) - len(bytes.TrimRight(mantissa, "0"))
+	mantissa = mantissa[:len(mantissa)-trailingZeros]
+	exponent := new(big.Int).Neg(big.NewInt(int64(fractionDigits)))
+	if len(exponentText) > 0 {
+		if exponentText[0] == '+' {
+			exponentText = exponentText[1:]
+		}
+		parsed, ok := new(big.Int).SetString(string(exponentText), 10)
+		if !ok {
+			return connectorNumber{}, connectorRunError("checkpoint", "must be valid JSON")
+		}
+		exponent.Add(exponent, parsed)
+	}
+	exponent.Add(exponent, big.NewInt(int64(trailingZeros)))
+	return connectorNumber{negative: negative, significand: string(mantissa), exponent: exponent}, nil
+}

--- a/source/connector_lifecycle_test.go
+++ b/source/connector_lifecycle_test.go
@@ -1,0 +1,414 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package source_test
+
+import (
+	"context"
+	"encoding/json/jsontext"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ob-labs/powercontext-go/source"
+)
+
+func TestConnectorCheckpointKeepsAbsentDistinctFromJSONNullAndComparesLosslessly(t *testing.T) {
+	absent := source.NoConnectorCheckpoint()
+	nullCheckpoint, err := source.NewConnectorCheckpoint(jsontext.Value("null"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if equal, compareErr := source.EqualConnectorCheckpoints(absent, nullCheckpoint); compareErr != nil || equal {
+		t.Fatalf("absent and null equal = %t, %v", equal, compareErr)
+	}
+	if _, found := absent.Value(); found {
+		t.Fatal("absent checkpoint exposed a JSON value")
+	}
+	if value, found := nullCheckpoint.Value(); !found || string(value) != "null" {
+		t.Fatalf("null checkpoint = %q, found=%t", value, found)
+	}
+
+	left, err := source.NewConnectorCheckpoint(jsontext.Value(`{"offset":9007199254740993,"flags":[true,1.0]}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	right, err := source.NewConnectorCheckpoint(jsontext.Value(`{"flags":[true,1e0],"offset":9007199254740993}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if equal, compareErr := source.EqualConnectorCheckpoints(left, right); compareErr != nil || !equal {
+		t.Fatalf("value-equivalent checkpoints equal = %t, %v", equal, compareErr)
+	}
+	changed, err := source.NewConnectorCheckpoint(jsontext.Value(`{"offset":9007199254740994,"flags":[true,1]}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if equal, compareErr := source.EqualConnectorCheckpoints(left, changed); compareErr != nil || equal {
+		t.Fatalf("large integer change equal = %t, %v", equal, compareErr)
+	}
+}
+
+func TestConnectorRunSessionRecordsOnlyDurableAcceptedAndTypedRejectedItems(t *testing.T) {
+	binding := connectorLifecycleBinding(t)
+	accepted := connectorLifecycleObservation(t, "remote.note", "item-1")
+	rejection, err := source.NewConnectorSubmissionRejectedError("schema rejected")
+	if err != nil {
+		t.Fatal(err)
+	}
+	sink := &connectorLifecycleSink{results: []connectorLifecycleSinkResult{
+		{ref: accepted.Observation().Ref()},
+		{err: rejection},
+	}}
+	session, err := source.NewConnectorRunSession(
+		binding, source.NoConnectorCheckpoint(), []string{"remote.note"}, sink,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	first, err := session.Submit(t.Context(), "provider-1", "remote.note", accepted)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.Status() != source.ConnectorSubmissionAccepted {
+		t.Fatalf("first status = %q", first.Status())
+	}
+	if ref, found := first.SourceRef(); !found || ref != accepted.Observation().Ref() {
+		t.Fatalf("accepted ref = %#v, found=%t", ref, found)
+	}
+
+	second, err := session.Submit(t.Context(), "provider-2", "remote.note", accepted)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if second.Status() != source.ConnectorSubmissionRejected {
+		t.Fatalf("rejected status = %q", second.Status())
+	}
+	if detail, found := second.Detail(); !found || detail != "schema rejected" {
+		t.Fatalf("rejection detail = %q, found=%t", detail, found)
+	}
+	if _, found := second.SourceRef(); found {
+		t.Fatal("rejected item carried a durable Source reference")
+	}
+	if len(session.Outcomes()) != 2 || sink.calls != 2 {
+		t.Fatalf("outcomes=%d sink calls=%d", len(session.Outcomes()), sink.calls)
+	}
+}
+
+func TestConnectorRunSessionRejectsDuplicateUndeclaredAndWrongSourceRef(t *testing.T) {
+	binding := connectorLifecycleBinding(t)
+	accepted := connectorLifecycleObservation(t, "remote.note", "item-1")
+	wrong := connectorLifecycleObservation(t, "remote.other", "item-1")
+	session, err := source.NewConnectorRunSession(
+		binding, source.NoConnectorCheckpoint(), []string{"remote.note"}, &connectorLifecycleSink{results: []connectorLifecycleSinkResult{{ref: accepted.Observation().Ref()}}},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := session.Submit(t.Context(), "item", "remote.other", accepted); err == nil {
+		t.Fatal("undeclared definition was accepted")
+	} else if _, ok := errors.AsType[*source.InvalidConnectorRunError](err); !ok {
+		t.Fatalf("undeclared definition error = %T %v", err, err)
+	}
+	if _, err := session.Submit(t.Context(), "item", "remote.note", accepted); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := session.Submit(t.Context(), "item", "remote.note", accepted); err == nil {
+		t.Fatal("duplicate item was accepted")
+	} else if _, ok := errors.AsType[*source.InvalidConnectorRunError](err); !ok {
+		t.Fatalf("duplicate item error = %T %v", err, err)
+	}
+	if _, err := session.Submit(t.Context(), "wrong", "remote.note", wrong); err == nil {
+		t.Fatal("wrong Source reference was accepted")
+	} else if _, ok := errors.AsType[*source.InvalidConnectorRunError](err); !ok {
+		t.Fatalf("wrong source reference error = %T %v", err, err)
+	}
+
+	connector := connectorLifecycleFake{name: "other", version: binding.ConnectorVersion(), definitions: []string{"remote.note"}}
+	if _, err := source.ValidateConnector(connector, binding); err == nil {
+		t.Fatal("binding mismatch was accepted")
+	} else if _, ok := errors.AsType[*source.InvalidConnectorError](err); !ok {
+		t.Fatalf("binding mismatch error = %T %v", err, err)
+	}
+}
+
+func TestConnectorRunSessionConcurrentClaimsPreserveReservationOrder(t *testing.T) {
+	binding := connectorLifecycleBinding(t)
+	accepted := connectorLifecycleObservation(t, "remote.note", "item-1")
+	firstStarted := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	release := sync.OnceFunc(func() { close(releaseFirst) })
+	t.Cleanup(release)
+	sink := &concurrentConnectorLifecycleSink{
+		firstStarted: firstStarted,
+		releaseFirst: releaseFirst,
+		ref:          accepted.Observation().Ref(),
+		calls:        make(map[string]int),
+	}
+	session, err := source.NewConnectorRunSession(
+		binding, source.NoConnectorCheckpoint(), []string{"remote.note"}, sink,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	doneReading := make(chan struct{})
+	stopReaders := sync.OnceFunc(func() { close(doneReading) })
+	defer stopReaders()
+	var readers sync.WaitGroup
+	for range 8 {
+		readers.Go(func() {
+			for {
+				select {
+				case <-doneReading:
+					return
+				default:
+					_ = session.Outcomes()
+					_ = session.Failure()
+				}
+			}
+		})
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+	type submitResult struct {
+		outcome source.ConnectorItemOutcome
+		err     error
+	}
+	firstResult := make(chan submitResult, 1)
+	secondResult := make(chan submitResult, 1)
+	var submissions sync.WaitGroup
+	submissions.Go(func() {
+		outcome, submitErr := session.Submit(ctx, "first", "remote.note", accepted)
+		firstResult <- submitResult{outcome: outcome, err: submitErr}
+	})
+	<-firstStarted
+
+	submissions.Go(func() {
+		outcome, submitErr := session.Submit(ctx, "second", "remote.note", accepted)
+		secondResult <- submitResult{outcome: outcome, err: submitErr}
+	})
+	var second submitResult
+	select {
+	case second = <-secondResult:
+	case <-ctx.Done():
+		release()
+		first := <-firstResult
+		second = <-secondResult
+		submissions.Wait()
+		t.Fatalf("second Submit() did not finish while the first sink call waited: first=%v second=%v", first.err, second.err)
+	}
+	if second.err != nil || second.outcome.Status() != source.ConnectorSubmissionAccepted {
+		t.Fatalf("second Submit() = %#v, %v", second.outcome, second.err)
+	}
+	var writes sync.WaitGroup
+	writeErrors := make(chan error, 2)
+	writes.Go(func() {
+		_, rejectErr := session.Reject("rejected", "remote.note", "provider rejected item")
+		writeErrors <- rejectErr
+	})
+	writes.Go(func() {
+		_, failErr := session.Fail("failed", "remote.note", "provider unavailable")
+		writeErrors <- failErr
+	})
+	writes.Wait()
+	for range 2 {
+		if writeErr := <-writeErrors; writeErr != nil {
+			t.Fatalf("concurrent unsafe outcome error = %v", writeErr)
+		}
+	}
+	if _, duplicateErr := session.Submit(t.Context(), "first", "remote.note", accepted); duplicateErr == nil {
+		t.Fatal("concurrent duplicate item was accepted")
+	} else if _, ok := errors.AsType[*source.InvalidConnectorRunError](duplicateErr); !ok {
+		t.Fatalf("concurrent duplicate error = %T %v", duplicateErr, duplicateErr)
+	}
+	if outcomes := session.Outcomes(); len(outcomes) != 3 {
+		t.Fatalf("outcomes before first sink release = %#v", outcomes)
+	}
+
+	release()
+	first := <-firstResult
+	submissions.Wait()
+	if first.err != nil {
+		t.Fatalf("first Submit() = %v", first.err)
+	}
+	stopReaders()
+	readers.Wait()
+
+	outcomes := session.Outcomes()
+	if len(outcomes) != 4 || outcomes[0].ItemID() != "first" || outcomes[1].ItemID() != "second" {
+		t.Fatalf("outcomes ordered by sink completion instead of reservation = %#v", outcomes)
+	}
+	if sink.CallCount("first") != 1 || sink.CallCount("second") != 1 {
+		t.Fatalf("sink calls first=%d second=%d", sink.CallCount("first"), sink.CallCount("second"))
+	}
+	if _, ok := errors.AsType[*source.InvalidConnectorRunError](session.Failure()); !ok {
+		t.Fatalf("Failure() = %T %v", session.Failure(), session.Failure())
+	}
+}
+
+func TestConnectorRunSessionFinalizeClosesClaimsBeforeCanceledDrainCompletes(t *testing.T) {
+	binding := connectorLifecycleBinding(t)
+	accepted := connectorLifecycleObservation(t, "remote.note", "item-1")
+	firstStarted := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	sink := &concurrentConnectorLifecycleSink{
+		firstStarted: firstStarted,
+		releaseFirst: releaseFirst,
+		ref:          accepted.Observation().Ref(),
+		calls:        make(map[string]int),
+	}
+	session, err := source.NewConnectorRunSession(
+		binding, source.NoConnectorCheckpoint(), []string{"remote.note"}, sink,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	submitted := make(chan error, 1)
+	go func() {
+		_, submitErr := session.Submit(t.Context(), "first", "remote.note", accepted)
+		submitted <- submitErr
+	}()
+	<-firstStarted
+
+	drainContext, cancelDrain := context.WithCancel(t.Context())
+	cancelDrain()
+	if finalizeErr := session.Finalize(drainContext); !errors.Is(finalizeErr, context.Canceled) {
+		t.Fatalf("Finalize() error = %T %v, want context cancellation", finalizeErr, finalizeErr)
+	}
+	if _, submitErr := session.Submit(t.Context(), "late", "remote.note", accepted); submitErr == nil {
+		t.Fatal("Submit() accepted a claim after Finalize closed the session")
+	} else if _, ok := errors.AsType[*source.InvalidConnectorRunError](submitErr); !ok {
+		t.Fatalf("late Submit() error = %T %v", submitErr, submitErr)
+	}
+	if calls := sink.CallCount("late"); calls != 0 {
+		t.Fatalf("late sink calls = %d, want 0", calls)
+	}
+
+	close(releaseFirst)
+	if submitErr := <-submitted; submitErr != nil {
+		t.Fatalf("in-flight Submit() error = %v", submitErr)
+	}
+	if finalizeErr := session.Finalize(t.Context()); finalizeErr != nil {
+		t.Fatalf("Finalize() after settlement = %v", finalizeErr)
+	}
+}
+
+type connectorLifecycleSinkResult struct {
+	ref source.Ref
+	err error
+}
+
+type connectorLifecycleSink struct {
+	results []connectorLifecycleSinkResult
+	calls   int
+}
+
+type concurrentConnectorLifecycleSink struct {
+	mu           sync.Mutex
+	firstStarted chan<- struct{}
+	releaseFirst <-chan struct{}
+	ref          source.Ref
+	calls        map[string]int
+}
+
+func (s *concurrentConnectorLifecycleSink) Submit(
+	ctx context.Context,
+	_ source.ConnectorBinding,
+	itemID, _ string,
+	_ *source.AdmittedObservation,
+) (source.Ref, error) {
+	s.mu.Lock()
+	s.calls[itemID]++
+	s.mu.Unlock()
+	if itemID == "first" {
+		s.firstStarted <- struct{}{}
+		select {
+		case <-s.releaseFirst:
+		case <-ctx.Done():
+			return source.Ref{}, ctx.Err()
+		}
+	}
+	return s.ref, nil
+}
+
+func (s *concurrentConnectorLifecycleSink) CallCount(itemID string) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.calls[itemID]
+}
+
+func (s *connectorLifecycleSink) Submit(
+	_ context.Context,
+	_ source.ConnectorBinding,
+	_, _ string,
+	_ *source.AdmittedObservation,
+) (source.Ref, error) {
+	result := s.results[s.calls]
+	s.calls++
+	return result.ref, result.err
+}
+
+type connectorLifecycleFake struct {
+	name        string
+	version     string
+	definitions []string
+}
+
+func (f connectorLifecycleFake) Name() string                { return f.name }
+func (f connectorLifecycleFake) Version() string             { return f.version }
+func (f connectorLifecycleFake) SourceDefinitions() []string { return f.definitions }
+func (connectorLifecycleFake) Run(context.Context, *source.ConnectorRunSession) (source.ConnectorRunCompletion, error) {
+	return source.ConnectorRunCompletion{}, nil
+}
+
+func connectorLifecycleBinding(t *testing.T) source.ConnectorBinding {
+	t.Helper()
+	binding, err := source.NewConnectorBinding("scope", "binding", "connector", "v1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return binding
+}
+
+func connectorLifecycleObservation(t *testing.T, definition, identifier string) *source.AdmittedObservation {
+	t.Helper()
+	identity, err := source.NewDefinitionIdentity(definition, "1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest, err := source.NewDefinitionManifest(identity, jsontext.Value(`{"type":"object","required":["identifier","name","definition_version","materialization"],"properties":{"identifier":{"type":"string"},"name":{"type":"string"},"definition_version":{"type":"string"},"materialization":{"const":"captured"}}}`), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ref, err := source.NewRef(definition, identifier)
+	if err != nil {
+		t.Fatal(err)
+	}
+	observation, err := source.NewSourceObservation(ref, manifest.Version(), manifest.Fingerprint(), nil,
+		jsontext.Value(`{"identifier":"`+identifier+`","name":"`+identifier+`","definition_version":"1","materialization":"captured"}`), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	accepted, err := source.AdmitObservation(manifest, observation)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return accepted
+}


### PR DESCRIPTION
Part of #202 Phase 2. Adds connector contracts, runtime lifecycle and SQLite checkpoint adapter. Connector runs outside SQL and scope-write locks; each durable accepted submission precedes checkpoint evaluation. Checkpoint CAS occurs only after a drained session, complete safe outcome, changed JSON value and no cancellation. No HTTP, host or OpenAPI changes.