### PR TITLE
test(server): cover minimal SQLite startup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -517,6 +517,10 @@ source / artifact / trigger / inference
   load, provider run, or save, and an unknown scheduled scope acquires no lease
   or process callback while direct context references are all resolved before
   any recall begins.
+- When a Server owns a private Prometheus registry, register standard process
+  and Go runtime collectors in that registry instead of relying on global
+  registration. Verify the real metrics handler emits unlabelled CPU, RSS, and
+  Go runtime samples without exposing scope, content, or credential labels.
 - When a host-native MCP command distinguishes a caller-provided Scope from a
   durable resolved Scope, encode the former only as `explicit_scope_id` and
   return the latter only as `scope_id`. Verify an explicit override reaches the
@@ -546,6 +550,11 @@ source / artifact / trigger / inference
   then rebuild projections in the same transaction. On initialization, remove
   vec0 rows without metadata ownership. Verify revision cleanup, Scope
   isolation, startup orphan cleanup, and rollback after an invalid embedding.
+- When a SQLite Server has no configured inference models, keep the minimal
+  configuration runnable and attach no inference readiness probe or scheduler.
+  Require a generation model before enabling Memory reranking, Source-window
+  scheduling, or Experience incubation. Verify a real `OpenApplication` and
+  `/health/ready` path plus a focused refusal probe for each dependent feature.
 - When a short-lived supported host hook emits a classified failure diagnostic,
   limit each outcome across independent processes for the documented interval
   with a nonblocking state lock and an atomic content-free state replacement.

--- a/server/application_test.go
+++ b/server/application_test.go
@@ -112,6 +112,57 @@ func TestOpenApplicationProvidesRunnableSQLiteVerticalSlice(t *testing.T) {
 	}
 }
 
+func TestOpenApplicationRunsMinimalSQLiteServerWithoutInferenceModels(t *testing.T) {
+	t.Parallel()
+	config := applicationTestConfig(t)
+	config.SchedulerPath = filepath.Join(t.TempDir(), "scheduler.db")
+	config.Inference.GenerationModel = ""
+	config.Inference.EmbeddingModel = ""
+	config.Inference.EmbeddingProfileID = ""
+	config.Inference.EmbeddingDimension = 0
+	config.Runtime.MemoryRerankEnabled = false
+	config.Runtime.SourceWindowInterval = nil
+	config.Runtime.ExperienceIncubationInterval = nil
+	if err := config.Validate(); err != nil {
+		t.Fatalf("minimal SQLite configuration was rejected: %v", err)
+	}
+
+	application, err := OpenApplication(t.Context(), config, Dependencies{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := application.Close(ctx); err != nil {
+			t.Error(err)
+		}
+	})
+	if _, err := os.Stat(config.SchedulerPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("minimal Server unexpectedly opened scheduler storage: %v", err)
+	}
+
+	handler, err := application.HTTPHandler()
+	if err != nil {
+		t.Fatal(err)
+	}
+	response := perform(handler, http.MethodGet, "/health/ready", "")
+	if response.Code != http.StatusOK {
+		t.Fatalf("minimal Server readiness = %d: %s", response.Code, response.Body.String())
+	}
+	var readiness struct {
+		Status string            `json:"status"`
+		Checks map[string]string `json:"checks"`
+	}
+	if err := json.Unmarshal(response.Body.Bytes(), &readiness); err != nil {
+		t.Fatal(err)
+	}
+	if readiness.Status != "ready" || len(readiness.Checks) != 2 ||
+		readiness.Checks["runtime"] != "ready" || readiness.Checks["database"] != "ready" {
+		t.Fatalf("minimal Server readiness = %#v", readiness)
+	}
+}
+
 func TestOpenApplicationRejectsUnsupportedDatabaseBeforeStorageSideEffects(t *testing.T) {
 	config := applicationTestConfig(t)
 	path := filepath.Join(t.TempDir(), "unsupported-seekdb")

--- a/server/config_test.go
+++ b/server/config_test.go
@@ -497,16 +497,52 @@ func TestProcessConfigEnforcesTrustAndInferenceBoundariesWithoutSecrets(t *testi
 }
 
 func TestScheduledExperienceIncubationRequiresGenerationModel(t *testing.T) {
+	interval := time.Minute
+	assertGenerationModelRequired(t, func(config *ProcessConfig) {
+		config.Runtime.ExperienceIncubationInterval = &interval
+	}, "server: scheduled Experience incubation requires a generation model")
+}
+
+func TestProcessConfigRejectsOtherGenerationDependentFeaturesWithoutGenerationModel(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		name      string
+		configure func(*ProcessConfig)
+		want      string
+	}{
+		{
+			name: "Memory reranking",
+			configure: func(config *ProcessConfig) {
+				config.Runtime.MemoryRerankEnabled = true
+			},
+			want: "server: Memory reranking requires a generation model",
+		},
+		{
+			name: "Source scheduler",
+			configure: func(config *ProcessConfig) {
+				interval := time.Minute
+				config.Runtime.SourceWindowInterval = &interval
+			},
+			want: "server: scheduled Source processing requires a generation model",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			assertGenerationModelRequired(t, test.configure, test.want)
+		})
+	}
+}
+
+func assertGenerationModelRequired(t *testing.T, configure func(*ProcessConfig), want string) {
+	t.Helper()
 	config, err := DefaultConfig()
 	if err != nil {
 		t.Fatal(err)
 	}
-	interval := time.Minute
-	config.Runtime.ExperienceIncubationInterval = &interval
 	config.Inference.GenerationModel = ""
-	err = config.Validate()
-	if err == nil || !strings.Contains(err.Error(), "scheduled Experience incubation requires a generation model") {
-		t.Fatalf("validation error = %v", err)
+	configure(&config)
+
+	if err := config.Validate(); err == nil || err.Error() != want {
+		t.Fatalf("validation error = %v, want %q", err, want)
 	}
 }
 


### PR DESCRIPTION
Part of #202 Phase 5. Adds SQLite-only evidence for the already-supported minimal Server configuration: no inference models starts a real Application and /health/ready contains only runtime/database checks with no scheduler sidecar. Also makes the existing generation-model requirement table-driven across Memory reranking, Source-window scheduling, and Experience incubation. No production behavior, agent surface, or database backend support changes.