### PR TITLE
docs: prevent stale version and conflict markers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -471,6 +471,10 @@ source / artifact / trigger / inference
   and Runtime instances cannot commit opposite parent edges or duplicate an
   idempotent default bootstrap, and prove that an injected default-setting
   failure rolls the Scope and its creation key back together.
+- When maintained documentation states the supported Go version, validate it
+  against the authoritative `go.mod` directive and reject unresolved Git
+  conflict boundaries before rendering. Verify a version-mismatch fixture and
+  a conflict-marker fixture fail while the current documentation tree passes.
 
 - When a remote manifest restricts JSON Schema dialects, walk only the pinned
   draft's schema-bearing keyword paths when finding nested resource roots.

--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ PUBLIC_API_PACKAGES := \
 
 .PHONY: help lint-tools lint lint-fix api-compat-tools api-baseline api-compat govulncheck-tools license-eye-tools actionlint-tools actionlint modern-go-tools modern-go dependency-security generate check-generated parity-inventory-check release-contract-check module-check module-inventory module-integrity contract-test license-check license-fix license-dependencies fmt fmt-check vet build-all coverage coverage-check governance-check \
 	test unit-test e2e-test test-sqlite race-debt-check race-debt-functional test-race test-full real-provider-test \
-	docs-sync docs-test docs-build harness-sync harness-check harness-compose-check \
+	docs-sync docs-check docs-test docs-build harness-sync harness-check harness-compose-check \
 	harness-compose-acceptance harness-compose-down build build-full smoke smoke-full check \
 	portable-sdk-check check-portable generated-consumers downstream-compat package-standard package-full clean
 
@@ -363,10 +363,14 @@ real-provider-test: ## Run explicit credentialed real-provider smoke tests.
 docs-sync: ## Synchronize the locked documentation environment.
 	$(UV) sync --project tools/docs --frozen
 
-docs-test: ## Strictly build documentation without publishing it.
+docs-check: ## Verify documentation contracts before rendering.
+	$(UV) run --project tools/docs --frozen python -m unittest tools.docs.test_check_contract -v
+	$(UV) run --project tools/docs --frozen python tools/docs/check_contract.py
+
+docs-test: docs-check ## Strictly build documentation without publishing it.
 	$(UV) run --project tools/docs --frozen zensical build -s
 
-docs-build: ## Clean and build the documentation site.
+docs-build: docs-check ## Clean and build the documentation site.
 	$(UV) run --project tools/docs --frozen zensical build --clean
 
 harness-sync: ## Download and verify the E2E harness module graph.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # PowerContext Go
 
-PowerContext Go is the Go 1.25 implementation of PowerContext. It preserves the public HTTP, MCP, persistence, CLI,
+PowerContext Go is the Go 1.27.0 implementation of PowerContext. It preserves the public HTTP, MCP, persistence, CLI,
 Dashboard, integration, and release contracts while using Go-native domain and runtime boundaries.
 
 Start with the [architecture overview](architecture/README.md), then use the

