### PR TITLE
feat(integrations): throttle host hook diagnostics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -517,10 +517,6 @@ source / artifact / trigger / inference
   load, provider run, or save, and an unknown scheduled scope acquires no lease
   or process callback while direct context references are all resolved before
   any recall begins.
-- When a Server owns a private Prometheus registry, register standard process
-  and Go runtime collectors in that registry instead of relying on global
-  registration. Verify the real metrics handler emits unlabelled CPU, RSS, and
-  Go runtime samples without exposing scope, content, or credential labels.
 - When a host-native MCP command distinguishes a caller-provided Scope from a
   durable resolved Scope, encode the former only as `explicit_scope_id` and
   return the latter only as `scope_id`. Verify an explicit override reaches the
@@ -550,3 +546,10 @@ source / artifact / trigger / inference
   then rebuild projections in the same transaction. On initialization, remove
   vec0 rows without metadata ownership. Verify revision cleanup, Scope
   isolation, startup orphan cleanup, and rollback after an invalid embedding.
+- When a short-lived supported host hook emits a classified failure diagnostic,
+  limit each outcome across independent processes for the documented interval
+  with a nonblocking state lock and an atomic content-free state replacement.
+  Treat unreadable or unwritable state as fail-open, and never render a state
+  path or request-sensitive value. Verify real hook processes emit only the
+  first repeated failure, a corrupted state recovers, and lock contention
+  returns within the hook budget.

--- a/build/release-integration-files.txt
+++ b/build/release-integration-files.txt
@@ -3,6 +3,7 @@ integrations/codex/README.md
 integrations/codex/plugins/powercontext/.codex-plugin/plugin.json
 integrations/codex/plugins/powercontext/.mcp.json
 integrations/codex/plugins/powercontext/README.md
+integrations/codex/plugins/powercontext/hooks/diagnostics.py
 integrations/codex/plugins/powercontext/hooks/hooks.json
 integrations/codex/plugins/powercontext/hooks/mcp_client.py
 integrations/codex/plugins/powercontext/hooks/prepared_context.py
@@ -16,9 +17,11 @@ integrations/codex/plugins/powercontext/uv.lock
 integrations/codex/tests/__init__.py
 integrations/codex/tests/conftest.py
 integrations/codex/tests/test_contract.py
+integrations/codex/tests/test_diagnostics.py
 integrations/codex/tests/test_recall.py
 integrations/workbuddy/README.md
 integrations/workbuddy/plugins/powercontext/.mcp.json
+integrations/workbuddy/plugins/powercontext/hooks/diagnostics.py
 integrations/workbuddy/plugins/powercontext/hooks/hooks.workbuddy.json
 integrations/workbuddy/plugins/powercontext/hooks/powercontext_project_scope.py
 integrations/workbuddy/plugins/powercontext/hooks/prepared_context.py
@@ -32,5 +35,6 @@ integrations/workbuddy/tests/test_artifacts.py
 integrations/workbuddy/tests/test_config.py
 integrations/workbuddy/tests/test_configuration_contract.py
 integrations/workbuddy/tests/test_configuration_template.py
+integrations/workbuddy/tests/test_diagnostics.py
 integrations/workbuddy/tests/test_scope.py
 integrations/workbuddy/tests/test_service_chain.py

