### PR TITLE
feat(openapi): guard legacy compatibility surface

### DIFF
--- a/client/legacy_compatibility_test.go
+++ b/client/legacy_compatibility_test.go
@@ -12,7 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package openapi owns generation of the immutable HTTP contract.
-package openapi
+package client
 
-//go:generate go run ../tools/api-generate -spec powercontext.yaml -target ../api/v1 -package v1 -client-invoker ../client/invoker_gen.go -compatibility compatibility-surface.json
+import (
+	"context"
+
+	v1 "github.com/ob-labs/powercontext-go/api/v1"
+)
+
+var (
+	_ v1.Invoker                                                                = (*Client)(nil)
+	_ func(*Client) *v1.Client                                                  = (*Client).Raw
+	_ func(*Client, context.Context, v1.GetStatsParams) (v1.GetStatsRes, error) = (*Client).GetStats
+)

--- a/internal/mcpapi/server_test.go
+++ b/internal/mcpapi/server_test.go
@@ -17,7 +17,10 @@ package mcpapi
 import (
 	"context"
 	"encoding/json"
+	jsonv2 "encoding/json/v2"
 	"errors"
+	"os"
+	"path/filepath"
 	"reflect"
 	"slices"
 	"testing"
@@ -51,6 +54,52 @@ var baseToolNames = []string{
 	"revise_artifact_candidate",
 	"revise_memory_entry",
 	"search_memory",
+}
+
+func TestGeneratedOpenAPIToolsMatchCompatibilitySurface(t *testing.T) {
+	t.Parallel()
+	contents, err := os.ReadFile(filepath.Join("..", "..", "openapi", "compatibility-surface.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var surface struct {
+		Canonical struct {
+			UpstreamOnlyOperations []struct {
+				OperationID string `json:"operation_id"`
+			} `json:"upstream_only_operations"`
+		} `json:"canonical"`
+		MCPGeneratedOpenAPIOperations []string `json:"mcp_generated_openapi_operations"`
+	}
+	if decodeErr := jsonv2.Unmarshal(contents, &surface); decodeErr != nil {
+		t.Fatal(decodeErr)
+	}
+	server, err := NewServer(endpoint.NewHandler(endpoint.HandlerOptions{}), Options{HandoffReportEnabled: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := connectInMemory(t, server).ListTools(t.Context(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := make([]string, 0, len(result.Tools))
+	for _, tool := range result.Tools {
+		// This picker and optional Scope Binding tools are native MCP additions.
+		// The compatibility surface covers only generated OpenAPI-dispatch tools.
+		if tool.Name != "select_handoff_workstream" {
+			got = append(got, tool.Name)
+		}
+	}
+	slices.Sort(got)
+	want := slices.Clone(surface.MCPGeneratedOpenAPIOperations)
+	slices.Sort(want)
+	if !slices.Equal(got, want) {
+		t.Fatalf("generated OpenAPI MCP tools = %v, want compatibility operations %v", got, want)
+	}
+	for _, operation := range surface.Canonical.UpstreamOnlyOperations {
+		if slices.Contains(got, operation.OperationID) {
+			t.Fatalf("unimplemented canonical operation %q is exposed through MCP", operation.OperationID)
+		}
+	}
 }
 
 func TestDefaultServerInfoMatchesFrozenPython(t *testing.T) {

--- a/openapi/README.md
+++ b/openapi/README.md
@@ -1,7 +1,18 @@
 # OpenAPI
 
 `powercontext.yaml` is copied from the current Python reference baseline and is
-the sole source of truth for HTTP wire generation.
+the sole source of truth for the generated legacy HTTP wire surface.
+
+`compatibility-surface.json` pins the later upstream operation inventory while
+the corresponding use cases are implemented incrementally. Generation validates
+the inventory without treating it as a second OpenAPI document. This preserves
+the public legacy `v1.Handler`, `v1.Invoker`, `v1.NewServer`, `v1.NewClient`,
+and `GET /v1/stats` contracts. It also reserves `GetStatsCanonical` for the
+future canonical `POST /v1/stats` operation and records the 14 retained Go
+Handoff Report extensions. `mcp_generated_openapi_operations` enumerates only
+the generated OpenAPI-dispatch MCP tools; native conditional tools such as the
+Handoff picker and Scope Binding tools are registered and tested separately. A
+schema inventory entry alone does not expose a generated OpenAPI tool.
 
 OpenAPI 3.0 cannot encode the combined `source_refs` + `artifact_refs` maximum
 described by the Candidate schemas. The generator derives the affected model

--- a/openapi/compatibility-surface.json
+++ b/openapi/compatibility-surface.json
@@ -1,0 +1,102 @@
+{
+  "schema_version": 1,
+  "upstream": {
+    "repository": "oceanbase/powercontext",
+    "commit": "74b961fbb07165595314726715d412a3d0d90589"
+  },
+  "legacy": {
+    "operation_count": 53
+  },
+  "canonical": {
+    "operation_count": 77,
+    "upstream_only_operations": [
+      {"operation_id": "clear_scope_binding", "method": "post", "path": "/v1/scope-bindings/clear"},
+      {"operation_id": "commit_connector_checkpoint", "method": "post", "path": "/v1/connector-checkpoints/commit"},
+      {"operation_id": "create_artifact", "method": "post", "path": "/v1/scopes/{scope_id}/artifacts"},
+      {"operation_id": "create_remote_skill_target", "method": "post", "path": "/v1/skill/remote/target/create"},
+      {"operation_id": "create_scope", "method": "post", "path": "/v1/scopes"},
+      {"operation_id": "create_source", "method": "post", "path": "/v1/scopes/{scope_id}/sources"},
+      {"operation_id": "download_remote_skill_package", "method": "post", "path": "/v1/skill/remote/package/download"},
+      {"operation_id": "download_skill_package", "method": "post", "path": "/v1/skill/package/download"},
+      {"operation_id": "enroll_remote_skill_target", "method": "post", "path": "/v1/skill/remote/target/enroll"},
+      {"operation_id": "get_artifact", "method": "get", "path": "/v1/scopes/{scope_id}/artifacts/{family}/{artifact_id}"},
+      {"operation_id": "get_artifact_revision", "method": "get", "path": "/v1/scopes/{scope_id}/artifacts/{family}/{artifact_id}/revisions/{revision}"},
+      {"operation_id": "get_connector_checkpoint", "method": "post", "path": "/v1/connector-checkpoints/get"},
+      {"operation_id": "get_default_scope", "method": "get", "path": "/v1/scopes/default"},
+      {"operation_id": "get_scope", "method": "get", "path": "/v1/scopes/{scope_id}"},
+      {"operation_id": "get_skill_package_manifest", "method": "post", "path": "/v1/skill/package/manifest"},
+      {"operation_id": "get_source", "method": "get", "path": "/v1/scopes/{scope_id}/sources/{source_type}/{source_id}"},
+      {"operation_id": "list_artifacts", "method": "get", "path": "/v1/scopes/{scope_id}/artifacts/{family}"},
+      {"operation_id": "list_managed_skills", "method": "post", "path": "/v1/skill/library"},
+      {"operation_id": "list_remote_skill_targets", "method": "post", "path": "/v1/skill/remote/targets"},
+      {"operation_id": "list_scopes", "method": "get", "path": "/v1/scopes"},
+      {"operation_id": "propose_skill_package", "method": "post", "path": "/v1/skill/package/propose"},
+      {"operation_id": "publish_artifact", "method": "post", "path": "/v1/artifact-publications"},
+      {"operation_id": "publish_remote_skill", "method": "post", "path": "/v1/skill/remote/publication/publish"},
+      {"operation_id": "reconcile_remote_skills", "method": "post", "path": "/v1/skill/remote/reconcile"},
+      {"operation_id": "record_remote_skill_receipt", "method": "post", "path": "/v1/skill/remote/receipt"},
+      {"operation_id": "record_skill_usage", "method": "post", "path": "/v1/skill/usage"},
+      {"operation_id": "register_source_definition", "method": "post", "path": "/v1/source-definitions/register"},
+      {"operation_id": "rename_remote_skill_target", "method": "post", "path": "/v1/skill/remote/target/rename"},
+      {"operation_id": "replace_artifact", "method": "put", "path": "/v1/scopes/{scope_id}/artifacts/{family}/{artifact_id}"},
+      {"operation_id": "resolve_scope_binding", "method": "post", "path": "/v1/scope-bindings/resolve"},
+      {"operation_id": "resolve_scope_selection", "method": "post", "path": "/v1/scopes/selection/resolve"},
+      {"operation_id": "revoke_remote_skill_target", "method": "post", "path": "/v1/skill/remote/target/revoke"},
+      {"operation_id": "set_default_scope", "method": "put", "path": "/v1/scopes/default"},
+      {"operation_id": "set_scope_binding", "method": "put", "path": "/v1/scope-bindings"},
+      {"operation_id": "submit_source_observation", "method": "post", "path": "/v1/source-observations"},
+      {"operation_id": "unpublish_remote_skill", "method": "post", "path": "/v1/skill/remote/publication/unpublish"},
+      {"operation_id": "update_scope", "method": "put", "path": "/v1/scopes/{scope_id}"},
+      {"operation_id": "update_skill_lifecycle", "method": "post", "path": "/v1/skill/lifecycle"}
+    ]
+  },
+  "retained_go_extensions": [
+    {"operation_id": "attach_handoff_report_workspace", "method": "post", "path": "/v1/handoff-reports/workspace-bindings/attach"},
+    {"operation_id": "create_handoff_report_project", "method": "post", "path": "/v1/handoff-reports/projects/create"},
+    {"operation_id": "detach_handoff_report_workspace", "method": "post", "path": "/v1/handoff-reports/workspace-bindings/detach"},
+    {"operation_id": "get_handoff_report_project", "method": "post", "path": "/v1/handoff-reports/projects/get"},
+    {"operation_id": "get_handoff_report_workspace", "method": "post", "path": "/v1/handoff-reports/workspace-bindings/get"},
+    {"operation_id": "list_handoff_report_activities", "method": "post", "path": "/v1/handoff-reports/activities/list"},
+    {"operation_id": "list_handoff_report_known_scopes", "method": "post", "path": "/v1/handoff-reports/scopes/list-known"},
+    {"operation_id": "list_handoff_report_projects", "method": "post", "path": "/v1/handoff-reports/projects/list"},
+    {"operation_id": "list_handoff_report_workstreams", "method": "post", "path": "/v1/handoff-reports/workstreams/list"},
+    {"operation_id": "purge_handoff_report_activities", "method": "post", "path": "/v1/handoff-reports/activities/purge"},
+    {"operation_id": "record_handoff_report_activity", "method": "post", "path": "/v1/handoff-reports/activities/record"},
+    {"operation_id": "register_handoff_report_workstream", "method": "post", "path": "/v1/handoff-reports/workstreams/register"},
+    {"operation_id": "update_handoff_report_project", "method": "post", "path": "/v1/handoff-reports/projects/update"},
+    {"operation_id": "update_handoff_report_workstream", "method": "post", "path": "/v1/handoff-reports/workstreams/update"}
+  ],
+  "method_migrations": [
+    {
+      "operation_id": "get_stats",
+      "legacy": {"method": "get", "path": "/v1/stats"},
+      "canonical": {"method": "post", "path": "/v1/stats"},
+      "canonical_method_name": "GetStatsCanonical"
+    }
+  ],
+  "mcp_generated_openapi_operations": [
+    "acknowledge_handoff",
+    "activate_handoff",
+    "approve_artifact_candidate",
+    "capture_content_source",
+    "commit_handoff",
+    "continue_handoff",
+    "create_work_contract",
+    "finalize_handoff",
+    "get_artifact_candidate",
+    "get_handoff_report",
+    "get_handoff_report_workspace",
+    "get_memory_entry",
+    "handoff_current_work",
+    "list_artifact_candidates",
+    "list_handoff_report_known_scopes",
+    "list_memory_entries",
+    "record_task_outcome",
+    "reject_artifact_candidate",
+    "remember_memory",
+    "retire_memory_entry",
+    "revise_artifact_candidate",
+    "revise_memory_entry",
+    "search_memory"
+  ]
+}

--- a/test/generator-inventory.json
+++ b/test/generator-inventory.json
@@ -4,7 +4,7 @@
     {
       "name": "openapi-go-client",
       "command": "go run ./tools/api-generate",
-      "inputs": ["openapi/powercontext.yaml"],
+      "inputs": ["openapi/compatibility-surface.json", "openapi/powercontext.yaml"],
       "outputs": [
         "api/v1/oas_cfg_gen.go",
         "api/v1/oas_client_gen.go",

--- a/tools/api-generate/README.md
+++ b/tools/api-generate/README.md
@@ -1,7 +1,18 @@
 # API generator
 
 Generation tooling for `api/v1` belongs here. Generated output derives only
-from `openapi/powercontext.yaml`.
+from the legacy `openapi/powercontext.yaml` contract.
+
+`openapi/compatibility-surface.json` is a pinned inventory for the later
+upstream snapshot. The generator verifies it before regenerating the legacy
+surface: the 14 retained Go Handoff Report operations stay available, while
+the 38 upstream-only operations remain unimplemented. In particular, legacy
+`GET /v1/stats` keeps `GetStats`; the future canonical `POST /v1/stats` is
+reserved as `GetStatsCanonical`. The inventory is a migration gate, not an
+alternate OpenAPI input, so it cannot expand `v1.Handler` or `v1.Invoker`.
+Its `mcp_generated_openapi_operations` field covers only schema-generated
+OpenAPI-dispatch tools. Native conditional MCP tools have their own registration
+and tests.
 
 The frozen OpenAPI 3.0 document uses `$ref` with a `nullable: true` sibling.
 OpenAPI 3.0 formally ignores `$ref` siblings, so the generator command creates

--- a/tools/api-generate/compatibility.go
+++ b/tools/api-generate/compatibility.go
@@ -1,0 +1,281 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"encoding/json/v2"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/ghodss/yaml"
+)
+
+const (
+	legacyOperationCount       = 53
+	canonicalOperationCount    = 77
+	upstreamOnlyOperationCount = 38
+	retainedExtensionCount     = 14
+	explicitMCPToolCount       = 23
+)
+
+// compatibilitySurface records a pinned upstream operation inventory without
+// claiming that every canonical operation has a generated Go transport yet.
+// The legacy contract remains the only input to ogen until each canonical
+// cluster has a separate implementation and compatibility review.
+type compatibilitySurface struct {
+	SchemaVersion                 int                      `json:"schema_version"`
+	Upstream                      compatibilityUpstream    `json:"upstream"`
+	Legacy                        compatibilityLegacy      `json:"legacy"`
+	Canonical                     compatibilityCanonical   `json:"canonical"`
+	RetainedGoExtensions          []compatibilityOperation `json:"retained_go_extensions"`
+	MethodMigrations              []compatibilityMigration `json:"method_migrations"`
+	MCPGeneratedOpenAPIOperations []string                 `json:"mcp_generated_openapi_operations"`
+}
+
+type compatibilityUpstream struct {
+	Repository string `json:"repository"`
+	Commit     string `json:"commit"`
+}
+
+type compatibilityLegacy struct {
+	OperationCount int `json:"operation_count"`
+}
+
+type compatibilityCanonical struct {
+	OperationCount         int                      `json:"operation_count"`
+	UpstreamOnlyOperations []compatibilityOperation `json:"upstream_only_operations"`
+}
+
+type compatibilityOperation struct {
+	OperationID string `json:"operation_id"`
+	Method      string `json:"method"`
+	Path        string `json:"path"`
+}
+
+type compatibilityMigration struct {
+	OperationID         string                `json:"operation_id"`
+	Legacy              compatibilityEndpoint `json:"legacy"`
+	Canonical           compatibilityEndpoint `json:"canonical"`
+	CanonicalMethodName string                `json:"canonical_method_name"`
+}
+
+type compatibilityEndpoint struct {
+	Method string `json:"method"`
+	Path   string `json:"path"`
+}
+
+func validateCompatibilitySurface(specification, contents []byte) error {
+	surface, err := decodeCompatibilitySurface(contents)
+	if err != nil {
+		return err
+	}
+	operations, err := parseOpenAPIOperations(specification)
+	if err != nil {
+		return err
+	}
+	return surface.validate(operations)
+}
+
+func decodeCompatibilitySurface(contents []byte) (compatibilitySurface, error) {
+	var surface compatibilitySurface
+	if err := json.Unmarshal(contents, &surface, json.RejectUnknownMembers(true)); err != nil {
+		return compatibilitySurface{}, fmt.Errorf("decode compatibility surface: %w", err)
+	}
+	return surface, nil
+}
+
+func cloneCompatibilitySurface(surface compatibilitySurface) (compatibilitySurface, error) {
+	contents, err := json.Marshal(surface)
+	if err != nil {
+		return compatibilitySurface{}, err
+	}
+	return decodeCompatibilitySurface(contents)
+}
+
+func parseOpenAPIOperations(specification []byte) (map[string]compatibilityEndpoint, error) {
+	encoded, err := yaml.YAMLToJSON(specification)
+	if err != nil {
+		return nil, fmt.Errorf("convert OpenAPI YAML: %w", err)
+	}
+	var document struct {
+		Paths map[string]map[string]struct {
+			OperationID string `json:"operationId"`
+		} `json:"paths"`
+	}
+	if err := json.Unmarshal(encoded, &document); err != nil {
+		return nil, fmt.Errorf("decode OpenAPI: %w", err)
+	}
+	operations := make(map[string]compatibilityEndpoint)
+	for path, item := range document.Paths {
+		for method, operation := range item {
+			if !isHTTPMethod(method) {
+				continue
+			}
+			if operation.OperationID == "" {
+				return nil, fmt.Errorf("%s %s has no operationId", method, path)
+			}
+			if _, exists := operations[operation.OperationID]; exists {
+				return nil, fmt.Errorf("duplicate OpenAPI operationId %q", operation.OperationID)
+			}
+			operations[operation.OperationID] = compatibilityEndpoint{
+				Method: strings.ToLower(method), Path: path,
+			}
+		}
+	}
+	if len(operations) == 0 {
+		return nil, errors.New("OpenAPI contains no operations")
+	}
+	return operations, nil
+}
+
+func (surface compatibilitySurface) validate(legacy map[string]compatibilityEndpoint) error {
+	if surface.SchemaVersion != 1 {
+		return fmt.Errorf("compatibility surface schema_version = %d, want 1", surface.SchemaVersion)
+	}
+	if surface.Upstream.Repository != "oceanbase/powercontext" ||
+		surface.Upstream.Commit != "74b961fbb07165595314726715d412a3d0d90589" {
+		return fmt.Errorf("unexpected upstream snapshot %q at %q", surface.Upstream.Repository, surface.Upstream.Commit)
+	}
+	if surface.Legacy.OperationCount != legacyOperationCount || len(legacy) != legacyOperationCount {
+		return fmt.Errorf("legacy operation count = %d/%d, want %d", surface.Legacy.OperationCount, len(legacy), legacyOperationCount)
+	}
+	if surface.Canonical.OperationCount != canonicalOperationCount {
+		return fmt.Errorf("canonical operation count = %d, want %d", surface.Canonical.OperationCount, canonicalOperationCount)
+	}
+
+	retained, err := validateRetainedExtensions(surface.RetainedGoExtensions, legacy)
+	if err != nil {
+		return err
+	}
+	upstreamOnly, err := validateUpstreamOnlyOperations(surface.Canonical.UpstreamOnlyOperations, legacy)
+	if err != nil {
+		return err
+	}
+	if len(legacy)-len(retained)+len(upstreamOnly) != surface.Canonical.OperationCount {
+		return fmt.Errorf("canonical operation calculation = %d, want %d", len(legacy)-len(retained)+len(upstreamOnly), surface.Canonical.OperationCount)
+	}
+	if err := validateMethodMigrations(surface.MethodMigrations, legacy, upstreamOnly); err != nil {
+		return err
+	}
+	return validateGeneratedOpenAPITools(surface.MCPGeneratedOpenAPIOperations, legacy, upstreamOnly)
+}
+
+func validateRetainedExtensions(
+	entries []compatibilityOperation,
+	legacy map[string]compatibilityEndpoint,
+) (map[string]struct{}, error) {
+	if len(entries) != retainedExtensionCount {
+		return nil, fmt.Errorf("retained Go extensions = %d, want %d", len(entries), retainedExtensionCount)
+	}
+	result := make(map[string]struct{}, len(entries))
+	for _, entry := range entries {
+		if err := validateOperation(entry); err != nil {
+			return nil, fmt.Errorf("retained Go extension: %w", err)
+		}
+		if _, exists := result[entry.OperationID]; exists {
+			return nil, fmt.Errorf("duplicate retained Go extension %q", entry.OperationID)
+		}
+		endpoint, found := legacy[entry.OperationID]
+		if !found || endpoint != (compatibilityEndpoint{Method: entry.Method, Path: entry.Path}) {
+			return nil, fmt.Errorf("retained Go extension %q does not match legacy OpenAPI", entry.OperationID)
+		}
+		if !strings.HasPrefix(entry.Path, "/v1/handoff-reports/") {
+			return nil, fmt.Errorf("retained Go extension %q is outside Handoff Report", entry.OperationID)
+		}
+		result[entry.OperationID] = struct{}{}
+	}
+	return result, nil
+}
+
+func validateUpstreamOnlyOperations(
+	entries []compatibilityOperation,
+	legacy map[string]compatibilityEndpoint,
+) (map[string]struct{}, error) {
+	if len(entries) != upstreamOnlyOperationCount {
+		return nil, fmt.Errorf("upstream-only operations = %d, want %d", len(entries), upstreamOnlyOperationCount)
+	}
+	result := make(map[string]struct{}, len(entries))
+	for _, entry := range entries {
+		if err := validateOperation(entry); err != nil {
+			return nil, fmt.Errorf("upstream-only operation: %w", err)
+		}
+		if _, exists := result[entry.OperationID]; exists {
+			return nil, fmt.Errorf("duplicate upstream-only operation %q", entry.OperationID)
+		}
+		if _, exists := legacy[entry.OperationID]; exists {
+			return nil, fmt.Errorf("upstream-only operation %q already exists in legacy OpenAPI", entry.OperationID)
+		}
+		result[entry.OperationID] = struct{}{}
+	}
+	return result, nil
+}
+
+func validateMethodMigrations(
+	entries []compatibilityMigration,
+	legacy map[string]compatibilityEndpoint,
+	upstreamOnly map[string]struct{},
+) error {
+	if len(entries) != 1 {
+		return fmt.Errorf("method migrations = %d, want 1", len(entries))
+	}
+	migration := entries[0]
+	if migration.OperationID != "get_stats" || migration.Legacy != (compatibilityEndpoint{Method: "get", Path: "/v1/stats"}) ||
+		migration.Canonical != (compatibilityEndpoint{Method: "post", Path: "/v1/stats"}) ||
+		migration.CanonicalMethodName != "GetStatsCanonical" {
+		return errors.New("get_stats migration must reserve POST /v1/stats as GetStatsCanonical")
+	}
+	if legacy[migration.OperationID] != migration.Legacy {
+		return errors.New("legacy GET /v1/stats is not preserved")
+	}
+	if _, found := upstreamOnly[migration.OperationID]; found {
+		return errors.New("get_stats migration cannot be upstream-only")
+	}
+	if migration.CanonicalMethodName == operationMethodName(migration.OperationID) {
+		return errors.New("canonical get_stats method collides with legacy generated method")
+	}
+	return nil
+}
+
+func validateGeneratedOpenAPITools(
+	operations []string,
+	legacy map[string]compatibilityEndpoint,
+	upstreamOnly map[string]struct{},
+) error {
+	if len(operations) != explicitMCPToolCount {
+		return fmt.Errorf("generated OpenAPI MCP tools = %d, want %d", len(operations), explicitMCPToolCount)
+	}
+	seen := make(map[string]struct{}, len(operations))
+	for _, operationID := range operations {
+		if _, exists := seen[operationID]; exists {
+			return fmt.Errorf("duplicate generated OpenAPI MCP tool %q", operationID)
+		}
+		if _, found := legacy[operationID]; !found {
+			return fmt.Errorf("generated OpenAPI MCP tool %q is absent from the implemented legacy contract", operationID)
+		}
+		if _, found := upstreamOnly[operationID]; found {
+			return fmt.Errorf("generated OpenAPI MCP tool %q is not implemented", operationID)
+		}
+		seen[operationID] = struct{}{}
+	}
+	return nil
+}
+
+func validateOperation(entry compatibilityOperation) error {
+	if entry.OperationID == "" || entry.Path == "" || !strings.HasPrefix(entry.Path, "/") || !isHTTPMethod(entry.Method) {
+		return fmt.Errorf("invalid %q %q %q", entry.OperationID, entry.Method, entry.Path)
+	}
+	return nil
+}

--- a/tools/api-generate/compatibility_test.go
+++ b/tools/api-generate/compatibility_test.go
@@ -1,0 +1,195 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"encoding/json/v2"
+	"os"
+	"strings"
+	"testing"
+)
+
+type upstreamCompatibilityLedger struct {
+	Upstream        compatibilityUpstream `json:"upstream"`
+	OperationCounts struct {
+		Common       int `json:"common"`
+		UpstreamOnly int `json:"upstream_only"`
+		GoOnly       int `json:"go_only"`
+	} `json:"operation_counts"`
+	MethodMigrations []struct {
+		OperationID string                `json:"operation_id"`
+		Go          compatibilityEndpoint `json:"go"`
+		Upstream    compatibilityEndpoint `json:"upstream"`
+	} `json:"method_migrations"`
+	UpstreamOnly []compatibilityOperation `json:"upstream_only"`
+	GoOnly       []compatibilityOperation `json:"go_only"`
+}
+
+func TestCompatibilitySurfaceProtectsLegacyContract(t *testing.T) {
+	t.Parallel()
+	specification, err := os.ReadFile("../../openapi/powercontext.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	contents, err := os.ReadFile("../../openapi/compatibility-surface.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := validateCompatibilitySurface(specification, contents); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCompatibilitySurfaceMatchesPinnedUpstreamLedger(t *testing.T) {
+	t.Parallel()
+	contents, err := os.ReadFile("../../openapi/compatibility-surface.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	surface, err := decodeCompatibilitySurface(contents)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ledgerContents, err := os.ReadFile("../../test/conformance/upstream-master-openapi-ledger.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var ledger upstreamCompatibilityLedger
+	if err := json.Unmarshal(ledgerContents, &ledger); err != nil {
+		t.Fatal(err)
+	}
+	if surface.Upstream != ledger.Upstream || surface.Canonical.OperationCount != ledger.OperationCounts.Common+ledger.OperationCounts.UpstreamOnly ||
+		surface.Legacy.OperationCount != ledger.OperationCounts.Common+ledger.OperationCounts.GoOnly {
+		t.Fatalf("compatibility surface does not match pinned ledger: %#v", surface)
+	}
+	if !sameCompatibilityOperations(surface.Canonical.UpstreamOnlyOperations, ledger.UpstreamOnly) ||
+		!sameCompatibilityOperations(surface.RetainedGoExtensions, ledger.GoOnly) {
+		t.Fatal("compatibility operation inventory does not match pinned ledger")
+	}
+	if len(surface.MethodMigrations) != 1 || len(ledger.MethodMigrations) != 1 ||
+		surface.MethodMigrations[0].OperationID != ledger.MethodMigrations[0].OperationID ||
+		surface.MethodMigrations[0].Legacy != ledger.MethodMigrations[0].Go ||
+		surface.MethodMigrations[0].Canonical != ledger.MethodMigrations[0].Upstream {
+		t.Fatal("compatibility get_stats migration does not match pinned ledger")
+	}
+}
+
+func TestCompatibilitySurfaceRejectsAmbiguousJSON(t *testing.T) {
+	t.Parallel()
+	contents, err := os.ReadFile("../../openapi/compatibility-surface.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, mutant := range []string{
+		strings.Replace(string(contents), `"schema_version": 1,`, `"schema_version": 1, "unknown": true,`, 1),
+		strings.Replace(string(contents), `"schema_version": 1,`, `"schema_version": 2, "schema_version": 1,`, 1),
+	} {
+		if _, err := decodeCompatibilitySurface([]byte(mutant)); err == nil {
+			t.Fatal("accepted ambiguous compatibility surface JSON")
+		}
+	}
+}
+
+func TestCompatibilitySurfaceRejectsContractMutants(t *testing.T) {
+	t.Parallel()
+	specification, err := os.ReadFile("../../openapi/powercontext.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	contents, err := os.ReadFile("../../openapi/compatibility-surface.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	surface, err := decodeCompatibilitySurface(contents)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, test := range []struct {
+		name   string
+		mutate func(*compatibilitySurface, *[]byte)
+	}{
+		{
+			name: "missing retained extension",
+			mutate: func(surface *compatibilitySurface, _ *[]byte) {
+				surface.RetainedGoExtensions = surface.RetainedGoExtensions[1:]
+			},
+		},
+		{
+			name: "wrong canonical operation count",
+			mutate: func(surface *compatibilitySurface, _ *[]byte) {
+				surface.Canonical.OperationCount--
+			},
+		},
+		{
+			name: "canonical stats keeps legacy method name",
+			mutate: func(surface *compatibilitySurface, _ *[]byte) {
+				surface.MethodMigrations[0].CanonicalMethodName = "GetStats"
+			},
+		},
+		{
+			name: "unimplemented canonical generated MCP tool",
+			mutate: func(surface *compatibilitySurface, _ *[]byte) {
+				surface.MCPGeneratedOpenAPIOperations = append(surface.MCPGeneratedOpenAPIOperations, "create_scope")
+			},
+		},
+		{
+			name: "stats stops preserving GET legacy endpoint",
+			mutate: func(_ *compatibilitySurface, specification *[]byte) {
+				before := string(*specification)
+				after := strings.Replace(before, "  /v1/stats:\n    get:", "  /v1/stats:\n    post:", 1)
+				if before == after {
+					*specification = []byte("not: OpenAPI")
+					return
+				}
+				*specification = []byte(after)
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			clone, cloneErr := cloneCompatibilitySurface(surface)
+			if cloneErr != nil {
+				t.Fatal(cloneErr)
+			}
+			mutantSpecification := append([]byte(nil), specification...)
+			test.mutate(&clone, &mutantSpecification)
+			mutantContents, marshalErr := json.Marshal(clone)
+			if marshalErr != nil {
+				t.Fatal(marshalErr)
+			}
+			if err := validateCompatibilitySurface(mutantSpecification, mutantContents); err == nil {
+				t.Fatal("invalid compatibility surface was accepted")
+			}
+		})
+	}
+}
+
+func sameCompatibilityOperations(left, right []compatibilityOperation) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	values := make(map[string]compatibilityEndpoint, len(left))
+	for _, operation := range left {
+		values[operation.OperationID] = compatibilityEndpoint{Method: operation.Method, Path: operation.Path}
+	}
+	if len(values) != len(left) {
+		return false
+	}
+	for _, operation := range right {
+		if values[operation.OperationID] != (compatibilityEndpoint{Method: operation.Method, Path: operation.Path}) {
+			return false
+		}
+	}
+	return true
+}

--- a/tools/api-generate/main.go
+++ b/tools/api-generate/main.go
@@ -32,24 +32,35 @@ func main() {
 	var target string
 	var packageName string
 	var clientInvoker string
+	var compatibility string
 	flag.StringVar(&specification, "spec", "powercontext.yaml", "canonical OpenAPI document")
 	flag.StringVar(&target, "target", "../api/v1", "generated package directory")
 	flag.StringVar(&packageName, "package", "v1", "generated Go package name")
 	flag.StringVar(&clientInvoker, "client-invoker", "", "optional normalized Client Invoker output")
+	flag.StringVar(&compatibility, "compatibility", "", "optional legacy/canonical compatibility surface")
 	flag.Parse()
-	if err := run(specification, target, packageName, clientInvoker); err != nil {
+	if err := run(specification, target, packageName, clientInvoker, compatibility); err != nil {
 		fmt.Fprintln(os.Stderr, "api-generate:", err)
 		os.Exit(1)
 	}
 }
 
-func run(specification, target, packageName, clientInvoker string) error {
+func run(specification, target, packageName, clientInvoker, compatibility string) error {
 	if specification == "" || target == "" || packageName == "" {
 		return errors.New("spec, target, and package must not be empty")
 	}
 	source, err := os.ReadFile(specification)
 	if err != nil {
 		return err
+	}
+	if compatibility != "" {
+		contents, readErr := os.ReadFile(compatibility)
+		if readErr != nil {
+			return fmt.Errorf("read compatibility surface: %w", readErr)
+		}
+		if validateErr := validateCompatibilitySurface(source, contents); validateErr != nil {
+			return fmt.Errorf("validate compatibility surface: %w", validateErr)
+		}
 	}
 	generatedInput, err := normalizeNullableReferences(source)
 	if err != nil {

--- a/tools/generated-consumers/main_test.go
+++ b/tools/generated-consumers/main_test.go
@@ -31,9 +31,20 @@ import (
 const generatedAPIConsumerTest = `package generatedconsumer
 
 import (
+	"context"
 	"testing"
 
 	v1 "example.com/powercontext-generated-api/api/v1"
+)
+
+type legacyHandler struct{ v1.UnimplementedHandler }
+
+var (
+	_ v1.Handler = legacyHandler{}
+	_ v1.Invoker = (*v1.Client)(nil)
+	_ func(v1.Handler, v1.SecurityHandler, ...v1.ServerOption) (*v1.Server, error) = v1.NewServer
+	_ func(string, v1.SecuritySource, ...v1.ClientOption) (*v1.Client, error) = v1.NewClient
+	_ func(*v1.Client, context.Context, v1.GetStatsParams) (v1.GetStatsRes, error) = (*v1.Client).GetStats
 )
 
 func TestGeneratedClientConstruction(t *testing.T) {
@@ -336,6 +347,7 @@ func TestOpenAPIGeneratorProducesGoldenBuildableConsumer(t *testing.T) {
 		"-target", generatedAPI,
 		"-package", "v1",
 		"-client-invoker", invoker,
+		"-compatibility", filepath.Join(repository, "openapi", "compatibility-surface.json"),
 	)
 
 	compareTree(t, filepath.Join(repository, "api", "v1"), generatedAPI)


### PR DESCRIPTION
Part of #202 Phase 3. Adds a generated-contract migration gate for the fixed upstream 77-operation snapshot while preserving the current 53-operation v1 Handler, Invoker, NewServer, NewClient, Client.Raw(), and legacy GET /v1/stats surface. Records 14 retained Go Handoff Report extensions, reserves canonical POST stats as GetStatsCanonical, and distinguishes OpenAPI-dispatch MCP tools from conditional native Scope Binding/Handoff picker tools. This PR deliberately implements no canonical HTTP operation; it prevents accidental public API and MCP surface expansion before each cluster has behavior and compatibility evidence.