--- a/tools/docs/check_contract.py
+++ b/tools/docs/check_contract.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 OceanBase.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Validate documentation facts that the renderer cannot detect."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+GO_DIRECTIVE = re.compile(r"^go\s+(\d+\.\d+(?:\.\d+)?)\s*$", re.MULTILINE)
+DOCUMENTED_GO_VERSION = re.compile(
+    r"\bGo (\d+\.\d+(?:\.\d+)?) implementation\b"
+)
+CONFLICT_BOUNDARY = re.compile(r"^(?:<<<<<<<|>>>>>>>) .+$")
+
+
+def documentation_errors(root: Path) -> list[str]:
+    errors: list[str] = []
+    go_mod = (root / "go.mod").read_text(encoding="utf-8")
+    index_path = root / "docs" / "index.md"
+    index = index_path.read_text(encoding="utf-8")
+
+    go_match = GO_DIRECTIVE.search(go_mod)
+    if go_match is None:
+        errors.append("go.mod: missing Go version directive")
+    else:
+        documented_match = DOCUMENTED_GO_VERSION.search(index)
+        if documented_match is None:
+            errors.append("docs/index.md: missing documented Go implementation version")
+        elif documented_match.group(1) != go_match.group(1):
+            errors.append(
+                "docs/index.md: documented Go version "
+                f"{documented_match.group(1)} does not match go.mod {go_match.group(1)}"
+            )
+
+    for path in sorted((root / "docs").rglob("*.md")):
+        for line_number, line in enumerate(
+            path.read_text(encoding="utf-8").splitlines(), start=1
+        ):
+            if CONFLICT_BOUNDARY.fullmatch(line):
+                relative_path = path.relative_to(root).as_posix()
+                errors.append(
+                    f"{relative_path}:{line_number}: unresolved Git conflict marker"
+                )
+
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    args = parser.parse_args()
+
+    errors = documentation_errors(args.root)
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/docs/test_check_contract.py
+++ b/tools/docs/test_check_contract.py
@@ -1,0 +1,95 @@
+# Copyright (c) 2026 OceanBase.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+CHECKER = Path(__file__).with_name("check_contract.py")
+
+
+class DocumentationContractTest(unittest.TestCase):
+    def test_mismatched_documented_go_version_is_rejected(self) -> None:
+        result = self.run_checker(
+            go_version="1.27.0",
+            index_version="1.25",
+            architecture="# Architecture\n",
+        )
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn(
+            "docs/index.md: documented Go version 1.25 does not match go.mod 1.27.0",
+            result.stderr,
+        )
+
+    def test_documentation_conflict_marker_is_rejected(self) -> None:
+        result = self.run_checker(
+            go_version="1.27.0",
+            index_version="1.27.0",
+            architecture="# Architecture\n<<<<<<< HEAD\ncurrent\n=======\nincoming\n>>>>>>> branch\n",
+        )
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn(
+            "docs/architecture/README.md:2: unresolved Git conflict marker",
+            result.stderr,
+        )
+
+    def test_matching_clean_documentation_is_accepted(self) -> None:
+        result = self.run_checker(
+            go_version="1.27.0",
+            index_version="1.27.0",
+            architecture="# Architecture\n",
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stderr, "")
+
+    def run_checker(
+        self,
+        *,
+        go_version: str,
+        index_version: str,
+        architecture: str,
+    ) -> subprocess.CompletedProcess[str]:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "go.mod").write_text(
+                f"module example.com/docs-contract\n\ngo {go_version}\n",
+                encoding="utf-8",
+            )
+            (root / "docs" / "architecture").mkdir(parents=True)
+            (root / "docs" / "index.md").write_text(
+                f"# Example\n\nExample is the Go {index_version} implementation.\n",
+                encoding="utf-8",
+            )
+            (root / "docs" / "architecture" / "README.md").write_text(
+                architecture,
+                encoding="utf-8",
+            )
+            return subprocess.run(
+                [sys.executable, str(CHECKER), "--root", str(root)],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Tracking\n\n- Tracking issue: None; requested directly from the verified documentation findings.\n- Relationship: Standalone focused fix.\n\n## Problem and rationale\n\ndocs/index.md still described the repository as a Go 1.25 implementation while the authoritative go.mod, README, and CONTRIBUTING policy require Go 1.27.0. The documentation build only rendered the site, so it did not reject that version drift or unresolved Git conflict boundaries.\n\nThe latest origin/main already contains the correct SQLite-only architecture wording, so this change does not rewrite docs/architecture/README.md. Instead it adds the smallest shared pre-render contract gate that prevents the observed conflict-marker class from passing either test or deployment builds.\n\n## Changes\n\n- Align docs/index.md with the Go 1.27.0 module directive.\n- Add a dependency-free documentation contract checker and focused subprocess tests.\n- Run the shared docs-check target before both docs-test and docs-build.\n- Record the reusable prevention rule in AGENTS.md.\n\n## Behavior and compatibility\n\n- User-visible behavior: Documentation now reports Go 1.27.0, and documentation rendering fails on version drift or unresolved conflict boundaries under docs/**/*.md.\n- Public API or protocol impact: None.\n- Breaking changes or migration requirements: None.\n- Explicit non-goals: No architecture-content rewrite; no Go runtime, generated contract, dependency, or release workflow change.\n\n## Backport declaration (release/v* only)\n\nNot applicable; base branch is main.\n\n## Generated, dependency, and workflow impact\n\n- [x] No generated contract changed.\n- [x] No dependency changed; go.mod, go.sum, and 	ools/docs/uv.lock are unchanged.\n- [x] No CI or release workflow changed; existing documentation targets retain their names and now share a pre-render gate.\n- [x] No credential, private Source/Memory content, or unredacted production log is included.\n\n## Validation\n\nCommands run against submitted Head 2feb93b658ae22211df22fd95eb0118dd994f36f:\n\n`	ext\npython -m unittest tools.docs.test_check_contract -v\n# 3 tests passed\n\nmake docs-test\n# documentation contracts passed; strict Zensical build: No issues found\n\nmake docs-build\n# documentation contracts passed; clean Zensical build: No issues found\n\nmake license-check\n# 1203 files checked; 943 valid, 0 invalid, 260 ignored\n\ngit diff HEAD^ HEAD --check\n# exit 0\n\ngit status --short --branch\n# clean; branch tracks origin/codex/fix-doc-contract\n`\n\nRegression evidence before the document correction:\n\n`	ext\npython tools/docs/check_contract.py --root .\ndocs/index.md: documented Go version 1.25 does not match go.mod 1.27.0\n# exit 1\n`\n\nThe same checker was also run read-only against the original conflicted worktree and reported the observed markers in docs/architecture/README.md.\n\n- [x] git diff --check\n- [x] git status --short was inspected after validation.\n- [x] Formatter evidence: no Python formatter is configured for 	ools/docs; both new Python files were executed by the locked documentation target and inspected in the exact staged diff.\n- [x] Generated-consumer evidence: not applicable because no generator or generated output changed.\n- [x] Compatibility evidence: documentation contract tests and both render entrypoints cover the changed behavior; no public Go surface changed.\n- [x] Relevant documentation and license checks were run.\n- [x] Full Go unit, race, E2E, and API compatibility suites were intentionally not run because no Go code, generated transport, persistence, runtime, or public API path changed.\n\n## AI usage\n\nCodex assisted with the implementation. The result was independently checked against fresh origin/main, reviewed as an exact five-file diff, exercised through failing and passing regression evidence, and validated through both documentation render entrypoints and the repository license gate.\n