### PR TITLE
feat(scope): expose durable bindings through MCP

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -518,3 +518,7 @@ source / artifact / trigger / inference
   return the latter only as `scope_id`. Verify an explicit override reaches the
   resolver, ordered binding keys remain a fallback, and no unvalidated local
   Scope reaches capture, recall, or persistence.
+- When Application composition conditionally adds native MCP tools, update the
+  release process-smoke inventory independently from direct-handler tool tests.
+  Verify the configured production Server lists the exact additional tools and
+  the Handoff Report variant retains its own additive count.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -513,3 +513,8 @@ source / artifact / trigger / inference
   load, provider run, or save, and an unknown scheduled scope acquires no lease
   or process callback while direct context references are all resolved before
   any recall begins.
+- When a host-native MCP command distinguishes a caller-provided Scope from a
+  durable resolved Scope, encode the former only as `explicit_scope_id` and
+  return the latter only as `scope_id`. Verify an explicit override reaches the
+  resolver, ordered binding keys remain a fallback, and no unvalidated local
+  Scope reaches capture, recall, or persistence.

--- a/internal/endpoint/errors.go
+++ b/internal/endpoint/errors.go
@@ -26,6 +26,7 @@ import (
 	"github.com/ob-labs/powercontext-go/internal/handoffreport"
 	"github.com/ob-labs/powercontext-go/internal/review"
 	"github.com/ob-labs/powercontext-go/internal/runtime"
+	"github.com/ob-labs/powercontext-go/internal/scope"
 	"github.com/ob-labs/powercontext-go/internal/work"
 	"github.com/ob-labs/powercontext-go/source"
 )
