### PR TITLE
feat(workbuddy): resolve hook scopes through MCP

### DIFF
--- a/internal/cli/workbuddy_hook.go
+++ b/internal/cli/workbuddy_hook.go
@@ -25,13 +25,13 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"regexp"
 	"strconv"
 	"strings"
 	"time"
 	"unicode/utf8"
 
 	"github.com/go-faster/jx"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/spf13/cobra"
 
 	v1 "github.com/ob-labs/powercontext-go/api/v1"
@@ -42,7 +42,7 @@ import (
 const (
 	workBuddyHookMaximumInputBytes  = 64 * 1024
 	workBuddyHookMaximumOutputBytes = 64 * 1024
-	workBuddyHookMaximumScopeBytes  = 256
+	workBuddyHookCloseTimeout       = 50 * time.Millisecond
 )
 
 var (
@@ -52,10 +52,7 @@ var (
 
 const (
 	workBuddyHookScopeEnvironment = "POWERCONTEXT_WORKBUDDY_SCOPE_ID"
-	workBuddyHookWorkspaceSchema  = "powercontext.codex-workspace.v1"
 )
-
-var workBuddyHookSCPRemote = regexp.MustCompile(`^(?:[^@/\s]+@)?([^:/\s]+):(.+)$`)
 
 type workBuddyHookPayload struct {
 	HookEventName string `json:"hook_event_name"`
@@ -77,8 +74,26 @@ type workBuddyHookResponse struct {
 type workBuddyHookRuntime struct {
 	configuration workBuddyConfiguration
 	getenv        func(string) string
+	lookupEnv     func(string) (string, bool)
 	httpClient    *http.Client
 	now           func() time.Time
+	scopeResolver workBuddyHookScopeResolver
+}
+
+type workBuddyHookScopeBindingKey struct {
+	Integration string `json:"integration"`
+	Kind        string `json:"kind"`
+	ExternalID  string `json:"external_id"`
+}
+
+type workBuddyHookScopeResolver interface {
+	Resolve(context.Context, *string, []workBuddyHookScopeBindingKey) (string, bool)
+}
+
+type workBuddyHookScopeResolverFunc func(context.Context, *string, []workBuddyHookScopeBindingKey) (string, bool)
+
+func (resolve workBuddyHookScopeResolverFunc) Resolve(ctx context.Context, explicit *string, keys []workBuddyHookScopeBindingKey) (string, bool) {
+	return resolve(ctx, explicit, keys)
 }
 
 func newHookCommand(state *commandState) *cobra.Command {
@@ -141,6 +156,10 @@ func runWorkBuddyHook(
 	if getenv == nil {
 		getenv = os.Getenv
 	}
+	lookupEnv := runtime.lookupEnv
+	if lookupEnv == nil {
+		lookupEnv = os.LookupEnv
+	}
 	now := runtime.now
 	if now == nil {
 		now = time.Now
@@ -149,11 +168,18 @@ func runWorkBuddyHook(
 	operationContext, cancel := context.WithTimeout(ctx, budget)
 	defer cancel()
 
-	scope, ok := resolveWorkBuddyHookScope(operationContext, payload.CWD, runtime.configuration.ScopeMode, getenv)
+	client, ok := newWorkBuddyHookClient(operationContext, runtime.configuration, getenv, runtime.httpClient, now)
 	if !ok {
 		return writeWorkBuddyHookResponse(output, "")
 	}
-	client, ok := newWorkBuddyHookClient(operationContext, runtime.configuration, getenv, runtime.httpClient, now)
+	resolver := runtime.scopeResolver
+	if resolver == nil {
+		resolver, ok = newWorkBuddyHookMCPScopeResolver(operationContext, runtime.configuration, getenv, runtime.httpClient, now)
+		if !ok {
+			return writeWorkBuddyHookResponse(output, "")
+		}
+	}
+	scope, ok := resolver.Resolve(operationContext, workBuddyHookExplicitScope(lookupEnv), workBuddyHookScopeBindingKeys(operationContext, payload))
 	if !ok {
 		return writeWorkBuddyHookResponse(output, "")
 	}
@@ -179,20 +205,104 @@ func recallWorkBuddyContext(ctx context.Context, client *pcclient.Client, payloa
 }
 
 func newWorkBuddyHookClient(ctx context.Context, configuration workBuddyConfiguration, getenv func(string) string, supplied *http.Client, now func() time.Time) (*pcclient.Client, bool) {
-	deadline, ok := ctx.Deadline()
+	timeout, ok := workBuddyHookRequestTimeout(ctx, configuration, now)
 	if !ok {
 		return nil, false
 	}
-	remaining := deadline.Sub(now())
-	if remaining <= 0 {
-		return nil, false
-	}
-	timeout := time.Duration(configuration.RequestTimeoutSeconds * float64(time.Second))
-	if remaining < timeout {
-		timeout = remaining
-	}
 	result, err := pcclient.New(configuration.ServerURL, pcclient.Options{BearerToken: workBuddyHookBearerToken(getenv(configuration.AuthorizationEnvironment)), Timeout: timeout, HTTPClient: workBuddyHookHTTPClient(supplied, workBuddyHookResponseLimit(configuration))})
 	return result, err == nil
+}
+
+func workBuddyHookRequestTimeout(ctx context.Context, configuration workBuddyConfiguration, now func() time.Time) (time.Duration, bool) {
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		return 0, false
+	}
+	remaining := deadline.Sub(now())
+	if remaining <= 0 {
+		return 0, false
+	}
+	timeout := time.Duration(configuration.RequestTimeoutSeconds * float64(time.Second))
+	return min(timeout, remaining), true
+}
+
+type workBuddyHookMCPScopeResolver struct {
+	endpoint   string
+	client     *mcp.Client
+	httpClient *http.Client
+	now        func() time.Time
+}
+
+func newWorkBuddyHookMCPScopeResolver(ctx context.Context, configuration workBuddyConfiguration, getenv func(string) string, supplied *http.Client, now func() time.Time) (workBuddyHookScopeResolver, bool) {
+	timeout, ok := workBuddyHookRequestTimeout(ctx, configuration, now)
+	if !ok {
+		return nil, false
+	}
+	serverURL, err := normalizeWorkBuddyServerURL(configuration.ServerURL)
+	if err != nil {
+		return nil, false
+	}
+	httpClient := workBuddyHookHTTPClient(supplied, workBuddyHookMaximumOutputBytes)
+	httpClient.Timeout = timeout
+	httpClient.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+	if token := workBuddyHookBearerToken(getenv(configuration.AuthorizationEnvironment)); token != "" {
+		httpClient.Transport = workBuddyHookAuthorizationTransport{next: httpClient.Transport, authorization: "Bearer " + token}
+	}
+	return workBuddyHookMCPScopeResolver{
+		endpoint: serverURL + "/mcp/", client: mcp.NewClient(&mcp.Implementation{Name: "powercontext-workbuddy-hook", Version: "1"}, nil),
+		httpClient: httpClient, now: now,
+	}, true
+}
+
+func (resolver workBuddyHookMCPScopeResolver) Resolve(ctx context.Context, explicit *string, keys []workBuddyHookScopeBindingKey) (string, bool) {
+	session, err := resolver.client.Connect(ctx, &mcp.StreamableClientTransport{
+		Endpoint: resolver.endpoint, HTTPClient: resolver.httpClient, DisableStandaloneSSE: true, MaxRetries: -1,
+	}, nil)
+	if err != nil {
+		return "", false
+	}
+	defer resolver.close(ctx, session)
+	arguments := map[string]any{"binding_keys": keys}
+	if explicit != nil {
+		arguments["explicit_scope_id"] = *explicit
+	}
+	result, err := session.CallTool(ctx, &mcp.CallToolParams{Name: "scope_binding_resolve", Arguments: arguments})
+	if err != nil || result.IsError {
+		return "", false
+	}
+	content, ok := result.StructuredContent.(map[string]any)
+	if !ok {
+		return "", false
+	}
+	scope, ok := content["scope_id"].(string)
+	if !ok || !validWorkBuddyHookScope(scope) {
+		return "", false
+	}
+	return scope, true
+}
+
+func (resolver workBuddyHookMCPScopeResolver) close(ctx context.Context, session *mcp.ClientSession) {
+	timeout := workBuddyHookCloseTimeout
+	if deadline, ok := ctx.Deadline(); ok {
+		remaining := deadline.Sub(resolver.now())
+		if remaining > 0 {
+			timeout = min(timeout, remaining)
+		}
+	}
+	resolver.httpClient.Timeout = timeout
+	_ = session.Close()
+}
+
+type workBuddyHookAuthorizationTransport struct {
+	next          http.RoundTripper
+	authorization string
+}
+
+func (transport workBuddyHookAuthorizationTransport) RoundTrip(request *http.Request) (*http.Response, error) {
+	clone := request.Clone(request.Context())
+	clone.Header = request.Header.Clone()
+	clone.Header.Set("Authorization", transport.authorization)
+	return transport.next.RoundTrip(clone)
 }
 
 func workBuddyHookBearerToken(authorization string) string {
@@ -291,127 +401,50 @@ func (body *workBuddyHookResponseBody) Close() error {
 	return body.body.Close()
 }
 
-func resolveWorkBuddyHookScope(ctx context.Context, cwd, mode string, getenv func(string) string) (string, bool) {
-	if explicit := strings.TrimSpace(getenv(workBuddyHookScopeEnvironment)); explicit != "" {
-		return boundedWorkBuddyScope("", explicit), true
+func workBuddyHookExplicitScope(lookupEnv func(string) (string, bool)) *string {
+	value, present := lookupEnv(workBuddyHookScopeEnvironment)
+	if !present {
+		return nil
 	}
-	if mode == "agent" {
-		return "workbuddy:agent", true
-	}
-	if mode != "project" {
-		return "", false
-	}
-	if gitDirectory := workBuddyHookGitValue(ctx, cwd, "rev-parse", "--absolute-git-dir"); gitDirectory != "" {
-		if scope, ok := readWorkBuddyHookBoundScope(filepath.Join(gitDirectory, "powercontext", "codex-workspace.json")); ok {
-			return scope, true
-		}
-	}
-	projectRoot := workBuddyHookProjectRoot(cwd)
-	if root := workBuddyHookGitValue(ctx, cwd, "rev-parse", "--show-toplevel"); root != "" {
-		projectRoot = workBuddyHookProjectRoot(root)
-	}
-	if remote := workBuddyHookGitValue(ctx, projectRoot, "config", "--get", "remote.origin.url"); remote != "" {
-		if normalized := normalizeWorkBuddyHookGitRemote(remote); normalized != "" {
-			return boundedWorkBuddyScope("git", normalized), true
-		}
-	}
-	sum := sha256.Sum256([]byte(projectRoot))
-	return "local:" + fmtHex(sum[:]), true
+	return &value
 }
 
-func boundedWorkBuddyScope(prefix, value string) string {
-	candidate := value
-	if prefix != "" {
-		candidate = prefix + ":" + value
+func workBuddyHookScopeBindingKeys(ctx context.Context, payload workBuddyHookPayload) []workBuddyHookScopeBindingKey {
+	keys := make([]workBuddyHookScopeBindingKey, 0, 2)
+	if session := strings.TrimSpace(payload.SessionID); session != "" {
+		keys = append(keys, workBuddyHookScopeBindingKey{Integration: "workbuddy", Kind: "session", ExternalID: session})
 	}
-	if len(candidate) <= workBuddyHookMaximumScopeBytes {
-		return candidate
-	}
-	sum := sha256.Sum256([]byte(value))
-	if prefix == "" {
-		return "sha256:" + fmtHex(sum[:])
-	}
-	return prefix + ":sha256:" + fmtHex(sum[:])
+	keys = append(keys, workBuddyHookScopeBindingKey{Integration: "workbuddy", Kind: "workspace", ExternalID: workBuddyHookWorkspaceHash(workBuddyHookGitRoot(ctx, payload.CWD))})
+	return keys
 }
 
-func readWorkBuddyHookBoundScope(path string) (string, bool) {
-	payload, err := os.ReadFile(path)
-	if err != nil {
-		return "", false
-	}
-	var state struct {
-		Schema  string `json:"schema"`
-		ScopeID string `json:"scope_id"`
-	}
-	if err := json.Unmarshal(payload, &state); err != nil || state.Schema != workBuddyHookWorkspaceSchema || strings.TrimSpace(state.ScopeID) != state.ScopeID || state.ScopeID == "" || len(state.ScopeID) > workBuddyHookMaximumScopeBytes {
-		return "", false
-	}
-	return state.ScopeID, true
-}
-
-func workBuddyHookGitValue(ctx context.Context, cwd string, arguments ...string) string {
+func workBuddyHookGitRoot(ctx context.Context, cwd string) string {
 	executable, err := exec.LookPath("git")
 	if err != nil {
-		return ""
+		return cwd
 	}
 	commandContext, cancel := context.WithTimeout(ctx, 2*time.Second)
 	defer cancel()
-	command := exec.CommandContext(commandContext, executable, arguments...)
+	command := exec.CommandContext(commandContext, executable, "rev-parse", "--show-toplevel")
 	command.Dir = cwd
 	output, err := command.Output()
 	if err != nil {
-		return ""
+		return cwd
 	}
-	return strings.TrimSpace(string(output))
+	root := strings.TrimSuffix(strings.TrimSuffix(string(output), "\n"), "\r")
+	if root == "" {
+		return cwd
+	}
+	return root
 }
 
-func workBuddyHookProjectRoot(cwd string) string {
-	root, err := filepath.Abs(cwd)
-	if err != nil {
-		return filepath.Clean(cwd)
-	}
-	if resolved, err := filepath.EvalSymlinks(root); err == nil {
-		return resolved
-	}
-	return filepath.Clean(root)
+func workBuddyHookWorkspaceHash(workspace string) string {
+	sum := sha256.Sum256([]byte(workspace))
+	return fmtHex(sum[:])
 }
 
-func normalizeWorkBuddyHookGitRemote(remote string) string {
-	value := strings.TrimSpace(remote)
-	if value == "" {
-		return ""
-	}
-	if matched := workBuddyHookSCPRemote.FindStringSubmatch(value); matched != nil && !strings.Contains(value, "://") {
-		if path := normalizeWorkBuddyHookGitPath(matched[2]); path != "" {
-			return strings.ToLower(matched[1]) + "/" + path
-		}
-		return ""
-	}
-	parsed, err := url.Parse(value)
-	if err != nil || (parsed.Scheme != "http" && parsed.Scheme != "https" && parsed.Scheme != "ssh" && parsed.Scheme != "git") || parsed.Hostname() == "" {
-		return ""
-	}
-	path := normalizeWorkBuddyHookGitPath(parsed.Path)
-	if path == "" {
-		return ""
-	}
-	host := strings.ToLower(parsed.Hostname())
-	if port := parsed.Port(); port != "" {
-		host += ":" + port
-	}
-	return host + "/" + path
-}
-
-func normalizeWorkBuddyHookGitPath(path string) string {
-	parts := strings.Split(strings.ReplaceAll(path, `\`, "/"), "/")
-	normalized := make([]string, 0, len(parts))
-	for _, part := range parts {
-		if part != "" {
-			normalized = append(normalized, part)
-		}
-	}
-	result := strings.Join(normalized, "/")
-	return strings.TrimSuffix(result, ".git")
+func validWorkBuddyHookScope(value string) bool {
+	return value != "" && value == strings.TrimSpace(value) && utf8.ValidString(value) && utf8.RuneCountInString(value) <= 256
 }
 
 func fmtHex(value []byte) string {
@@ -443,7 +476,7 @@ func captureWorkBuddyPrompt(ctx context.Context, client *pcclient.Client, payloa
 		promptID = strings.TrimSpace(payload.RequestID)
 	}
 	sum := sha256.Sum256([]byte(scope + "\x00" + session + "\x00" + promptID + "\x00" + prompt))
-	metadata, ok := workBuddyHookCaptureMetadata(payload.CWD, session, promptID)
+	metadata, ok := workBuddyHookCaptureMetadata(session, promptID)
 	if !ok {
 		return 0
 	}
@@ -458,11 +491,10 @@ func captureWorkBuddyPrompt(ctx context.Context, client *pcclient.Client, payloa
 	return value.Response.Position
 }
 
-func workBuddyHookCaptureMetadata(cwd, sessionID, promptID string) (v1.CaptureContentSourceRequestMetadata, bool) {
+func workBuddyHookCaptureMetadata(sessionID, promptID string) (v1.CaptureContentSourceRequestMetadata, bool) {
 	values := map[string]string{
 		"origin": "workbuddy",
 		"event":  "user_prompt_submit",
-		"cwd":    cwd,
 	}
 	if sessionID != "" {
 		values["session_id"] = sessionID

--- a/internal/cli/workbuddy_hook_test.go
+++ b/internal/cli/workbuddy_hook_test.go
@@ -28,12 +28,12 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 
 	v1 "github.com/ob-labs/powercontext-go/api/v1"
 )
@@ -65,7 +65,21 @@ func TestWorkBuddyHookCommandWritesStableEmptyContext(t *testing.T) {
 }
 
 func TestWorkBuddyHookRecallCaptureFlush(t *testing.T) {
+	const scope = "durable-workbuddy-scope"
 	var paths []string
+	resolver := workBuddyHookScopeResolverFunc(func(_ context.Context, explicit *string, keys []workBuddyHookScopeBindingKey) (string, bool) {
+		if explicit != nil {
+			t.Fatalf("explicit scope = %q, want omitted", *explicit)
+		}
+		want := []workBuddyHookScopeBindingKey{
+			{Integration: "workbuddy", Kind: "session", ExternalID: "session"},
+			{Integration: "workbuddy", Kind: "workspace", ExternalID: workBuddyHookWorkspaceHash("C:/workspace")},
+		}
+		if diff := cmp.Diff(want, keys); diff != "" {
+			t.Fatalf("resolver keys (-want +got):\n%s", diff)
+		}
+		return scope, true
+	})
 	handler := http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 		paths = append(paths, request.URL.Path)
 		switch request.URL.Path {
@@ -77,7 +91,7 @@ func TestWorkBuddyHookRecallCaptureFlush(t *testing.T) {
 			if err := json.UnmarshalRead(request.Body, &body); err != nil {
 				t.Fatal(err)
 			}
-			if body.ScopeID != "workbuddy:agent" || body.MaxBytes != 8000 {
+			if body.ScopeID != scope || body.MaxBytes != 8000 {
 				t.Fatalf("prepare = %#v", body)
 			}
 			writer.Header().Set("Content-Type", "application/json")
@@ -93,11 +107,11 @@ func TestWorkBuddyHookRecallCaptureFlush(t *testing.T) {
 			if err := json.UnmarshalRead(request.Body, &body); err != nil {
 				t.Fatal(err)
 			}
-			sum := sha256.Sum256([]byte("workbuddy:agent\x00session\x00request\x00hello"))
+			sum := sha256.Sum256([]byte(scope + "\x00session\x00request\x00hello"))
 			want := captureBody{
-				ScopeID: "workbuddy:agent", SourceID: "workbuddy-user-prompt:" + hex.EncodeToString(sum[:]), Content: "hello",
+				ScopeID: scope, SourceID: "workbuddy-user-prompt:" + hex.EncodeToString(sum[:]), Content: "hello",
 				Metadata: map[string]string{
-					"origin": "workbuddy", "event": "user_prompt_submit", "cwd": "C:/workspace",
+					"origin": "workbuddy", "event": "user_prompt_submit",
 					"session_id": "session", "prompt_id": "request",
 				},
 			}
@@ -127,7 +141,7 @@ func TestWorkBuddyHookRecallCaptureFlush(t *testing.T) {
 	err := runWorkBuddyHook(t.Context(), strings.NewReader(`{"hook_event_name":"UserPromptSubmit","prompt":"hello","cwd":"C:/workspace","session_id":"session","request_id":"request"}`), &output, &diagnostics, workBuddyHookRuntime{configuration: workBuddyConfiguration{
 		Schema: workBuddyConfigSchema, ServerURL: "http://127.0.0.1:8000", ScopeMode: "agent", AuthorizationEnvironment: workBuddyDefaultAuthorizationEnvironment,
 		RequestTimeoutSeconds: 1, RequestBudgetSeconds: 2, PrepareMaxBytes: 8000, SourceMaxBytes: 16384,
-	}, httpClient: client})
+	}, httpClient: client, scopeResolver: resolver})
 	if err != nil {
 		t.Fatalf("runWorkBuddyHook() error = %v", err)
 	}
@@ -137,6 +151,138 @@ func TestWorkBuddyHookRecallCaptureFlush(t *testing.T) {
 	wantPaths := []string{"/v1/context/prepare", "/v1/sources/content", "/v1/memory/flush"}
 	if diff := cmp.Diff(wantPaths, paths); diff != "" {
 		t.Fatalf("request paths (-want +got):\n%s", diff)
+	}
+}
+
+func TestWorkBuddyHookResolverFailureDoesNotReachScopeOperations(t *testing.T) {
+	requests := 0
+	client := &http.Client{Transport: workBuddyHookRoundTripper(func(*http.Request) (*http.Response, error) {
+		requests++
+		return nil, errors.New("scope operation must not run")
+	})}
+	resolver := workBuddyHookScopeResolverFunc(func(context.Context, *string, []workBuddyHookScopeBindingKey) (string, bool) {
+		return "", false
+	})
+	var output, diagnostics bytes.Buffer
+	err := runWorkBuddyHook(t.Context(), strings.NewReader(`{"hook_event_name":"UserPromptSubmit","prompt":"hello","cwd":"C:/private/workbuddy-checkout"}`), &output, &diagnostics, workBuddyHookRuntime{configuration: workBuddyConfiguration{
+		Schema: workBuddyConfigSchema, ServerURL: "http://127.0.0.1:8000", ScopeMode: "project", AuthorizationEnvironment: workBuddyDefaultAuthorizationEnvironment,
+		RequestTimeoutSeconds: 1, RequestBudgetSeconds: 2, PrepareMaxBytes: 8000, SourceMaxBytes: 16384,
+	}, httpClient: client, scopeResolver: resolver})
+	if err != nil {
+		t.Fatalf("runWorkBuddyHook() error = %v", err)
+	}
+	if got := output.String(); got != workBuddyHookEmptyResponse {
+		t.Fatalf("output = %q, want empty context", got)
+	}
+	if requests != 0 {
+		t.Fatalf("scope operation requests = %d, want 0", requests)
+	}
+}
+
+func TestWorkBuddyHookPassesExplicitOverrideOnlyToResolver(t *testing.T) {
+	const override = "durable-user-override"
+	resolver := workBuddyHookScopeResolverFunc(func(_ context.Context, explicit *string, _ []workBuddyHookScopeBindingKey) (string, bool) {
+		if explicit == nil || *explicit != override {
+			t.Fatalf("explicit Scope = %#v, want %q", explicit, override)
+		}
+		return "", false
+	})
+	var output, diagnostics bytes.Buffer
+	err := runWorkBuddyHook(t.Context(), strings.NewReader(`{"hook_event_name":"UserPromptSubmit","prompt":"hello","cwd":"C:/private/workbuddy-checkout"}`), &output, &diagnostics, workBuddyHookRuntime{configuration: workBuddyConfiguration{
+		Schema: workBuddyConfigSchema, ServerURL: "http://127.0.0.1:8000", ScopeMode: "project", AuthorizationEnvironment: workBuddyDefaultAuthorizationEnvironment,
+		RequestTimeoutSeconds: 1, RequestBudgetSeconds: 2, PrepareMaxBytes: 8000, SourceMaxBytes: 16384,
+	}, lookupEnv: func(name string) (string, bool) { return override, name == workBuddyHookScopeEnvironment }, scopeResolver: resolver})
+	if err != nil {
+		t.Fatalf("runWorkBuddyHook() error = %v", err)
+	}
+	if got := output.String(); got != workBuddyHookEmptyResponse {
+		t.Fatalf("output = %q, want empty context", got)
+	}
+}
+
+func TestWorkBuddyHookExplicitOverridePreservesPresenceAndRawValue(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		value   string
+		present bool
+	}{
+		{name: "unset"},
+		{name: "empty", present: true},
+		{name: "space", value: " ", present: true},
+		{name: "overlength", value: strings.Repeat("x", 257), present: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			resolver := workBuddyHookScopeResolverFunc(func(_ context.Context, explicit *string, _ []workBuddyHookScopeBindingKey) (string, bool) {
+				if !test.present {
+					if explicit != nil {
+						t.Fatalf("explicit Scope = %q, want omitted", *explicit)
+					}
+				} else if explicit == nil || *explicit != test.value {
+					t.Fatalf("explicit Scope = %#v, want raw %q", explicit, test.value)
+				}
+				return "", false
+			})
+			var output, diagnostics bytes.Buffer
+			err := runWorkBuddyHook(t.Context(), strings.NewReader(`{"hook_event_name":"UserPromptSubmit","prompt":"secret-prompt","cwd":"C:/private/workbuddy-checkout"}`), &output, &diagnostics, workBuddyHookRuntime{configuration: workBuddyConfiguration{
+				Schema: workBuddyConfigSchema, ServerURL: "http://127.0.0.1:8000", ScopeMode: "project", AuthorizationEnvironment: workBuddyDefaultAuthorizationEnvironment,
+				RequestTimeoutSeconds: 1, RequestBudgetSeconds: 2, PrepareMaxBytes: 8000, SourceMaxBytes: 16384,
+			}, lookupEnv: func(name string) (string, bool) {
+				return test.value, test.present && name == workBuddyHookScopeEnvironment
+			}, scopeResolver: resolver})
+			if err != nil {
+				t.Fatalf("runWorkBuddyHook() error = %v", err)
+			}
+			if got := output.String(); got != workBuddyHookEmptyResponse {
+				t.Fatalf("output = %q, want empty context", got)
+			}
+			if strings.Contains(output.String(), "secret-prompt") || strings.Contains(diagnostics.String(), "secret-prompt") || (test.value != "" && strings.Contains(diagnostics.String(), test.value)) {
+				t.Fatalf("hook output leaked protected input: stdout=%q stderr=%q", output.String(), diagnostics.String())
+			}
+		})
+	}
+}
+
+func TestWorkBuddyHookMCPResolverClosesExpiredSessionWithinCleanupBudget(t *testing.T) {
+	server := mcp.NewServer(&mcp.Implementation{Name: "workbuddy-hook-test", Version: "1"}, nil)
+	server.AddTool(&mcp.Tool{Name: "scope_binding_resolve", InputSchema: map[string]any{"type": "object"}}, func(ctx context.Context, _ *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	})
+	mcpHandler := mcp.NewStreamableHTTPHandler(func(*http.Request) *mcp.Server { return server }, nil)
+	var sessionID string
+	deleted := false
+	client := &http.Client{Transport: workBuddyHookRoundTripper(func(request *http.Request) (*http.Response, error) {
+		if request.Method == http.MethodDelete {
+			deleted = true
+			if request.Header.Get("Mcp-Session-Id") != sessionID {
+				t.Fatalf("DELETE session ID = %q, want %q", request.Header.Get("Mcp-Session-Id"), sessionID)
+			}
+		}
+		response := httptest.NewRecorder()
+		mcpHandler.ServeHTTP(response, request)
+		if id := response.Header().Get("Mcp-Session-Id"); id != "" {
+			sessionID = id
+		}
+		return response.Result(), nil
+	})}
+	ctx, cancel := context.WithTimeout(t.Context(), 20*time.Millisecond)
+	defer cancel()
+	resolver, ok := newWorkBuddyHookMCPScopeResolver(ctx, workBuddyConfiguration{
+		ServerURL: "http://127.0.0.1:8000", AuthorizationEnvironment: workBuddyDefaultAuthorizationEnvironment,
+		RequestTimeoutSeconds: 1,
+	}, func(string) string { return "" }, client, time.Now)
+	if !ok {
+		t.Fatal("newWorkBuddyHookMCPScopeResolver() failed")
+	}
+	started := time.Now()
+	if scope, resolved := resolver.Resolve(ctx, nil, []workBuddyHookScopeBindingKey{{Integration: "workbuddy", Kind: "workspace", ExternalID: "hash"}}); resolved || scope != "" {
+		t.Fatalf("Resolve() = %q, %t, want empty fail-closed", scope, resolved)
+	}
+	if elapsed := time.Since(started); elapsed > 2*workBuddyHookCloseTimeout {
+		t.Fatalf("Resolve() elapsed = %s, cleanup exceeded strict budget", elapsed)
+	}
+	if sessionID == "" || !deleted {
+		t.Fatalf("MCP session/DELETE = %q/%t, want established session and cleanup DELETE", sessionID, deleted)
 	}
 }
 
@@ -189,7 +335,7 @@ func TestWorkBuddyHookPrepareFailureStillCapturesAndFlushes(t *testing.T) {
 	err := runWorkBuddyHook(t.Context(), strings.NewReader(`{"hook_event_name":"UserPromptSubmit","prompt":"hello","cwd":"C:/workspace","session_id":"session","prompt_id":"prompt"}`), &output, &diagnostics, workBuddyHookRuntime{configuration: workBuddyConfiguration{
 		Schema: workBuddyConfigSchema, ServerURL: "http://127.0.0.1:8000", ScopeMode: "agent", AuthorizationEnvironment: workBuddyDefaultAuthorizationEnvironment,
 		RequestTimeoutSeconds: 1, RequestBudgetSeconds: 2, PrepareMaxBytes: 8000, SourceMaxBytes: 16384,
-	}, httpClient: client})
+	}, httpClient: client, scopeResolver: workBuddyHookTestResolver()})
 	if err != nil {
 		t.Fatalf("runWorkBuddyHook() error = %v", err)
 	}
@@ -226,7 +372,7 @@ func TestWorkBuddyHookOverLimitPrepareResponseFailsOpenBeforeDecode(t *testing.T
 			Schema: workBuddyConfigSchema, ServerURL: "http://127.0.0.1:8000", ScopeMode: "agent", AuthorizationEnvironment: workBuddyDefaultAuthorizationEnvironment,
 			RequestTimeoutSeconds: 1, RequestBudgetSeconds: 2, PrepareMaxBytes: 8000, SourceMaxBytes: 64,
 		},
-		getenv: getenv, httpClient: client,
+		getenv: getenv, httpClient: client, scopeResolver: workBuddyHookTestResolver(),
 	})
 	if err != nil {
 		t.Fatalf("runWorkBuddyHook() error = %v", err)
@@ -286,7 +432,7 @@ func TestWorkBuddyHookUnknownLengthResponseStopsAtLimitBeforeDecode(t *testing.T
 			}
 			return ""
 		},
-		httpClient: client,
+		httpClient: client, scopeResolver: workBuddyHookTestResolver(),
 	})
 	if err != nil {
 		t.Fatalf("runWorkBuddyHook() error = %v", err)
@@ -366,7 +512,7 @@ func TestWorkBuddyHookPrepareFailuresStillCapture(t *testing.T) {
 					}
 					return ""
 				},
-				httpClient: client,
+				httpClient: client, scopeResolver: workBuddyHookTestResolver(),
 			})
 			if err != nil {
 				t.Fatalf("runWorkBuddyHook() error = %v", err)
@@ -387,158 +533,40 @@ func workBuddyHookJSONResponse(request *http.Request, status int, body string) *
 	}
 }
 
-func TestResolveWorkBuddyHookScope(t *testing.T) {
-	getenv := func(string) string { return "" }
-
-	for _, test := range []struct {
-		name   string
-		mode   string
-		getenv func(string) string
-		setup  func(*testing.T, string)
-		want   func(*testing.T, string) string
-	}{
-		{
-			name: "explicit scope retains 256 byte boundary",
-			mode: "project",
-			getenv: func(name string) string {
-				if name == "POWERCONTEXT_WORKBUDDY_SCOPE_ID" {
-					return strings.Repeat("e", 256)
-				}
-				return ""
-			},
-			want: func(*testing.T, string) string { return strings.Repeat("e", 256) },
-		},
-		{
-			name: "explicit scope hashes above 256 byte boundary",
-			mode: "project",
-			getenv: func(name string) string {
-				if name == "POWERCONTEXT_WORKBUDDY_SCOPE_ID" {
-					return strings.Repeat("e", 257)
-				}
-				return ""
-			},
-			want: func(*testing.T, string) string {
-				sum := sha256.Sum256([]byte(strings.Repeat("e", 257)))
-				return "sha256:" + hex.EncodeToString(sum[:])
-			},
-		},
-		{name: "agent mode", mode: "agent", getenv: getenv, want: func(*testing.T, string) string { return "workbuddy:agent" }},
-		{
-			name:   "git private binding",
-			mode:   "project",
-			getenv: getenv,
-			setup: func(t *testing.T, project string) {
-				gitDirectory := workBuddyHookGitOutput(t, project, "rev-parse", "--absolute-git-dir")
-				writeTestFile(t, filepath.Join(gitDirectory, "powercontext", "codex-workspace.json"), `{"schema":"powercontext.codex-workspace.v1","scope_id":"bound-scope"}`)
-			},
-			want: func(*testing.T, string) string { return "bound-scope" },
-		},
-		{
-			name:   "normalized remote",
-			mode:   "project",
-			getenv: getenv,
-			setup: func(t *testing.T, project string) {
-				workBuddyHookGit(t, project, "config", "remote.origin.url", "ssh://user@GitHub.COM:8443/ob-labs/powercontext-go.git")
-			},
-			want: func(*testing.T, string) string { return "git:github.com:8443/ob-labs/powercontext-go" },
-		},
-		{
-			name:   "local path fallback",
-			mode:   "project",
-			getenv: getenv,
-			want:   workBuddyHookLocalScope,
-		},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			project := newWorkBuddyHookGitProject(t)
-			if test.setup != nil {
-				test.setup(t, project)
-			}
-			got, ok := resolveWorkBuddyHookScope(t.Context(), project, test.mode, test.getenv)
-			if want := test.want(t, project); !ok || got != want {
-				t.Fatalf("resolveWorkBuddyHookScope() = %q, %t, want %q, true", got, ok, want)
-			}
-		})
-	}
+func workBuddyHookTestResolver() workBuddyHookScopeResolver {
+	return workBuddyHookScopeResolverFunc(func(context.Context, *string, []workBuddyHookScopeBindingKey) (string, bool) {
+		return "workbuddy:test", true
+	})
 }
 
-func TestResolveWorkBuddyHookScopeUTF8ByteBoundaries(t *testing.T) {
-	exactly256 := strings.Repeat("界", 85) + "a"
-	over256 := exactly256 + "b"
-	if got := len([]byte(exactly256)); got != 256 {
-		t.Fatalf("exactly256 byte length = %d, want 256", got)
+func TestWorkBuddyHookBindingKeysHashGitRootBeforeNestedCWD(t *testing.T) {
+	project := filepath.Join(t.TempDir(), "project")
+	if err := os.MkdirAll(project, 0o700); err != nil {
+		t.Fatal(err)
 	}
-	if got := len([]byte(over256)); got != 257 {
-		t.Fatalf("over256 byte length = %d, want 257", got)
+	command := exec.CommandContext(t.Context(), "git", "init")
+	command.Dir = project
+	if output, err := command.CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v\n%s", err, output)
 	}
-
-	for _, test := range []struct {
-		name  string
-		value string
-		want  string
-	}{
-		{name: "explicit exact boundary", value: exactly256, want: exactly256},
-		{
-			name:  "explicit above boundary",
-			value: over256,
-			want: func() string {
-				sum := sha256.Sum256([]byte(over256))
-				return "sha256:" + hex.EncodeToString(sum[:])
-			}(),
-		},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			got, ok := resolveWorkBuddyHookScope(t.Context(), t.TempDir(), "project", func(name string) string {
-				if name == workBuddyHookScopeEnvironment {
-					return test.value
-				}
-				return ""
-			})
-			if !ok || got != test.want {
-				t.Fatalf("resolveWorkBuddyHookScope() = %q, %t, want %q, true", got, ok, test.want)
-			}
-		})
+	nested := filepath.Join(project, "nested")
+	if err := os.MkdirAll(nested, 0o700); err != nil {
+		t.Fatal(err)
 	}
-
-	project := newWorkBuddyHookGitProject(t)
-	gitDirectory := workBuddyHookGitOutput(t, project, "rev-parse", "--absolute-git-dir")
-	writeTestFile(t, filepath.Join(gitDirectory, "powercontext", "codex-workspace.json"), `{"schema":"powercontext.codex-workspace.v1","scope_id":`+strconv.Quote(exactly256)+`}`)
-	got, ok := resolveWorkBuddyHookScope(t.Context(), project, "project", func(string) string { return "" })
-	if !ok || got != exactly256 {
-		t.Fatalf("Git-private UTF-8 boundary scope = %q, %t, want %q, true", got, ok, exactly256)
+	rootCommand := exec.CommandContext(t.Context(), "git", "rev-parse", "--show-toplevel")
+	rootCommand.Dir = nested
+	rootOutput, err := rootCommand.Output()
+	if err != nil {
+		t.Fatal(err)
 	}
-}
-
-func TestResolveWorkBuddyHookScopeInvalidGitPrivateBindingFallsThrough(t *testing.T) {
-	remote := "git@GitHub.COM:ob-labs/powercontext-go.git"
-	const wantRemote = "git:github.com/ob-labs/powercontext-go"
-	over256 := strings.Repeat("界", 85) + "ab"
-
-	for _, test := range []struct {
-		name    string
-		payload string
-		remote  bool
-		want    func(*testing.T, string) string
-	}{
-		{name: "wrong schema", payload: `{"schema":"wrong","scope_id":"bound"}`, remote: true, want: func(*testing.T, string) string { return wantRemote }},
-		{name: "empty scope", payload: `{"schema":"powercontext.codex-workspace.v1","scope_id":""}`, remote: true, want: func(*testing.T, string) string { return wantRemote }},
-		{name: "whitespace padded scope", payload: `{"schema":"powercontext.codex-workspace.v1","scope_id":" bound "}`, remote: true, want: func(*testing.T, string) string { return wantRemote }},
-		{name: "malformed JSON", payload: `{`, remote: true, want: func(*testing.T, string) string { return wantRemote }},
-		{name: "UTF-8 scope above boundary", payload: `{"schema":"powercontext.codex-workspace.v1","scope_id":` + strconv.Quote(over256) + `}`, remote: true, want: func(*testing.T, string) string { return wantRemote }},
-		{name: "no remote uses local fallback", payload: `{`, want: workBuddyHookLocalScope},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			project := newWorkBuddyHookGitProject(t)
-			gitDirectory := workBuddyHookGitOutput(t, project, "rev-parse", "--absolute-git-dir")
-			writeTestFile(t, filepath.Join(gitDirectory, "powercontext", "codex-workspace.json"), test.payload)
-			if test.remote {
-				workBuddyHookGit(t, project, "config", "remote.origin.url", remote)
-			}
-			got, ok := resolveWorkBuddyHookScope(t.Context(), project, "project", func(string) string { return "" })
-			if want := test.want(t, project); !ok || got != want {
-				t.Fatalf("resolveWorkBuddyHookScope() = %q, %t, want %q, true", got, ok, want)
-			}
-		})
+	gitRoot := strings.TrimSuffix(strings.TrimSuffix(string(rootOutput), "\n"), "\r")
+	keys := workBuddyHookScopeBindingKeys(t.Context(), workBuddyHookPayload{CWD: nested, SessionID: "session"})
+	want := []workBuddyHookScopeBindingKey{
+		{Integration: "workbuddy", Kind: "session", ExternalID: "session"},
+		{Integration: "workbuddy", Kind: "workspace", ExternalID: workBuddyHookWorkspaceHash(gitRoot)},
+	}
+	if diff := cmp.Diff(want, keys); diff != "" {
+		t.Fatalf("binding keys (-want +got):\n%s", diff)
 	}
 }
 
@@ -571,79 +599,6 @@ func TestWorkBuddyHookRequestTimeoutUsesRemainingBudget(t *testing.T) {
 	if remaining < 100*time.Millisecond || remaining > 500*time.Millisecond {
 		t.Fatalf("request deadline remaining = %s, want timeout capped near 250ms", remaining)
 	}
-}
-
-func TestNormalizeWorkBuddyHookGitRemote(t *testing.T) {
-	for _, test := range []struct {
-		name   string
-		remote string
-		want   string
-	}{
-		{name: "scp", remote: "git@GitHub.COM:ob-labs/powercontext-go.git", want: "github.com/ob-labs/powercontext-go"},
-		{name: "http strips credentials and retains port", remote: "http://user:secret@GitHub.COM:8443/ob-labs\\powercontext-go.git", want: "github.com:8443/ob-labs/powercontext-go"},
-		{name: "https", remote: "https://GitHub.COM/ob-labs/powercontext-go.git", want: "github.com/ob-labs/powercontext-go"},
-		{name: "ssh", remote: "ssh://git@GitHub.COM/ob-labs/powercontext-go.git", want: "github.com/ob-labs/powercontext-go"},
-		{name: "git", remote: "git://GitHub.COM/ob-labs/powercontext-go.git", want: "github.com/ob-labs/powercontext-go"},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			if got := normalizeWorkBuddyHookGitRemote(test.remote); got != test.want {
-				t.Fatalf("normalizeWorkBuddyHookGitRemote() = %q, want %q", got, test.want)
-			}
-		})
-	}
-}
-
-func TestResolveWorkBuddyHookScopeHashesLongRemote(t *testing.T) {
-	project := newWorkBuddyHookGitProject(t)
-	path := strings.Repeat("x", 300)
-	workBuddyHookGit(t, project, "config", "remote.origin.url", "git@github.com:"+path+".git")
-
-	got, ok := resolveWorkBuddyHookScope(t.Context(), project, "project", func(string) string { return "" })
-	sum := sha256.Sum256([]byte("github.com/" + path))
-	want := "git:sha256:" + hex.EncodeToString(sum[:])
-	if !ok || got != want {
-		t.Fatalf("resolveWorkBuddyHookScope() = %q, %t, want %q, true", got, ok, want)
-	}
-}
-
-func newWorkBuddyHookGitProject(t *testing.T) string {
-	t.Helper()
-	project := filepath.Join(t.TempDir(), "project")
-	if err := os.MkdirAll(project, 0o700); err != nil {
-		t.Fatal(err)
-	}
-	workBuddyHookGit(t, project, "init")
-	return project
-}
-
-func workBuddyHookGit(t *testing.T, directory string, arguments ...string) {
-	t.Helper()
-	command := exec.CommandContext(t.Context(), "git", arguments...)
-	command.Dir = directory
-	if output, err := command.CombinedOutput(); err != nil {
-		t.Fatalf("git %s: %v\n%s", strings.Join(arguments, " "), err, output)
-	}
-}
-
-func workBuddyHookGitOutput(t *testing.T, directory string, arguments ...string) string {
-	t.Helper()
-	command := exec.CommandContext(t.Context(), "git", arguments...)
-	command.Dir = directory
-	output, err := command.Output()
-	if err != nil {
-		t.Fatalf("git %s: %v", strings.Join(arguments, " "), err)
-	}
-	return strings.TrimSpace(string(output))
-}
-
-func workBuddyHookLocalScope(t *testing.T, project string) string {
-	t.Helper()
-	resolved, err := filepath.EvalSymlinks(project)
-	if err != nil {
-		t.Fatal(err)
-	}
-	sum := sha256.Sum256([]byte(resolved))
-	return "local:" + hex.EncodeToString(sum[:])
 }
 
 type workBuddyHookRoundTripper func(*http.Request) (*http.Response, error)

--- a/test/e2e/workbuddy_service_chain_test.go
+++ b/test/e2e/workbuddy_service_chain_test.go
@@ -23,12 +23,14 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -92,10 +94,12 @@ func TestWorkBuddyHookAndMCPShareOneGoServiceConfiguration(t *testing.T) {
 			if handlerErr != nil {
 				t.Fatal(handlerErr)
 			}
-			service := httptest.NewServer(handler)
+			trace := &workBuddyServiceTrace{handler: handler}
+			service := httptest.NewServer(trace)
 			t.Cleanup(service.Close)
 			assertWorkBuddyServiceReady(t, service)
 			scope := seedWorkBuddyWorkspaceBinding(t, service, config.Auth.Token, releaseRoot)
+			trace.reset(scope)
 
 			setupWorkBuddy(t, service.URL, binary, releaseRoot)
 			assertWorkBuddyServerConfiguration(t, service.URL)
@@ -105,7 +109,11 @@ func TestWorkBuddyHookAndMCPShareOneGoServiceConfiguration(t *testing.T) {
 			if first != "" {
 				t.Fatalf("first hook context = %q, want empty before capture", first)
 			}
+			trace.assertFirstHook(t)
+			assertWorkBuddyMemorySearch(t, service, config.Auth.Token, scope)
+			trace.reset(scope)
 			second := runWorkBuddyHook(t, binary, releaseRoot, "Which WorkBuddy service chain should I use?", "prompt-2")
+			trace.assertSecondHook(t)
 			if !strings.Contains(second, "Remember this WorkBuddy service chain.") {
 				t.Fatalf("recalled context = %q, want captured WorkBuddy content", second)
 			}
@@ -150,6 +158,74 @@ func TestWorkBuddyHookAndMCPShareOneGoServiceConfiguration(t *testing.T) {
 	}
 }
 
+type workBuddyServiceTrace struct {
+	handler  http.Handler
+	mu       sync.Mutex
+	scope    string
+	resolve  int
+	prepare  int
+	capture  int
+	flush    int
+	mismatch bool
+}
+
+func (trace *workBuddyServiceTrace) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
+	body, _ := io.ReadAll(request.Body)
+	request.Body = io.NopCloser(bytes.NewReader(body))
+	trace.record(request.URL.Path, body)
+	trace.handler.ServeHTTP(writer, request)
+}
+
+func (trace *workBuddyServiceTrace) record(path string, body []byte) {
+	trace.mu.Lock()
+	defer trace.mu.Unlock()
+	if path == "/mcp/" && bytes.Contains(body, []byte(`"scope_binding_resolve"`)) {
+		trace.resolve++
+		return
+	}
+	if path != "/v1/context/prepare" && path != "/v1/sources/content" && path != "/v1/memory/flush" {
+		return
+	}
+	var value struct {
+		ScopeID string `json:"scope_id"`
+	}
+	if json.Unmarshal(body, &value) != nil || value.ScopeID != trace.scope {
+		trace.mismatch = true
+	}
+	switch path {
+	case "/v1/context/prepare":
+		trace.prepare++
+	case "/v1/sources/content":
+		trace.capture++
+	case "/v1/memory/flush":
+		trace.flush++
+	}
+}
+
+func (trace *workBuddyServiceTrace) reset(scope string) {
+	trace.mu.Lock()
+	defer trace.mu.Unlock()
+	trace.scope, trace.resolve, trace.prepare, trace.capture, trace.flush, trace.mismatch = scope, 0, 0, 0, 0, false
+}
+
+func (trace *workBuddyServiceTrace) assertFirstHook(t *testing.T) {
+	t.Helper()
+	trace.mu.Lock()
+	defer trace.mu.Unlock()
+	if trace.resolve != 1 || trace.prepare != 1 || trace.capture != 1 || trace.flush < 1 || trace.mismatch {
+		t.Fatalf("first hook stages resolver=%d prepare=%d capture=%d flush=%d scope_mismatch=%t", trace.resolve, trace.prepare, trace.capture, trace.flush, trace.mismatch)
+	}
+}
+
+func (trace *workBuddyServiceTrace) assertSecondHook(t *testing.T) {
+	t.Helper()
+	trace.mu.Lock()
+	defer trace.mu.Unlock()
+	if trace.resolve != 1 || trace.prepare != 1 || trace.capture != 1 || trace.flush < 1 || trace.mismatch {
+		t.Fatalf("second hook stages resolver=%d prepare=%d capture=%d flush=%d scope_mismatch=%t", trace.resolve, trace.prepare, trace.capture, trace.flush, trace.mismatch)
+	}
+}
+
 func seedWorkBuddyWorkspaceBinding(t *testing.T, service *httptest.Server, token, workspace string) string {
 	t.Helper()
 	authorization := ""
@@ -187,6 +263,39 @@ func seedWorkBuddyWorkspaceBinding(t *testing.T, service *httptest.Server, token
 		t.Fatalf("set WorkBuddy workspace binding = %#v, %v", set, err)
 	}
 	return scope
+}
+
+func assertWorkBuddyMemorySearch(t *testing.T, service *httptest.Server, token, scope string) {
+	t.Helper()
+	authorization := ""
+	if token != "" {
+		authorization = "Bearer " + token
+	}
+	client := mcp.NewClient(&mcp.Implementation{Name: "workbuddy-memory-check", Version: "test"}, nil)
+	session, err := client.Connect(t.Context(), &mcp.StreamableClientTransport{
+		Endpoint:             service.URL + "/mcp/",
+		HTTPClient:           &http.Client{Transport: workBuddyAuthorizationTransport{base: service.Client().Transport, authorization: authorization}},
+		DisableStandaloneSSE: true,
+		MaxRetries:           -1,
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = session.Close() })
+	result, err := session.CallTool(t.Context(), &mcp.CallToolParams{Name: "search_memory", Arguments: map[string]any{
+		"scope_id": scope, "query": "WorkBuddy service chain",
+	}})
+	if err != nil || result.IsError {
+		t.Fatalf("first-hook memory search failed: result_error=%t call_error=%t", result.IsError, err != nil)
+	}
+	content, ok := result.StructuredContent.(map[string]any)
+	if !ok {
+		t.Fatalf("first-hook memory search structured result is invalid")
+	}
+	hits, ok := content["hits"].([]any)
+	if !ok || len(hits) == 0 {
+		t.Fatalf("first hook did not materialize searchable Memory")
+	}
 }
 
 func assertWorkBuddyServiceReady(t *testing.T, service *httptest.Server) {

--- a/test/e2e/workbuddy_service_chain_test.go
+++ b/test/e2e/workbuddy_service_chain_test.go
@@ -36,6 +36,9 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
+	"github.com/ob-labs/powercontext-go/internal/runtime"
+	"github.com/ob-labs/powercontext-go/internal/scope"
+	"github.com/ob-labs/powercontext-go/internal/sqlstore"
 	"github.com/ob-labs/powercontext-go/server"
 )
 
@@ -98,8 +101,11 @@ func TestWorkBuddyHookAndMCPShareOneGoServiceConfiguration(t *testing.T) {
 			service := httptest.NewServer(trace)
 			t.Cleanup(service.Close)
 			assertWorkBuddyServiceReady(t, service)
-			scope := seedWorkBuddyWorkspaceBinding(t, service, config.Auth.Token, releaseRoot)
-			trace.reset(scope)
+			scope := createWorkBuddyNonDefaultScope(t, config)
+			workspaceHash := workBuddyWorkspaceHash(releaseRoot)
+			seedWorkBuddyWorkspaceBinding(t, service, config.Auth.Token, workspaceHash, scope)
+			assertWorkBuddyScopeIsNotDefault(t, service, config.Auth.Token, scope)
+			trace.reset(scope, workspaceHash)
 
 			setupWorkBuddy(t, service.URL, binary, releaseRoot)
 			assertWorkBuddyServerConfiguration(t, service.URL)
@@ -111,7 +117,7 @@ func TestWorkBuddyHookAndMCPShareOneGoServiceConfiguration(t *testing.T) {
 			}
 			trace.assertFirstHook(t)
 			assertWorkBuddyMemorySearch(t, service, config.Auth.Token, scope)
-			trace.reset(scope)
+			trace.reset(scope, workspaceHash)
 			second := runWorkBuddyHook(t, binary, releaseRoot, "Which WorkBuddy service chain should I use?", "prompt-2")
 			trace.assertSecondHook(t)
 			if !strings.Contains(second, "Remember this WorkBuddy service chain.") {
@@ -174,15 +180,53 @@ func unsetWorkBuddyScopeOverride(t *testing.T) {
 	})
 }
 
+func createWorkBuddyNonDefaultScope(t *testing.T, config server.ProcessConfig) string {
+	t.Helper()
+	databasePath, err := server.SQLiteDSN(config.Database.SQLite.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	database, err := sqlstore.OpenSQLite(t.Context(), sqlstore.DefaultSQLiteConfig(databasePath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = database.Close(context.Background()) })
+	store, err := sqlstore.NewRuntimeScopeStore(database, sqlstore.ScopeRepository{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	application, err := runtime.NewScopeApplication(runtime.New(), store, func() string { return "scope-workbuddy-e2e" })
+	if err != nil {
+		t.Fatal(err)
+	}
+	draft, err := scope.NewDraft("WorkBuddy E2E", "WorkBuddy durable test scope", "", nil, nil, "workbuddy-e2e-scope")
+	if err != nil {
+		t.Fatal(err)
+	}
+	created, err := application.Create(t.Context(), draft)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return created.ID()
+}
+
+func workBuddyWorkspaceHash(workspace string) string {
+	sum := sha256.Sum256([]byte(workspace))
+	return hex.EncodeToString(sum[:])
+}
+
 type workBuddyServiceTrace struct {
-	handler  http.Handler
-	mu       sync.Mutex
-	scope    string
-	resolve  int
-	prepare  int
-	capture  int
-	flush    int
-	mismatch bool
+	handler       http.Handler
+	mu            sync.Mutex
+	scope         string
+	workspaceHash string
+	resolve       int
+	prepare       int
+	capture       int
+	flush         int
+	mismatch      bool
+	workspaceKey  bool
+	sessionFirst  bool
 }
 
 func (trace *workBuddyServiceTrace) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
@@ -197,6 +241,10 @@ func (trace *workBuddyServiceTrace) record(path string, body []byte) {
 	defer trace.mu.Unlock()
 	if path == "/mcp/" && bytes.Contains(body, []byte(`"scope_binding_resolve"`)) {
 		trace.resolve++
+		workspace := bytes.Index(body, []byte(trace.workspaceHash))
+		session := bytes.Index(body, []byte(`"workbuddy-e2e-session"`))
+		trace.workspaceKey = workspace >= 0
+		trace.sessionFirst = session >= 0 && workspace >= 0 && session < workspace
 		return
 	}
 	if path != "/v1/context/prepare" && path != "/v1/sources/content" && path != "/v1/memory/flush" {
@@ -218,18 +266,18 @@ func (trace *workBuddyServiceTrace) record(path string, body []byte) {
 	}
 }
 
-func (trace *workBuddyServiceTrace) reset(scope string) {
+func (trace *workBuddyServiceTrace) reset(scope, workspaceHash string) {
 	trace.mu.Lock()
 	defer trace.mu.Unlock()
-	trace.scope, trace.resolve, trace.prepare, trace.capture, trace.flush, trace.mismatch = scope, 0, 0, 0, 0, false
+	trace.scope, trace.workspaceHash, trace.resolve, trace.prepare, trace.capture, trace.flush, trace.mismatch, trace.workspaceKey, trace.sessionFirst = scope, workspaceHash, 0, 0, 0, 0, false, false, false
 }
 
 func (trace *workBuddyServiceTrace) assertFirstHook(t *testing.T) {
 	t.Helper()
 	trace.mu.Lock()
 	defer trace.mu.Unlock()
-	if trace.resolve != 1 || trace.prepare != 1 || trace.capture != 1 || trace.flush < 1 || trace.mismatch {
-		t.Fatalf("first hook stages resolver=%d prepare=%d capture=%d flush=%d scope_mismatch=%t", trace.resolve, trace.prepare, trace.capture, trace.flush, trace.mismatch)
+	if trace.resolve != 1 || trace.prepare != 1 || trace.capture != 1 || trace.flush < 1 || trace.mismatch || !trace.workspaceKey || !trace.sessionFirst {
+		t.Fatalf("first hook stages resolver=%d prepare=%d capture=%d flush=%d scope_mismatch=%t workspace_key=%t session_first=%t", trace.resolve, trace.prepare, trace.capture, trace.flush, trace.mismatch, trace.workspaceKey, trace.sessionFirst)
 	}
 }
 
@@ -237,12 +285,12 @@ func (trace *workBuddyServiceTrace) assertSecondHook(t *testing.T) {
 	t.Helper()
 	trace.mu.Lock()
 	defer trace.mu.Unlock()
-	if trace.resolve != 1 || trace.prepare != 1 || trace.capture != 1 || trace.flush < 1 || trace.mismatch {
-		t.Fatalf("second hook stages resolver=%d prepare=%d capture=%d flush=%d scope_mismatch=%t", trace.resolve, trace.prepare, trace.capture, trace.flush, trace.mismatch)
+	if trace.resolve != 1 || trace.prepare != 1 || trace.capture != 1 || trace.flush < 1 || trace.mismatch || !trace.workspaceKey || !trace.sessionFirst {
+		t.Fatalf("second hook stages resolver=%d prepare=%d capture=%d flush=%d scope_mismatch=%t workspace_key=%t session_first=%t", trace.resolve, trace.prepare, trace.capture, trace.flush, trace.mismatch, trace.workspaceKey, trace.sessionFirst)
 	}
 }
 
-func seedWorkBuddyWorkspaceBinding(t *testing.T, service *httptest.Server, token, workspace string) string {
+func seedWorkBuddyWorkspaceBinding(t *testing.T, service *httptest.Server, token, workspaceHash, scope string) {
 	t.Helper()
 	authorization := ""
 	if token != "" {
@@ -259,26 +307,39 @@ func seedWorkBuddyWorkspaceBinding(t *testing.T, service *httptest.Server, token
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { _ = session.Close() })
-	resolved, err := session.CallTool(t.Context(), &mcp.CallToolParams{Name: "scope_binding_resolve", Arguments: map[string]any{}})
-	if err != nil || resolved.IsError {
-		t.Fatalf("resolve default Scope binding = %#v, %v", resolved, err)
-	}
-	content, ok := resolved.StructuredContent.(map[string]any)
-	if !ok {
-		t.Fatalf("resolved Scope structured content = %T", resolved.StructuredContent)
-	}
-	scope, ok := content["scope_id"].(string)
-	if !ok || scope == "" {
-		t.Fatalf("resolved Scope ID = %#v", content["scope_id"])
-	}
-	sum := sha256.Sum256([]byte(workspace))
 	set, err := session.CallTool(t.Context(), &mcp.CallToolParams{Name: "scope_binding_set", Arguments: map[string]any{
-		"integration": "workbuddy", "kind": "workspace", "external_id": hex.EncodeToString(sum[:]), "scope_id": scope,
+		"integration": "workbuddy", "kind": "workspace", "external_id": workspaceHash, "scope_id": scope,
 	}})
 	if err != nil || set.IsError {
 		t.Fatalf("set WorkBuddy workspace binding = %#v, %v", set, err)
 	}
-	return scope
+}
+
+func assertWorkBuddyScopeIsNotDefault(t *testing.T, service *httptest.Server, token, scope string) {
+	t.Helper()
+	authorization := ""
+	if token != "" {
+		authorization = "Bearer " + token
+	}
+	client := mcp.NewClient(&mcp.Implementation{Name: "workbuddy-default-check", Version: "test"}, nil)
+	session, err := client.Connect(t.Context(), &mcp.StreamableClientTransport{
+		Endpoint:             service.URL + "/mcp/",
+		HTTPClient:           &http.Client{Transport: workBuddyAuthorizationTransport{base: service.Client().Transport, authorization: authorization}},
+		DisableStandaloneSSE: true,
+		MaxRetries:           -1,
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = session.Close() })
+	resolved, err := session.CallTool(t.Context(), &mcp.CallToolParams{Name: "scope_binding_resolve", Arguments: map[string]any{}})
+	if err != nil || resolved.IsError {
+		t.Fatalf("default Scope resolution failed: result_error=%t call_error=%t", resolved.IsError, err != nil)
+	}
+	content, ok := resolved.StructuredContent.(map[string]any)
+	if !ok || content["scope_id"] == scope {
+		t.Fatalf("workspace Scope is not distinguishable from the durable default")
+	}
 }
 
 func assertWorkBuddyMemorySearch(t *testing.T, service *httptest.Server, token, scope string) {

--- a/test/e2e/workbuddy_service_chain_test.go
+++ b/test/e2e/workbuddy_service_chain_test.go
@@ -57,7 +57,7 @@ func TestWorkBuddyHookAndMCPShareOneGoServiceConfiguration(t *testing.T) {
 			home := t.TempDir()
 			t.Setenv("WORKBUDDY_HOME", filepath.Join(home, "workbuddy"))
 			t.Setenv(server.PowerContextHomeEnv, filepath.Join(home, "powercontext"))
-			t.Setenv("POWERCONTEXT_WORKBUDDY_SCOPE_ID", "")
+			unsetWorkBuddyScopeOverride(t)
 			t.Setenv("POWERCONTEXT_WORKBUDDY_FLUSH_ON_CAPTURE", "true")
 			t.Setenv("WORKBUDDY_SERVICE_TOKEN", "")
 
@@ -156,6 +156,22 @@ func TestWorkBuddyHookAndMCPShareOneGoServiceConfiguration(t *testing.T) {
 			}
 		})
 	}
+}
+
+func unsetWorkBuddyScopeOverride(t *testing.T) {
+	t.Helper()
+	const name = "POWERCONTEXT_WORKBUDDY_SCOPE_ID"
+	value, present := os.LookupEnv(name)
+	if err := os.Unsetenv(name); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if present {
+			_ = os.Setenv(name, value)
+			return
+		}
+		_ = os.Unsetenv(name)
+	})
 }
 
 type workBuddyServiceTrace struct {

--- a/test/e2e/workbuddy_service_chain_test.go
+++ b/test/e2e/workbuddy_service_chain_test.go
@@ -19,6 +19,8 @@ package e2e_test
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -34,8 +36,6 @@ import (
 
 	"github.com/ob-labs/powercontext-go/server"
 )
-
-const workBuddyServiceChainScope = "project:workbuddy-service-chain"
 
 func TestWorkBuddyHookAndMCPShareOneGoServiceConfiguration(t *testing.T) {
 	checkoutRoot, err := filepath.Abs(filepath.Join("..", ".."))
@@ -55,7 +55,7 @@ func TestWorkBuddyHookAndMCPShareOneGoServiceConfiguration(t *testing.T) {
 			home := t.TempDir()
 			t.Setenv("WORKBUDDY_HOME", filepath.Join(home, "workbuddy"))
 			t.Setenv(server.PowerContextHomeEnv, filepath.Join(home, "powercontext"))
-			t.Setenv("POWERCONTEXT_WORKBUDDY_SCOPE_ID", workBuddyServiceChainScope)
+			t.Setenv("POWERCONTEXT_WORKBUDDY_SCOPE_ID", "")
 			t.Setenv("POWERCONTEXT_WORKBUDDY_FLUSH_ON_CAPTURE", "true")
 			t.Setenv("WORKBUDDY_SERVICE_TOKEN", "")
 
@@ -95,6 +95,7 @@ func TestWorkBuddyHookAndMCPShareOneGoServiceConfiguration(t *testing.T) {
 			service := httptest.NewServer(handler)
 			t.Cleanup(service.Close)
 			assertWorkBuddyServiceReady(t, service)
+			scope := seedWorkBuddyWorkspaceBinding(t, service, config.Auth.Token, releaseRoot)
 
 			setupWorkBuddy(t, service.URL, binary, releaseRoot)
 			assertWorkBuddyServerConfiguration(t, service.URL)
@@ -123,7 +124,7 @@ func TestWorkBuddyHookAndMCPShareOneGoServiceConfiguration(t *testing.T) {
 			result, callErr := session.CallTool(t.Context(), &mcp.CallToolParams{
 				Name: "search_memory",
 				Arguments: map[string]any{
-					"scope_id": workBuddyServiceChainScope,
+					"scope_id": scope,
 					"query":    "WorkBuddy service chain",
 				},
 			})
@@ -147,6 +148,45 @@ func TestWorkBuddyHookAndMCPShareOneGoServiceConfiguration(t *testing.T) {
 			}
 		})
 	}
+}
+
+func seedWorkBuddyWorkspaceBinding(t *testing.T, service *httptest.Server, token, workspace string) string {
+	t.Helper()
+	authorization := ""
+	if token != "" {
+		authorization = "Bearer " + token
+	}
+	client := mcp.NewClient(&mcp.Implementation{Name: "workbuddy-scope-seed", Version: "test"}, nil)
+	session, err := client.Connect(t.Context(), &mcp.StreamableClientTransport{
+		Endpoint:             service.URL + "/mcp/",
+		HTTPClient:           &http.Client{Transport: workBuddyAuthorizationTransport{base: service.Client().Transport, authorization: authorization}},
+		DisableStandaloneSSE: true,
+		MaxRetries:           -1,
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = session.Close() })
+	resolved, err := session.CallTool(t.Context(), &mcp.CallToolParams{Name: "scope_binding_resolve", Arguments: map[string]any{}})
+	if err != nil || resolved.IsError {
+		t.Fatalf("resolve default Scope binding = %#v, %v", resolved, err)
+	}
+	content, ok := resolved.StructuredContent.(map[string]any)
+	if !ok {
+		t.Fatalf("resolved Scope structured content = %T", resolved.StructuredContent)
+	}
+	scope, ok := content["scope_id"].(string)
+	if !ok || scope == "" {
+		t.Fatalf("resolved Scope ID = %#v", content["scope_id"])
+	}
+	sum := sha256.Sum256([]byte(workspace))
+	set, err := session.CallTool(t.Context(), &mcp.CallToolParams{Name: "scope_binding_set", Arguments: map[string]any{
+		"integration": "workbuddy", "kind": "workspace", "external_id": hex.EncodeToString(sum[:]), "scope_id": scope,
+	}})
+	if err != nil || set.IsError {
+		t.Fatalf("set WorkBuddy workspace binding = %#v, %v", set, err)
+	}
+	return scope
 }
 
 func assertWorkBuddyServiceReady(t *testing.T, service *httptest.Server) {


### PR DESCRIPTION
## WorkBuddy host migration to durable MCP Scope bindings

Part of #202 Phase 2. This moves the installed Go WorkBuddy hook from locally derived `git:`/`local:`/agent Scope IDs to the MCP-native durable binding resolver introduced by #222.

- Resolves through `scope_binding_resolve` before any prepare/capture/flush.
- Preserves explicit override *presence* and raw value only for Server-side validation; resolver errors fail closed with empty hook context and no downstream writes.
- Uses ordered WorkBuddy `session` then SHA-256 workspace binding keys; workspace source paths are never persisted in metadata or emitted diagnostics.
- Uses a short stateful Streamable MCP session with explicit no-retry behavior and bounded DELETE cleanup even after the operation deadline expires.
- Removes retired local Git/private/path Scope tests and helpers.
- Updates the SQLite release-hook E2E to seed/resolve bindings over real MCP and validate public/bearer recall through MCP search.

## Verification

- `go test -count=1 ./internal/cli`
- `go vet ./internal/cli`
- `git diff --check`
- Independent review and scoped re-review: all P0/P1/P2 findings addressed.

## Local environment gap

The actual SQLite release-hook E2E cannot run locally because Windows loopback readiness fails before hook execution. The exact Linux CI Acceptance and host-adapter gates are the required evidence for the public/bearer service chain.