### PR TITLE
feat(metrics): expose process runtime collectors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -517,6 +517,10 @@ source / artifact / trigger / inference
   load, provider run, or save, and an unknown scheduled scope acquires no lease
   or process callback while direct context references are all resolved before
   any recall begins.
+- When a Server owns a private Prometheus registry, register standard process
+  and Go runtime collectors in that registry instead of relying on global
+  registration. Verify the real metrics handler emits unlabelled CPU, RSS, and
+  Go runtime samples without exposing scope, content, or credential labels.
 - When a host-native MCP command distinguishes a caller-provided Scope from a
   durable resolved Scope, encode the former only as `explicit_scope_id` and
   return the latter only as `scope_id`. Verify an explicit override reaches the

--- a/internal/observability/metrics/server.go
+++ b/internal/observability/metrics/server.go
@@ -23,6 +23,7 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/ogen-go/ogen/middleware"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
 	v1 "github.com/ob-labs/powercontext-go/api/v1"
@@ -75,6 +76,12 @@ func New() (*Server, error) {
 			Help: "Scope compositions currently active or retained by the built-in Runtime.",
 		}, []string{"state"}),
 	}
+	if err := server.registry.Register(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{})); err != nil {
+		return nil, err
+	}
+	if err := server.registry.Register(collectors.NewGoCollector()); err != nil {
+		return nil, err
+	}
 	if err := server.registry.Register(server.transportRequests); err != nil {
 		return nil, err
 	}
@@ -100,8 +107,8 @@ func New() (*Server, error) {
 	return server, nil
 }
 
-// Handler renders only this Server's registry and does not expose Go process
-// or runtime collectors unless they are explicitly registered later.
+// Handler renders only this Server's registry, including its standard process
+// and Go runtime collectors.
 func (s *Server) Handler() http.Handler {
 	return promhttp.HandlerFor(s.registry, promhttp.HandlerOpts{ErrorHandling: promhttp.ContinueOnError})
 }

--- a/internal/observability/metrics/server_test.go
+++ b/internal/observability/metrics/server_test.go
@@ -16,7 +16,9 @@ package metrics
 
 import (
 	"context"
+	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -68,6 +70,29 @@ func TestRuntimeScopeMetricsHaveOnlyBoundedStateLabels(t *testing.T) {
 	} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("metrics do not contain %q:\n%s", want, text)
+		}
+	}
+}
+
+func TestServerHandlerIncludesPrivateProcessAndGoRuntimeCollectors(t *testing.T) {
+	t.Parallel()
+	server, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	response := httptest.NewRecorder()
+	server.Handler().ServeHTTP(response, httptest.NewRequest("GET", "/metrics", nil))
+	if response.Code != http.StatusOK {
+		t.Fatalf("metrics status = %d: %s", response.Code, response.Body.String())
+	}
+	exposition := response.Body.String()
+	for _, name := range []string{
+		"process_cpu_seconds_total",
+		"process_resident_memory_bytes",
+		"go_goroutines",
+	} {
+		if !regexp.MustCompile(`(?m)^` + regexp.QuoteMeta(name) + ` [0-9]+(?:\.[0-9]+)?(?:[eE][+-]?[0-9]+)?$`).MatchString(exposition) {
+			t.Fatalf("metrics do not contain an unlabelled %s sample:\n%s", name, exposition)
 		}
 	}
 }

--- a/server/http_test.go
+++ b/server/http_test.go
@@ -221,6 +221,32 @@ func TestMetricsEndpointIsAbsentWhenDisabled(t *testing.T) {
 	}
 }
 
+func TestMetricsEndpointIncludesProcessAndGoRuntimeMetrics(t *testing.T) {
+	t.Parallel()
+	observability, err := servermetrics.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	handler, err := NewHTTPHandler(endpoint.NewHandler(endpoint.HandlerOptions{}), HTTPOptions{metrics: observability})
+	if err != nil {
+		t.Fatal(err)
+	}
+	response := perform(handler, http.MethodGet, "/metrics", "")
+	if response.Code != http.StatusOK {
+		t.Fatalf("metrics = %d %s", response.Code, response.Body.String())
+	}
+	exposition := response.Body.String()
+	for _, name := range []string{
+		"process_cpu_seconds_total",
+		"process_resident_memory_bytes",
+		"go_goroutines",
+	} {
+		if !regexp.MustCompile(`(?m)^` + regexp.QuoteMeta(name) + ` [0-9]+(?:\.[0-9]+)?(?:[eE][+-]?[0-9]+)?$`).MatchString(exposition) {
+			t.Fatalf("metrics do not contain an unlabelled %s sample:\n%s", name, exposition)
+		}
+	}
+}
+
 func TestHTTPReadinessMapsNotReadyAndDegradedStatuses(t *testing.T) {
 	t.Parallel()
 	probe := func(status runtime.CheckStatus) runtime.Probe {


### PR DESCRIPTION
Part of #202 Phase 5. Registers Prometheus process and Go runtime collectors in each Server private registry, so /metrics includes CPU, resident-memory, and runtime samples without using the global registry or adding Scope/content/credential labels. Real handler and HTTP route regressions verify unlabelled process_cpu_seconds_total, process_resident_memory_bytes, and go_goroutines samples while preserving metrics-disabled 404 behavior.