### PR TITLE
feat(server): admit only durable scopes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -530,3 +530,10 @@ source / artifact / trigger / inference
   subprocess, provision the pinned Python and uv runtime in every job that
   executes that target. Verify the workflow contract and the real target so a
   clean runner cannot fail before the cross-language service chain begins.
+- When Server composition owns durable Scope admission, install its SQLite
+  ScopeReader before constructing Runtime and bootstrap the default through an
+  unscoped lifecycle operation. Make release, downstream, differential, and
+  benchmark consumers use a durable Scope or the MCP resolver. Verify public
+  HTTP rejects an unknown Scope with a redacted 404 before any Source or Memory
+  persistence, and verify a process consumer resolves the same default Scope
+  across restart.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -537,3 +537,7 @@ source / artifact / trigger / inference
   HTTP rejects an unknown Scope with a redacted 404 before any Source or Memory
   persistence, and verify a process consumer resolves the same default Scope
   across restart.
+- When SQLite initialization uses `CREATE TABLE IF NOT EXISTS`, verify every
+  expected `sqlite_master` object is a table in the same transaction. Prove a
+  same-named view fails without leaving a partial schema or changing existing
+  persisted data.

--- a/internal/sqlstore/phase2_sqlite_upgrade_test.go
+++ b/internal/sqlstore/phase2_sqlite_upgrade_test.go
@@ -1,0 +1,236 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sqlstore_test
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	"github.com/ob-labs/powercontext-go/internal/sqlstore"
+)
+
+const (
+	legacySourcePayload   = `{"kind":"legacy-source"}`
+	legacyArtifactContent = `{"kind":"legacy-artifact"}`
+)
+
+// These definitions are the Source and Artifact tables from the schema before
+// Phase 2 added Scope, Definition, Observation acceptance, and checkpoint state.
+var prePhase2SQLiteSchema = []string{
+	`CREATE TABLE pc_source_journal_heads (
+        scope_id VARCHAR(256) NOT NULL,
+        position BIGINT NOT NULL,
+        PRIMARY KEY (scope_id),
+        CONSTRAINT ck_pc_source_journal_heads_position_nonnegative CHECK (position >= 0)
+    )`,
+	`CREATE TABLE pc_sources (
+        scope_id VARCHAR(256) NOT NULL,
+        source_type VARCHAR(128) NOT NULL,
+        source_id VARCHAR(256) NOT NULL,
+        payload BLOB NOT NULL,
+        journal_position BIGINT NOT NULL,
+        PRIMARY KEY (scope_id, source_type, source_id),
+        CONSTRAINT uq_pc_sources_scope_journal_position UNIQUE (scope_id, journal_position)
+    )`,
+	`CREATE TABLE pc_artifacts (
+        scope_id VARCHAR(256) NOT NULL,
+        family VARCHAR(128) NOT NULL,
+        artifact_id VARCHAR(128) NOT NULL,
+        revision INTEGER NOT NULL,
+        content BLOB NOT NULL,
+        PRIMARY KEY (scope_id, family, artifact_id, revision)
+    )`,
+	`CREATE TABLE pc_artifact_heads (
+        scope_id VARCHAR(256) NOT NULL,
+        family VARCHAR(128) NOT NULL,
+        artifact_id VARCHAR(128) NOT NULL,
+        revision INTEGER NOT NULL,
+        searchable_text TEXT,
+        PRIMARY KEY (scope_id, family, artifact_id),
+        CONSTRAINT fk_pc_artifact_heads_revision FOREIGN KEY (scope_id, family, artifact_id, revision)
+            REFERENCES pc_artifacts (scope_id, family, artifact_id, revision) ON DELETE RESTRICT,
+        CONSTRAINT ck_pc_artifact_heads_revision_positive CHECK (revision > 0)
+    )`,
+}
+
+func TestOpenSQLiteUpgradesPrePhase2DatabaseIdempotently(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "pre-phase-2.db")
+	seedPrePhase2SQLiteDatabase(t, path)
+
+	database, err := sqlstore.OpenSQLite(t.Context(), sqlstore.DefaultSQLiteConfig(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertPhase2SQLiteTables(t, database.SQLDB())
+	assertPrePhase2Data(t, database.SQLDB())
+	if closeErr := database.Close(context.Background()); closeErr != nil {
+		t.Fatal(closeErr)
+	}
+
+	reopened, err := sqlstore.OpenSQLite(t.Context(), sqlstore.DefaultSQLiteConfig(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = reopened.Close(context.Background()) })
+	assertPhase2SQLiteTables(t, reopened.SQLDB())
+	assertPrePhase2Data(t, reopened.SQLDB())
+}
+
+// Regression: SQLite accepts CREATE TABLE IF NOT EXISTS for a same-named view.
+func TestOpenSQLitePhase2UpgradeFailureRollsBackSchema(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "pre-phase-2-failure.db")
+	seedPrePhase2SQLiteDatabase(t, path)
+
+	legacy, err := sql.Open("sqlite3", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, execErr := legacy.Exec(`CREATE VIEW pc_connector_checkpoints AS SELECT 1 AS checkpoint`); execErr != nil {
+		t.Fatal(execErr)
+	}
+	if closeErr := legacy.Close(); closeErr != nil {
+		t.Fatal(closeErr)
+	}
+
+	if database, openErr := sqlstore.OpenSQLite(t.Context(), sqlstore.DefaultSQLiteConfig(path)); openErr == nil {
+		_ = database.Close(context.Background())
+		t.Fatal("OpenSQLite succeeded with a conflicting checkpoint view")
+	}
+
+	inspected, err := sql.Open("sqlite3", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = inspected.Close() })
+	assertPrePhase2Data(t, inspected)
+	for _, name := range []string{
+		"pc_scopes",
+		"pc_scope_context_references",
+		"pc_scope_external_references",
+		"pc_scope_creation_requests",
+		"pc_scope_settings",
+		"pc_scope_bindings",
+		"pc_source_definition_manifests",
+		"pc_source_observation_acceptances",
+	} {
+		assertSQLiteObjectMissing(t, inspected, name)
+	}
+
+	var objectType string
+	if queryErr := inspected.QueryRowContext(t.Context(), `SELECT type FROM sqlite_master WHERE name = 'pc_connector_checkpoints'`).Scan(&objectType); queryErr != nil {
+		t.Fatal(queryErr)
+	}
+	if objectType != "view" {
+		t.Fatalf("checkpoint object type = %q, want view", objectType)
+	}
+}
+
+func seedPrePhase2SQLiteDatabase(t *testing.T, path string) {
+	t.Helper()
+	legacy, err := sql.Open("sqlite3", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, statement := range prePhase2SQLiteSchema {
+		if _, execErr := legacy.ExecContext(t.Context(), statement); execErr != nil {
+			_ = legacy.Close()
+			t.Fatal(execErr)
+		}
+	}
+	for _, entry := range []struct {
+		statement string
+		arguments []any
+	}{
+		{
+			statement: "INSERT INTO pc_source_journal_heads (scope_id, position) VALUES (?, ?)",
+			arguments: []any{"legacy-scope", 1},
+		},
+		{
+			statement: "INSERT INTO pc_sources (scope_id, source_type, source_id, payload, journal_position) VALUES (?, ?, ?, ?, ?)",
+			arguments: []any{"legacy-scope", "legacy.source", "source-1", []byte(legacySourcePayload), 1},
+		},
+		{
+			statement: "INSERT INTO pc_artifacts (scope_id, family, artifact_id, revision, content) VALUES (?, ?, ?, ?, ?)",
+			arguments: []any{"legacy-scope", "memory", "artifact-1", 1, []byte(legacyArtifactContent)},
+		},
+		{
+			statement: "INSERT INTO pc_artifact_heads (scope_id, family, artifact_id, revision, searchable_text) VALUES (?, ?, ?, ?, ?)",
+			arguments: []any{"legacy-scope", "memory", "artifact-1", 1, "legacy artifact"},
+		},
+	} {
+		if _, execErr := legacy.ExecContext(t.Context(), entry.statement, entry.arguments...); execErr != nil {
+			_ = legacy.Close()
+			t.Fatal(execErr)
+		}
+	}
+	if closeErr := legacy.Close(); closeErr != nil {
+		t.Fatal(closeErr)
+	}
+}
+
+func assertPhase2SQLiteTables(t *testing.T, database *sql.DB) {
+	t.Helper()
+	for _, name := range []string{
+		"pc_scopes",
+		"pc_scope_context_references",
+		"pc_scope_external_references",
+		"pc_scope_creation_requests",
+		"pc_scope_settings",
+		"pc_scope_bindings",
+		"pc_connector_checkpoints",
+		"pc_source_definition_manifests",
+		"pc_source_observation_acceptances",
+	} {
+		var objectType string
+		if err := database.QueryRowContext(t.Context(), "SELECT type FROM sqlite_master WHERE name = ?", name).Scan(&objectType); err != nil {
+			t.Fatalf("lookup %s: %v", name, err)
+		}
+		if objectType != "table" {
+			t.Fatalf("%s object type = %q, want table", name, objectType)
+		}
+	}
+}
+
+func assertPrePhase2Data(t *testing.T, database *sql.DB) {
+	t.Helper()
+	var sourcePayload, artifactContent []byte
+	if err := database.QueryRowContext(t.Context(), `SELECT payload FROM pc_sources
+        WHERE scope_id = ? AND source_type = ? AND source_id = ?`, "legacy-scope", "legacy.source", "source-1").Scan(&sourcePayload); err != nil {
+		t.Fatal(err)
+	}
+	if err := database.QueryRowContext(t.Context(), `SELECT content FROM pc_artifacts
+        WHERE scope_id = ? AND family = ? AND artifact_id = ? AND revision = ?`, "legacy-scope", "memory", "artifact-1", 1).Scan(&artifactContent); err != nil {
+		t.Fatal(err)
+	}
+	if string(sourcePayload) != legacySourcePayload {
+		t.Fatalf("legacy source payload = %q", sourcePayload)
+	}
+	if string(artifactContent) != legacyArtifactContent {
+		t.Fatalf("legacy artifact content = %q", artifactContent)
+	}
+}
+
+func assertSQLiteObjectMissing(t *testing.T, database *sql.DB, name string) {
+	t.Helper()
+	var count int
+	if err := database.QueryRowContext(t.Context(), "SELECT COUNT(*) FROM sqlite_master WHERE name = ?", name).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 0 {
+		t.Fatalf("unexpected SQLite object %q after failed upgrade", name)
+	}
+}

--- a/internal/sqlstore/schema.go
+++ b/internal/sqlstore/schema.go
@@ -351,6 +351,32 @@ var builtinSchema = []string{
     )`,
 }
 
+var sqliteBuiltinSchemaTables = []string{
+	"pc_scopes",
+	"pc_scope_context_references",
+	"pc_scope_external_references",
+	"pc_scope_creation_requests",
+	"pc_scope_settings",
+	"pc_scope_bindings",
+	"pc_connector_checkpoints",
+	"pc_source_definition_manifests",
+	"pc_source_journal_heads",
+	"pc_sources",
+	"pc_source_observation_acceptances",
+	"pc_artifacts",
+	"pc_artifact_heads",
+	"pc_artifact_lineage_sources",
+	"pc_artifact_lineage_artifacts",
+	"pc_artifact_candidate_versions",
+	"pc_artifact_candidate_heads",
+	"pc_source_cursors",
+	"pc_external_skill_registrations",
+	"pc_memory_entry_versions",
+	"pc_memory_entry_heads",
+	"pc_model_usage_daily",
+	"pc_recall_token_daily",
+}
+
 // EnsureBuiltinSchema creates only absent Python-compatible core tables.
 func EnsureBuiltinSchema(ctx context.Context, db DBTX) error {
 	return EnsureBuiltinSchemaForDialect(ctx, db, SQLiteDialect)
@@ -372,6 +398,22 @@ func EnsureBuiltinSchemaForDialect(ctx context.Context, db DBTX, dialect Dialect
 		}
 		if _, err := db.ExecContext(ctx, statement); err != nil {
 			return err
+		}
+	}
+	if dialect == SQLiteDialect {
+		return ensureSQLiteBuiltinSchemaTables(ctx, db)
+	}
+	return nil
+}
+
+func ensureSQLiteBuiltinSchemaTables(ctx context.Context, db DBTX) error {
+	for _, name := range sqliteBuiltinSchemaTables {
+		var objectType string
+		if err := db.QueryRowContext(ctx, "SELECT type FROM sqlite_master WHERE name = ?", name).Scan(&objectType); err != nil {
+			return fmt.Errorf("sqlstore: find SQLite schema object %q: %w", name, err)
+		}
+		if objectType != "table" {
+			return fmt.Errorf("sqlstore: SQLite schema object %q must be a table", name)
 		}
 	}
 	return nil

--- a/server/application_foundation.go
+++ b/server/application_foundation.go
@@ -77,6 +77,18 @@ func openApplicationFoundation(
 		ownedResources = append(ownedResources, tracingResource)
 	}
 	ownedResources = append(ownedResources, assembled.resources...)
+	scopeReader, scopeReaderErr := sqlstore.NewRuntimeScopeReader(storage.database, sqlstore.ScopeRepository{})
+	if scopeReaderErr != nil {
+		closeCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		var closeErrors []error
+		for index := len(ownedResources) - 1; index >= 0; index-- {
+			if ownedResources[index] != nil {
+				closeErrors = append(closeErrors, ownedResources[index].Close(closeCtx))
+			}
+		}
+		return applicationFoundation{}, errors.Join(append([]error{scopeReaderErr}, closeErrors...)...)
+	}
 	var scopeObserver pcruntime.ScopeCacheObserver
 	if metrics != nil {
 		scopeObserver = metrics.SetRuntimeScopes
@@ -85,6 +97,7 @@ func openApplicationFoundation(
 		ScopeCacheSize: config.Runtime.ScopeCacheSize,
 		ScopeObserver:  scopeObserver,
 		Tracing:        newRuntimeStageTracing(tracingProvider),
+		ScopeReader:    scopeReader,
 	}, relationalModelUsageRecorder{
 		database: storage.database, repository: statisticsRepository,
 		clock: statisticsClock, logger: dependencies.Logger,

--- a/server/application_test.go
+++ b/server/application_test.go
@@ -67,16 +67,17 @@ func TestOpenApplicationProvidesRunnableSQLiteVerticalSlice(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	scopeID := applicationDefaultScopeID(t, application)
 
 	recorder := postApplicationJSON(t, handler, "/v1/sources/content", map[string]any{
-		"scope_id": "project:application", "source_id": "source-1", "content": "captured",
+		"scope_id": scopeID, "source_id": "source-1", "content": "captured",
 	})
 	if recorder.Code != http.StatusAccepted {
 		t.Fatalf("capture status = %d: %s", recorder.Code, recorder.Body.String())
 	}
 
 	recorder = postApplicationJSON(t, handler, "/v1/memory/remember", map[string]any{
-		"scope_id": "project:application", "kind": "fact", "text": "Go server is running.",
+		"scope_id": scopeID, "kind": "fact", "text": "Go server is running.",
 	})
 	if recorder.Code != http.StatusOK {
 		t.Fatalf("remember status = %d: %s", recorder.Code, recorder.Body.String())
@@ -209,18 +210,23 @@ func TestApplicationCloseWaitsForInFlightHTTPMemoryFlush(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	scopeID := applicationDefaultScopeID(t, application)
 	if response := postApplicationJSON(t, handler, "/v1/sources/content", map[string]any{
-		"scope_id": "project:shutdown", "source_id": "source-1", "content": "flush while closing",
+		"scope_id": scopeID, "source_id": "source-1", "content": "flush while closing",
 	}); response.Code != http.StatusAccepted {
 		t.Fatalf("capture = %d: %s", response.Code, response.Body.String())
 	}
+	flushBody, err := json.Marshal(map[string]any{"scope_id": scopeID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	flushRequest := httptest.NewRequest(http.MethodPost, "/v1/memory/flush", bytes.NewReader(flushBody))
+	flushRequest.Header.Set("Content-Type", "application/json")
 
 	flush := make(chan *httptest.ResponseRecorder, 1)
 	go func() {
-		request := httptest.NewRequest(http.MethodPost, "/v1/memory/flush", strings.NewReader(`{"scope_id":"project:shutdown"}`))
-		request.Header.Set("Content-Type", "application/json")
 		response := httptest.NewRecorder()
-		handler.ServeHTTP(response, request)
+		handler.ServeHTTP(response, flushRequest)
 		flush <- response
 	}()
 	<-pipeline.started
@@ -270,7 +276,7 @@ func TestGoClientExercisesReviewHTTPRuntimeSQLiteVerticalSlice(t *testing.T) {
 		t.Fatal(err)
 	}
 	ctx := t.Context()
-	const scope = "project:go-client-review"
+	scope := applicationDefaultScopeID(t, application)
 
 	capturedResult, err := sdk.CaptureContentSource(ctx, &v1.CaptureContentSourceRequest{
 		ScopeID: scope, SourceID: "task-1", Content: "Regeneration and contract validation passed.",
@@ -464,7 +470,7 @@ func TestGoClientGeneratesReviewedExperienceAndSkillCandidates(t *testing.T) {
 		t.Fatal(err)
 	}
 	ctx := t.Context()
-	const scope = "project:go-client-generation"
+	scope := applicationDefaultScopeID(t, application)
 	capturedResult, err := sdk.CaptureContentSource(ctx, &v1.CaptureContentSourceRequest{
 		ScopeID: scope, SourceID: "task-1", Content: "The contract checks passed.",
 	})
@@ -824,19 +830,20 @@ func TestOpenApplicationPersistsBusinessInferenceAndRecallAcrossRestartWithoutMe
 	if err != nil {
 		t.Fatal(err)
 	}
+	scopeID := applicationDefaultScopeID(t, application)
 
 	if response := postApplicationJSON(t, handler, "/v1/sources/content", map[string]any{
-		"scope_id": "scope-statistics", "source_id": "source-1", "content": sourceContent,
+		"scope_id": scopeID, "source_id": "source-1", "content": sourceContent,
 	}); response.Code != http.StatusAccepted {
 		t.Fatalf("capture = %d: %s", response.Code, response.Body.String())
 	}
 	if response := postApplicationJSON(t, handler, "/v1/memory/flush", map[string]any{
-		"scope_id": "scope-statistics",
+		"scope_id": scopeID,
 	}); response.Code != http.StatusOK {
 		t.Fatalf("flush = %d: %s", response.Code, response.Body.String())
 	}
 	preparedResponse := postApplicationJSON(t, handler, "/v1/context/prepare", map[string]any{
-		"scope_id": "scope-statistics", "query": "statistics contract",
+		"scope_id": scopeID, "query": "statistics contract",
 	})
 	if preparedResponse.Code != http.StatusOK {
 		t.Fatalf("prepare = %d: %s", preparedResponse.Code, preparedResponse.Body.String())
@@ -852,9 +859,7 @@ func TestOpenApplicationPersistsBusinessInferenceAndRecallAcrossRestartWithoutMe
 		t.Fatalf("prepared = %#v", prepared)
 	}
 
-	statisticsResponse := perform(
-		handler, http.MethodGet, "/v1/stats?scope_id=scope-statistics&period=today", "",
-	)
+	statisticsResponse := perform(handler, http.MethodGet, "/v1/stats?scope_id="+scopeID+"&period=today", "")
 	if statisticsResponse.Code != http.StatusOK {
 		t.Fatalf("statistics = %d: %s", statisticsResponse.Code, statisticsResponse.Body.String())
 	}
@@ -925,9 +930,7 @@ func TestOpenApplicationPersistsBusinessInferenceAndRecallAcrossRestartWithoutMe
 	if err != nil {
 		t.Fatal(err)
 	}
-	restoredResponse := perform(
-		handler, http.MethodGet, "/v1/stats?scope_id=scope-statistics&period=7d", "",
-	)
+	restoredResponse := perform(handler, http.MethodGet, "/v1/stats?scope_id="+scopeID+"&period=7d", "")
 	if restoredResponse.Code != http.StatusOK {
 		t.Fatalf("restored statistics = %d: %s", restoredResponse.Code, restoredResponse.Body.String())
 	}
@@ -946,7 +949,7 @@ func TestOpenApplicationPersistsBusinessInferenceAndRecallAcrossRestartWithoutMe
 	}
 
 	preparedAgainResponse := postApplicationJSON(t, handler, "/v1/context/prepare", map[string]any{
-		"scope_id": "scope-statistics", "query": "statistics contract",
+		"scope_id": scopeID, "query": "statistics contract",
 	})
 	if preparedAgainResponse.Code != http.StatusOK {
 		t.Fatalf("prepare after restart = %d: %s", preparedAgainResponse.Code, preparedAgainResponse.Body.String())
@@ -958,9 +961,7 @@ func TestOpenApplicationPersistsBusinessInferenceAndRecallAcrossRestartWithoutMe
 	if preparedAgain.Status != "ready" || preparedAgain.Content == nil || *preparedAgain.Content != *prepared.Content {
 		t.Fatalf("prepared after restart = %#v", preparedAgain)
 	}
-	updatedResponse := perform(
-		handler, http.MethodGet, "/v1/stats?scope_id=scope-statistics&period=7d", "",
-	)
+	updatedResponse := perform(handler, http.MethodGet, "/v1/stats?scope_id="+scopeID+"&period=7d", "")
 	if updatedResponse.Code != http.StatusOK {
 		t.Fatalf("updated statistics = %d: %s", updatedResponse.Code, updatedResponse.Body.String())
 	}
@@ -992,6 +993,7 @@ func TestOpenApplicationStatsUsesInclusiveUTCPeriodsForEmptyScope(t *testing.T) 
 	if err != nil {
 		t.Fatal(err)
 	}
+	scopeID := applicationDefaultScopeID(t, application)
 
 	type usageValue struct {
 		Requests     int `json:"requests"`
@@ -1046,9 +1048,7 @@ func TestOpenApplicationStatsUsesInclusiveUTCPeriodsForEmptyScope(t *testing.T) 
 		{name: "thirty days", query: "&period=30d", preset: "30d", days: 30},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			response := perform(
-				handler, http.MethodGet, "/v1/stats?scope_id=project%3Atest"+test.query, "",
-			)
+			response := perform(handler, http.MethodGet, "/v1/stats?scope_id="+scopeID+test.query, "")
 			if response.Code != http.StatusOK {
 				t.Fatalf("statistics = %d: %s", response.Code, response.Body.String())
 			}
@@ -1061,7 +1061,7 @@ func TestOpenApplicationStatsUsesInclusiveUTCPeriodsForEmptyScope(t *testing.T) 
 			if err := json.Unmarshal(response.Body.Bytes(), &body); err != nil {
 				t.Fatal(err)
 			}
-			if body.ScopeID != "project:test" || !body.AsOf.Equal(utcNow) {
+			if body.ScopeID != scopeID || !body.AsOf.Equal(utcNow) {
 				t.Fatalf("statistics identity = scope:%q as_of:%s", body.ScopeID, body.AsOf)
 			}
 			endDate := time.Date(utcNow.Year(), utcNow.Month(), utcNow.Day(), 0, 0, 0, 0, time.UTC)
@@ -1090,9 +1090,7 @@ func TestOpenApplicationStatsUsesInclusiveUTCPeriodsForEmptyScope(t *testing.T) 
 		})
 	}
 
-	invalid := perform(
-		handler, http.MethodGet, "/v1/stats?scope_id=project%3Atest&period=all", "",
-	)
+	invalid := perform(handler, http.MethodGet, "/v1/stats?scope_id="+scopeID+"&period=all", "")
 	if invalid.Code != http.StatusUnprocessableEntity {
 		t.Fatalf("invalid period = %d: %s", invalid.Code, invalid.Body.String())
 	}

--- a/server/scope_admission_test.go
+++ b/server/scope_admission_test.go
@@ -1,0 +1,138 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build sqlite_fts5
+
+package server
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+func TestOpenApplicationAdmitsOnlyDurableScopesBeforeHTTPWork(t *testing.T) {
+	application, err := OpenApplication(t.Context(), applicationTestConfig(t), Dependencies{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		closeCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if closeErr := application.Close(closeCtx); closeErr != nil {
+			t.Error(closeErr)
+		}
+	})
+	handler, err := application.HTTPHandler()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defaultScope := applicationDefaultScopeID(t, application)
+
+	accepted := postApplicationJSON(t, handler, "/v1/sources/content", map[string]any{
+		"scope_id": defaultScope, "source_id": "default-scope-source", "content": "Durable Scope admission succeeds.",
+	})
+	if accepted.Code != http.StatusAccepted {
+		t.Fatalf("capture in default Scope = %d: %s", accepted.Code, accepted.Body.String())
+	}
+
+	databasePath, err := SQLiteDSN(application.config.Database.SQLite.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	database, err := sql.Open("sqlite3", databasePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+
+	const unknownScope = "unregistered-scope"
+	for _, request := range []struct {
+		name, path   string
+		body         map[string]any
+		privateValue string
+	}{
+		{
+			name: "capture", path: "/v1/sources/content",
+			body:         map[string]any{"scope_id": unknownScope, "source_id": "must-not-persist", "content": "must not reach Source persistence"},
+			privateValue: "must not reach Source persistence",
+		},
+		{
+			name: "prepare", path: "/v1/context/prepare",
+			body:         map[string]any{"scope_id": unknownScope, "query": "must not reach Memory persistence"},
+			privateValue: "must not reach Memory persistence",
+		},
+	} {
+		t.Run(request.name, func(t *testing.T) {
+			response := postApplicationJSON(t, handler, request.path, request.body)
+			if response.Code != http.StatusNotFound {
+				t.Fatalf("%s status = %d: %s", request.name, response.Code, response.Body.String())
+			}
+			var envelope struct {
+				Error struct {
+					Code string `json:"code"`
+				} `json:"error"`
+			}
+			if decodeErr := json.Unmarshal(response.Body.Bytes(), &envelope); decodeErr != nil {
+				t.Fatal(decodeErr)
+			}
+			if envelope.Error.Code != "scope_not_found" {
+				t.Fatalf("%s error = %#v", request.name, envelope.Error)
+			}
+			for _, private := range []string{unknownScope, request.privateValue} {
+				if private != "" && strings.Contains(response.Body.String(), private) {
+					t.Fatalf("%s error exposed %q: %s", request.name, private, response.Body.String())
+				}
+			}
+		})
+	}
+	assertNoScopePersistence(t, database, unknownScope)
+}
+
+func applicationDefaultScopeID(t *testing.T, application *Application) string {
+	t.Helper()
+	if application == nil || application.scopes == nil {
+		t.Fatal("application does not expose Scope resolution")
+	}
+	descriptor, err := application.scopes.Resolve(t.Context(), nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return descriptor.ID()
+}
+
+func assertNoScopePersistence(t *testing.T, database *sql.DB, scopeID string) {
+	t.Helper()
+	for _, table := range []string{
+		"pc_sources",
+		"pc_source_journal_heads",
+		"pc_artifacts",
+		"pc_memory_entry_versions",
+		"pc_memory_entry_heads",
+	} {
+		var count int
+		if err := database.QueryRowContext(t.Context(), "SELECT COUNT(*) FROM "+table+" WHERE scope_id = ?", scopeID).Scan(&count); err != nil {
+			t.Fatalf("count %s: %v", table, err)
+		}
+		if count != 0 {
+			t.Fatalf("unknown Scope persisted %d rows in %s", count, table)
+		}
+	}
+}

--- a/test/differential/compare_servers.py
+++ b/test/differential/compare_servers.py
@@ -25,6 +25,7 @@ import json
 import os
 import signal
 import socket
+import sqlite3
 import subprocess
 import sys
 import tempfile
@@ -117,7 +118,7 @@ def _free_loopback_port() -> int:
         return int(listener.getsockname()[1])
 
 
-def _isolated_environment(home: Path, *, enable_mcp: bool) -> dict[str, str]:
+def _isolated_environment(home: Path) -> dict[str, str]:
     environment = {
         key: value
         for key, value in os.environ.items()
@@ -131,7 +132,7 @@ def _isolated_environment(home: Path, *, enable_mcp: bool) -> dict[str, str]:
             "POWERCONTEXT_SERVER_LOGGING_ACCESS": "false",
             "POWERCONTEXT_SERVER_LOGGING_FORMAT": "json",
             "POWERCONTEXT_SERVER_LOGGING_LEVEL": "ERROR",
-            "POWERCONTEXT_SERVER_MCP_ENABLED": "true" if enable_mcp else "false",
+            "POWERCONTEXT_SERVER_MCP_ENABLED": "false",
             "POWERCONTEXT_SERVER_METRICS_ENABLED": "false",
             "POWERCONTEXT_SERVER_TRACING_ENABLED": "false",
         }
@@ -145,8 +146,6 @@ def _server(
     cwd: Path,
     home: Path,
     startup_timeout: float,
-    *,
-    enable_mcp: bool,
 ) -> Iterator[str]:
     if not executable.is_file():
         raise ComparisonFailure(f"server executable does not exist: {executable}")
@@ -167,7 +166,7 @@ def _server(
         process = subprocess.Popen(
             command,
             cwd=cwd,
-            env=_isolated_environment(home, enable_mcp=enable_mcp),
+            env=_isolated_environment(home),
             stdin=subprocess.DEVNULL,
             stdout=output,
             stderr=subprocess.STDOUT,
@@ -302,10 +301,7 @@ def _normalize_json(value: Any) -> Any:
 
 
 def _scenario(base_url: str) -> dict[str, Any]:
-    return _scenario_for_scope(base_url, "differential:scope")
-
-
-def _scenario_for_scope(base_url: str, scope: str) -> dict[str, Any]:
+    scope = "differential:scope"
     source_citation = {
         "kind": "source",
         "source_ref": {"name": "content", "source_id": "evidence-1"},
@@ -600,176 +596,46 @@ def _run_one(
     root: Path,
     startup_timeout: float,
     *,
-    resolve_go_scope: bool,
+    seed_go_scope: bool,
 ) -> dict[str, Any]:
     home = root / "home"
     home.mkdir(parents=True, mode=0o700)
+    if seed_go_scope:
+        with _server(executable.resolve(), cwd.resolve(), home, startup_timeout):
+            pass
+        _seed_go_durable_scope(home)
     with _server(
         executable.resolve(),
         cwd.resolve(),
         home,
         startup_timeout,
-        enable_mcp=resolve_go_scope,
     ) as base_url:
-        if not resolve_go_scope:
-            return _scenario(base_url)
-        scope = _resolve_go_default_scope(base_url)
-        # The frozen v0.1 server accepts first-write Scope identities. Go now
-        # resolves a durable default first, so preserve every observation while
-        # mapping only that one runtime-generated identity to the fixture value.
-        return _normalize_go_scope(_scenario_for_scope(base_url, scope), scope)
+        return _scenario(base_url)
 
 
-def _resolve_go_default_scope(base_url: str) -> str:
-    session_id: str | None = None
-    protocol_version = "2025-11-25"
+def _seed_go_durable_scope(home: Path) -> None:
+    # The frozen scenario owns this public identity. Seed it only before the Go
+    # process starts so the compared HTTP calls and their selection digests stay
+    # byte-for-byte comparable with the v0.1 Oracle.
+    database = home / "powercontext.db"
+    if not database.is_file():
+        raise ComparisonFailure("Go bootstrap did not create the SQLite database")
     try:
-        initialized, headers = _mcp_request(
-            base_url,
-            {
-                "jsonrpc": "2.0",
-                "id": 1,
-                "method": "initialize",
-                "params": {
-                    "protocolVersion": protocol_version,
-                    "capabilities": {},
-                    "clientInfo": {"name": "frozen-differential", "version": "1"},
-                },
-            },
-            session_id=None,
-            protocol_version=None,
-            allow_empty=False,
-        )
-        result = _mcp_result(initialized, 1)
-        negotiated = result.get("protocolVersion")
-        if not isinstance(negotiated, str) or not negotiated:
-            raise ComparisonFailure("Go MCP did not negotiate a protocol version")
-        protocol_version = negotiated
-        session_id = headers.get("mcp-session-id")
-        if session_id is not None and (not session_id or len(session_id) > 256):
-            raise ComparisonFailure("Go MCP returned an invalid session identity")
-        _mcp_request(
-            base_url,
-            {"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}},
-            session_id=session_id,
-            protocol_version=protocol_version,
-            allow_empty=True,
-        )
-        response, _headers = _mcp_request(
-            base_url,
-            {
-                "jsonrpc": "2.0",
-                "id": 2,
-                "method": "tools/call",
-                "params": {"name": "scope_binding_resolve", "arguments": {}},
-            },
-            session_id=session_id,
-            protocol_version=protocol_version,
-            allow_empty=False,
-        )
-        tool_result = _mcp_result(response, 2)
-        if tool_result.get("isError") is True:
-            raise ComparisonFailure("Go MCP default Scope resolution failed")
-        content = tool_result.get("structuredContent")
-        if not isinstance(content, dict):
-            raise ComparisonFailure("Go MCP default Scope resolution has no structured result")
-        scope = content.get("scope_id")
-        if not isinstance(scope, str) or not scope or scope.strip() != scope:
-            raise ComparisonFailure("Go MCP default Scope resolution returned an invalid identity")
-        return scope
-    finally:
-        if session_id:
-            _close_mcp_session(base_url, session_id, protocol_version)
-
-
-def _mcp_request(
-    base_url: str,
-    payload: Mapping[str, object],
-    *,
-    session_id: str | None,
-    protocol_version: str | None,
-    allow_empty: bool,
-) -> tuple[dict[str, object], dict[str, str]]:
-    headers = {
-        "Accept": "application/json, text/event-stream",
-        "Content-Type": "application/json",
-        "User-Agent": "powercontext-frozen-differential/1",
-    }
-    if protocol_version is not None:
-        headers["Mcp-Protocol-Version"] = protocol_version
-    if session_id is not None:
-        headers["Mcp-Session-Id"] = session_id
-    request = Request(
-        base_url + "/mcp/",
-        data=json.dumps(payload, separators=(",", ":")).encode("utf-8"),
-        headers=headers,
-        method="POST",
-    )
-    try:
-        response = _LOOPBACK_OPENER.open(request, timeout=10)
-    except HTTPError as error:
-        response = error
-    with response:
-        raw = response.read(1_048_577)
-        status = int(response.status)
-        response_headers = {key.lower(): value for key, value in response.headers.items()}
-    if len(raw) > 1_048_576:
-        raise ComparisonFailure("Go MCP response exceeded the differential limit")
-    if status == 202 and allow_empty:
-        return {}, response_headers
-    if status != 200:
-        raise ComparisonFailure(f"Go MCP returned HTTP {status} during Scope resolution")
-    content_type = response_headers.get("content-type", "")
-    if "application/json" in content_type:
-        decoded = json.loads(raw)
-    elif "text/event-stream" in content_type:
-        events = [
-            line.removeprefix(b"data:").lstrip()
-            for line in raw.splitlines()
-            if line.startswith(b"data:")
-        ]
-        if len(events) != 1:
-            raise ComparisonFailure("Go MCP Scope resolution returned an invalid event stream")
-        decoded = json.loads(events[0])
-    else:
-        raise ComparisonFailure("Go MCP Scope resolution returned an unknown content type")
-    if not isinstance(decoded, dict):
-        raise ComparisonFailure("Go MCP Scope resolution returned a non-object response")
-    return decoded, response_headers
-
-
-def _mcp_result(response: Mapping[str, object], request_id: int) -> Mapping[str, object]:
-    if response.get("jsonrpc") != "2.0" or response.get("id") != request_id or "error" in response:
-        raise ComparisonFailure("Go MCP Scope resolution returned an invalid JSON-RPC response")
-    result = response.get("result")
-    if not isinstance(result, dict):
-        raise ComparisonFailure("Go MCP Scope resolution returned no result")
-    return result
-
-
-def _close_mcp_session(base_url: str, session_id: str, protocol_version: str) -> None:
-    request = Request(
-        base_url + "/mcp/",
-        headers={
-            "Accept": "application/json, text/event-stream",
-            "Mcp-Protocol-Version": protocol_version,
-            "Mcp-Session-Id": session_id,
-        },
-        method="DELETE",
-    )
-    with contextlib.suppress(OSError, HTTPError):
-        with _LOOPBACK_OPENER.open(request, timeout=10):
-            pass
-
-
-def _normalize_go_scope(value: Any, scope: str) -> Any:
-    if isinstance(value, list):
-        return [_normalize_go_scope(item, scope) for item in value]
-    if isinstance(value, dict):
-        return {key: _normalize_go_scope(item, scope) for key, item in value.items()}
-    if value == scope:
-        return "differential:scope"
-    return value
+        with sqlite3.connect(database) as connection:
+            connection.execute("PRAGMA foreign_keys = ON")
+            connection.execute(
+                """INSERT INTO pc_scopes (scope_id, title, summary, parent_scope_id, version)
+                VALUES (?, ?, ?, NULL, 1)""",
+                ("differential:scope", "Differential", "Frozen differential Scope"),
+            )
+            updated = connection.execute(
+                "UPDATE pc_scope_settings SET scope_id = ? WHERE name = 'default'",
+                ("differential:scope",),
+            )
+            if updated.rowcount != 1:
+                raise ComparisonFailure("Go bootstrap did not persist one default Scope setting")
+    except sqlite3.Error as error:
+        raise ComparisonFailure("seed durable Go differential Scope") from error
 
 
 def _canonical(value: Any) -> str:
@@ -785,14 +651,14 @@ def main() -> int:
             args.python_cwd,
             root / "python",
             args.startup_timeout,
-            resolve_go_scope=False,
+            seed_go_scope=False,
         )
         go_observation = _run_one(
             args.go_executable,
             args.go_cwd,
             root / "go",
             args.startup_timeout,
-            resolve_go_scope=True,
+            seed_go_scope=True,
         )
     if python_observation != go_observation:
         difference = "".join(

--- a/test/differential/compare_servers.py
+++ b/test/differential/compare_servers.py
@@ -117,7 +117,7 @@ def _free_loopback_port() -> int:
         return int(listener.getsockname()[1])
 
 
-def _isolated_environment(home: Path) -> dict[str, str]:
+def _isolated_environment(home: Path, *, enable_mcp: bool) -> dict[str, str]:
     environment = {
         key: value
         for key, value in os.environ.items()
@@ -131,7 +131,7 @@ def _isolated_environment(home: Path) -> dict[str, str]:
             "POWERCONTEXT_SERVER_LOGGING_ACCESS": "false",
             "POWERCONTEXT_SERVER_LOGGING_FORMAT": "json",
             "POWERCONTEXT_SERVER_LOGGING_LEVEL": "ERROR",
-            "POWERCONTEXT_SERVER_MCP_ENABLED": "false",
+            "POWERCONTEXT_SERVER_MCP_ENABLED": "true" if enable_mcp else "false",
             "POWERCONTEXT_SERVER_METRICS_ENABLED": "false",
             "POWERCONTEXT_SERVER_TRACING_ENABLED": "false",
         }
@@ -145,6 +145,8 @@ def _server(
     cwd: Path,
     home: Path,
     startup_timeout: float,
+    *,
+    enable_mcp: bool,
 ) -> Iterator[str]:
     if not executable.is_file():
         raise ComparisonFailure(f"server executable does not exist: {executable}")
@@ -165,7 +167,7 @@ def _server(
         process = subprocess.Popen(
             command,
             cwd=cwd,
-            env=_isolated_environment(home),
+            env=_isolated_environment(home, enable_mcp=enable_mcp),
             stdin=subprocess.DEVNULL,
             stdout=output,
             stderr=subprocess.STDOUT,
@@ -300,7 +302,10 @@ def _normalize_json(value: Any) -> Any:
 
 
 def _scenario(base_url: str) -> dict[str, Any]:
-    scope = "differential:scope"
+    return _scenario_for_scope(base_url, "differential:scope")
+
+
+def _scenario_for_scope(base_url: str, scope: str) -> dict[str, Any]:
     source_citation = {
         "kind": "source",
         "source_ref": {"name": "content", "source_id": "evidence-1"},
@@ -594,13 +599,177 @@ def _run_one(
     cwd: Path,
     root: Path,
     startup_timeout: float,
+    *,
+    resolve_go_scope: bool,
 ) -> dict[str, Any]:
     home = root / "home"
     home.mkdir(parents=True, mode=0o700)
     with _server(
-        executable.resolve(), cwd.resolve(), home, startup_timeout
+        executable.resolve(),
+        cwd.resolve(),
+        home,
+        startup_timeout,
+        enable_mcp=resolve_go_scope,
     ) as base_url:
-        return _scenario(base_url)
+        if not resolve_go_scope:
+            return _scenario(base_url)
+        scope = _resolve_go_default_scope(base_url)
+        # The frozen v0.1 server accepts first-write Scope identities. Go now
+        # resolves a durable default first, so preserve every observation while
+        # mapping only that one runtime-generated identity to the fixture value.
+        return _normalize_go_scope(_scenario_for_scope(base_url, scope), scope)
+
+
+def _resolve_go_default_scope(base_url: str) -> str:
+    session_id: str | None = None
+    protocol_version = "2025-11-25"
+    try:
+        initialized, headers = _mcp_request(
+            base_url,
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": protocol_version,
+                    "capabilities": {},
+                    "clientInfo": {"name": "frozen-differential", "version": "1"},
+                },
+            },
+            session_id=None,
+            protocol_version=None,
+            allow_empty=False,
+        )
+        result = _mcp_result(initialized, 1)
+        negotiated = result.get("protocolVersion")
+        if not isinstance(negotiated, str) or not negotiated:
+            raise ComparisonFailure("Go MCP did not negotiate a protocol version")
+        protocol_version = negotiated
+        session_id = headers.get("mcp-session-id")
+        if session_id is not None and (not session_id or len(session_id) > 256):
+            raise ComparisonFailure("Go MCP returned an invalid session identity")
+        _mcp_request(
+            base_url,
+            {"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}},
+            session_id=session_id,
+            protocol_version=protocol_version,
+            allow_empty=True,
+        )
+        response, _headers = _mcp_request(
+            base_url,
+            {
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "tools/call",
+                "params": {"name": "scope_binding_resolve", "arguments": {}},
+            },
+            session_id=session_id,
+            protocol_version=protocol_version,
+            allow_empty=False,
+        )
+        tool_result = _mcp_result(response, 2)
+        if tool_result.get("isError") is True:
+            raise ComparisonFailure("Go MCP default Scope resolution failed")
+        content = tool_result.get("structuredContent")
+        if not isinstance(content, dict):
+            raise ComparisonFailure("Go MCP default Scope resolution has no structured result")
+        scope = content.get("scope_id")
+        if not isinstance(scope, str) or not scope or scope.strip() != scope:
+            raise ComparisonFailure("Go MCP default Scope resolution returned an invalid identity")
+        return scope
+    finally:
+        if session_id:
+            _close_mcp_session(base_url, session_id, protocol_version)
+
+
+def _mcp_request(
+    base_url: str,
+    payload: Mapping[str, object],
+    *,
+    session_id: str | None,
+    protocol_version: str | None,
+    allow_empty: bool,
+) -> tuple[dict[str, object], dict[str, str]]:
+    headers = {
+        "Accept": "application/json, text/event-stream",
+        "Content-Type": "application/json",
+        "User-Agent": "powercontext-frozen-differential/1",
+    }
+    if protocol_version is not None:
+        headers["Mcp-Protocol-Version"] = protocol_version
+    if session_id is not None:
+        headers["Mcp-Session-Id"] = session_id
+    request = Request(
+        base_url + "/mcp/",
+        data=json.dumps(payload, separators=(",", ":")).encode("utf-8"),
+        headers=headers,
+        method="POST",
+    )
+    try:
+        response = _LOOPBACK_OPENER.open(request, timeout=10)
+    except HTTPError as error:
+        response = error
+    with response:
+        raw = response.read(1_048_577)
+        status = int(response.status)
+        response_headers = {key.lower(): value for key, value in response.headers.items()}
+    if len(raw) > 1_048_576:
+        raise ComparisonFailure("Go MCP response exceeded the differential limit")
+    if status == 202 and allow_empty:
+        return {}, response_headers
+    if status != 200:
+        raise ComparisonFailure(f"Go MCP returned HTTP {status} during Scope resolution")
+    content_type = response_headers.get("content-type", "")
+    if "application/json" in content_type:
+        decoded = json.loads(raw)
+    elif "text/event-stream" in content_type:
+        events = [
+            line.removeprefix(b"data:").lstrip()
+            for line in raw.splitlines()
+            if line.startswith(b"data:")
+        ]
+        if len(events) != 1:
+            raise ComparisonFailure("Go MCP Scope resolution returned an invalid event stream")
+        decoded = json.loads(events[0])
+    else:
+        raise ComparisonFailure("Go MCP Scope resolution returned an unknown content type")
+    if not isinstance(decoded, dict):
+        raise ComparisonFailure("Go MCP Scope resolution returned a non-object response")
+    return decoded, response_headers
+
+
+def _mcp_result(response: Mapping[str, object], request_id: int) -> Mapping[str, object]:
+    if response.get("jsonrpc") != "2.0" or response.get("id") != request_id or "error" in response:
+        raise ComparisonFailure("Go MCP Scope resolution returned an invalid JSON-RPC response")
+    result = response.get("result")
+    if not isinstance(result, dict):
+        raise ComparisonFailure("Go MCP Scope resolution returned no result")
+    return result
+
+
+def _close_mcp_session(base_url: str, session_id: str, protocol_version: str) -> None:
+    request = Request(
+        base_url + "/mcp/",
+        headers={
+            "Accept": "application/json, text/event-stream",
+            "Mcp-Protocol-Version": protocol_version,
+            "Mcp-Session-Id": session_id,
+        },
+        method="DELETE",
+    )
+    with contextlib.suppress(OSError, HTTPError):
+        with _LOOPBACK_OPENER.open(request, timeout=10):
+            pass
+
+
+def _normalize_go_scope(value: Any, scope: str) -> Any:
+    if isinstance(value, list):
+        return [_normalize_go_scope(item, scope) for item in value]
+    if isinstance(value, dict):
+        return {key: _normalize_go_scope(item, scope) for key, item in value.items()}
+    if value == scope:
+        return "differential:scope"
+    return value
 
 
 def _canonical(value: Any) -> str:
@@ -616,12 +785,14 @@ def main() -> int:
             args.python_cwd,
             root / "python",
             args.startup_timeout,
+            resolve_go_scope=False,
         )
         go_observation = _run_one(
             args.go_executable,
             args.go_cwd,
             root / "go",
             args.startup_timeout,
+            resolve_go_scope=True,
         )
     if python_observation != go_observation:
         difference = "".join(

--- a/test/downstream/consumer_test.go
+++ b/test/downstream/consumer_test.go
@@ -29,13 +29,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
 	v1 "github.com/ob-labs/powercontext-go/api/v1"
 	"github.com/ob-labs/powercontext-go/client"
 	"github.com/ob-labs/powercontext-go/inference"
 )
 
 const (
-	downstreamScope           = "project:downstream-consumer"
 	downstreamSourceID        = "downstream-work-boundary"
 	downstreamReceiptSourceID = "downstream-receipt"
 	maximumServerLogBytes     = 32 * 1024
@@ -50,9 +51,10 @@ func TestPublicClientCompletesCurrentWorkHandoff(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create public client: %v", err)
 	}
+	scopeID := resolveDefaultScope(t, ctx, serverURL)
 
 	if _, createErr := api.CreateWorkContract(ctx, &v1.CreateWorkContractRequest{
-		ScopeID:  downstreamScope,
+		ScopeID:  scopeID,
 		SourceID: "downstream-contract",
 		Contract: v1.WorkContract{
 			Schema:             v1.WorkContractSchemaPowercontextWorkContractV1,
@@ -68,7 +70,7 @@ func TestPublicClientCompletesCurrentWorkHandoff(t *testing.T) {
 	}); createErr != nil {
 		t.Fatalf("create work contract through public client: %v", createErr)
 	}
-	preparedResult, err := api.HandoffCurrentWork(ctx, currentWorkHandoffRequest())
+	preparedResult, err := api.HandoffCurrentWork(ctx, currentWorkHandoffRequest(scopeID))
 	if err != nil {
 		t.Fatalf("prepare current-work Handoff through public client: %v", err)
 	}
@@ -78,7 +80,7 @@ func TestPublicClientCompletesCurrentWorkHandoff(t *testing.T) {
 	}
 
 	committedResult, err := api.CommitHandoff(ctx, &v1.CommitHandoffRequest{
-		ScopeID: downstreamScope,
+		ScopeID: scopeID,
 		Handoff: prepared.Response.Handoff,
 	})
 	if err != nil {
@@ -90,7 +92,7 @@ func TestPublicClientCompletesCurrentWorkHandoff(t *testing.T) {
 	}
 
 	acknowledgedResult, err := api.AcknowledgeHandoff(ctx, &v1.AcknowledgeHandoffRequest{
-		ScopeID:   downstreamScope,
+		ScopeID:   scopeID,
 		SourceID:  downstreamReceiptSourceID,
 		Receiver:  "downstream-consumer",
 		Status:    v1.HandoffReceiptStatusAccepted,
@@ -111,7 +113,7 @@ func TestPublicClientCompletesCurrentWorkHandoff(t *testing.T) {
 }
 
 func TestCurrentWorkHandoffRequestUsesPublicContract(t *testing.T) {
-	if err := currentWorkHandoffRequest().Validate(); err != nil {
+	if err := currentWorkHandoffRequest("project:downstream-consumer").Validate(); err != nil {
 		t.Fatalf("current-work Handoff request violates the public contract: %v", err)
 	}
 }
@@ -173,9 +175,10 @@ func TestPublicClientMemoryPersistsAcrossGracefulServerRestart(t *testing.T) {
 			t.Fatalf("empty Memory request error = %#v", rememberErr)
 		}
 	}
+	firstScopeID := resolveDefaultScope(t, ctx, firstURL)
 
 	rememberedResult, err := firstClient.RememberMemory(ctx, &v1.RememberMemoryRequest{
-		ScopeID: downstreamScope,
+		ScopeID: firstScopeID,
 		Kind:    "fact",
 		Text:    "A public client persisted this Memory entry.",
 	})
@@ -193,7 +196,11 @@ func TestPublicClientMemoryPersistsAcrossGracefulServerRestart(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create restarted public client: %v", err)
 	}
-	listedResult, err := secondClient.ListMemoryEntries(ctx, &v1.ListMemoryEntriesRequest{ScopeID: downstreamScope})
+	secondScopeID := resolveDefaultScope(t, ctx, secondURL)
+	if secondScopeID != firstScopeID {
+		t.Fatalf("default Scope changed across restart")
+	}
+	listedResult, err := secondClient.ListMemoryEntries(ctx, &v1.ListMemoryEntriesRequest{ScopeID: secondScopeID})
 	if err != nil {
 		t.Fatalf("list Memory through restarted public client: %v", err)
 	}
@@ -249,9 +256,9 @@ func TestServerLogBufferRetainsLatestBoundedOutput(t *testing.T) {
 	}
 }
 
-func currentWorkHandoffRequest() *v1.HandoffCurrentWorkRequest {
+func currentWorkHandoffRequest(scopeID string) *v1.HandoffCurrentWorkRequest {
 	return &v1.HandoffCurrentWorkRequest{
-		ScopeID:  downstreamScope,
+		ScopeID:  scopeID,
 		SourceID: downstreamSourceID,
 		Handoff: v1.CurrentWorkHandoff{
 			Schema:      v1.CurrentWorkHandoffSchemaPowercontextCurrentWorkHandoffV1,
@@ -263,6 +270,33 @@ func currentWorkHandoffRequest() *v1.HandoffCurrentWorkRequest {
 			Omissions:   []string{},
 		},
 	}
+}
+
+func resolveDefaultScope(t *testing.T, ctx context.Context, serverURL string) string {
+	t.Helper()
+	client := mcp.NewClient(&mcp.Implementation{Name: "downstream-public-consumer", Version: "1"}, nil)
+	session, err := client.Connect(ctx, &mcp.StreamableClientTransport{
+		Endpoint: serverURL + "/mcp/", HTTPClient: &http.Client{Timeout: 5 * time.Second}, DisableStandaloneSSE: true,
+	}, nil)
+	if err != nil {
+		t.Fatalf("connect public MCP client: %v", err)
+	}
+	t.Cleanup(func() { _ = session.Close() })
+	result, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name: "scope_binding_resolve", Arguments: map[string]any{},
+	})
+	if err != nil || result.IsError {
+		t.Fatalf("resolve default Scope through MCP: %#v, %v", result, err)
+	}
+	content, ok := result.StructuredContent.(map[string]any)
+	if !ok {
+		t.Fatalf("default Scope result = %T", result.StructuredContent)
+	}
+	scopeID, ok := content["scope_id"].(string)
+	if !ok || strings.TrimSpace(scopeID) != scopeID || scopeID == "" {
+		t.Fatalf("default Scope identity is invalid: %#v", content)
+	}
+	return scopeID
 }
 
 func startServer(t *testing.T, ctx context.Context) string {

--- a/test/downstream/go.mod
+++ b/test/downstream/go.mod
@@ -2,7 +2,10 @@ module example.com/powercontext-downstream
 
 go 1.27.0
 
-require github.com/ob-labs/powercontext-go v0.0.0
+require (
+	github.com/modelcontextprotocol/go-sdk v1.6.1
+	github.com/ob-labs/powercontext-go v0.0.0
+)
 
 require (
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
@@ -20,7 +23,6 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.22 // indirect
-	github.com/modelcontextprotocol/go-sdk v1.6.1 // indirect
 	github.com/ogen-go/ogen v1.23.0 // indirect
 	github.com/segmentio/asm v1.2.1 // indirect
 	github.com/segmentio/encoding v0.5.4 // indirect

--- a/tools/locomo/configuration.go
+++ b/tools/locomo/configuration.go
@@ -17,11 +17,15 @@ package main
 import (
 	"bufio"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
+	"maps"
 	"net/http"
 	"os"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -29,6 +33,9 @@ import (
 	"github.com/ob-labs/powercontext-go/inference"
 	"github.com/ob-labs/powercontext-go/internal/benchmark/locomo"
 	"github.com/ob-labs/powercontext-go/internal/modelprovider"
+	pcruntime "github.com/ob-labs/powercontext-go/internal/runtime"
+	"github.com/ob-labs/powercontext-go/internal/scope"
+	"github.com/ob-labs/powercontext-go/internal/sqlstore"
 	"github.com/ob-labs/powercontext-go/server"
 )
 
@@ -58,9 +65,10 @@ func publicConfiguration(config server.ProcessConfig) (locomo.PublicConfiguratio
 }
 
 type benchmarkApplication struct {
-	application *server.Application
-	operations  endpointOperations
-	model       inference.TextModel
+	application   *server.Application
+	scopeDatabase *sqlstore.Database
+	operations    endpointOperations
+	model         inference.TextModel
 }
 
 func openBenchmarkApplication(
@@ -69,6 +77,7 @@ func openBenchmarkApplication(
 	rerank locomo.RerankMode,
 	candidateLimit int,
 	needAnswerModel bool,
+	scopeIDs []string,
 ) (*benchmarkApplication, error) {
 	config.Runtime.SourceWindowLimit = 1
 	config.Runtime.SourceWindowInterval = nil
@@ -101,22 +110,120 @@ func openBenchmarkApplication(
 		recorder = &recordingReranker{next: reranker}
 		dependencies.MemoryReranker = recorder
 	}
-	application, err := server.OpenApplication(ctx, config, dependencies)
+	scopeDatabase, err := registerBenchmarkScopes(ctx, config, scopeIDs)
 	if err != nil {
 		return nil, err
 	}
+	application, err := server.OpenApplication(ctx, config, dependencies)
+	if err != nil {
+		_ = scopeDatabase.Close(ctx)
+		return nil, err
+	}
 	return &benchmarkApplication{
-		application: application,
-		operations:  endpointOperations{handler: application.Endpoint(), recorder: recorder},
-		model:       model,
+		application:   application,
+		scopeDatabase: scopeDatabase,
+		operations:    endpointOperations{handler: application.Endpoint(), recorder: recorder},
+		model:         model,
 	}, nil
 }
 
 func (a *benchmarkApplication) Close(ctx context.Context) error {
-	if a == nil || a.application == nil {
+	if a == nil {
 		return nil
 	}
-	return a.application.Close(ctx)
+	var closeErrors []error
+	if a.application != nil {
+		closeErrors = append(closeErrors, a.application.Close(ctx))
+	}
+	if a.scopeDatabase != nil {
+		closeErrors = append(closeErrors, a.scopeDatabase.Close(ctx))
+	}
+	return errors.Join(closeErrors...)
+}
+
+func benchmarkScopeIDs(dataset locomo.Dataset, runID string) ([]string, error) {
+	values := make(map[string]struct{})
+	for _, conversation := range dataset.Conversations() {
+		scopeID, err := locomo.ScopeID(runID, conversation.SampleID())
+		if err != nil {
+			return nil, err
+		}
+		values[scopeID] = struct{}{}
+	}
+	for _, question := range dataset.Questions() {
+		scopeID, err := locomo.ScopeID(runID, question.SampleID())
+		if err != nil {
+			return nil, err
+		}
+		values[scopeID] = struct{}{}
+	}
+	return slices.Sorted(maps.Keys(values)), nil
+}
+
+func registerBenchmarkScopes(
+	ctx context.Context,
+	config server.ProcessConfig,
+	scopeIDs []string,
+) (*sqlstore.Database, error) {
+	dsn, err := server.SQLiteDSN(config.Database.SQLite.URL)
+	if err != nil {
+		return nil, err
+	}
+	database, err := sqlstore.OpenSQLite(ctx, sqlstore.SQLiteConfig{
+		DSN: dsn, BusyTimeout: config.Database.SQLite.BusyTimeout,
+		JournalMode: config.Database.SQLite.JournalMode, ForeignKeys: config.Database.SQLite.ForeignKeys,
+		MaxOpenConns: config.Database.SQLite.MaxOpenConns, MaxIdleConns: config.Database.SQLite.MaxIdleConns,
+	})
+	if err != nil {
+		return nil, err
+	}
+	closeWithError := func(cause error) (*sqlstore.Database, error) {
+		return nil, errors.Join(cause, database.Close(ctx))
+	}
+	ids := slices.Sorted(maps.Keys(scopeIDSet(scopeIDs)))
+	index := 0
+	store, err := sqlstore.NewRuntimeScopeStore(database, sqlstore.ScopeRepository{})
+	if err != nil {
+		return closeWithError(err)
+	}
+	application, err := pcruntime.NewScopeApplication(pcruntime.New(), store, func() string {
+		id := ids[index]
+		index++
+		return id
+	})
+	if err != nil {
+		return closeWithError(err)
+	}
+	for _, id := range ids {
+		draft, draftErr := scope.NewDraft(
+			"LoCoMo benchmark", "An isolated durable Scope for one LoCoMo sample.", "", nil, nil,
+			benchmarkScopeIdempotencyKey(id),
+		)
+		if draftErr != nil {
+			return closeWithError(draftErr)
+		}
+		created, createErr := application.Create(ctx, draft)
+		if createErr != nil {
+			return closeWithError(createErr)
+		}
+		if created.ID() != id {
+			return closeWithError(errors.New("benchmark Scope registration returned a different identity"))
+		}
+	}
+	return database, nil
+}
+
+func scopeIDSet(values []string) map[string]struct{} {
+	result := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		result[value] = struct{}{}
+	}
+	return result
+}
+
+func benchmarkScopeIdempotencyKey(scopeID string) string {
+	sum := sha256.Sum256([]byte(scopeID))
+	return "locomo.scope." + hex.EncodeToString(sum[:])
 }
 
 func textModel(modelID string, client *http.Client) (inference.TextModel, error) {

--- a/tools/locomo/configuration_test.go
+++ b/tools/locomo/configuration_test.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build sqlite_fts5
+
+package main
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/ob-labs/powercontext-go/internal/benchmark/locomo"
+	"github.com/ob-labs/powercontext-go/server"
+)
+
+func TestOpenBenchmarkApplicationRegistersDurableConversationScopes(t *testing.T) {
+	config, err := server.DefaultConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	config.Database.SQLite.URL = "sqlite+aiosqlite:///" + filepath.ToSlash(filepath.Join(t.TempDir(), "locomo.db"))
+	config.Dashboard.Enabled = false
+	config.HandoffReport.Enabled = false
+	config.MCP.Enabled = false
+	config.Metrics.Enabled = false
+
+	const scopeID = "benchmark:locomo:scope-admission:sample-1"
+	application, err := openBenchmarkApplication(
+		t.Context(), config, locomo.RerankNone, 1, false, []string{scopeID},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		closeCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if closeErr := application.Close(closeCtx); closeErr != nil {
+			t.Error(closeErr)
+		}
+	})
+
+	if _, err := application.operations.Capture(t.Context(), scopeID, "source-1", "benchmark capture", nil); err != nil {
+		t.Fatalf("capture in registered benchmark Scope: %v", err)
+	}
+}

--- a/tools/locomo/main.go
+++ b/tools/locomo/main.go
@@ -224,7 +224,13 @@ func runCommand(ctx context.Context, arguments []string) error {
 	if flags.skipEvaluation {
 		applicationRerank = locomo.RerankNone
 	}
-	application, err := openBenchmarkApplication(ctx, config, applicationRerank, flags.topK, !flags.skipEvaluation)
+	scopeIDs, err := benchmarkScopeIDs(dataset, runID)
+	if err != nil {
+		return err
+	}
+	application, err := openBenchmarkApplication(
+		ctx, config, applicationRerank, flags.topK, !flags.skipEvaluation, scopeIDs,
+	)
 	if err != nil {
 		return err
 	}

--- a/tools/process-smoke/main.go
+++ b/tools/process-smoke/main.go
@@ -144,11 +144,15 @@ func run(ctx context.Context, opts options) (runErr error) {
 		if err := exerciseCLI(ctx, binary, baseEnvironment, baseURL, ""); err != nil {
 			return err
 		}
-		if err := exerciseMemory(ctx, baseURL, "", true); err != nil {
-			return err
+		scopeID, scopeErr := resolveDefaultScope(ctx, baseURL, "")
+		if scopeErr != nil {
+			return scopeErr
 		}
-		if err := exerciseMCP(ctx, baseURL, "", true); err != nil {
-			return err
+		if memoryErr := exerciseMemory(ctx, baseURL, "", scopeID, true); memoryErr != nil {
+			return memoryErr
+		}
+		if mcpErr := exerciseMCP(ctx, baseURL, "", scopeID, true); mcpErr != nil {
+			return mcpErr
 		}
 		response, err := request(ctx, http.MethodPost, baseURL+"/v1/handoff-reports/projects/list", "", `{}`)
 		if err != nil {
@@ -181,10 +185,14 @@ func run(ctx context.Context, opts options) (runErr error) {
 		if err := exerciseCLI(ctx, binary, secureEnvironment, baseURL, smokeToken); err != nil {
 			return err
 		}
-		if err := exerciseMemory(ctx, baseURL, smokeToken, false); err != nil {
-			return err
+		scopeID, scopeErr := resolveDefaultScope(ctx, baseURL, smokeToken)
+		if scopeErr != nil {
+			return scopeErr
 		}
-		return exerciseMCP(ctx, baseURL, smokeToken, true)
+		if memoryErr := exerciseMemory(ctx, baseURL, smokeToken, scopeID, false); memoryErr != nil {
+			return memoryErr
+		}
+		return exerciseMCP(ctx, baseURL, smokeToken, scopeID, true)
 	}); err != nil {
 		return withLog(err, secondLog)
 	}
@@ -198,8 +206,12 @@ func run(ctx context.Context, opts options) (runErr error) {
 	)
 	thirdLog := filepath.Join(root, "server-reports-disabled.log")
 	if err := runPhase(ctx, binary, root, thirdLog, disabledEnvironment, opts.timeout, func(baseURL string) error {
-		if err := exerciseMCP(ctx, baseURL, "", false); err != nil {
-			return err
+		scopeID, scopeErr := resolveDefaultScope(ctx, baseURL, "")
+		if scopeErr != nil {
+			return scopeErr
+		}
+		if mcpErr := exerciseMCP(ctx, baseURL, "", scopeID, false); mcpErr != nil {
+			return mcpErr
 		}
 		response, err := request(ctx, http.MethodPost, baseURL+"/v1/handoff-reports/projects/list", "", `{}`)
 		if err != nil {
@@ -461,7 +473,7 @@ func exerciseCLI(ctx context.Context, binary string, environment []string, baseU
 	return nil
 }
 
-func exerciseMemory(ctx context.Context, baseURL, token string, remember bool) error {
+func exerciseMemory(ctx context.Context, baseURL, token, scopeID string, remember bool) error {
 	api, err := pcclient.New(baseURL, pcclient.Options{BearerToken: token, Timeout: 10 * time.Second})
 	if err != nil {
 		return err
@@ -476,7 +488,7 @@ func exerciseMemory(ctx context.Context, baseURL, token string, remember bool) e
 	}
 	if remember {
 		result, rememberErr := api.RememberMemory(ctx, &v1.RememberMemoryRequest{
-			ScopeID: smokeScope, Kind: "fact", Text: smokeText,
+			ScopeID: scopeID, Kind: "fact", Text: smokeText,
 		})
 		if rememberErr != nil {
 			return fmt.Errorf("remember through Go Client: %w", rememberErr)
@@ -491,7 +503,7 @@ func exerciseMemory(ctx context.Context, baseURL, token string, remember bool) e
 		}
 	}
 	result, err := api.SearchMemory(ctx, &v1.SearchMemoryRequest{
-		ScopeID: smokeScope,
+		ScopeID: scopeID,
 		Query:   "release verification retrieves private memory",
 		Mode:    v1.NewOptMemorySearchMode(v1.MemorySearchModeFts),
 	})
@@ -508,17 +520,10 @@ func exerciseMemory(ctx context.Context, baseURL, token string, remember bool) e
 	return nil
 }
 
-func exerciseMCP(ctx context.Context, baseURL, token string, reports bool) (returnErr error) {
-	httpClient := &http.Client{Timeout: 15 * time.Second, CheckRedirect: noRedirect}
-	if token != "" {
-		httpClient.Transport = bearerTransport{token: token, next: http.DefaultTransport}
-	}
-	client := mcp.NewClient(&mcp.Implementation{Name: "powercontext-process-smoke", Version: "1"}, nil)
-	session, err := client.Connect(ctx, &mcp.StreamableClientTransport{
-		Endpoint: baseURL + "/mcp/", HTTPClient: httpClient, DisableStandaloneSSE: true,
-	}, nil)
+func exerciseMCP(ctx context.Context, baseURL, token, scopeID string, reports bool) (returnErr error) {
+	session, err := connectMCP(ctx, baseURL, token)
 	if err != nil {
-		return fmt.Errorf("connect MCP: %w", err)
+		return err
 	}
 	defer func() {
 		if closeErr := session.Close(); closeErr != nil {
@@ -552,7 +557,7 @@ func exerciseMCP(ctx context.Context, baseURL, token string, reports bool) (retu
 		return fmt.Errorf("MCP tools are %v, want %v", actual, expected)
 	}
 	result, err := session.CallTool(ctx, &mcp.CallToolParams{
-		Name: "list_memory_entries", Arguments: map[string]any{"scope_id": smokeScope},
+		Name: "list_memory_entries", Arguments: map[string]any{"scope_id": scopeID},
 	})
 	if err != nil {
 		return fmt.Errorf("call MCP tool: %w", err)
@@ -569,6 +574,51 @@ func exerciseMCP(ctx context.Context, baseURL, token string, reports bool) (retu
 		return fmt.Errorf("MCP prompts are not the frozen empty surface: %w", err)
 	}
 	return nil
+}
+
+func resolveDefaultScope(ctx context.Context, baseURL, token string) (scopeID string, returnErr error) {
+	session, err := connectMCP(ctx, baseURL, token)
+	if err != nil {
+		return "", err
+	}
+	defer func() {
+		if closeErr := session.Close(); closeErr != nil {
+			returnErr = errors.Join(returnErr, fmt.Errorf("close MCP session: %w", closeErr))
+		}
+	}()
+	result, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name: "scope_binding_resolve", Arguments: map[string]any{},
+	})
+	if err != nil {
+		return "", fmt.Errorf("resolve default Scope through MCP: %w", err)
+	}
+	if result.IsError {
+		return "", errors.New("MCP default Scope resolution returned an error")
+	}
+	content, ok := result.StructuredContent.(map[string]any)
+	if !ok {
+		return "", errors.New("MCP default Scope resolution did not return structured content")
+	}
+	scopeID, ok = content["scope_id"].(string)
+	if !ok || scopeID == "" || strings.TrimSpace(scopeID) != scopeID {
+		return "", errors.New("MCP default Scope resolution did not return a valid identity")
+	}
+	return scopeID, nil
+}
+
+func connectMCP(ctx context.Context, baseURL, token string) (*mcp.ClientSession, error) {
+	httpClient := &http.Client{Timeout: 15 * time.Second, CheckRedirect: noRedirect}
+	if token != "" {
+		httpClient.Transport = bearerTransport{token: token, next: http.DefaultTransport}
+	}
+	client := mcp.NewClient(&mcp.Implementation{Name: "powercontext-process-smoke", Version: "1"}, nil)
+	session, err := client.Connect(ctx, &mcp.StreamableClientTransport{
+		Endpoint: baseURL + "/mcp/", HTTPClient: httpClient, DisableStandaloneSSE: true,
+	}, nil)
+	if err != nil {
+		return nil, fmt.Errorf("connect MCP: %w", err)
+	}
+	return session, nil
 }
 
 func exerciseSecureHTTP(ctx context.Context, baseURL string) error {


### PR DESCRIPTION
Part of #202 Phase 2. Server now installs the SQLite ScopeReader before Runtime construction, so direct HTTP work must use a durable Scope. Release smoke, downstream consumer, frozen v0.1 differential, and LoCoMo benchmark now establish durable Scope prerequisites before exercising existing public paths. Added real HTTP/SQLite rejection coverage for unknown Scope IDs, durable benchmark Scope registration, and a pre-Phase-2 SQLite upgrade fixture that preserves existing Source/Artifact data and rejects a same-named checkpoint View atomically. Focused Server/Runtime/SQLite/LoCoMo/process-smoke tests and lint pass locally; Windows cannot complete child-process loopback checks, so Linux CI is required for release smoke, downstream, frozen differential, and host subprocess evidence.