--- a/integrations/codex/plugins/powercontext/hooks/diagnostics.py
+++ b/integrations/codex/plugins/powercontext/hooks/diagnostics.py
@@ -1,0 +1,121 @@
+# Copyright (c) 2026 OceanBase.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Best-effort cross-process throttling for Codex hook diagnostics."""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+
+_FAILURE_OUTCOMES = frozenset(
+    {
+        "authentication_failed",
+        "version_mismatch",
+        "server_unavailable",
+        "invalid_response",
+    }
+)
+_COOLDOWN_SECONDS = 60.0
+
+
+def _state_path() -> Path:
+    configured = os.environ.get("POWERCONTEXT_DIAGNOSTIC_STATE_FILE")
+    if configured and configured.strip():
+        return Path(configured)
+    if os.name == "nt":
+        root = Path(os.environ.get("LOCALAPPDATA") or Path.home() / "AppData" / "Local")
+    else:
+        root = Path(
+            os.environ.get("XDG_STATE_HOME") or Path.home() / ".local" / "state"
+        )
+    return root / "powercontext" / "codex-diagnostics.json"
+
+
+@contextmanager
+def _locked(lock_path: Path) -> Iterator[None]:
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with lock_path.open("a+b") as lock_file:
+        if os.name == "nt":
+            import msvcrt
+
+            lock_file.seek(0, os.SEEK_END)
+            if lock_file.tell() == 0:
+                lock_file.write(b"\0")
+                lock_file.flush()
+            lock_file.seek(0)
+            msvcrt.locking(lock_file.fileno(), msvcrt.LK_NBLCK, 1)
+        else:
+            import fcntl
+
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        try:
+            yield
+        finally:
+            if os.name == "nt":
+                import msvcrt
+
+                lock_file.seek(0)
+                msvcrt.locking(lock_file.fileno(), msvcrt.LK_UNLCK, 1)
+            else:
+                import fcntl
+
+                fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+
+
+def should_emit(outcome: str) -> bool:
+    """Return whether a diagnostic should be written for one hook invocation."""
+
+    if outcome not in _FAILURE_OUTCOMES:
+        return True
+
+    try:
+        now = time.time()
+        state_path = _state_path()
+        with _locked(state_path.with_name(f"{state_path.name}.lock")):
+            try:
+                state = json.loads(state_path.read_text(encoding="utf-8"))
+            except (
+                FileNotFoundError,
+                OSError,
+                UnicodeDecodeError,
+                json.JSONDecodeError,
+            ):
+                state = {}
+            if not isinstance(state, dict):
+                state = {}
+            previous = state.get(outcome)
+            if (
+                isinstance(previous, (int, float))
+                and not isinstance(previous, bool)
+                and 0 <= now - previous < _COOLDOWN_SECONDS
+            ):
+                return False
+
+            state[outcome] = now
+            temporary_path = state_path.with_name(
+                f".{state_path.name}.{os.getpid()}.tmp"
+            )
+            temporary_path.write_text(
+                json.dumps(state, separators=(",", ":")), encoding="utf-8"
+            )
+            os.replace(temporary_path, state_path)
+    except (OSError, TypeError, ValueError):
+        # Diagnostic state must never block a host hook.
+        return True
+    return True

--- a/integrations/codex/plugins/powercontext/hooks/recall.py
+++ b/integrations/codex/plugins/powercontext/hooks/recall.py
@@ -36,8 +36,9 @@ from typing_extensions import override
 _PLUGIN_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(_PLUGIN_ROOT))
 
-from hooks import prepared_context as _prepared_context  # noqa: E402
+from hooks import diagnostics as _diagnostics  # noqa: E402
 from hooks import mcp_client as _mcp_client  # noqa: E402
+from hooks import prepared_context as _prepared_context  # noqa: E402
 from scripts.project_scope import scope_binding_keys  # noqa: E402
 from settings import CodexPluginSettings, _is_loopback_host  # noqa: E402
 
@@ -448,6 +449,8 @@ def _emit_context_event(
     context_status: str | None = None,
     content_bytes: int | None = None,
 ) -> None:
+    if not _diagnostics.should_emit(outcome):
+        return
     event: dict[str, object] = {
         "component": "powercontext.codex.recall",
         "event": "context_prepare",

--- a/integrations/codex/tests/test_diagnostics.py
+++ b/integrations/codex/tests/test_diagnostics.py
@@ -1,0 +1,217 @@
+# Copyright (c) 2026 OceanBase.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+import threading
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+PLUGIN_ROOT = REPOSITORY_ROOT / "integrations" / "codex" / "plugins" / "powercontext"
+
+_HOOK_CHILD = """
+import sys
+from pathlib import Path
+
+plugin_root = Path(sys.argv[1])
+configuration_path = Path(sys.argv[2])
+sys.path.insert(0, str(plugin_root))
+
+import settings
+
+settings._MCP_CONFIGURATION_PATH = configuration_path
+from hooks import recall
+
+recall._resolve_scope_id = lambda *_args, **_kwargs: "scope-bound-by-test"
+raise SystemExit(recall.main())
+"""
+
+_LOCK_HOLDER = """
+import os
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+path.parent.mkdir(parents=True, exist_ok=True)
+with path.open("a+b") as lock_file:
+    if os.name == "nt":
+        import msvcrt
+
+        lock_file.seek(0, os.SEEK_END)
+        if lock_file.tell() == 0:
+            lock_file.write(b"\\0")
+            lock_file.flush()
+        lock_file.seek(0)
+        msvcrt.locking(lock_file.fileno(), msvcrt.LK_LOCK, 1)
+    else:
+        import fcntl
+
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+    print("ready", flush=True)
+    sys.stdin.read(1)
+"""
+
+
+@contextmanager
+def _serve_unavailable() -> Iterator[str]:
+    class Service(BaseHTTPRequestHandler):
+        def do_POST(self) -> None:
+            self.send_response(503)
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+
+        def log_message(self, _format: str, *_arguments: object) -> None:
+            return
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Service)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}"
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+        server.server_close()
+
+
+def _run_hook(
+    configuration_path: Path,
+    payload: dict[str, object],
+    state_path: Path,
+) -> subprocess.CompletedProcess[str]:
+    environment = dict(os.environ)
+    environment["POWERCONTEXT_DIAGNOSTIC_STATE_FILE"] = str(state_path)
+    environment["POWERCONTEXT_CODEX_AUTHORIZATION"] = "Bearer diagnostic-test-token"
+    return subprocess.run(
+        [sys.executable, "-c", _HOOK_CHILD, str(PLUGIN_ROOT), str(configuration_path)],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        env=environment,
+        timeout=15,
+        check=False,
+    )
+
+
+def _load_diagnostics() -> object:
+    path = PLUGIN_ROOT / "hooks" / "diagnostics.py"
+    spec = importlib.util.spec_from_file_location(
+        "powercontext_codex_diagnostics", path
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_unavailable_hook_diagnostic_is_rate_limited_across_processes(
+    tmp_path: Path,
+) -> None:
+    state_path = tmp_path / "codex-diagnostics.json"
+    state_path.write_text("not json", encoding="utf-8")
+    private_workspace = tmp_path / "private workspace"
+    prompt = "query with diagnostic-test-token and private content"
+    payload = {
+        "hook_event_name": "UserPromptSubmit",
+        "cwd": str(private_workspace),
+        "prompt": prompt,
+    }
+
+    with _serve_unavailable() as server_url:
+        configuration_path = tmp_path / "mcp.json"
+        configuration_path.write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "powercontext": {
+                            "type": "http",
+                            "url": f"{server_url}/mcp",
+                            "required": False,
+                            "env_http_headers": {
+                                "Authorization": "POWERCONTEXT_CODEX_AUTHORIZATION"
+                            },
+                        }
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        first = _run_hook(configuration_path, payload, state_path)
+        second = _run_hook(configuration_path, payload, state_path)
+
+    assert first.returncode == 0, first.stderr
+    assert first.stdout == ""
+    assert json.loads(first.stderr) == {
+        "component": "powercontext.codex.recall",
+        "event": "context_prepare",
+        "outcome": "server_unavailable",
+        "http_status": 503,
+    }
+    assert second.returncode == 0, second.stderr
+    assert second.stdout == ""
+    assert second.stderr == ""
+    assert json.loads(state_path.read_text(encoding="utf-8")).keys() == {
+        "server_unavailable"
+    }
+    assert state_path.with_name(f"{state_path.name}.lock").is_file()
+    assert list(tmp_path.glob(f".{state_path.name}.*.tmp")) == []
+    for protected in (
+        server_url,
+        "diagnostic-test-token",
+        prompt,
+        str(private_workspace),
+        "scope-bound-by-test",
+    ):
+        assert protected not in first.stderr
+
+
+def test_diagnostic_lock_contention_returns_without_waiting(
+    monkeypatch, tmp_path: Path
+) -> None:
+    diagnostics = _load_diagnostics()
+    state_path = tmp_path / "codex-diagnostics.json"
+    lock_path = state_path.with_name(f"{state_path.name}.lock")
+    monkeypatch.setenv("POWERCONTEXT_DIAGNOSTIC_STATE_FILE", str(state_path))
+    holder = subprocess.Popen(
+        [sys.executable, "-c", _LOCK_HOLDER, str(lock_path)],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        assert holder.stdout is not None
+        assert holder.stdout.readline().strip() == "ready"
+        started = time.monotonic()
+        assert diagnostics.should_emit("server_unavailable") is True
+        assert time.monotonic() - started < 0.6
+        assert not state_path.exists()
+    finally:
+        if holder.stdin is not None:
+            holder.stdin.write("\n")
+            holder.stdin.flush()
+        try:
+            holder.wait(timeout=2)
+        except subprocess.TimeoutExpired:
+            holder.kill()
+            holder.wait(timeout=2)

--- a/integrations/workbuddy/plugins/powercontext/hooks/diagnostics.py
+++ b/integrations/workbuddy/plugins/powercontext/hooks/diagnostics.py
@@ -1,0 +1,121 @@
+# Copyright (c) 2026 OceanBase.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Best-effort cross-process throttling for WorkBuddy hook diagnostics."""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+
+_FAILURE_OUTCOMES = frozenset(
+    {
+        "authentication_failed",
+        "version_mismatch",
+        "server_unavailable",
+        "invalid_response",
+    }
+)
+_COOLDOWN_SECONDS = 60.0
+
+
+def _state_path() -> Path:
+    configured = os.environ.get("POWERCONTEXT_DIAGNOSTIC_STATE_FILE")
+    if configured and configured.strip():
+        return Path(configured)
+    if os.name == "nt":
+        root = Path(os.environ.get("LOCALAPPDATA") or Path.home() / "AppData" / "Local")
+    else:
+        root = Path(
+            os.environ.get("XDG_STATE_HOME") or Path.home() / ".local" / "state"
+        )
+    return root / "powercontext" / "workbuddy-diagnostics.json"
+
+
+@contextmanager
+def _locked(lock_path: Path) -> Iterator[None]:
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with lock_path.open("a+b") as lock_file:
+        if os.name == "nt":
+            import msvcrt
+
+            lock_file.seek(0, os.SEEK_END)
+            if lock_file.tell() == 0:
+                lock_file.write(b"\0")
+                lock_file.flush()
+            lock_file.seek(0)
+            msvcrt.locking(lock_file.fileno(), msvcrt.LK_NBLCK, 1)
+        else:
+            import fcntl
+
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        try:
+            yield
+        finally:
+            if os.name == "nt":
+                import msvcrt
+
+                lock_file.seek(0)
+                msvcrt.locking(lock_file.fileno(), msvcrt.LK_UNLCK, 1)
+            else:
+                import fcntl
+
+                fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+
+
+def should_emit(outcome: str) -> bool:
+    """Return whether a diagnostic should be written for one hook invocation."""
+
+    if outcome not in _FAILURE_OUTCOMES:
+        return True
+
+    try:
+        now = time.time()
+        state_path = _state_path()
+        with _locked(state_path.with_name(f"{state_path.name}.lock")):
+            try:
+                state = json.loads(state_path.read_text(encoding="utf-8"))
+            except (
+                FileNotFoundError,
+                OSError,
+                UnicodeDecodeError,
+                json.JSONDecodeError,
+            ):
+                state = {}
+            if not isinstance(state, dict):
+                state = {}
+            previous = state.get(outcome)
+            if (
+                isinstance(previous, (int, float))
+                and not isinstance(previous, bool)
+                and 0 <= now - previous < _COOLDOWN_SECONDS
+            ):
+                return False
+
+            state[outcome] = now
+            temporary_path = state_path.with_name(
+                f".{state_path.name}.{os.getpid()}.tmp"
+            )
+            temporary_path.write_text(
+                json.dumps(state, separators=(",", ":")), encoding="utf-8"
+            )
+            os.replace(temporary_path, state_path)
+    except (OSError, TypeError, ValueError):
+        # Diagnostic state must never block a host hook.
+        return True
+    return True

--- a/integrations/workbuddy/plugins/powercontext/hooks/workbuddy_powercontext_hook.py
+++ b/integrations/workbuddy/plugins/powercontext/hooks/workbuddy_powercontext_hook.py
@@ -46,6 +46,7 @@ _PLUGIN_ROOT = _HOOKS_ROOT.parent
 sys.path.insert(0, str(_PLUGIN_ROOT))
 sys.path.insert(0, str(_HOOKS_ROOT))
 
+import diagnostics as _diagnostics  # noqa: E402
 import prepared_context as _prepared_context  # noqa: E402
 from workbuddy_settings import (  # noqa: E402
     WorkBuddyConfigurationError,
@@ -416,6 +417,8 @@ def _emit_context_event(
     context_status: str | None = None,
     content_bytes: int | None = None,
 ) -> None:
+    if not _diagnostics.should_emit(outcome):
+        return
     event: dict[str, object] = {
         "component": "powercontext.workbuddy.recall",
         "event": "context_prepare",

--- a/integrations/workbuddy/tests/test_diagnostics.py
+++ b/integrations/workbuddy/tests/test_diagnostics.py
@@ -1,0 +1,212 @@
+# Copyright (c) 2026 OceanBase.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+import threading
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+PLUGIN_ROOT = (
+    REPOSITORY_ROOT / "integrations" / "workbuddy" / "plugins" / "powercontext"
+)
+
+_HOOK_CHILD = """
+import importlib.util
+import sys
+from pathlib import Path
+
+plugin_root = Path(sys.argv[1])
+hooks_root = plugin_root / "hooks"
+sys.path[:0] = [str(hooks_root), str(plugin_root / "scripts")]
+spec = importlib.util.spec_from_file_location("powercontext_workbuddy_hook_child", hooks_root / "workbuddy_powercontext_hook.py")
+assert spec is not None and spec.loader is not None
+hook = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = hook
+spec.loader.exec_module(hook)
+hook.resolve_scope_id = lambda *_args, **_kwargs: "scope-bound-by-test"
+raise SystemExit(hook.main())
+"""
+
+_LOCK_HOLDER = """
+import os
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+path.parent.mkdir(parents=True, exist_ok=True)
+with path.open("a+b") as lock_file:
+    if os.name == "nt":
+        import msvcrt
+
+        lock_file.seek(0, os.SEEK_END)
+        if lock_file.tell() == 0:
+            lock_file.write(b"\\0")
+            lock_file.flush()
+        lock_file.seek(0)
+        msvcrt.locking(lock_file.fileno(), msvcrt.LK_LOCK, 1)
+    else:
+        import fcntl
+
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+    print("ready", flush=True)
+    sys.stdin.read(1)
+"""
+
+
+@contextmanager
+def _serve_unavailable() -> Iterator[str]:
+    class Service(BaseHTTPRequestHandler):
+        def do_POST(self) -> None:
+            self.send_response(503)
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+
+        def log_message(self, _format: str, *_arguments: object) -> None:
+            return
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Service)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}"
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+        server.server_close()
+
+
+def _run_hook(
+    server_url: str,
+    payload: dict[str, object],
+    state_path: Path,
+) -> subprocess.CompletedProcess[str]:
+    environment = dict(os.environ)
+    environment["POWERCONTEXT_DIAGNOSTIC_STATE_FILE"] = str(state_path)
+    environment["POWERCONTEXT_WORKBUDDY_SERVER_URL"] = server_url
+    environment["POWERCONTEXT_WORKBUDDY_AUTHORIZATION"] = "Bearer diagnostic-test-token"
+    return subprocess.run(
+        [sys.executable, "-c", _HOOK_CHILD, str(PLUGIN_ROOT)],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        env=environment,
+        timeout=15,
+        check=False,
+    )
+
+
+def _load_diagnostics() -> object:
+    path = PLUGIN_ROOT / "hooks" / "diagnostics.py"
+    spec = importlib.util.spec_from_file_location(
+        "powercontext_workbuddy_diagnostics", path
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_unavailable_hook_diagnostic_is_rate_limited_across_processes(
+    tmp_path: Path,
+) -> None:
+    state_path = tmp_path / "workbuddy-diagnostics.json"
+    state_path.write_text("not json", encoding="utf-8")
+    private_workspace = tmp_path / "private workspace"
+    prompt = "query with diagnostic-test-token and private content"
+    payload = {
+        "hook_event_name": "UserPromptSubmit",
+        "cwd": str(private_workspace),
+        "prompt": prompt,
+    }
+
+    with _serve_unavailable() as server_url:
+        first = _run_hook(server_url, payload, state_path)
+        second = _run_hook(server_url, payload, state_path)
+
+    assert first.returncode == 0, first.stderr
+    assert json.loads(first.stdout) == {
+        "hookSpecificOutput": {
+            "hookEventName": "UserPromptSubmit",
+            "additionalContext": "",
+        }
+    }
+    assert json.loads(first.stderr) == {
+        "component": "powercontext.workbuddy.recall",
+        "event": "context_prepare",
+        "outcome": "server_unavailable",
+        "http_status": 503,
+    }
+    assert second.returncode == 0, second.stderr
+    assert json.loads(second.stdout) == {
+        "hookSpecificOutput": {
+            "hookEventName": "UserPromptSubmit",
+            "additionalContext": "",
+        }
+    }
+    assert second.stderr == ""
+    assert json.loads(state_path.read_text(encoding="utf-8")).keys() == {
+        "server_unavailable"
+    }
+    assert state_path.with_name(f"{state_path.name}.lock").is_file()
+    assert list(tmp_path.glob(f".{state_path.name}.*.tmp")) == []
+    for protected in (
+        server_url,
+        "diagnostic-test-token",
+        prompt,
+        str(private_workspace),
+        "scope-bound-by-test",
+    ):
+        assert protected not in first.stderr
+
+
+def test_diagnostic_lock_contention_returns_without_waiting(
+    monkeypatch, tmp_path: Path
+) -> None:
+    diagnostics = _load_diagnostics()
+    state_path = tmp_path / "workbuddy-diagnostics.json"
+    lock_path = state_path.with_name(f"{state_path.name}.lock")
+    monkeypatch.setenv("POWERCONTEXT_DIAGNOSTIC_STATE_FILE", str(state_path))
+    holder = subprocess.Popen(
+        [sys.executable, "-c", _LOCK_HOLDER, str(lock_path)],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        assert holder.stdout is not None
+        assert holder.stdout.readline().strip() == "ready"
+        started = time.monotonic()
+        assert diagnostics.should_emit("server_unavailable") is True
+        assert time.monotonic() - started < 0.6
+        assert not state_path.exists()
+    finally:
+        if holder.stdin is not None:
+            holder.stdin.write("\n")
+            holder.stdin.flush()
+        try:
+            holder.wait(timeout=2)
+        except subprocess.TimeoutExpired:
+            holder.kill()
+            holder.wait(timeout=2)


### PR DESCRIPTION
Part of #202 Phase 5. Adds release-owned, standard-library diagnostic throttling to the supported Codex and WorkBuddy hooks. The four classified request failures are limited once per 60 seconds across processes with nonblocking locks and atomic content-free state replacement; corrupt/locked/unwritable state fails open without delaying the host. Real hook subprocess tests cover repeated 503 failures, state corruption, lock contention, and redaction. No non-target adapters are changed.