@@ -254,6 +255,14 @@ func mapHandoffError(err error) (ErrorMapping, bool) {
 }
 
 func mapDomainError(err error) ErrorMapping {
+	var scopeMissing *scope.NotFoundError
+	if errors.As(err, &scopeMissing) {
+		return mapping(http.StatusNotFound, "scope_not_found", "The requested Scope was not found.", nil)
+	}
+	var bindingMissing *scope.BindingNotFoundError
+	if errors.As(err, &bindingMissing) {
+		return mapping(http.StatusNotFound, "scope_binding_not_found", "No Scope binding is available.", nil)
+	}
 	var artifactMissing *artifact.NotFoundError
 	if errors.As(err, &artifactMissing) {
 		return mapping(http.StatusNotFound, "artifact_not_found", "The requested Artifact was not found.", nil)
@@ -300,7 +309,9 @@ func invalidDomainRequest(err error) bool {
 	var citation *memory.InvalidCitationError
 	var operation *memory.InvalidOperationError
 	var canonical *memory.CanonicalError
-	var scope *runtime.InvalidScopeError
+	var invalidScope *runtime.InvalidScopeError
+	var scopeValidation *scope.ValidationError
+	var scopeRelationship *scope.RelationshipError
 	var handoffScope *handoff.ScopeMismatchError
 	var handoffRef *handoff.InvalidReferenceError
 	var sourceRef *source.InvalidReferenceError
@@ -308,7 +319,8 @@ func invalidDomainRequest(err error) bool {
 	var invalidWork *work.InvalidError
 	var invalidWorkRequest *work.InvalidRequestError
 	return errors.As(err, &candidate) || errors.As(err, &evidence) || errors.As(err, &citation) ||
-		errors.As(err, &operation) || errors.As(err, &canonical) || errors.As(err, &scope) ||
+		errors.As(err, &operation) || errors.As(err, &canonical) || errors.As(err, &invalidScope) ||
+		errors.As(err, &scopeValidation) || errors.As(err, &scopeRelationship) ||
 		errors.As(err, &handoffScope) || errors.As(err, &handoffRef) || errors.As(err, &sourceRef) ||
 		errors.As(err, &artifactRef) || errors.As(err, &invalidWork) || errors.As(err, &invalidWorkRequest)
 }

--- a/internal/endpoint/errors_test.go
+++ b/internal/endpoint/errors_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ob-labs/powercontext-go/internal/handoffreport"
 	"github.com/ob-labs/powercontext-go/internal/review"
 	"github.com/ob-labs/powercontext-go/internal/runtime"
+	"github.com/ob-labs/powercontext-go/internal/scope"
 )
 
 func TestMapErrorFrozenTaxonomy(t *testing.T) {
@@ -45,6 +46,9 @@ func TestMapErrorFrozenTaxonomy(t *testing.T) {
 		details map[string]any
 	}{
 		{name: "runtime", err: &runtime.StateError{Code: "closed"}, status: 503, code: "runtime_not_ready"},
+		{name: "scope missing", err: &scope.NotFoundError{}, status: 404, code: "scope_not_found"},
+		{name: "binding missing", err: &scope.BindingNotFoundError{}, status: 404, code: "scope_binding_not_found"},
+		{name: "scope validation", err: &scope.ValidationError{}, status: 422, code: "invalid_request"},
 		{name: "candidate missing", err: &review.CandidateNotFoundError{}, status: 404, code: "candidate_not_found"},
 		{name: "candidate CAS", err: &review.CandidateConflictError{ExpectedVersion: 2, CurrentVersion: 4}, status: 409, code: "candidate_conflict", details: map[string]any{"expected_version": int64(2), "current_version": int64(4)}},
 		{name: "artifact CAS", err: &review.ArtifactTargetConflictError{Current: current}, status: 409, code: "artifact_conflict", details: map[string]any{"current": map[string]any{"family": "experience", "artifact_id": "exp_1", "revision": int64(3)}}},

--- a/internal/mcpapi/scope_bindings.go
+++ b/internal/mcpapi/scope_bindings.go
@@ -1,0 +1,291 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mcpapi
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	jsonv2 "encoding/json/v2"
+	"errors"
+	"io"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/ob-labs/powercontext-go/internal/endpoint"
+	"github.com/ob-labs/powercontext-go/internal/scope"
+)
+
+const (
+	scopeBindingSetToolName     = "scope_binding_set"
+	scopeBindingResolveToolName = "scope_binding_resolve"
+	scopeBindingClearToolName   = "scope_binding_clear"
+)
+
+// ScopeBindingOperations is the MCP consumer contract for durable Scope
+// bindings. It intentionally does not depend on generated OpenAPI types.
+type ScopeBindingOperations interface {
+	Bind(context.Context, scope.BindingKey, string) (scope.Binding, error)
+	Resolve(context.Context, *string, []scope.BindingKey) (scope.Descriptor, error)
+	ClearBinding(context.Context, scope.BindingKey) (bool, error)
+}
+
+type scopeBindingKeyInput struct {
+	Integration string `json:"integration"`
+	Kind        string `json:"kind"`
+	ExternalID  string `json:"external_id"`
+}
+
+type scopeBindingSetInput struct {
+	scopeBindingKeyInput
+	ScopeID string           `json:"scope_id"`
+	Key     scope.BindingKey `json:"-"`
+}
+
+type scopeBindingResolveInput struct {
+	ExplicitScopeID *string                `json:"explicit_scope_id"`
+	BindingKeys     []scopeBindingKeyInput `json:"binding_keys"`
+}
+
+type decodedScopeBindingResolveInput struct {
+	ExplicitScopeID *string
+	BindingKeys     []scope.BindingKey
+}
+
+type scopeBindingResult struct {
+	Key     scopeBindingKeyResult `json:"key"`
+	ScopeID string                `json:"scope_id"`
+}
+
+type scopeBindingKeyResult struct {
+	Integration string `json:"integration"`
+	Kind        string `json:"kind"`
+	ExternalID  string `json:"external_id"`
+}
+
+type scopeBindingResolveResult struct {
+	ScopeID string `json:"scope_id"`
+}
+
+type scopeBindingClearResult struct {
+	Cleared bool `json:"cleared"`
+}
+
+var scopeBindingKeyInputSchema = map[string]any{
+	"type": "object", "additionalProperties": false,
+	"required": []string{"integration", "kind", "external_id"},
+	"properties": map[string]any{
+		"integration": map[string]any{"type": "string", "enum": []string{"codex", "workbuddy"}, "minLength": 1, "maxLength": scope.MaxBindingIntegrationLength, "pattern": ".*\\S.*"},
+		"kind":        map[string]any{"type": "string", "minLength": 1, "maxLength": scope.MaxBindingKindLength, "pattern": ".*\\S.*"},
+		"external_id": map[string]any{"type": "string", "minLength": 1, "maxLength": scope.MaxBindingExternalIDLength, "pattern": ".*\\S.*"},
+	},
+}
+
+var scopeBindingSetInputSchema = map[string]any{
+	"type": "object", "additionalProperties": false,
+	"required": []string{"integration", "kind", "external_id", "scope_id"},
+	"properties": map[string]any{
+		"integration": scopeBindingKeyInputSchema["properties"].(map[string]any)["integration"],
+		"kind":        scopeBindingKeyInputSchema["properties"].(map[string]any)["kind"],
+		"external_id": scopeBindingKeyInputSchema["properties"].(map[string]any)["external_id"],
+		"scope_id":    map[string]any{"type": "string", "minLength": 1, "maxLength": scope.MaxIDLength, "pattern": ".*\\S.*"},
+	},
+}
+
+var scopeBindingResolveInputSchema = map[string]any{
+	"type": "object", "additionalProperties": false,
+	"properties": map[string]any{
+		"explicit_scope_id": map[string]any{"type": []string{"string", "null"}, "minLength": 1, "maxLength": scope.MaxIDLength, "pattern": ".*\\S.*"},
+		"binding_keys":      map[string]any{"type": "array", "items": scopeBindingKeyInputSchema},
+	},
+}
+
+var scopeBindingClearInputSchema = map[string]any{
+	"type": "object", "additionalProperties": false,
+	"required":   []string{"integration", "kind", "external_id"},
+	"properties": scopeBindingKeyInputSchema["properties"],
+}
+
+var scopeBindingSetOutputSchema = map[string]any{
+	"type": "object", "additionalProperties": false, "required": []string{"key", "scope_id"},
+	"properties": map[string]any{
+		"key": scopeBindingKeyInputSchema, "scope_id": map[string]any{"type": "string"},
+	},
+}
+
+var scopeBindingResolveOutputSchema = map[string]any{
+	"type": "object", "additionalProperties": false, "required": []string{"scope_id"},
+	"properties": map[string]any{"scope_id": map[string]any{"type": "string"}},
+}
+
+var scopeBindingClearOutputSchema = map[string]any{
+	"type": "object", "additionalProperties": false, "required": []string{"cleared"},
+	"properties": map[string]any{"cleared": map[string]any{"type": "boolean"}},
+}
+
+func registerScopeBindingTools(server *mcp.Server, operations ScopeBindingOperations, options Options) {
+	server.AddTool(&mcp.Tool{
+		Name: scopeBindingSetToolName, Description: "Create or replace a durable external Scope binding.",
+		InputSchema: scopeBindingSetInputSchema, OutputSchema: scopeBindingSetOutputSchema,
+		Annotations: annotations(scopeBindingSetToolName),
+	}, func(ctx context.Context, request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return runTool(ctx, options, scopeBindingSetToolName, func(ctx context.Context) (any, error) {
+			input, err := decodeScopeBindingSetInput(request.Params.Arguments)
+			if err != nil {
+				return nil, err
+			}
+			binding, err := operations.Bind(ctx, input.Key, input.ScopeID)
+			if err != nil {
+				return nil, err
+			}
+			return scopeBindingResult{Key: scopeBindingKeyValue(binding.Key()), ScopeID: binding.ScopeID()}, nil
+		})
+	})
+	server.AddTool(&mcp.Tool{
+		Name: scopeBindingResolveToolName, Description: "Resolve an explicit Scope, ordered durable binding keys, or the durable default Scope.",
+		InputSchema: scopeBindingResolveInputSchema, OutputSchema: scopeBindingResolveOutputSchema,
+		Annotations: annotations(scopeBindingResolveToolName),
+	}, func(ctx context.Context, request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return runTool(ctx, options, scopeBindingResolveToolName, func(ctx context.Context) (any, error) {
+			input, err := decodeScopeBindingResolveInput(request.Params.Arguments)
+			if err != nil {
+				return nil, err
+			}
+			descriptor, err := operations.Resolve(ctx, input.ExplicitScopeID, input.BindingKeys)
+			if err != nil {
+				return nil, err
+			}
+			return scopeBindingResolveResult{ScopeID: descriptor.ID()}, nil
+		})
+	})
+	server.AddTool(&mcp.Tool{
+		Name: scopeBindingClearToolName, Description: "Remove a durable external Scope binding. Repeating the operation is a no-op.",
+		InputSchema: scopeBindingClearInputSchema, OutputSchema: scopeBindingClearOutputSchema,
+		Annotations: annotations(scopeBindingClearToolName),
+	}, func(ctx context.Context, request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return runTool(ctx, options, scopeBindingClearToolName, func(ctx context.Context) (any, error) {
+			key, err := decodeScopeBindingKey(request.Params.Arguments)
+			if err != nil {
+				return nil, err
+			}
+			cleared, err := operations.ClearBinding(ctx, key)
+			if err != nil {
+				return nil, err
+			}
+			return scopeBindingClearResult{Cleared: cleared}, nil
+		})
+	})
+}
+
+func decodeScopeBindingSetInput(raw json.RawMessage) (scopeBindingSetInput, error) {
+	var input scopeBindingSetInput
+	if err := decodeScopeBindingJSON(raw, &input); err != nil {
+		return scopeBindingSetInput{}, err
+	}
+	key, err := scopeBindingKey(input.scopeBindingKeyInput)
+	if err != nil {
+		return scopeBindingSetInput{}, err
+	}
+	if _, err := scope.NewBinding(key, input.ScopeID); err != nil {
+		return scopeBindingSetInput{}, &endpoint.InvalidRequestError{Field: "arguments.scope_id"}
+	}
+	input.scopeBindingKeyInput = scopeBindingKeyInput{Integration: key.Integration(), Kind: key.Kind(), ExternalID: key.ExternalID()}
+	input.Key = key
+	return input, nil
+}
+
+func decodeScopeBindingResolveInput(raw json.RawMessage) (decodedScopeBindingResolveInput, error) {
+	object, err := scopeBindingJSONObject(raw)
+	if err != nil {
+		return decodedScopeBindingResolveInput{}, err
+	}
+	if value, present := object["binding_keys"]; present && bytes.Equal(bytes.TrimSpace(value), []byte("null")) {
+		return decodedScopeBindingResolveInput{}, &endpoint.InvalidRequestError{Field: "arguments.binding_keys"}
+	}
+	var input scopeBindingResolveInput
+	if err := decodeScopeBindingJSON(raw, &input); err != nil {
+		return decodedScopeBindingResolveInput{}, err
+	}
+	if input.ExplicitScopeID != nil && !validScopeBindingText(*input.ExplicitScopeID, scope.MaxIDLength) {
+		return decodedScopeBindingResolveInput{}, &endpoint.InvalidRequestError{Field: "arguments.explicit_scope_id"}
+	}
+	keys := make([]scope.BindingKey, len(input.BindingKeys))
+	for index, value := range input.BindingKeys {
+		key, err := scopeBindingKey(value)
+		if err != nil {
+			return decodedScopeBindingResolveInput{}, err
+		}
+		keys[index] = key
+	}
+	return decodedScopeBindingResolveInput{ExplicitScopeID: input.ExplicitScopeID, BindingKeys: keys}, nil
+}
+
+func decodeScopeBindingKey(raw json.RawMessage) (scope.BindingKey, error) {
+	var input scopeBindingKeyInput
+	if err := decodeScopeBindingJSON(raw, &input); err != nil {
+		return scope.BindingKey{}, err
+	}
+	return scopeBindingKey(input)
+}
+
+func scopeBindingKey(input scopeBindingKeyInput) (scope.BindingKey, error) {
+	key, err := scope.NewBindingKey(input.Integration, input.Kind, input.ExternalID)
+	if err != nil {
+		return scope.BindingKey{}, &endpoint.InvalidRequestError{Field: "arguments"}
+	}
+	if key.Integration() != "codex" && key.Integration() != "workbuddy" {
+		return scope.BindingKey{}, &endpoint.InvalidRequestError{Field: "arguments.integration"}
+	}
+	return key, nil
+}
+
+func scopeBindingJSONObject(raw json.RawMessage) (map[string]json.RawMessage, error) {
+	if len(raw) == 0 || !utf8.Valid(raw) {
+		return nil, &endpoint.InvalidRequestError{Field: "arguments"}
+	}
+	var object map[string]json.RawMessage
+	if err := jsonv2.Unmarshal(raw, &object); err != nil || object == nil {
+		return nil, &endpoint.InvalidRequestError{Field: "arguments"}
+	}
+	return object, nil
+}
+
+func decodeScopeBindingJSON(raw json.RawMessage, target any) error {
+	if len(raw) == 0 {
+		raw = json.RawMessage(`{}`)
+	}
+	if !utf8.Valid(raw) {
+		return &endpoint.InvalidRequestError{Field: "arguments"}
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(target); err != nil {
+		return &endpoint.InvalidRequestError{Field: "arguments"}
+	}
+	if err := decoder.Decode(new(any)); !errors.Is(err, io.EOF) {
+		return &endpoint.InvalidRequestError{Field: "arguments"}
+	}
+	return nil
+}
+
+func validScopeBindingText(value string, maximum int) bool {
+	return utf8.ValidString(value) && value == strings.TrimSpace(value) && value != "" && utf8.RuneCountInString(value) <= maximum
+}
+
+func scopeBindingKeyValue(key scope.BindingKey) scopeBindingKeyResult {
+	return scopeBindingKeyResult{Integration: key.Integration(), Kind: key.Kind(), ExternalID: key.ExternalID()}
+}

--- a/internal/mcpapi/scope_bindings_test.go
+++ b/internal/mcpapi/scope_bindings_test.go
@@ -1,0 +1,247 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mcpapi
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/ob-labs/powercontext-go/internal/endpoint"
+	"github.com/ob-labs/powercontext-go/internal/scope"
+)
+
+func TestScopeBindingToolsAreOptionalAndOperateThroughMCP(t *testing.T) {
+	t.Parallel()
+
+	without, err := NewServer(endpoint.NewHandler(endpoint.HandlerOptions{}), Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if scopeBindingToolsPresent(t, connectInMemory(t, without)) {
+		t.Fatal("Scope Binding tools were registered without a Scope binding service")
+	}
+
+	operations := &scopeBindingOperationsStub{}
+	with, err := NewServer(endpoint.NewHandler(endpoint.HandlerOptions{}), Options{ScopeBindings: operations})
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := connectInMemory(t, with)
+	if !scopeBindingToolsPresent(t, client) {
+		t.Fatal("Scope Binding tools were not registered with a Scope binding service")
+	}
+
+	set, err := client.CallTool(t.Context(), &mcp.CallToolParams{Name: scopeBindingSetToolName, Arguments: map[string]any{
+		"integration": "codex", "kind": "project", "external_id": "repository", "scope_id": "scope-a",
+	}})
+	if err != nil || set.IsError {
+		t.Fatalf("set result = %#v, %v", set, err)
+	}
+	if got, want := set.StructuredContent, map[string]any{
+		"key": map[string]any{"integration": "codex", "kind": "project", "external_id": "repository"}, "scope_id": "scope-a",
+	}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("set structured content = %#v, want %#v", got, want)
+	}
+
+	resolved, err := client.CallTool(t.Context(), &mcp.CallToolParams{Name: scopeBindingResolveToolName, Arguments: map[string]any{
+		"binding_keys": []any{map[string]any{"integration": "codex", "kind": "project", "external_id": "repository"}},
+	}})
+	if err != nil || resolved.IsError {
+		t.Fatalf("resolve result = %#v, %v", resolved, err)
+	}
+	if got := resolved.StructuredContent.(map[string]any)["scope_id"]; got != "scope-a" {
+		t.Fatalf("resolved scope_id = %#v, want scope-a", got)
+	}
+	explicit, err := client.CallTool(t.Context(), &mcp.CallToolParams{Name: scopeBindingResolveToolName, Arguments: map[string]any{
+		"explicit_scope_id": "scope-explicit",
+	}})
+	if err != nil || explicit.IsError {
+		t.Fatalf("explicit resolve result = %#v, %v", explicit, err)
+	}
+	if got := explicit.StructuredContent.(map[string]any)["scope_id"]; got != "scope-explicit" {
+		t.Fatalf("explicit scope_id = %#v, want scope-explicit", got)
+	}
+
+	cleared, err := client.CallTool(t.Context(), &mcp.CallToolParams{Name: scopeBindingClearToolName, Arguments: map[string]any{
+		"integration": "codex", "kind": "project", "external_id": "repository",
+	}})
+	if err != nil || cleared.IsError || !reflect.DeepEqual(cleared.StructuredContent, map[string]any{"cleared": true}) {
+		t.Fatalf("clear result = %#v, %v", cleared, err)
+	}
+}
+
+func TestScopeBindingToolsRejectInvalidInputAndExposeRedactedErrors(t *testing.T) {
+	t.Parallel()
+	operations := &scopeBindingOperationsStub{resolveErr: &scope.NotFoundError{}}
+	server, err := NewServer(endpoint.NewHandler(endpoint.HandlerOptions{}), Options{ScopeBindings: operations})
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := connectInMemory(t, server)
+	invalid, err := client.CallTool(t.Context(), &mcp.CallToolParams{Name: scopeBindingSetToolName, Arguments: map[string]any{
+		"integration": "codex", "kind": "project", "external_id": "repository", "scope_id": "scope-a", "unexpected": true,
+	}})
+	if err != nil || !invalid.IsError {
+		t.Fatalf("unknown field result = %#v, %v", invalid, err)
+	}
+	if code := invalid.StructuredContent.(map[string]any)["error"].(map[string]any)["code"]; code != "invalid_request" {
+		t.Fatalf("unknown field code = %#v, want invalid_request", code)
+	}
+	missing, err := client.CallTool(t.Context(), &mcp.CallToolParams{Name: scopeBindingResolveToolName, Arguments: map[string]any{}})
+	if err != nil || !missing.IsError {
+		t.Fatalf("missing resolve = %#v, %v", missing, err)
+	}
+	if code := missing.StructuredContent.(map[string]any)["error"].(map[string]any)["code"]; code != "scope_not_found" {
+		t.Fatalf("scope error code = %#v, want scope_not_found", code)
+	}
+}
+
+func TestScopeBindingInputValidationAndAnnotations(t *testing.T) {
+	t.Parallel()
+	for _, raw := range []json.RawMessage{
+		[]byte(`{"integration":" ","kind":"project","external_id":"repository","scope_id":"scope-a"}`),
+		[]byte(`{"integration":"codex","kind":"project","external_id":"repository","scope_id":" ` + string(make([]byte, scope.MaxIDLength+1)) + `"}`),
+		[]byte{'{', '"', 'i', 'n', 't', 'e', 'g', 'r', 'a', 't', 'i', 'o', 'n', '"', ':', '"', 0xff, '"', '}'},
+	} {
+		if _, err := decodeScopeBindingSetInput(raw); err == nil {
+			t.Fatalf("invalid input %q was accepted", raw)
+		}
+	}
+	server, err := NewServer(endpoint.NewHandler(endpoint.HandlerOptions{}), Options{ScopeBindings: &scopeBindingOperationsStub{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	tools, err := connectInMemory(t, server).ListTools(t.Context(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	byName := map[string]*mcp.Tool{}
+	for _, tool := range tools.Tools {
+		byName[tool.Name] = tool
+	}
+	resolve := byName[scopeBindingResolveToolName].Annotations
+	if resolve == nil || !resolve.ReadOnlyHint || !resolve.IdempotentHint || resolve.OpenWorldHint == nil || *resolve.OpenWorldHint {
+		t.Fatalf("resolve annotations = %#v", resolve)
+	}
+	for _, name := range []string{scopeBindingSetToolName, scopeBindingClearToolName} {
+		decision := byName[name].Annotations
+		if decision == nil || decision.ReadOnlyHint || !decision.IdempotentHint || decision.DestructiveHint == nil || !*decision.DestructiveHint || decision.OpenWorldHint == nil || *decision.OpenWorldHint {
+			t.Fatalf("%s annotations = %#v", name, decision)
+		}
+	}
+}
+
+func TestScopeBindingDecoderRejectsNonObjectAndNullBindingKeys(t *testing.T) {
+	t.Parallel()
+	for _, raw := range []json.RawMessage{
+		[]byte(`null`),
+		[]byte(`[]`),
+		[]byte(`{"binding_keys":null}`),
+	} {
+		if _, err := decodeScopeBindingResolveInput(raw); err == nil {
+			t.Fatalf("resolve input %q was accepted", raw)
+		}
+	}
+}
+
+func TestScopeBindingDecoderRejectsDuplicateMembersAndAcceptsExplicitNull(t *testing.T) {
+	t.Parallel()
+	if _, err := decodeScopeBindingResolveInput([]byte(`{"binding_keys":[],"binding_keys":[]}`)); err == nil {
+		t.Fatal("duplicate binding_keys was accepted")
+	}
+	decoded, err := decodeScopeBindingResolveInput([]byte(`{"explicit_scope_id":null}`))
+	if err != nil || decoded.ExplicitScopeID != nil || len(decoded.BindingKeys) != 0 {
+		t.Fatalf("explicit null decode = %#v, %v", decoded, err)
+	}
+}
+
+func TestScopeBindingToolsRejectNonTargetIntegrationWithoutWriting(t *testing.T) {
+	t.Parallel()
+	operations := &scopeBindingOperationsStub{}
+	server, err := NewServer(endpoint.NewHandler(endpoint.HandlerOptions{}), Options{ScopeBindings: operations})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := connectInMemory(t, server).CallTool(t.Context(), &mcp.CallToolParams{Name: scopeBindingSetToolName, Arguments: map[string]any{
+		"integration": "claude-code", "kind": "session", "external_id": "session-1", "scope_id": "scope-a",
+	}})
+	if err != nil || !result.IsError {
+		t.Fatalf("non-target integration result = %#v, %v", result, err)
+	}
+	if code := result.StructuredContent.(map[string]any)["error"].(map[string]any)["code"]; code != "invalid_request" {
+		t.Fatalf("non-target integration code = %#v, want invalid_request", code)
+	}
+	if len(operations.bindings) != 0 {
+		t.Fatalf("non-target integration wrote bindings = %#v", operations.bindings)
+	}
+}
+
+func scopeBindingToolsPresent(t *testing.T, client *mcp.ClientSession) bool {
+	t.Helper()
+	tools, err := client.ListTools(t.Context(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	names := map[string]bool{}
+	for _, tool := range tools.Tools {
+		names[tool.Name] = true
+	}
+	return names[scopeBindingSetToolName] && names[scopeBindingResolveToolName] && names[scopeBindingClearToolName]
+}
+
+type scopeBindingOperationsStub struct {
+	bindings   map[scope.BindingKey]string
+	resolveErr error
+}
+
+func (s *scopeBindingOperationsStub) Bind(_ context.Context, key scope.BindingKey, scopeID string) (scope.Binding, error) {
+	if s.bindings == nil {
+		s.bindings = make(map[scope.BindingKey]string)
+	}
+	s.bindings[key] = scopeID
+	return scope.NewBinding(key, scopeID)
+}
+
+func (s *scopeBindingOperationsStub) Resolve(_ context.Context, explicitID *string, keys []scope.BindingKey) (scope.Descriptor, error) {
+	if s.resolveErr != nil {
+		return scope.Descriptor{}, s.resolveErr
+	}
+	if explicitID != nil {
+		return scope.NewDescriptor(*explicitID, "Explicit Scope", "Scope summary", "", nil, nil, 1)
+	}
+	for _, key := range keys {
+		if id, ok := s.bindings[key]; ok {
+			return scope.NewDescriptor(id, "Scope A", "Scope summary", "", nil, nil, 1)
+		}
+	}
+	return scope.Descriptor{}, &scope.BindingNotFoundError{}
+}
+
+func (s *scopeBindingOperationsStub) ClearBinding(_ context.Context, key scope.BindingKey) (bool, error) {
+	if s.bindings == nil {
+		return false, nil
+	}
+	if _, ok := s.bindings[key]; !ok {
+		return false, nil
+	}
+	delete(s.bindings, key)
+	return true, nil
+}
+
+var _ ScopeBindingOperations = (*scopeBindingOperationsStub)(nil)

--- a/internal/mcpapi/server.go
+++ b/internal/mcpapi/server.go
@@ -52,6 +52,7 @@ var errUnexpectedEndpointResponse = errors.New("unexpected endpoint response")
 type Options struct {
 	Version              string
 	HandoffReportEnabled bool
+	ScopeBindings        ScopeBindingOperations
 	ReceivingMiddleware  []mcp.Middleware
 	ApplicationObserver  ApplicationObserver
 	ApplicationLogger    *slog.Logger
@@ -118,6 +119,9 @@ func NewServer(handler v1.Handler, options Options) (*mcp.Server, error) {
 	}
 	if options.HandoffReportEnabled {
 		registerHandoffWorkstreamPicker(server, handler, options)
+	}
+	if options.ScopeBindings != nil {
+		registerScopeBindingTools(server, options.ScopeBindings, options)
 	}
 	return server, nil
 }
@@ -520,6 +524,20 @@ func annotations(name string) *mcp.ToolAnnotations {
 		// pending-head CAS before another write can occur.
 		return &mcp.ToolAnnotations{
 			DestructiveHint: new(true),
+			IdempotentHint:  true,
+			OpenWorldHint:   &closedWorld,
+		}
+	case scopeBindingResolveToolName:
+		value := &mcp.ToolAnnotations{OpenWorldHint: &closedWorld}
+		value.ReadOnlyHint = true
+		nondestructive := false
+		value.DestructiveHint = &nondestructive
+		value.IdempotentHint = true
+		return value
+	case scopeBindingSetToolName, scopeBindingClearToolName:
+		destructive := true
+		return &mcp.ToolAnnotations{
+			DestructiveHint: &destructive,
 			IdempotentHint:  true,
 			OpenWorldHint:   &closedWorld,
 		}

--- a/internal/runtime/scope_application.go
+++ b/internal/runtime/scope_application.go
@@ -34,6 +34,7 @@ type ScopeStore interface {
 	SetDefault(context.Context, string) (scope.Descriptor, error)
 	Default(context.Context) (scope.Descriptor, bool, error)
 	SetBinding(context.Context, scope.BindingKey, string) (scope.Binding, error)
+	ClearBinding(context.Context, scope.BindingKey) (bool, error)
 	Binding(context.Context, scope.BindingKey) (scope.Binding, bool, error)
 }
 
@@ -126,6 +127,17 @@ func (a *ScopeApplication) Bind(ctx context.Context, key scope.BindingKey, id st
 		return bindErr
 	})
 	return result, err
+}
+
+// ClearBinding removes one durable external Scope binding. A missing binding is
+// an idempotent no-op and reports cleared=false.
+func (a *ScopeApplication) ClearBinding(ctx context.Context, key scope.BindingKey) (cleared bool, err error) {
+	err = a.runtime.Operation(ctx, func(ctx context.Context) error {
+		var clearErr error
+		cleared, clearErr = a.store.ClearBinding(ctx, key)
+		return clearErr
+	})
+	return cleared, err
 }
 
 // Resolve treats nil as omitted and every explicit value, including an empty

--- a/internal/runtime/scope_application_test.go
+++ b/internal/runtime/scope_application_test.go
@@ -94,6 +94,43 @@ func TestScopeApplicationRejectsInvalidRelationships(t *testing.T) {
 	}
 }
 
+func TestScopeApplicationClearBindingIsIdempotent(t *testing.T) {
+	store := &memoryScopeStore{scopes: map[string]scope.Descriptor{}}
+	application, err := NewScopeApplication(New(), store, func() string { return "scope-created" })
+	if err != nil {
+		t.Fatal(err)
+	}
+	draft, err := scope.NewDraft("title", "summary", "", nil, nil, "clear-binding")
+	if err != nil {
+		t.Fatal(err)
+	}
+	created, err := application.Create(t.Context(), draft)
+	if err != nil {
+		t.Fatal(err)
+	}
+	key, err := scope.NewBindingKey("codex", "project", "repository")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, bindErr := application.Bind(t.Context(), key, created.ID()); bindErr != nil {
+		t.Fatal(bindErr)
+	}
+
+	cleared, err := application.ClearBinding(t.Context(), key)
+	if err != nil || !cleared {
+		t.Fatalf("first clear = (%t, %v), want (true, nil)", cleared, err)
+	}
+	if _, resolveErr := application.Resolve(t.Context(), nil, []scope.BindingKey{key}); resolveErr == nil {
+		t.Fatal("cleared binding resolved a Scope")
+	} else if _, ok := resolveErr.(*scope.BindingNotFoundError); !ok {
+		t.Fatalf("resolve after clear error = %T %v, want BindingNotFoundError", resolveErr, resolveErr)
+	}
+	repeated, err := application.ClearBinding(t.Context(), key)
+	if err != nil || repeated {
+		t.Fatalf("repeated clear = (%t, %v), want (false, nil)", repeated, err)
+	}
+}
+
 type memoryScopeStore struct {
 	scopes    map[string]scope.Descriptor
 	defaultID string
@@ -176,6 +213,14 @@ func (s *memoryScopeStore) SetBinding(_ context.Context, key scope.BindingKey, i
 	}
 	s.bindings[key] = binding
 	return binding, nil
+}
+
+func (s *memoryScopeStore) ClearBinding(_ context.Context, key scope.BindingKey) (bool, error) {
+	if _, found := s.bindings[key]; !found {
+		return false, nil
+	}
+	delete(s.bindings, key)
+	return true, nil
 }
 
 func (s *memoryScopeStore) Binding(_ context.Context, key scope.BindingKey) (scope.Binding, bool, error) {

--- a/internal/sqlstore/runtime_scopes.go
+++ b/internal/sqlstore/runtime_scopes.go
@@ -184,6 +184,18 @@ func (s *RuntimeScopeStore) SetBinding(ctx context.Context, key scope.BindingKey
 	return result, err
 }
 
+func (s *RuntimeScopeStore) ClearBinding(ctx context.Context, key scope.BindingKey) (cleared bool, err error) {
+	err = s.database.Transaction(ctx, func(tx DBTX) error {
+		if lockErr := s.repository.LockHierarchy(ctx, tx); lockErr != nil {
+			return lockErr
+		}
+		var clearErr error
+		cleared, clearErr = s.repository.ClearBinding(ctx, tx, key)
+		return clearErr
+	})
+	return cleared, err
+}
+
 func requiredScopeError(err error) error {
 	if errors.Is(err, sql.ErrNoRows) {
 		return &scope.NotFoundError{}

--- a/internal/sqlstore/runtime_scopes_test.go
+++ b/internal/sqlstore/runtime_scopes_test.go
@@ -66,6 +66,72 @@ func TestRuntimeScopeStoreOwnsScopeTransactions(t *testing.T) {
 	if err != nil || !bindingFound || binding.ScopeID() != created.ID() {
 		t.Fatalf("binding = %#v, %t, %v", binding, bindingFound, err)
 	}
+	cleared, err := store.ClearBinding(t.Context(), key)
+	if err != nil || !cleared {
+		t.Fatalf("clear binding = (%t, %v), want (true, nil)", cleared, err)
+	}
+	_, bindingFound, err = store.Binding(t.Context(), key)
+	if err != nil || bindingFound {
+		t.Fatalf("binding after clear = (found=%t, err=%v), want (false, nil)", bindingFound, err)
+	}
+	cleared, err = store.ClearBinding(t.Context(), key)
+	if err != nil || cleared {
+		t.Fatalf("repeated clear binding = (%t, %v), want (false, nil)", cleared, err)
+	}
+	if _, setErr := store.SetBinding(t.Context(), key, created.ID()); setErr != nil {
+		t.Fatal(setErr)
+	}
+	cancelled, cancel := context.WithCancel(t.Context())
+	cancel()
+	cleared, err = store.ClearBinding(cancelled, key)
+	if err == nil || cleared {
+		t.Fatalf("cancelled clear binding = (%t, %v), want (false, context error)", cleared, err)
+	}
+	_, bindingFound, err = store.Binding(t.Context(), key)
+	if err != nil || !bindingFound {
+		t.Fatalf("cancelled clear removed binding: found=%t err=%v", bindingFound, err)
+	}
+}
+
+func TestRuntimeScopeStoreClearBindingRollsBackInjectedDeleteFailure(t *testing.T) {
+	database := openTestDatabase(t)
+	store, err := sqlstore.NewRuntimeScopeStore(database, sqlstore.ScopeRepository{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	draft, err := scope.NewDraft("title", "summary", "", nil, nil, "clear-failure")
+	if err != nil {
+		t.Fatal(err)
+	}
+	created, err := store.Create(t.Context(), "scope-clear-failure", draft, func([]scope.Descriptor) error { return nil })
+	if err != nil {
+		t.Fatal(err)
+	}
+	key, err := scope.NewBindingKey("workbuddy", "session", "session-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.SetBinding(t.Context(), key, created.ID()); err != nil {
+		t.Fatal(err)
+	}
+	if err := database.Transaction(t.Context(), func(tx sqlstore.DBTX) error {
+		_, triggerErr := tx.ExecContext(t.Context(), `CREATE TRIGGER reject_scope_binding_delete
+			BEFORE DELETE ON pc_scope_bindings
+			BEGIN
+				SELECT RAISE(ABORT, 'scope binding delete blocked');
+			END`)
+		return triggerErr
+	}); err != nil {
+		t.Fatal(err)
+	}
+	cleared, clearErr := store.ClearBinding(t.Context(), key)
+	if clearErr == nil || cleared {
+		t.Fatalf("injected delete failure = (%t, %v), want (false, error)", cleared, clearErr)
+	}
+	_, found, lookupErr := store.Binding(t.Context(), key)
+	if lookupErr != nil || !found {
+		t.Fatalf("failed clear removed binding: found=%t err=%v", found, lookupErr)
+	}
 }
 
 func TestScopeApplicationSQLiteValidatesRelationshipsBeforeMetadataCAS(t *testing.T) {

--- a/internal/sqlstore/scopes.go
+++ b/internal/sqlstore/scopes.go
@@ -204,6 +204,21 @@ func (ScopeRepository) SetBinding(ctx context.Context, db DBTX, key scope.Bindin
 	return scope.NewBinding(key, id)
 }
 
+// ClearBinding removes a complete durable external binding key. Missing keys
+// are deliberately an idempotent no-op.
+func (ScopeRepository) ClearBinding(ctx context.Context, db DBTX, key scope.BindingKey) (bool, error) {
+	result, err := db.ExecContext(ctx, `DELETE FROM pc_scope_bindings
+        WHERE integration = ? AND kind = ? AND external_id = ?`, key.Integration(), key.Kind(), key.ExternalID())
+	if err != nil {
+		return false, err
+	}
+	count, err := result.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	return count > 0, nil
+}
+
 func (ScopeRepository) Binding(ctx context.Context, db DBTX, key scope.BindingKey) (scope.Binding, bool, error) {
 	var id string
 	err := db.QueryRowContext(ctx, `SELECT scope_id FROM pc_scope_bindings

--- a/server/application.go
+++ b/server/application.go
@@ -135,8 +135,9 @@ func (a *Application) HTTPHandler() (http.Handler, error) {
 	return NewHTTPHandler(a.endpoint, HTTPOptions{
 		BearerToken: token, HandoffReportRoutes: a.config.HandoffReport.Enabled,
 		metrics: a.metrics, TracerProvider: a.tracing, Logger: a.logger, AccessLog: a.config.Logging.Access,
-		MCP:   MCPOptions{Enabled: a.config.MCP.Enabled, Path: a.config.MCP.Path},
-		webUI: webOptions,
+		MCP:           MCPOptions{Enabled: a.config.MCP.Enabled, Path: a.config.MCP.Path},
+		webUI:         webOptions,
+		scopeBindings: a.scopes,
 	})
 }
 

--- a/server/http.go
+++ b/server/http.go
@@ -47,6 +47,7 @@ type HTTPOptions struct {
 	MCP                 MCPOptions
 	metrics             *servermetrics.Server
 	webUI               *webui.Options
+	scopeBindings       mcpapi.ScopeBindingOperations
 }
 
 // MCPOptions controls the optional MCP Streamable HTTP route. Path defaults to
@@ -138,6 +139,7 @@ func NewHTTPHandler(handler v1.Handler, options HTTPOptions) (http.Handler, erro
 		mcpServer, mcpErr := mcpapi.NewServer(handler, mcpapi.Options{
 			Version:              options.MCP.Version,
 			HandoffReportEnabled: options.HandoffReportRoutes,
+			ScopeBindings:        options.scopeBindings,
 			ApplicationObserver:  options.metrics,
 			ApplicationLogger:    applicationLogger,
 			TracerProvider:       options.TracerProvider,

--- a/server/scope_application_test.go
+++ b/server/scope_application_test.go
@@ -19,11 +19,15 @@ package server
 import (
 	"context"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/ob-labs/powercontext-go/internal/sqlstore"
 )
@@ -137,6 +141,87 @@ func TestOpenApplicationBootstrapFailureRollsBackAndAllowsRetry(t *testing.T) {
 	}
 }
 
+func TestOpenApplicationMCPPersistsScopeBindingAndRequiresAuthentication(t *testing.T) {
+	databasePath := filepath.Join(t.TempDir(), "powercontext.db")
+	config := scopeApplicationTestConfig(t, databasePath)
+	config.MCP.Enabled = true
+	config.Auth.Enabled = true
+	config.Auth.Token = "scope-mcp-secret"
+
+	first, err := OpenApplication(t.Context(), config, Dependencies{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstHandler, err := first.HTTPHandler()
+	if err != nil {
+		t.Fatal(err)
+	}
+	unauthorized := httptest.NewRecorder()
+	firstHandler.ServeHTTP(unauthorized, httptest.NewRequest(http.MethodPost, "/mcp/", nil))
+	if unauthorized.Code != http.StatusUnauthorized || unauthorized.Header().Get("WWW-Authenticate") != "Bearer" {
+		t.Fatalf("unauthorized MCP = %d %#v", unauthorized.Code, unauthorized.Header())
+	}
+	defaultScope, err := first.scopes.Resolve(t.Context(), nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstClient := connectScopeMCP(t, firstHandler, config.Auth.Token)
+	set, err := firstClient.CallTool(t.Context(), &mcp.CallToolParams{Name: "scope_binding_set", Arguments: map[string]any{
+		"integration": "codex", "kind": "project", "external_id": "repository", "scope_id": defaultScope.ID(),
+	}})
+	if err != nil || set.IsError {
+		t.Fatalf("set binding = %#v, %v", set, err)
+	}
+	set, err = firstClient.CallTool(t.Context(), &mcp.CallToolParams{Name: "scope_binding_set", Arguments: map[string]any{
+		"integration": "workbuddy", "kind": "session", "external_id": "session-1", "scope_id": defaultScope.ID(),
+	}})
+	if err != nil || set.IsError {
+		t.Fatalf("set WorkBuddy binding = %#v, %v", set, err)
+	}
+	if closeErr := first.Close(t.Context()); closeErr != nil {
+		t.Fatal(closeErr)
+	}
+
+	second, err := OpenApplication(t.Context(), config, Dependencies{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { closeScopeTestApplication(t, second) })
+	secondHandler, err := second.HTTPHandler()
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondClient := connectScopeMCP(t, secondHandler, config.Auth.Token)
+	for _, key := range []map[string]any{
+		{"integration": "codex", "kind": "project", "external_id": "repository"},
+		{"integration": "workbuddy", "kind": "session", "external_id": "session-1"},
+	} {
+		resolved, resolveErr := secondClient.CallTool(t.Context(), &mcp.CallToolParams{
+			Name: "scope_binding_resolve", Arguments: map[string]any{"binding_keys": []any{key}},
+		})
+		if resolveErr != nil || resolved.IsError {
+			t.Fatalf("resolve binding after restart = %#v, %v", resolved, resolveErr)
+		}
+		content := resolved.StructuredContent.(map[string]any)
+		if content["scope_id"] != defaultScope.ID() {
+			t.Fatalf("resolved scope_id = %#v, want %q", content["scope_id"], defaultScope.ID())
+		}
+	}
+	thirdParty, err := secondClient.CallTool(t.Context(), &mcp.CallToolParams{Name: "scope_binding_set", Arguments: map[string]any{
+		"integration": "claude-code", "kind": "session", "external_id": "session-1", "scope_id": defaultScope.ID(),
+	}})
+	if err != nil || !thirdParty.IsError {
+		t.Fatalf("non-target binding result = %#v, %v", thirdParty, err)
+	}
+	workBuddyKey := map[string]any{"integration": "workbuddy", "kind": "session", "external_id": "session-1"}
+	for _, want := range []bool{true, false} {
+		cleared, clearErr := secondClient.CallTool(t.Context(), &mcp.CallToolParams{Name: "scope_binding_clear", Arguments: workBuddyKey})
+		if clearErr != nil || cleared.IsError || cleared.StructuredContent.(map[string]any)["cleared"] != want {
+			t.Fatalf("clear WorkBuddy binding = %#v, %v, want %t", cleared, clearErr, want)
+		}
+	}
+}
+
 func scopeApplicationTestConfig(t *testing.T, databasePath string) ProcessConfig {
 	t.Helper()
 	config, err := DefaultConfig()
@@ -166,4 +251,24 @@ func closeScopeTestApplication(t *testing.T, application *Application) {
 	if closeErr := application.Close(ctx); closeErr != nil {
 		t.Error(closeErr)
 	}
+}
+
+func connectScopeMCP(t *testing.T, handler http.Handler, token string) *mcp.ClientSession {
+	t.Helper()
+	client := mcp.NewClient(&mcp.Implementation{Name: "scope-binding-test", Version: "1"}, nil)
+	session, err := client.Connect(t.Context(), &mcp.StreamableClientTransport{
+		Endpoint: "http://powercontext.test/mcp/",
+		HTTPClient: &http.Client{Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+			request.Header.Set("Authorization", "Bearer "+token)
+			response := httptest.NewRecorder()
+			handler.ServeHTTP(response, request)
+			return response.Result(), nil
+		})},
+		DisableStandaloneSSE: true,
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = session.Close() })
+	return session
 }

--- a/tools/process-smoke/main.go
+++ b/tools/process-smoke/main.go
@@ -74,6 +74,9 @@ var baseToolNames = []string{
 	"revise_artifact_candidate",
 	"revise_memory_entry",
 	"search_memory",
+	"scope_binding_clear",
+	"scope_binding_resolve",
+	"scope_binding_set",
 }
 
 type options struct {
@@ -101,7 +104,7 @@ func main() {
 		os.Exit(1)
 	}
 	fmt.Printf(
-		"Verified PowerContext %s CLI, HTTP, authenticated Dashboard, MCP 20/24-tool surfaces, SQLite restart persistence, and graceful shutdown.\n",
+		"Verified PowerContext %s CLI, HTTP, authenticated Dashboard, MCP 23/27-tool surfaces, SQLite restart persistence, and graceful shutdown.\n",
 		*version,
 	)
 }

--- a/tools/process-smoke/main_test.go
+++ b/tools/process-smoke/main_test.go
@@ -209,8 +209,8 @@ func TestFrozenBaseToolNamesAreUnique(t *testing.T) {
 		}
 		seen[name] = struct{}{}
 	}
-	if len(seen) != 20 {
-		t.Fatalf("base MCP tools = %d, want 20", len(seen))
+	if len(seen) != 23 {
+		t.Fatalf("base MCP tools = %d, want 23", len(seen))
 	}
 }
 


### PR DESCRIPTION
## Phase 2 durable Scope bindings over MCP

This keeps Phase 2 within Issue #202's MCP-or-HTTP acceptance boundary, without prematurely adding Phase 3 Scope REST operations or expanding the published `api/v1.Handler` / `client.Invoker` interfaces.

- Adds optional MCP-native tools: `scope_binding_set`, `scope_binding_resolve`, and `scope_binding_clear`.
- Keeps the scope tool surface limited to `codex` and `workbuddy`; non-target integrations fail before any durable write.
- Supports explicit Scope resolution, ordered durable keys, and default-Scope fallback through the existing Runtime `ScopeApplication`.
- Adds transactional, idempotent SQLite binding deletion and Scope typed-error mapping with redacted wire/MCP results.
- Preserves outer MCP bearer authentication; a real SQLite Application test verifies Codex and WorkBuddy persistence across restart, clear/repeat-clear, and a non-target refusal.
- Uses `encoding/json/v2` for the new input object preflight to reject duplicate members, non-object roots, and invalid UTF-8 while allowing documented `explicit_scope_id: null`.

## Verification

- `go test -count=1 ./internal/runtime ./internal/sqlstore ./internal/endpoint ./internal/mcpapi`
- `go test -tags sqlite_fts5 -count=1 ./server -run '^TestOpenApplicationMCPPersistsScopeBindingAndRequiresAuthentication$'`
- `make check-generated`
- `make api-compat`
- Changed-path `golangci-lint --new-from-rev=b508162...` (0 issues)
- Independent review plus two scoped re-reviews: all P0/P1 findings resolved.

## Local environment limit

The broad Windows `make test-sqlite` run passes the changed packages but retains unrelated platform failures: symlink privilege, file-DSN scheduler parsing/Python scheduler path, process loopback readiness, and archive executable-mode expectations. Required Linux CI remains the authority for those broader process/platform paths.

Part of #202.