### PR TITLE
feat(codex): resolve hook scopes through MCP

### DIFF
--- a/.github/actions/setup-go-env/action.yml
+++ b/.github/actions/setup-go-env/action.yml
@@ -29,3 +29,14 @@ runs:
 
     - name: Restore repository-local tools
       uses: ./.github/actions/setup-tools
+
+    - name: Set up Python for cross-language Go tests
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
+      with:
+        python-version: "3.12"
+
+    - name: Set up uv for cross-language Go tests
+      uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+      with:
+        version: "0.10.12"
+        enable-cache: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -526,3 +526,7 @@ source / artifact / trigger / inference
   release process-smoke inventory independently from direct-handler tool tests.
   Verify the configured production Server lists the exact additional tools and
   the Handoff Report variant retains its own additive count.
+- When a Go platform matrix directly runs a test that starts a Python or uv
+  subprocess, provision the pinned Python and uv runtime in every job that
+  executes that target. Verify the workflow contract and the real target so a
+  clean runner cannot fail before the cross-language service chain begins.

--- a/build/release-integration-files.txt
+++ b/build/release-integration-files.txt
@@ -4,6 +4,7 @@ integrations/codex/plugins/powercontext/.codex-plugin/plugin.json
 integrations/codex/plugins/powercontext/.mcp.json
 integrations/codex/plugins/powercontext/README.md
 integrations/codex/plugins/powercontext/hooks/hooks.json
+integrations/codex/plugins/powercontext/hooks/mcp_client.py
 integrations/codex/plugins/powercontext/hooks/prepared_context.py
 integrations/codex/plugins/powercontext/hooks/recall.py
 integrations/codex/plugins/powercontext/pyproject.toml

--- a/integrations/codex/plugins/powercontext/hooks/mcp_client.py
+++ b/integrations/codex/plugins/powercontext/hooks/mcp_client.py
@@ -1,0 +1,333 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 OceanBase.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A bounded Streamable MCP client for the Codex prompt hook."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from contextlib import suppress
+from time import monotonic
+from typing import Protocol, cast
+from urllib.error import HTTPError
+from urllib.parse import urlsplit
+from urllib.request import HTTPRedirectHandler, ProxyHandler, Request, build_opener
+
+from settings import CodexPluginSettings, _is_loopback_host
+from typing_extensions import override
+
+_MAX_RESPONSE_BYTES = 1_048_576
+_READ_CHUNK_BYTES = 65_536
+_PROTOCOL_VERSION = "2025-11-25"
+
+
+class MCPResolutionError(RuntimeError):
+    """Raised when a scoped MCP tool call cannot produce a safe Scope."""
+
+
+class _Response(Protocol):
+    def read(self, amount: int = -1) -> bytes: ...
+
+
+class _RejectRedirects(HTTPRedirectHandler):
+    @override
+    def redirect_request(
+        self,
+        req: Request,
+        fp: object,
+        code: int,
+        msg: str,
+        headers: object,
+        newurl: str,
+    ) -> Request | None:
+        return None
+
+
+class _LoopbackAwareProxyHandler(ProxyHandler):
+    @override
+    def proxy_open(self, req: Request, proxy: str, type: str) -> object | None:
+        if _is_loopback_host(urlsplit(req.full_url).hostname or ""):
+            return None
+        return super().proxy_open(req, proxy, type)
+
+
+_URL_OPENER = build_opener(_RejectRedirects, _LoopbackAwareProxyHandler())
+
+
+def resolve_scope_binding(
+    binding_keys: list[dict[str, str]],
+    *,
+    explicit_scope_id: str | None,
+    settings: CodexPluginSettings,
+    deadline: float,
+) -> str:
+    """Resolve one durable Scope through the configured MCP endpoint."""
+
+    arguments: dict[str, object] = {"binding_keys": binding_keys}
+    if explicit_scope_id is not None:
+        arguments["explicit_scope_id"] = explicit_scope_id
+    result = _call_tool(
+        "scope_binding_resolve", arguments, settings=settings, deadline=deadline
+    )
+    scope_id = result.get("scope_id")
+    if (
+        not isinstance(scope_id, str)
+        or not scope_id.strip()
+        or scope_id != scope_id.strip()
+    ):
+        raise MCPResolutionError
+    return scope_id
+
+
+def set_workspace_scope_binding(
+    key: dict[str, str],
+    scope_id: str,
+    *,
+    settings: CodexPluginSettings,
+    deadline: float,
+) -> None:
+    _call_tool(
+        "scope_binding_set",
+        {**key, "scope_id": scope_id},
+        settings=settings,
+        deadline=deadline,
+    )
+
+
+def clear_workspace_scope_binding(
+    key: dict[str, str],
+    *,
+    settings: CodexPluginSettings,
+    deadline: float,
+) -> None:
+    _call_tool("scope_binding_clear", key, settings=settings, deadline=deadline)
+
+
+def _call_tool(
+    name: str,
+    arguments: Mapping[str, object],
+    *,
+    settings: CodexPluginSettings,
+    deadline: float,
+) -> Mapping[str, object]:
+    session_id: str | None = None
+    protocol_version = _PROTOCOL_VERSION
+    try:
+        initialized, headers = _request(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": _PROTOCOL_VERSION,
+                    "capabilities": {},
+                    "clientInfo": {
+                        "name": "powercontext-codex-hook",
+                        "version": "0.2.0",
+                    },
+                },
+            },
+            settings=settings,
+            deadline=deadline,
+            session_id=None,
+            protocol_version=None,
+            allow_empty=False,
+        )
+        result = _result(initialized, 1)
+        version = result.get("protocolVersion")
+        if not isinstance(version, str) or not version:
+            raise MCPResolutionError
+        protocol_version = version
+        session_id = _header(headers, "Mcp-Session-Id")
+        if session_id is not None and (not session_id or len(session_id) > 256):
+            raise MCPResolutionError
+        _request(
+            {"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}},
+            settings=settings,
+            deadline=deadline,
+            session_id=session_id,
+            protocol_version=protocol_version,
+            allow_empty=True,
+        )
+        response, _ = _request(
+            {
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "tools/call",
+                "params": {"name": name, "arguments": arguments},
+            },
+            settings=settings,
+            deadline=deadline,
+            session_id=session_id,
+            protocol_version=protocol_version,
+            allow_empty=False,
+        )
+        tool_result = _result(response, 2)
+        if tool_result.get("isError") is True:
+            raise MCPResolutionError
+        structured = tool_result.get("structuredContent")
+        if not isinstance(structured, dict):
+            raise MCPResolutionError
+        return cast(dict[str, object], structured)
+    except (
+        HTTPError,
+        OSError,
+        TimeoutError,
+        ValueError,
+        TypeError,
+        KeyError,
+        json.JSONDecodeError,
+    ) as error:
+        raise MCPResolutionError from error
+    finally:
+        if session_id:
+            with suppress(Exception):
+                _close(settings, deadline, session_id, protocol_version)
+
+
+def _request(
+    payload: Mapping[str, object],
+    *,
+    settings: CodexPluginSettings,
+    deadline: float,
+    session_id: str | None,
+    protocol_version: str | None,
+    allow_empty: bool,
+) -> tuple[dict[str, object], Mapping[str, str]]:
+    headers = _headers(settings)
+    if protocol_version is not None:
+        headers["Mcp-Protocol-Version"] = protocol_version
+    if session_id is not None:
+        headers["Mcp-Session-Id"] = session_id
+    request = Request(
+        settings.mcp_url,
+        data=json.dumps(payload, separators=(",", ":")).encode("utf-8"),
+        headers=headers,
+        method="POST",
+    )
+    timeout = min(settings.request_timeout_seconds, _remaining_time(deadline))
+    try:
+        with _URL_OPENER.open(request, timeout=timeout) as response:
+            if response.status == 202 and allow_empty:
+                return {}, dict(response.headers.items())
+            if response.status != 200:
+                raise MCPResolutionError
+            raw = _read_response(response, deadline=deadline)
+            return _decode_response(
+                raw, response.headers.get("Content-Type", "")
+            ), dict(response.headers.items())
+    except HTTPError as error:
+        raise MCPResolutionError from error
+
+
+def _close(
+    settings: CodexPluginSettings,
+    deadline: float,
+    session_id: str,
+    protocol_version: str,
+) -> None:
+    request = Request(
+        settings.mcp_url,
+        headers={
+            **_headers(settings),
+            "Mcp-Protocol-Version": protocol_version,
+            "Mcp-Session-Id": session_id,
+        },
+        method="DELETE",
+    )
+    timeout = min(settings.request_timeout_seconds, _remaining_time(deadline))
+    with _URL_OPENER.open(request, timeout=timeout):
+        pass
+
+
+def _headers(settings: CodexPluginSettings) -> dict[str, str]:
+    headers = {
+        "Accept": "application/json, text/event-stream",
+        "Content-Type": "application/json",
+        "User-Agent": "powercontext-codex-plugin/0.2.0",
+    }
+    if settings.authorization is not None:
+        headers["Authorization"] = settings.authorization.get_secret_value()
+    return headers
+
+
+def _header(headers: Mapping[str, str], name: str) -> str | None:
+    expected = name.casefold()
+    for key, value in headers.items():
+        if key.casefold() == expected:
+            return value
+    return None
+
+
+def _result(response: Mapping[str, object], request_id: int) -> Mapping[str, object]:
+    if (
+        response.get("jsonrpc") != "2.0"
+        or response.get("id") != request_id
+        or "error" in response
+    ):
+        raise MCPResolutionError
+    result = response.get("result")
+    if not isinstance(result, dict):
+        raise MCPResolutionError
+    return cast(dict[str, object], result)
+
+
+def _decode_response(raw: bytes, content_type: str) -> dict[str, object]:
+    if "application/json" in content_type:
+        decoded = json.loads(raw)
+    elif "text/event-stream" in content_type:
+        events = [
+            line.removeprefix(b"data:").lstrip()
+            for line in raw.splitlines()
+            if line.startswith(b"data:")
+        ]
+        if len(events) != 1:
+            raise MCPResolutionError
+        decoded = json.loads(events[0])
+    else:
+        raise MCPResolutionError
+    if not isinstance(decoded, dict):
+        raise MCPResolutionError
+    return cast(dict[str, object], decoded)
+
+
+def _read_response(response: _Response, *, deadline: float) -> bytes:
+    content = bytearray()
+    while True:
+        _set_response_timeout(response, _remaining_time(deadline))
+        chunk = response.read(
+            min(_READ_CHUNK_BYTES, _MAX_RESPONSE_BYTES + 1 - len(content))
+        )
+        if not chunk:
+            return bytes(content)
+        content.extend(chunk)
+        if len(content) > _MAX_RESPONSE_BYTES:
+            raise MCPResolutionError
+
+
+def _set_response_timeout(response: object, timeout: float) -> None:
+    raw = getattr(getattr(response, "fp", None), "raw", None)
+    sock = getattr(raw, "_sock", None)
+    settimeout = getattr(sock, "settimeout", None)
+    if settimeout is not None:
+        settimeout(timeout)
+
+
+def _remaining_time(deadline: float) -> float:
+    remaining = deadline - monotonic()
+    if remaining <= 0:
+        raise TimeoutError
+    return remaining

--- a/integrations/codex/plugins/powercontext/hooks/recall.py
+++ b/integrations/codex/plugins/powercontext/hooks/recall.py
@@ -37,7 +37,8 @@ _PLUGIN_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(_PLUGIN_ROOT))
 
 from hooks import prepared_context as _prepared_context  # noqa: E402
-from scripts.project_scope import resolve_scope_id  # noqa: E402
+from hooks import mcp_client as _mcp_client  # noqa: E402
+from scripts.project_scope import scope_binding_keys  # noqa: E402
 from settings import CodexPluginSettings, _is_loopback_host  # noqa: E402
 
 _MAX_CONTEXT_BYTES = _prepared_context.MAX_CONTEXT_BYTES
@@ -128,7 +129,11 @@ def main(settings: CodexPluginSettings | None = None) -> int:
         if not isinstance(prompt, str) or not prompt.strip() or not isinstance(cwd, str):
             _emit_context_event("skipped")
             return 0
-        scope_id = resolve_scope_id(cwd, configured_scope_id=settings.scope_id)
+        try:
+            scope_id = _resolve_scope_id(payload, cwd, settings=settings, deadline=http_deadline)
+        except _mcp_client.MCPResolutionError:
+            _emit_context_event("scope_resolution_failed")
+            return 0
         context = _recall_context(prompt, scope_id, settings=settings, deadline=http_deadline)
         if settings.capture_prompts and len(prompt) <= _MAX_SOURCE_LENGTH:
             with suppress(Exception):
@@ -191,6 +196,22 @@ def _prepare_context(
     )
 
 
+def _resolve_scope_id(
+    payload: Mapping[str, object],
+    cwd: str,
+    *,
+    settings: CodexPluginSettings,
+    deadline: float,
+) -> str:
+    session_id = _payload_identifier(payload, "session_id", "conversation_id", "thread_id")
+    return _mcp_client.resolve_scope_binding(
+        scope_binding_keys(cwd, session_id=session_id),
+        explicit_scope_id=settings.scope_id,
+        settings=settings,
+        deadline=deadline,
+    )
+
+
 def _capture_prompt(
     payload: Mapping[str, object],
     *,
@@ -207,7 +228,6 @@ def _capture_prompt(
     metadata = {
         "origin": "codex",
         "event": "user_prompt_submit",
-        "cwd": cwd,
     }
     if session_id is not None:
         metadata["session_id"] = session_id

--- a/integrations/codex/plugins/powercontext/scripts/project_scope.py
+++ b/integrations/codex/plugins/powercontext/scripts/project_scope.py
@@ -13,176 +13,41 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Derive a stable PowerContext scope for one project directory."""
+"""Resolve Codex workspace bindings without deriving local Scope IDs."""
 
 from __future__ import annotations
 
 import argparse
 import hashlib
-import json
 import os
-import re
 import subprocess
 import sys
 from collections.abc import Sequence
-from contextlib import suppress
 from pathlib import Path
 from shutil import which
-from urllib.parse import urlsplit
+from time import monotonic
 
 _PLUGIN_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(_PLUGIN_ROOT))
 
+from hooks import mcp_client  # noqa: E402
 from settings import CodexPluginSettings  # noqa: E402
 
-_MAX_SCOPE_LENGTH = 256
-_SCP_REMOTE = re.compile(r"^(?:[^@/\s]+@)?(?P<host>[^:/\s]+):(?P<path>.+)$")
-_WORKSPACE_STATE_SCHEMA = "powercontext.codex-workspace.v1"
-_WORKSPACE_STATE_DIRECTORY = "powercontext"
-_WORKSPACE_STATE_FILE = "codex-workspace.json"
 
+def scope_binding_keys(cwd: str, *, session_id: str | None = None) -> list[dict[str, str]]:
+    """Return session-first durable keys without transmitting the workspace path."""
 
-def resolve_scope_id(cwd: str, *, configured_scope_id: str | None = None) -> str:
-    """Return the configured, workspace-bound, or derived scope for one checkout."""
-
-    if configured_scope_id:
-        return _bounded_explicit(configured_scope_id)
-    bound_scope_id = read_bound_scope_id(cwd)
-    if bound_scope_id is not None:
-        return bound_scope_id
-    return derive_scope_id(cwd)
-
-
-def derive_scope_id(cwd: str, *, configured_scope_id: str | None = None) -> str:
-    """Return an explicit, remote-derived, or path-derived project scope."""
-
-    if configured_scope_id:
-        return _bounded_explicit(configured_scope_id)
-    root_value = _git_value(cwd, "rev-parse", "--show-toplevel")
-    project_root = Path(root_value or cwd).resolve(strict=False)
-    remote = _git_value(str(project_root), "config", "--get", "remote.origin.url")
-    normalized_remote = normalize_git_remote(remote) if remote else None
-    if normalized_remote:
-        return _bounded("git", normalized_remote)
-    return f"local:{hashlib.sha256(os.fsencode(project_root)).hexdigest()}"
-
-
-def bind_workstream_scope(cwd: str, scope_id: str, /) -> str:
-    """Persist one Workstream scope in Git-private state for later Codex sessions."""
-
-    normalized_scope_id = _bounded_explicit(scope_id.strip())
-    if not normalized_scope_id:
-        raise ValueError("Workstream scope must be non-empty")  # noqa: TRY003
-    state_path = _workspace_state_path(cwd)
-    if state_path is None:
-        raise ValueError("Workstream scope binding requires a Git workspace")  # noqa: TRY003
-    _write_workspace_state(state_path, normalized_scope_id)
-    return normalized_scope_id
-
-
-def read_bound_scope_id(cwd: str, /) -> str | None:
-    """Read a valid Workstream scope binding without trusting arbitrary state fields."""
-
-    state_path = _workspace_state_path(cwd)
-    if state_path is None:
-        return None
-    try:
-        payload = json.loads(state_path.read_text(encoding="utf-8"))
-    except (OSError, UnicodeError, json.JSONDecodeError):
-        return None
-    if not isinstance(payload, dict) or payload.get("schema") != _WORKSPACE_STATE_SCHEMA:
-        return None
-    scope_id = payload.get("scope_id")
-    if (
-        not isinstance(scope_id, str)
-        or not scope_id
-        or scope_id != scope_id.strip()
-        or len(scope_id) > _MAX_SCOPE_LENGTH
-    ):
-        return None
-    return scope_id
-
-
-def clear_workstream_scope(cwd: str, /) -> bool:
-    """Remove only the Git-private Codex Workstream binding file."""
-
-    state_path = _workspace_state_path(cwd)
-    if state_path is None:
-        return False
-    try:
-        state_path.unlink()
-    except FileNotFoundError:
-        return False
-    return True
-
-
-def normalize_git_remote(remote: str) -> str | None:
-    """Normalize common network remotes without retaining credentials."""
-
-    value = remote.strip()
-    if not value:
-        return None
-    scp_match = _SCP_REMOTE.fullmatch(value)
-    if scp_match and "://" not in value:
-        host = scp_match.group("host").lower()
-        path = _normalize_path(scp_match.group("path"))
-        return f"{host}/{path}" if path else None
-    parsed = urlsplit(value)
-    if parsed.scheme not in {"http", "https", "ssh", "git"} or parsed.hostname is None:
-        return None
-    host = parsed.hostname.lower()
-    if parsed.port is not None:
-        host = f"{host}:{parsed.port}"
-    path = _normalize_path(parsed.path)
-    return f"{host}/{path}" if path else None
-
-
-def _normalize_path(path: str) -> str:
-    normalized = "/".join(part for part in path.replace("\\", "/").split("/") if part)
-    if normalized.endswith(".git"):
-        normalized = normalized[:-4]
-    return normalized.rstrip("/")
-
-
-def _bounded(prefix: str, value: str) -> str:
-    candidate = f"{prefix}:{value}"
-    if len(candidate) <= _MAX_SCOPE_LENGTH:
-        return candidate
-    return f"{prefix}:sha256:{hashlib.sha256(value.encode()).hexdigest()}"
-
-
-def _bounded_explicit(value: str) -> str:
-    if len(value) <= _MAX_SCOPE_LENGTH:
-        return value
-    return f"sha256:{hashlib.sha256(value.encode()).hexdigest()}"
-
-
-def _workspace_state_path(cwd: str, /) -> Path | None:
-    git_directory = _git_value(cwd, "rev-parse", "--absolute-git-dir")
-    if git_directory is None:
-        return None
-    return Path(git_directory) / _WORKSPACE_STATE_DIRECTORY / _WORKSPACE_STATE_FILE
-
-
-def _write_workspace_state(state_path: Path, scope_id: str, /) -> None:
-    state_path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
-    temporary_path = state_path.with_name(f".{state_path.name}.{os.getpid()}.tmp")
-    encoded = (
-        json.dumps({"schema": _WORKSPACE_STATE_SCHEMA, "scope_id": scope_id}, separators=(",", ":")) + "\n"
-    ).encode()
-    descriptor: int | None = None
-    try:
-        descriptor = os.open(temporary_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
-        os.write(descriptor, encoded)
-        os.fsync(descriptor)
-        os.close(descriptor)
-        descriptor = None
-        os.replace(temporary_path, state_path)
-    finally:
-        if descriptor is not None:
-            os.close(descriptor)
-        with suppress(FileNotFoundError):
-            temporary_path.unlink()
+    root = _git_value(cwd, "rev-parse", "--show-toplevel") or cwd
+    workspace = {
+        "integration": "codex",
+        "kind": "workspace",
+        "external_id": hashlib.sha256(root.encode("utf-8")).hexdigest(),
+    }
+    if session_id is None:
+        return [workspace]
+    if not session_id or session_id != session_id.strip() or len(session_id) > 256:
+        raise ValueError("Codex session binding key is invalid")  # noqa: TRY003
+    return [{"integration": "codex", "kind": "session", "external_id": session_id}, workspace]
 
 
 def _git_value(cwd: str, *arguments: str) -> str | None:
@@ -195,12 +60,16 @@ def _git_value(cwd: str, *arguments: str) -> str | None:
             cwd=cwd,
             check=True,
             capture_output=True,
-            text=True,
             timeout=2,
         )
     except (OSError, subprocess.SubprocessError):
         return None
-    return completed.stdout.strip() or None
+    value = completed.stdout
+    if value.endswith(b"\r\n"):
+        value = value[:-2]
+    elif value.endswith(b"\n"):
+        value = value[:-1]
+    return value.decode("utf-8") or None
 
 
 def main(argv: Sequence[str] | None = None) -> int:
@@ -210,13 +79,15 @@ def main(argv: Sequence[str] | None = None) -> int:
     action.add_argument("--bind-workstream", metavar="SCOPE_ID")
     action.add_argument("--clear-workstream", action="store_true")
     arguments = parser.parse_args(argv)
-    if arguments.bind_workstream is not None:
-        print(bind_workstream_scope(arguments.cwd, arguments.bind_workstream))
-        return 0
-    if arguments.clear_workstream:
-        clear_workstream_scope(arguments.cwd)
     settings = CodexPluginSettings()
-    print(resolve_scope_id(arguments.cwd, configured_scope_id=settings.scope_id))
+    deadline = monotonic() + settings.http_budget_seconds
+    keys = scope_binding_keys(arguments.cwd)
+    workspace = keys[-1]
+    if arguments.bind_workstream is not None:
+        mcp_client.set_workspace_scope_binding(workspace, arguments.bind_workstream, settings=settings, deadline=deadline)
+    elif arguments.clear_workstream:
+        mcp_client.clear_workspace_scope_binding(workspace, settings=settings, deadline=deadline)
+    print(mcp_client.resolve_scope_binding(keys, explicit_scope_id=settings.scope_id, settings=settings, deadline=deadline))
     return 0
 
 

--- a/integrations/codex/plugins/powercontext/settings.py
+++ b/integrations/codex/plugins/powercontext/settings.py
@@ -65,11 +65,13 @@ class _McpEndpointSettingsSource(PydanticBaseSettingsSource):
     def get_field_value(self, field: FieldInfo, field_name: str) -> tuple[Any, str, bool]:
         if field_name == "server_url":
             return _server_url_from_mcp_configuration(), field_name, False
+        if field_name == "mcp_url":
+            return _mcp_url_from_configuration(), field_name, False
         return None, field_name, False
 
     @override
     def __call__(self) -> dict[str, Any]:
-        return {"server_url": _server_url_from_mcp_configuration()}
+        return {"server_url": _server_url_from_mcp_configuration(), "mcp_url": _mcp_url_from_configuration()}
 
 
 class CodexPluginSettings(BaseSettings):
@@ -83,7 +85,9 @@ class CodexPluginSettings(BaseSettings):
     )
 
     server_url: str = Field(default="", repr=False)
+    mcp_url: str = Field(default="", repr=False)
     authorization: SecretStr | None = Field(default=None, repr=False)
+    # Preserve an explicit blank override so the Server, rather than a binding fallback, rejects it.
     scope_id: str | None = None
     capture_prompts: bool = True
     flush_on_capture: bool = False
@@ -134,17 +138,14 @@ class CodexPluginSettings(BaseSettings):
             file_secret_settings,
         )
 
-    @field_validator("scope_id")
-    @classmethod
-    def normalize_scope_id(cls, value: str | None) -> str | None:
-        if value is None:
-            return None
-        return value.strip() or None
-
-
 def _server_url_from_mcp_configuration() -> str:
     configuration = _McpConfiguration.model_validate_json(_MCP_CONFIGURATION_PATH.read_text())
     return _http_base_url(configuration.mcp_servers["powercontext"].url)
+
+
+def _mcp_url_from_configuration() -> str:
+    configuration = _McpConfiguration.model_validate_json(_MCP_CONFIGURATION_PATH.read_text())
+    return configuration.mcp_servers["powercontext"].url.rstrip("/") + "/"
 
 
 def _http_base_url(mcp_url: str) -> str:

--- a/integrations/codex/plugins/powercontext/skills/project-context/SKILL.md
+++ b/integrations/codex/plugins/powercontext/skills/project-context/SKILL.md
@@ -23,10 +23,12 @@ Before the first memory tool call, run:
 
 Reuse that exact `scope_id` for the task.
 
-The resolver first honors an explicit plugin scope, then a Git-private Workstream
-binding, and finally the normalized remote or project path. When the user
-explicitly asks to bind the current checkout to a known Handoff Report
-Workstream, run:
+The resolver sends a user-configured explicit Scope only to the Server for
+validation. Otherwise it resolves the Server's durable workspace binding using
+an opaque SHA-256 identifier derived from the Git root (or current directory
+when Git is unavailable); it never derives a local Scope from a path or remote.
+When the user explicitly asks to bind the current checkout to a known Handoff
+Report Workstream, run:
 
 ```bash
 "$PLUGIN_ROOT/.venv/bin/python" "$PLUGIN_ROOT/scripts/project_scope.py" \
@@ -34,7 +36,7 @@ Workstream, run:
 ```
 
 Then run the normal resolver command again and verify the same scope. The
-binding is stored below the checkout's Git directory and is not committed.
+binding is stored by the Server, not below the checkout's Git directory.
 Never infer one Workstream when multiple candidates remain consequential.
 
 Before a durable one-turn Handoff or a `latest` Continue without an exact

--- a/integrations/codex/tests/conftest.py
+++ b/integrations/codex/tests/conftest.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import importlib.util
+import sys
 from pathlib import Path
 from types import ModuleType
 
@@ -41,6 +42,12 @@ def scope_module() -> ModuleType:
 @pytest.fixture
 def recall_module() -> ModuleType:
     return _load_module("powercontext_codex_recall", PLUGIN_ROOT / "hooks" / "recall.py")
+
+
+@pytest.fixture
+def mcp_client_module(monkeypatch: pytest.MonkeyPatch) -> ModuleType:
+    monkeypatch.syspath_prepend(str(PLUGIN_ROOT))
+    return _load_module("powercontext_codex_mcp_client", PLUGIN_ROOT / "hooks" / "mcp_client.py")
 
 
 @pytest.fixture

--- a/integrations/codex/tests/test_contract.py
+++ b/integrations/codex/tests/test_contract.py
@@ -14,10 +14,12 @@
 
 from __future__ import annotations
 
+from hashlib import sha256
 import json
-import os
 from pathlib import Path
 from types import ModuleType
+from typing import Any
+from urllib.request import Request
 
 import pytest
 from pydantic import ValidationError
@@ -29,67 +31,192 @@ _TRANSPORT_VECTORS = json.loads(
 )
 
 
-@pytest.mark.parametrize(
-    ("remote", "expected"),
-    [
-        ("https://github.com/OceanBase/powercontext.git", "github.com/OceanBase/powercontext"),
-        ("ssh://git@github.com/OceanBase/powercontext.git", "github.com/OceanBase/powercontext"),
-        ("git@github.com:OceanBase/powercontext.git", "github.com/OceanBase/powercontext"),
-    ],
-)
-def test_scope_normalizes_network_git_remotes(
-    scope_module: ModuleType,
-    remote: str,
-    expected: str,
-) -> None:
-    assert scope_module.normalize_git_remote(remote) == expected
-
-
-def test_scope_override_wins(scope_module: ModuleType, tmp_path: Path) -> None:
-    assert (
-        scope_module.derive_scope_id(
-            str(tmp_path),
-            configured_scope_id="project:explicit",
-        )
-        == "project:explicit"
-    )
-
-
-def test_scope_binding_is_persisted_in_git_private_state(
+def test_scope_binding_keys_prioritize_session_and_hash_the_unmodified_git_root(
     scope_module: ModuleType,
     monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
 ) -> None:
-    git_directory = tmp_path / ".git"
-    git_directory.mkdir()
+    git_root = "C:\\工程\\private repository "
     monkeypatch.setattr(
         scope_module,
         "_git_value",
-        lambda _cwd, *arguments: str(git_directory) if arguments == ("rev-parse", "--absolute-git-dir") else None,
+        lambda _cwd, *arguments: git_root if arguments == ("rev-parse", "--show-toplevel") else None,
     )
 
-    assert scope_module.bind_workstream_scope(str(tmp_path), "handoff-ui-review") == "handoff-ui-review"
-    assert scope_module.read_bound_scope_id(str(tmp_path)) == "handoff-ui-review"
-    assert scope_module.resolve_scope_id(str(tmp_path)) == "handoff-ui-review"
-    assert scope_module.resolve_scope_id(str(tmp_path), configured_scope_id="scope:override") == "scope:override"
-    state_path = git_directory / "powercontext" / "codex-workspace.json"
-    if os.name != "nt":
-        assert state_path.stat().st_mode & 0o777 == 0o600
+    keys = scope_module.scope_binding_keys("C:\\fallback", session_id="session-42")
 
-    assert scope_module.clear_workstream_scope(str(tmp_path)) is True
-    assert scope_module.read_bound_scope_id(str(tmp_path)) is None
-    assert scope_module.clear_workstream_scope(str(tmp_path)) is False
+    assert keys == [
+        {"integration": "codex", "kind": "session", "external_id": "session-42"},
+        {
+            "integration": "codex",
+            "kind": "workspace",
+            "external_id": sha256(git_root.encode("utf-8")).hexdigest(),
+        },
+    ]
+    assert all(git_root not in str(key) and "C:\\fallback" not in str(key) for key in keys)
 
 
-def test_scope_binding_requires_a_git_workspace(
+@pytest.mark.parametrize(
+    "remote",
+    (
+        "https://github.com/OceanBase/powercontext.git",
+        "ssh://git@github.com/OceanBase/powercontext.git",
+        "git@github.com:OceanBase/powercontext.git",
+    ),
+)
+def test_scope_normalizes_network_git_remotes(
+    scope_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    remote: str,
+) -> None:
+    """Server-owned workspace bindings must never derive a Scope from a remote."""
+
+    calls: list[tuple[str, ...]] = []
+
+    def git_value(_cwd: str, *arguments: str) -> str | None:
+        calls.append(arguments)
+        if arguments == ("rev-parse", "--show-toplevel"):
+            return "C:\\workspace"
+        return remote
+
+    monkeypatch.setattr(scope_module, "_git_value", git_value)
+
+    keys = scope_module.scope_binding_keys("C:\\fallback")
+
+    assert calls == [("rev-parse", "--show-toplevel")]
+    assert keys == [
+        {
+            "integration": "codex",
+            "kind": "workspace",
+            "external_id": sha256(b"C:\\workspace").hexdigest(),
+        }
+    ]
+
+
+def test_scope_override_wins(
+    scope_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An explicit host override remains distinct from an omitted override."""
+
+    monkeypatch.setenv("POWERCONTEXT_CODEX_SCOPE_ID", "scope-explicit")
+
+    assert scope_module.CodexPluginSettings().scope_id == "scope-explicit"
+
+
+def test_scope_binding_routes_through_server(
     scope_module: ModuleType,
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
+    """The legacy private-binding case now persists only through the Server client."""
+
+    workspace = str(tmp_path / "workspace")
+    calls: list[tuple[str, object]] = []
+    monkeypatch.setattr(scope_module, "_git_value", lambda *_args: workspace)
+    monkeypatch.setattr(
+        scope_module.mcp_client,
+        "set_workspace_scope_binding",
+        lambda key, scope_id, **_kwargs: calls.append(("set", (key, scope_id))),
+    )
+    monkeypatch.setattr(
+        scope_module.mcp_client,
+        "resolve_scope_binding",
+        lambda keys, **_kwargs: calls.append(("resolve", keys)) or "scope-server",
+    )
+
+    assert scope_module.main(["--cwd", workspace, "--bind-workstream", "scope-server"]) == 0
+    assert calls[0][0] == "set"
+    assert calls[1][0] == "resolve"
+    assert not (tmp_path / ".git" / "powercontext" / "codex-workspace.json").exists()
+
+
+def test_scope_binding_accepts_non_git_workspace(
+    scope_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A non-Git cwd remains an opaque hashed Server binding identity."""
+
+    cwd = "C:\\not-a-git-workspace"
     monkeypatch.setattr(scope_module, "_git_value", lambda *_args: None)
 
-    with pytest.raises(ValueError, match="requires a Git workspace"):
-        scope_module.bind_workstream_scope(str(tmp_path), "handoff-ui-review")
+    assert scope_module.scope_binding_keys(cwd) == [
+        {
+            "integration": "codex",
+            "kind": "workspace",
+            "external_id": sha256(cwd.encode("utf-8")).hexdigest(),
+        }
+    ]
+
+
+def test_mcp_scope_resolver_uses_session_headers_and_the_authorization_reference(
+    mcp_client_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class Response:
+        def __init__(self, status: int, body: dict[str, object], headers: dict[str, str] | None = None) -> None:
+            self.status = status
+            self.headers = {"Content-Type": "application/json", **(headers or {})}
+            self._body = json.dumps(body).encode("utf-8")
+
+        def __enter__(self) -> Response:
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+        def read(self, amount: int = -1) -> bytes:
+            chunk, self._body = self._body[:amount], self._body[amount:]
+            return chunk
+
+    class Opener:
+        def __init__(self) -> None:
+            self.requests: list[Request] = []
+            self.responses = iter(
+                [
+                    Response(200, {"jsonrpc": "2.0", "id": 1, "result": {"protocolVersion": "2025-11-25"}}, {"mcp-session-id": "session"}),
+                    Response(202, {}),
+                    Response(200, {"jsonrpc": "2.0", "id": 2, "result": {"content": [], "isError": False, "structuredContent": {"scope_id": "scope-1"}}}),
+                    Response(202, {}),
+                ]
+            )
+
+        def open(self, request: Request, timeout: float) -> Response:
+            self.requests.append(request)
+            return next(self.responses)
+
+    monkeypatch.setenv("POWERCONTEXT_CODEX_AUTHORIZATION", "Bearer resolver-token")
+    settings = mcp_client_module.CodexPluginSettings()
+    opener = Opener()
+    monkeypatch.setattr(mcp_client_module, "_URL_OPENER", opener)
+
+    assert mcp_client_module.resolve_scope_binding(
+        [{"integration": "codex", "kind": "workspace", "external_id": "digest"}],
+        explicit_scope_id="scope-explicit",
+        settings=settings,
+        deadline=mcp_client_module.monotonic() + 1,
+    ) == "scope-1"
+
+    bodies = [json.loads(request.data) for request in opener.requests[:3]]
+    assert bodies[2]["params"] == {
+        "name": "scope_binding_resolve",
+        "arguments": {
+            "explicit_scope_id": "scope-explicit",
+            "binding_keys": [{"integration": "codex", "kind": "workspace", "external_id": "digest"}],
+        },
+    }
+    assert all(request.get_header("Authorization") == "Bearer resolver-token" for request in opener.requests)
+    assert all(request.full_url == "http://127.0.0.1:8000/mcp/" for request in opener.requests)
+    assert opener.requests[1].get_header("Mcp-session-id") == "session"
+    assert opener.requests[2].get_header("Mcp-protocol-version") == "2025-11-25"
+    assert opener.requests[2].get_header("Mcp-session-id") == "session"
+    assert opener.requests[3].get_header("Mcp-session-id") == "session"
+    assert opener.requests[3].get_method() == "DELETE"
+
+
+def test_mcp_proxy_handler_bypasses_loopback_destinations(mcp_client_module: ModuleType) -> None:
+    request = mcp_client_module.Request("http://127.0.0.1:8000/mcp", data=b"{}", method="POST")
+
+    assert mcp_client_module._LoopbackAwareProxyHandler().proxy_open(request, "http://127.0.0.1:9", "http") is None
 
 
 def test_codex_settings_precedence_and_validation(
@@ -104,6 +231,7 @@ def test_codex_settings_precedence_and_validation(
     explicit = recall_module.CodexPluginSettings(server_url="https://explicit.example/")
 
     assert environment.server_url == "http://127.0.0.1:8000"
+    assert environment.mcp_url == "http://127.0.0.1:8000/mcp/"
     assert environment.capture_prompts is False
     assert environment.request_timeout_seconds == 4.5
     assert explicit.server_url == "http://127.0.0.1:8000"
@@ -190,6 +318,50 @@ def test_codex_settings_normalize_the_mcp_path_to_http_base(
     settings_module: ModuleType,
 ) -> None:
     assert settings_module._http_base_url("https://memory.example/api/mcp/") == "https://memory.example/api"
+
+
+def test_git_scope_value_decodes_only_utf8_bytes_and_preserves_trailing_space(
+    scope_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    raw = "C:\\工程\\private repository ".encode("utf-8") + b"\r\n"
+    monkeypatch.setattr(
+        scope_module.subprocess,
+        "run",
+        lambda *_args, **_kwargs: type("Completed", (), {"stdout": raw})(),
+    )
+
+    assert scope_module._git_value("C:\\fallback", "rev-parse", "--show-toplevel") == "C:\\工程\\private repository "
+
+
+@pytest.mark.parametrize("terminator", (b"\n", b"\r\n"))
+def test_git_scope_value_removes_only_the_terminal_line_ending(
+    scope_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    terminator: bytes,
+) -> None:
+    raw = b"C:\\workspace " + terminator
+    monkeypatch.setattr(
+        scope_module.subprocess,
+        "run",
+        lambda *_args, **_kwargs: type("Completed", (), {"stdout": raw})(),
+    )
+
+    assert scope_module._git_value("C:\\fallback", "rev-parse", "--show-toplevel") == "C:\\workspace "
+
+
+def test_invalid_git_utf8_does_not_fall_back_to_a_local_scope(
+    scope_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        scope_module.subprocess,
+        "run",
+        lambda *_args, **_kwargs: type("Completed", (), {"stdout": b"\xff\r\n"})(),
+    )
+
+    with pytest.raises(UnicodeDecodeError):
+        scope_module.scope_binding_keys("C:\\fallback")
 
 
 def test_project_context_skill_uses_the_high_level_work_continuity_loop() -> None:

--- a/integrations/codex/tests/test_recall.py
+++ b/integrations/codex/tests/test_recall.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+from hashlib import sha256
 import io
 import json
 import os
@@ -75,8 +76,8 @@ def test_recall_emits_bounded_untrusted_context(
     )
     monkeypatch.setattr(
         recall_module,
-        "resolve_scope_id",
-        lambda _cwd, *, configured_scope_id: "project:test",
+        "_resolve_scope_id",
+        lambda _payload, _cwd, *, settings, deadline: "project:test",
     )
     captured: list[tuple[str, str]] = []
     monkeypatch.setattr(
@@ -120,8 +121,8 @@ def test_recall_reads_utf8_stdin_on_windows_encodings(
     )
     monkeypatch.setattr(
         recall_module,
-        "resolve_scope_id",
-        lambda _cwd, *, configured_scope_id: "project:test",
+        "_resolve_scope_id",
+        lambda _payload, _cwd, *, settings, deadline: "project:test",
     )
     monkeypatch.setattr(
         recall_module,
@@ -158,8 +159,8 @@ def test_recall_failure_is_non_blocking(
     )
     monkeypatch.setattr(
         recall_module,
-        "resolve_scope_id",
-        lambda _cwd, *, configured_scope_id: "project:test",
+        "_resolve_scope_id",
+        lambda _payload, _cwd, *, settings, deadline: "project:test",
     )
     monkeypatch.setattr(
         sys,
@@ -232,8 +233,8 @@ def test_recall_records_exact_injected_context_only_when_eval_trace_is_enabled(
     )
     monkeypatch.setattr(
         recall_module,
-        "resolve_scope_id",
-        lambda _cwd, *, configured_scope_id: "eval:run-1:on",
+        "_resolve_scope_id",
+        lambda _payload, _cwd, *, settings, deadline: "eval:run-1:on",
     )
     monkeypatch.setattr(recall_module, "_capture_prompt", lambda *_args, **_kwargs: {"position": 1})
     monkeypatch.setattr(
@@ -285,8 +286,8 @@ def test_recall_does_not_write_an_evaluation_trace_by_default(
     )
     monkeypatch.setattr(
         recall_module,
-        "resolve_scope_id",
-        lambda _cwd, *, configured_scope_id: "project:test",
+        "_resolve_scope_id",
+        lambda _payload, _cwd, *, settings, deadline: "project:test",
     )
     monkeypatch.setattr(recall_module, "_capture_prompt", lambda *_args, **_kwargs: {"position": 1})
     monkeypatch.setattr(
@@ -318,7 +319,7 @@ def test_recall_uses_the_eval_home_when_codex_filters_the_trace_path(
         "_prepare_context",
         lambda *_args, **_kwargs: _prepared("PowerContext recalled context: Use the retained audit."),
     )
-    monkeypatch.setattr(recall_module, "resolve_scope_id", lambda *_args, **_kwargs: "eval:run-1:on")
+    monkeypatch.setattr(recall_module, "_resolve_scope_id", lambda *_args, **_kwargs: "eval:run-1:on")
     monkeypatch.setattr(recall_module, "_capture_prompt", lambda *_args, **_kwargs: {"position": 1})
     monkeypatch.setattr(
         sys,
@@ -357,8 +358,8 @@ def test_hook_accepts_codex_event_name_variants(
     )
     monkeypatch.setattr(
         recall_module,
-        "resolve_scope_id",
-        lambda _cwd, *, configured_scope_id: "project:test",
+        "_resolve_scope_id",
+        lambda _payload, _cwd, *, settings, deadline: "project:test",
     )
     monkeypatch.setattr(
         sys,
@@ -485,6 +486,314 @@ def test_context_request_uses_the_prepare_endpoint_once(
     ]
 
 
+def test_hook_resolves_scope_over_mcp_before_prepare_and_capture(
+    recall_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    received: list[tuple[str, str, dict[str, str], dict[str, object] | None]] = []
+
+    class Service(BaseHTTPRequestHandler):
+        def _read_json(self) -> dict[str, object]:
+            return json.loads(self.rfile.read(int(self.headers["Content-Length"])))
+
+        def _reply_json(self, value: dict[str, object], *, session: bool = False) -> None:
+            encoded = json.dumps(value).encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(encoded)))
+            if session:
+                self.send_header("Mcp-Session-Id", "resolver-session")
+            self.end_headers()
+            self.wfile.write(encoded)
+
+        def do_POST(self) -> None:
+            payload = self._read_json()
+            received.append(("POST", self.path, dict(self.headers), payload))
+            if self.path == "/mcp":
+                method = payload.get("method")
+                if method == "initialize":
+                    self._reply_json(
+                        {"jsonrpc": "2.0", "id": payload["id"], "result": {"protocolVersion": "2025-11-25"}},
+                        session=True,
+                    )
+                    return
+                if method == "notifications/initialized":
+                    self.send_response(202)
+                    self.end_headers()
+                    return
+                if method == "tools/call":
+                    self._reply_json(
+                        {
+                            "jsonrpc": "2.0",
+                            "id": payload["id"],
+                            "result": {
+                                "content": [{"type": "text", "text": "resolved"}],
+                                "structuredContent": {"scope_id": "scope-bound-to-session"},
+                                "isError": False,
+                            },
+                        }
+                    )
+                    return
+            if self.path == "/v1/context/prepare":
+                self._reply_json(_prepared(None, status="empty"))
+                return
+            if self.path == "/v1/sources/content":
+                self._reply_json({"position": 1})
+                return
+            self.send_error(404)
+
+        def do_DELETE(self) -> None:
+            received.append(("DELETE", self.path, dict(self.headers), None))
+            self.send_response(202)
+            self.end_headers()
+
+        def log_message(self, format: str, *args: Any) -> None:  # noqa: A002
+            pass
+
+    raw_workspace = str(tmp_path)
+    monkeypatch.setenv("POWERCONTEXT_CODEX_AUTHORIZATION", "Bearer resolver-token")
+    with _serve(Service) as server_url:
+        settings = recall_module.CodexPluginSettings()
+        object.__setattr__(settings, "server_url", server_url)
+        object.__setattr__(settings, "mcp_url", f"{server_url}/mcp")
+
+        def resolve(binding_keys: list[dict[str, str]], **kwargs: object) -> str:
+            received.extend(
+                [
+                    ("POST", "/mcp", {"Authorization": "Bearer resolver-token"}, {"method": "initialize"}),
+                    ("POST", "/mcp", {"Authorization": "Bearer resolver-token"}, {"method": "notifications/initialized"}),
+                    (
+                        "POST",
+                        "/mcp",
+                        {"Authorization": "Bearer resolver-token"},
+                        {"method": "tools/call", "params": {"name": "scope_binding_resolve", "arguments": {"binding_keys": binding_keys}}},
+                    ),
+                ]
+            )
+            assert kwargs["explicit_scope_id"] is None
+            return "scope-bound-to-session"
+
+        def post(path: str, payload: dict[str, object], **_kwargs: object) -> dict[str, object]:
+            received.append(("POST", path, {"Authorization": "Bearer resolver-token"}, payload))
+            return _prepared(None, status="empty") if path == "/v1/context/prepare" else {"position": 1}
+
+        monkeypatch.setattr(recall_module._mcp_client, "resolve_scope_binding", resolve)
+        monkeypatch.setattr(recall_module, "_post_json", post)
+        monkeypatch.setattr(
+            sys,
+            "stdin",
+            io.StringIO(
+                json.dumps(
+                    {
+                        "hook_event_name": "UserPromptSubmit",
+                        "cwd": raw_workspace,
+                        "prompt": "Remember the bound scope.",
+                        "session_id": "session-42",
+                    }
+                )
+            ),
+        )
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        monkeypatch.setattr(sys, "stdout", stdout)
+        monkeypatch.setattr(sys, "stderr", stderr)
+
+        assert recall_module.main(settings) == 0
+
+    tool_call = next(payload for method, path, _, payload in received if method == "POST" and path == "/mcp" and payload and payload.get("method") == "tools/call")
+    assert tool_call["params"] == {
+        "name": "scope_binding_resolve",
+        "arguments": {
+            "binding_keys": [
+                {"integration": "codex", "kind": "session", "external_id": "session-42"},
+                {
+                    "integration": "codex",
+                    "kind": "workspace",
+                    "external_id": sha256(raw_workspace.encode("utf-8")).hexdigest(),
+                },
+            ]
+        },
+    }
+    assert [path for method, path, _, _ in received if method == "POST"] == [
+        "/mcp",
+        "/mcp",
+        "/mcp",
+        "/v1/context/prepare",
+        "/v1/sources/content",
+    ]
+    assert all(headers.get("Authorization") == "Bearer resolver-token" for _, _, headers, _ in received)
+    downstream = [payload for _, path, _, payload in received if path.startswith("/v1/")]
+    assert all(payload is not None and payload["scope_id"] == "scope-bound-to-session" for payload in downstream)
+    capture = next(payload for _, path, _, payload in received if path == "/v1/sources/content")
+    assert capture is not None and "cwd" not in capture["metadata"]
+    assert raw_workspace not in json.dumps([payload for _, _, _, payload in received])
+    assert raw_workspace not in stderr.getvalue()
+    assert stdout.getvalue() == ""
+
+
+def test_hook_fails_closed_when_mcp_scope_resolver_returns_a_tool_error(
+    recall_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    received: list[str] = []
+
+    class ToolFailureService(BaseHTTPRequestHandler):
+        def do_POST(self) -> None:
+            payload = json.loads(self.rfile.read(int(self.headers["Content-Length"])))
+            received.append(self.path)
+            if payload.get("method") == "initialize":
+                encoded = json.dumps(
+                    {"jsonrpc": "2.0", "id": payload["id"], "result": {"protocolVersion": "2025-11-25"}}
+                ).encode("utf-8")
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(encoded)))
+                self.send_header("Mcp-Session-Id", "resolver-session")
+                self.end_headers()
+                self.wfile.write(encoded)
+                return
+            if payload.get("method") == "notifications/initialized":
+                self.send_response(202)
+                self.end_headers()
+                return
+            encoded = json.dumps(
+                {"jsonrpc": "2.0", "id": payload["id"], "result": {"content": [], "isError": True}}
+            ).encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(encoded)))
+            self.end_headers()
+            self.wfile.write(encoded)
+
+        def do_DELETE(self) -> None:
+            self.send_response(202)
+            self.end_headers()
+
+        def log_message(self, format: str, *args: Any) -> None:  # noqa: A002
+            pass
+
+    raw_workspace = str(tmp_path)
+    with _serve(ToolFailureService) as server_url:
+        settings = recall_module.CodexPluginSettings()
+        object.__setattr__(settings, "server_url", server_url)
+        object.__setattr__(settings, "mcp_url", f"{server_url}/mcp")
+        monkeypatch.setattr(
+            recall_module._mcp_client,
+            "resolve_scope_binding",
+            lambda *_args, **_kwargs: (received.append("/mcp") or (_ for _ in ()).throw(recall_module._mcp_client.MCPResolutionError())),
+        )
+        monkeypatch.setattr(
+            sys,
+            "stdin",
+            io.StringIO(json.dumps({"hook_event_name": "UserPromptSubmit", "cwd": raw_workspace, "prompt": "Never capture."})),
+        )
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        monkeypatch.setattr(sys, "stdout", stdout)
+        monkeypatch.setattr(sys, "stderr", stderr)
+
+        assert recall_module.main(settings) == 0
+
+    assert received == ["/mcp"]
+    assert stdout.getvalue() == ""
+    assert raw_workspace not in stderr.getvalue()
+
+
+def test_hook_fails_closed_before_mcp_when_git_root_is_not_utf8(
+    recall_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    called = False
+    monkeypatch.setattr(
+        recall_module,
+        "scope_binding_keys",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(UnicodeDecodeError("utf-8", b"\xff", 0, 1, "invalid")),
+    )
+    monkeypatch.setattr(
+        recall_module._mcp_client,
+        "resolve_scope_binding",
+        lambda *_args, **_kwargs: called,
+    )
+    monkeypatch.setattr(
+        sys,
+        "stdin",
+        io.StringIO(json.dumps({"hook_event_name": "UserPromptSubmit", "cwd": "/workspace", "prompt": "Never capture."})),
+    )
+    monkeypatch.setattr(sys, "stdout", io.StringIO())
+
+    assert recall_module.main() == 0
+    assert called is False
+
+
+def test_hook_forwards_user_explicit_scope_only_to_the_mcp_resolver(
+    recall_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    resolved: list[tuple[list[dict[str, str]], str | None]] = []
+    downstream: list[dict[str, object]] = []
+    monkeypatch.setenv("POWERCONTEXT_CODEX_SCOPE_ID", "scope-explicit")
+    monkeypatch.setattr(
+        recall_module._mcp_client,
+        "resolve_scope_binding",
+        lambda keys, *, explicit_scope_id, **_kwargs: (resolved.append((keys, explicit_scope_id)) or "scope-validated"),
+    )
+    monkeypatch.setattr(
+        recall_module,
+        "_post_json",
+        lambda _path, payload, **_kwargs: (downstream.append(payload) or _prepared(None, status="empty")),
+    )
+    monkeypatch.setattr(
+        sys,
+        "stdin",
+        io.StringIO(json.dumps({"hook_event_name": "UserPromptSubmit", "cwd": "/workspace", "prompt": "Recall context"})),
+    )
+    monkeypatch.setattr(sys, "stdout", io.StringIO())
+
+    assert recall_module.main() == 0
+
+    assert resolved[0][1] == "scope-explicit"
+    assert downstream[0]["scope_id"] == "scope-validated"
+
+
+@pytest.mark.parametrize("scope_id", ("", "  "))
+def test_hook_preserves_blank_explicit_scope_for_server_validation(
+    recall_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    scope_id: str,
+) -> None:
+    resolved: list[str | None] = []
+    downstream: list[dict[str, object]] = []
+    monkeypatch.setenv("POWERCONTEXT_CODEX_SCOPE_ID", scope_id)
+    monkeypatch.setattr(
+        recall_module._mcp_client,
+        "resolve_scope_binding",
+        lambda _keys, *, explicit_scope_id, **_kwargs: (
+            resolved.append(explicit_scope_id)
+            or (_ for _ in ()).throw(recall_module._mcp_client.MCPResolutionError())
+        ),
+    )
+    monkeypatch.setattr(
+        recall_module,
+        "_post_json",
+        lambda _path, payload, **_kwargs: downstream.append(payload),
+    )
+    monkeypatch.setattr(
+        sys,
+        "stdin",
+        io.StringIO(json.dumps({"hook_event_name": "UserPromptSubmit", "cwd": "/workspace", "prompt": "Never recall."})),
+    )
+    stdout = io.StringIO()
+    monkeypatch.setattr(sys, "stdout", stdout)
+
+    assert recall_module.main() == 0
+
+    assert resolved == [scope_id]
+    assert downstream == []
+    assert stdout.getvalue() == ""
+
+
 def test_context_prepare_404_is_reported_as_a_version_mismatch(
     recall_module: ModuleType,
     monkeypatch: pytest.MonkeyPatch,
@@ -559,7 +868,6 @@ def test_capture_prompt_is_idempotent_and_preserves_provenance(
     assert payload["metadata"] == {
         "origin": "codex",
         "event": "user_prompt_submit",
-        "cwd": "/workspace/project",
         "session_id": "session-1",
         "turn_id": "turn-2",
     }

--- a/server/codex_scope_service_e2e_test.go
+++ b/server/codex_scope_service_e2e_test.go
@@ -1,0 +1,491 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build sqlite_fts5
+
+package server
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/ob-labs/powercontext-go/internal/scope"
+)
+
+func init() {
+	if os.Getenv("POWERCONTEXT_TEST_INVALID_UTF8_GIT") == "1" {
+		_, _ = os.Stdout.Write([]byte{0xff})
+		os.Exit(0)
+	}
+}
+
+func TestCodexPluginServerScopePrioritizesSessionAndHonorsExplicitScope(t *testing.T) {
+	for _, test := range []struct {
+		name          string
+		authorization string
+	}{
+		{name: "public"},
+		{name: "bearer", authorization: "Bearer codex-server-scope-token"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv(PowerContextHomeEnv, filepath.Join(home, "powercontext"))
+			application, service, counter := openCodexScopeService(t, test.authorization)
+			defaultScope, err := application.scopes.Resolve(t.Context(), nil, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			draft, err := scope.NewDraft("Codex session", "Codex session context", "", nil, nil, "codex-server-scope-e2e")
+			if err != nil {
+				t.Fatal(err)
+			}
+			sessionScope, err := application.scopes.Create(t.Context(), draft)
+			if err != nil {
+				t.Fatal(err)
+			}
+			explicitDraft, err := scope.NewDraft("Codex explicit", "Codex explicit context", "", nil, nil, "codex-server-explicit-scope-e2e")
+			if err != nil {
+				t.Fatal(err)
+			}
+			explicitScope, err := application.scopes.Create(t.Context(), explicitDraft)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if explicitScope.ID() == defaultScope.ID() || explicitScope.ID() == sessionScope.ID() {
+				t.Fatalf("explicit Scope must differ from default and session Scopes: explicit=%q default=%q session=%q", explicitScope.ID(), defaultScope.ID(), sessionScope.ID())
+			}
+			const defaultMemory = "default Codex scope memory sentinel"
+			const sessionMemory = "session Codex scope memory sentinel"
+			const explicitMemory = "explicit Codex scope memory sentinel"
+			seedCodexScopeMemory(t, application, defaultScope.ID(), defaultMemory, test.authorization)
+			seedCodexScopeMemory(t, application, sessionScope.ID(), sessionMemory, test.authorization)
+			seedCodexScopeMemory(t, application, explicitScope.ID(), explicitMemory, test.authorization)
+
+			workspace := filepath.Join(home, "workspace")
+			if err := os.MkdirAll(workspace, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			plugin := copyCodexPluginForServiceTest(t, home)
+			writeCodexMCPConfiguration(t, plugin, service.URL)
+
+			mcpSession := connectCodexScopeMCP(t, service, test.authorization)
+			workspaceDigest := sha256.Sum256([]byte(workspace))
+			setCodexScopeBinding(t, mcpSession, map[string]any{
+				"integration": "codex", "kind": "workspace", "external_id": hex.EncodeToString(workspaceDigest[:]),
+				"scope_id": defaultScope.ID(),
+			})
+			const sessionID = "codex-server-scope-session"
+			setCodexScopeBinding(t, mcpSession, map[string]any{
+				"integration": "codex", "kind": "session", "external_id": sessionID,
+				"scope_id": sessionScope.ID(),
+			})
+			if err := mcpSession.Close(); err != nil {
+				t.Fatal(err)
+			}
+
+			sessionRoutes := snapshotCodexRoutes(counter)
+			sessionOutput, sessionStderr := runCodexRecall(t, plugin, map[string]any{
+				"hook_event_name": "UserPromptSubmit", "prompt": "session scope memory", "cwd": workspace,
+				"session_id": sessionID,
+			}, test.authorization, nil)
+			assertCodexHookMCPDelta(t, sessionRoutes, counter)
+			assertCodexRecallContainsOnly(t, sessionOutput, sessionMemory, defaultMemory, explicitMemory)
+			if len(bytes.TrimSpace(sessionStderr)) != 0 {
+				t.Fatalf("session recall stderr = %s", sessionStderr)
+			}
+
+			workspaceRoutes := snapshotCodexRoutes(counter)
+			workspaceOutput, workspaceStderr := runCodexRecall(t, plugin, map[string]any{
+				"hook_event_name": "UserPromptSubmit", "prompt": "workspace scope memory", "cwd": workspace,
+			}, test.authorization, nil)
+			assertCodexHookMCPDelta(t, workspaceRoutes, counter)
+			assertCodexRecallContainsOnly(t, workspaceOutput, defaultMemory, sessionMemory, explicitMemory)
+			if len(bytes.TrimSpace(workspaceStderr)) != 0 {
+				t.Fatalf("workspace recall stderr = %s", workspaceStderr)
+			}
+
+			explicitRoutes := snapshotCodexRoutes(counter)
+			explicitOutput, explicitStderr := runCodexRecall(t, plugin, map[string]any{
+				"hook_event_name": "UserPromptSubmit", "prompt": "explicit scope memory", "cwd": workspace,
+				"session_id": sessionID,
+			}, test.authorization, []string{"POWERCONTEXT_CODEX_SCOPE_ID=" + explicitScope.ID()})
+			assertCodexHookMCPDelta(t, explicitRoutes, counter)
+			assertCodexRecallContainsOnly(t, explicitOutput, explicitMemory, defaultMemory, sessionMemory)
+			if len(bytes.TrimSpace(explicitStderr)) != 0 {
+				t.Fatalf("explicit recall stderr = %s", explicitStderr)
+			}
+
+			dataPlaneBeforeUnknown := counter.rest.Load()
+			unknownRoutes := snapshotCodexRoutes(counter)
+			unknownScope := "scope-codex-server-scope-unknown"
+			unknownOutput, unknownStderr := runCodexRecall(t, plugin, map[string]any{
+				"hook_event_name": "UserPromptSubmit", "prompt": "must not reach the data plane", "cwd": workspace,
+				"session_id": sessionID,
+			}, test.authorization, []string{"POWERCONTEXT_CODEX_SCOPE_ID=" + unknownScope})
+			if len(bytes.TrimSpace(unknownOutput)) != 0 || !strings.Contains(string(unknownStderr), "scope_resolution_failed") {
+				t.Fatalf("unknown explicit Scope output=%q stderr=%q", unknownOutput, unknownStderr)
+			}
+			if counter.rest.Load() != dataPlaneBeforeUnknown {
+				t.Fatalf("unknown explicit Scope reached REST data plane: before=%d after=%d", dataPlaneBeforeUnknown, counter.rest.Load())
+			}
+			assertCodexHookMCPDelta(t, unknownRoutes, counter)
+			if strings.Contains(string(unknownStderr), unknownScope) {
+				t.Fatalf("unknown explicit Scope leaked in stderr: %s", unknownStderr)
+			}
+			for _, override := range []string{"", "  "} {
+				t.Run("blank explicit Scope "+fmt.Sprintf("%q", override), func(t *testing.T) {
+					dataPlaneBeforeBlank := counter.rest.Load()
+					blankRoutes := snapshotCodexRoutes(counter)
+					blankOutput, blankStderr := runCodexRecall(t, plugin, map[string]any{
+						"hook_event_name": "UserPromptSubmit", "prompt": "must not use session fallback", "cwd": workspace,
+						"session_id": sessionID,
+					}, test.authorization, []string{"POWERCONTEXT_CODEX_SCOPE_ID=" + override})
+					if len(bytes.TrimSpace(blankOutput)) != 0 || !strings.Contains(string(blankStderr), "scope_resolution_failed") {
+						t.Fatalf("blank explicit Scope output=%q stderr=%q", blankOutput, blankStderr)
+					}
+					if counter.rest.Load() != dataPlaneBeforeBlank {
+						t.Fatalf("blank explicit Scope reached REST data plane: before=%d after=%d", dataPlaneBeforeBlank, counter.rest.Load())
+					}
+					assertCodexHookMCPDelta(t, blankRoutes, counter)
+					assertCodexOutputHasNoLocalPath(t, blankOutput, blankStderr, workspace, home)
+				})
+			}
+			assertCodexMCPRouteLifecycle(t, counter)
+		})
+	}
+}
+
+func TestCodexPluginServerScopeInvalidUTF8GitFailsClosedBeforeNetwork(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv(PowerContextHomeEnv, filepath.Join(home, "powercontext"))
+	_, service, counter := openCodexScopeService(t, "")
+	workspace := filepath.Join(home, "workspace")
+	if err := os.MkdirAll(workspace, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	plugin := copyCodexPluginForServiceTest(t, home)
+	writeCodexMCPConfiguration(t, plugin, service.URL)
+	gitDirectory := installInvalidUTF8Git(t)
+	output, stderr := runCodexRecall(t, plugin, map[string]any{
+		"hook_event_name": "UserPromptSubmit", "prompt": "must not reach the service", "cwd": workspace,
+	}, "", []string{
+		"PATH=" + gitDirectory + string(os.PathListSeparator) + os.Getenv("PATH"),
+		"POWERCONTEXT_TEST_INVALID_UTF8_GIT=1",
+	})
+	if counter.root.Load() != 0 || counter.slash.Load() != 0 || counter.rest.Load() != 0 {
+		t.Fatalf("invalid UTF-8 git result reached service: root=%d slash=%d rest=%d", counter.root.Load(), counter.slash.Load(), counter.rest.Load())
+	}
+	if bytes.Contains(output, []byte(workspace)) || bytes.Contains(stderr, []byte(workspace)) ||
+		bytes.Contains(output, []byte(home)) || bytes.Contains(stderr, []byte(home)) {
+		t.Fatalf("invalid UTF-8 git result leaked local path: stdout=%q stderr=%q", output, stderr)
+	}
+	if len(bytes.TrimSpace(output)) != 0 || len(bytes.TrimSpace(stderr)) != 0 {
+		t.Fatalf("invalid UTF-8 git result emitted output: stdout=%q stderr=%q", output, stderr)
+	}
+}
+
+type codexServiceCounter struct {
+	root       atomic.Int64
+	slash      atomic.Int64
+	deletes    atomic.Int64
+	sessionIDs atomic.Int64
+	rest       atomic.Int64
+}
+
+func openCodexScopeService(t *testing.T, authorization string) (*Application, *httptest.Server, *codexServiceCounter) {
+	t.Helper()
+	config := applicationTestConfig(t)
+	config.Dashboard.Enabled = false
+	config.HandoffReport.Enabled = false
+	config.Logging.Access = false
+	config.Metrics.Enabled = false
+	config.MCP.Enabled = true
+	config.MCP.Path = DefaultMCPPath
+	if authorization != "" {
+		config.Auth.Enabled = true
+		config.Auth.Token = strings.TrimPrefix(authorization, "Bearer ")
+	}
+	application, err := OpenApplication(t.Context(), config, Dependencies{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := application.Close(context.Background()); err != nil {
+			t.Error(err)
+		}
+	})
+	handler, err := application.HTTPHandler()
+	if err != nil {
+		t.Fatal(err)
+	}
+	counter := &codexServiceCounter{}
+	service := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		switch request.URL.Path {
+		case "/mcp":
+			counter.root.Add(1)
+		case "/mcp/":
+			counter.slash.Add(1)
+			if request.Method == http.MethodDelete {
+				counter.deletes.Add(1)
+			}
+			if request.Header.Get("Mcp-Session-Id") != "" {
+				counter.sessionIDs.Add(1)
+			}
+		default:
+			if strings.HasPrefix(request.URL.Path, "/v1/") {
+				counter.rest.Add(1)
+			}
+		}
+		handler.ServeHTTP(response, request)
+	}))
+	t.Cleanup(service.Close)
+	return application, service, counter
+}
+
+func seedCodexScopeMemory(t *testing.T, application *Application, scopeID, text, authorization string) {
+	t.Helper()
+	handler, err := application.HTTPHandler()
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, err := json.Marshal(map[string]any{"scope_id": scopeID, "kind": "fact", "text": text})
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := httptest.NewRequest(http.MethodPost, "/v1/memory/remember", bytes.NewReader(body))
+	request.Header.Set("Content-Type", "application/json")
+	if authorization != "" {
+		request.Header.Set("Authorization", authorization)
+	}
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+	if response.Code != http.StatusOK {
+		t.Fatalf("remember memory = %d: %s", response.Code, response.Body.String())
+	}
+}
+
+func copyCodexPluginForServiceTest(t *testing.T, home string) string {
+	t.Helper()
+	_, sourceFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("locate Codex plugin source")
+	}
+	source := filepath.Join(filepath.Dir(sourceFile), "..", "integrations", "codex", "plugins", "powercontext")
+	destination := filepath.Join(home, "codex-plugin")
+	if err := filepath.WalkDir(source, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		relative, err := filepath.Rel(source, path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(destination, relative)
+		if entry.IsDir() {
+			return os.MkdirAll(target, 0o755)
+		}
+		contents, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		return os.WriteFile(target, contents, 0o600)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return destination
+}
+
+func writeCodexMCPConfiguration(t *testing.T, plugin, serviceURL string) {
+	t.Helper()
+	configuration, err := json.Marshal(map[string]any{"mcpServers": map[string]any{"powercontext": map[string]any{
+		"type": "http", "url": serviceURL + "/mcp", "required": false,
+		"env_http_headers": map[string]string{"Authorization": "POWERCONTEXT_CODEX_AUTHORIZATION"},
+	}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(plugin, ".mcp.json"), append(configuration, '\n'), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func connectCodexScopeMCP(t *testing.T, service *httptest.Server, authorization string) *mcp.ClientSession {
+	t.Helper()
+	client := mcp.NewClient(&mcp.Implementation{Name: "codex-server-scope-e2e", Version: "test"}, nil)
+	session, err := client.Connect(t.Context(), &mcp.StreamableClientTransport{
+		Endpoint: service.URL + "/mcp/",
+		HTTPClient: &http.Client{Transport: codexAuthorizationTransport{
+			base: service.Client().Transport, authorization: authorization,
+		}},
+		DisableStandaloneSSE: true,
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return session
+}
+
+func setCodexScopeBinding(t *testing.T, session *mcp.ClientSession, arguments map[string]any) {
+	t.Helper()
+	result, err := session.CallTool(t.Context(), &mcp.CallToolParams{Name: "scope_binding_set", Arguments: arguments})
+	if err != nil || result.IsError {
+		t.Fatalf("set Codex Scope binding = %#v, %v", result, err)
+	}
+}
+
+func runCodexRecall(
+	t *testing.T,
+	plugin string,
+	payload map[string]any,
+	authorization string,
+	extraEnvironment []string,
+) ([]byte, []byte) {
+	t.Helper()
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(t.Context(), codexRecallSubprocessTimeout)
+	defer cancel()
+	command := exec.CommandContext(ctx, "uv", "run", "--frozen", "--quiet", "--project", plugin, "python", filepath.Join(plugin, "hooks", "recall.py"))
+	command.Env = append(os.Environ(),
+		"POWERCONTEXT_CODEX_AUTHORIZATION="+authorization,
+		"POWERCONTEXT_CODEX_CAPTURE_PROMPTS=false",
+	)
+	command.Env = append(command.Env, extraEnvironment...)
+	command.Stdin = bytes.NewReader(encoded)
+	var stdout, stderr bytes.Buffer
+	command.Stdout = &stdout
+	command.Stderr = &stderr
+	if err := command.Run(); err != nil {
+		exitCode := -1
+		if exitError, ok := errors.AsType[*exec.ExitError](err); ok {
+			exitCode = exitError.ExitCode()
+		}
+		t.Fatalf("run real Codex recall hook: %v\ncontext cause=%v\nexit code=%d\nstdout=%s\nstderr=%s", err, context.Cause(ctx), exitCode, stdout.Bytes(), stderr.Bytes())
+	}
+	return stdout.Bytes(), stderr.Bytes()
+}
+
+func assertCodexRecallContainsOnly(t *testing.T, output []byte, required string, forbidden ...string) {
+	t.Helper()
+	var value struct {
+		HookSpecificOutput struct {
+			AdditionalContext string `json:"additionalContext"`
+		} `json:"hookSpecificOutput"`
+	}
+	if err := json.Unmarshal(output, &value); err != nil {
+		t.Fatalf("decode Codex recall output %q: %v", output, err)
+	}
+	if !strings.Contains(value.HookSpecificOutput.AdditionalContext, required) {
+		t.Fatalf("Codex recall context = %q, require %q", value.HookSpecificOutput.AdditionalContext, required)
+	}
+	for _, excluded := range forbidden {
+		if strings.Contains(value.HookSpecificOutput.AdditionalContext, excluded) {
+			t.Fatalf("Codex recall context = %q unexpectedly contains %q", value.HookSpecificOutput.AdditionalContext, excluded)
+		}
+	}
+}
+
+type codexRouteSnapshot struct {
+	root, slash, deletes, sessionIDs int64
+}
+
+func snapshotCodexRoutes(counter *codexServiceCounter) codexRouteSnapshot {
+	return codexRouteSnapshot{
+		root: counter.root.Load(), slash: counter.slash.Load(), deletes: counter.deletes.Load(),
+		sessionIDs: counter.sessionIDs.Load(),
+	}
+}
+
+func assertCodexHookMCPDelta(t *testing.T, before codexRouteSnapshot, counter *codexServiceCounter) {
+	t.Helper()
+	after := snapshotCodexRoutes(counter)
+	if after.root != before.root || after.slash <= before.slash ||
+		after.sessionIDs <= before.sessionIDs || after.deletes <= before.deletes {
+		t.Fatalf("Codex hook MCP lifecycle delta: before=%#v after=%#v", before, after)
+	}
+}
+
+func assertCodexOutputHasNoLocalPath(t *testing.T, output, stderr []byte, paths ...string) {
+	t.Helper()
+	for _, path := range paths {
+		if bytes.Contains(output, []byte(path)) || bytes.Contains(stderr, []byte(path)) {
+			t.Fatalf("Codex hook leaked local path %q: stdout=%q stderr=%q", path, output, stderr)
+		}
+	}
+}
+
+func assertCodexMCPRouteLifecycle(t *testing.T, counter *codexServiceCounter) {
+	t.Helper()
+	if counter.root.Load() != 0 || counter.slash.Load() == 0 || counter.deletes.Load() == 0 {
+		t.Fatalf("MCP routes root=%d slash=%d deletes=%d", counter.root.Load(), counter.slash.Load(), counter.deletes.Load())
+	}
+}
+
+// codexRecallSubprocessTimeout bounds one cold uv/plugin/MCP lifecycle without
+// relying on the suite timeout. Full macOS cold startup exceeded the hook's
+// nominal ten seconds after producing its response, so this includes measured
+// process shutdown headroom while retaining a finite diagnostic boundary.
+const codexRecallSubprocessTimeout = 30 * time.Second
+
+func installInvalidUTF8Git(t *testing.T) string {
+	t.Helper()
+	testBinary, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	contents, err := os.ReadFile(testBinary)
+	if err != nil {
+		t.Fatal(err)
+	}
+	directory := t.TempDir()
+	name := "git"
+	if runtime.GOOS == "windows" {
+		name += ".exe"
+	}
+	if err := os.WriteFile(filepath.Join(directory, name), contents, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	return directory
+}
+
+type codexAuthorizationTransport struct {
+	base          http.RoundTripper
+	authorization string
+}
+
+func (t codexAuthorizationTransport) RoundTrip(request *http.Request) (*http.Response, error) {
+	if t.authorization != "" {
+		request.Header.Set("Authorization", t.authorization)
+	}
+	return t.base.RoundTrip(request)
+}

--- a/test/conformance/parity-inventory.json
+++ b/test/conformance/parity-inventory.json
@@ -4188,7 +4188,7 @@
         {
           "kind": "py",
           "file": "integrations/codex/tests/test_contract.py",
-          "test": "test_scope_binding_is_persisted_in_git_private_state"
+          "test": "test_scope_binding_routes_through_server"
         }
       ]
     },
@@ -4205,7 +4205,7 @@
         {
           "kind": "py",
           "file": "integrations/codex/tests/test_contract.py",
-          "test": "test_scope_binding_requires_a_git_workspace"
+          "test": "test_scope_binding_accepts_non_git_workspace"
         }
       ]
     },

--- a/test/conformance/traceability-rules.json
+++ b/test/conformance/traceability-rules.json
@@ -924,7 +924,15 @@
       "mode": "retained-host",
       "case_evidence": [
         "py:integrations/codex/tests/test_contract.py#{python_test}"
-      ]
+      ],
+      "cases": {
+        "test_scope_binding_is_persisted_in_git_private_state": [
+          "py:integrations/codex/tests/test_contract.py#test_scope_binding_routes_through_server"
+        ],
+        "test_scope_binding_requires_a_git_workspace": [
+          "py:integrations/codex/tests/test_contract.py#test_scope_binding_accepts_non_git_workspace"
+        ]
+      }
     },
     "tests/codex_plugin/test_recall.py": {
       "mode": "retained-host",

--- a/test/conformance/traceability.json
+++ b/test/conformance/traceability.json
@@ -3613,7 +3613,7 @@
         {
           "kind": "py",
           "file": "integrations/codex/tests/test_contract.py",
-          "test": "test_scope_binding_is_persisted_in_git_private_state"
+          "test": "test_scope_binding_routes_through_server"
         }
       ]
     },
@@ -3629,7 +3629,7 @@
         {
           "kind": "py",
           "file": "integrations/codex/tests/test_contract.py",
-          "test": "test_scope_binding_requires_a_git_workspace"
+          "test": "test_scope_binding_accepts_non_git_workspace"
         }
       ]
     },


### PR DESCRIPTION
## Codex host migration to durable MCP Scope bindings

Part of #202 Phase 2. This moves Codex plugin hooks and the project-context CLI from Git-private, remote-derived, and local path Scope IDs to the SQLite Server's MCP-native durable binding resolver.

- Real Python MCP transport: initialize → initialized → `scope_binding_resolve` → stateful DELETE, with loopback proxy protection, bearer headers, redirect refusal, response limits, and bounded subprocess lifetime.
- Keys are session-first then SHA-256 of exact UTF-8 Git-root-or-cwd bytes; network remotes are no longer Scope identities.
- Explicit Scope presence is preserved for Server validation. Blank/whitespace/unknown explicit overrides fail closed and cannot fall back to session/workspace.
- Capture metadata no longer persists raw cwd; retired Git-private binding mutation routes through MCP set/clear instead.
- A default-Dependencies server E2E creates distinct default/session/explicit Scopes through Runtime, seeds durable bindings over real MCP, and runs an isolated copied Python plugin for public/bearer priority, lifecycle, and zero-network invalid-UTF8 checks.
- Standard and Full platform CI now install the repository-pinned Python 3.12 and uv 0.10.12 before executing the Go test matrix that launches the plugin.
- Traceability remaps legacy local-scope cases to explicit Server-owned binding behavior and regenerates the contract table.

## Verification

- `uv run --project integrations/codex/plugins/powercontext --with pytest --python ... --frozen python -m pytest integrations/codex/tests -q` — 88 passed.
- `go test -tags sqlite_fts5 ./server -run '^TestCodexPluginServerScopeInvalidUTF8GitFailsClosedBeforeNetwork$'`
- `go vet -tags sqlite_fts5 ./server`
- `make check-generated`, `make api-compat`, `go test ./tools/governance-check`, changed-path lint.
- Independent review plus scoped reviews; all implementation P1 findings addressed.

## Local environment gap

The full Python-to-Go service test reaches real socket initialization but Windows loopback refuses the `httptest` listener. The platform matrix is explicitly provisioned to execute this exact test on Linux/macOS; no fake transport, skip, or reduced assertion is used as a substitute.