### PR TITLE
feat(personalsvc): add pure lifecycle controller

### DIFF
--- a/internal/personalsvc/adapter.go
+++ b/internal/personalsvc/adapter.go
@@ -1,0 +1,145 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package personalsvc
+
+import "context"
+
+// ProbeState is the adapter result for one endpoint probe. Conflict is kept
+// separate from liveness because it must fail before an artifact is written.
+type ProbeState string
+
+const (
+	// ProbeLive means the endpoint returned the PowerContext liveness contract.
+	ProbeLive ProbeState = "live"
+	// ProbeUnreachable means the endpoint cannot currently be reached.
+	ProbeUnreachable ProbeState = "unreachable"
+	// ProbeConflict means another listener occupies the endpoint.
+	ProbeConflict ProbeState = "conflict"
+)
+
+// Artifact is an immutable inspection result for the exact native artifact.
+// Its registration is present only when State is RegistrationInstalled.
+type Artifact struct {
+	state           RegistrationState
+	definition      DefinitionState
+	registration    Registration
+	hasRegistration bool
+}
+
+// InstalledArtifact returns a verified owned artifact with its executable
+// available. Adapters may use InstalledArtifactWithDefinition when they can
+// independently determine a missing executable.
+func InstalledArtifact(registration Registration) Artifact {
+	return InstalledArtifactWithDefinition(registration, DefinitionCurrent)
+}
+
+// InstalledArtifactWithDefinition returns a verified owned artifact with a
+// platform-observed definition state.
+func InstalledArtifactWithDefinition(registration Registration, definition DefinitionState) Artifact {
+	return Artifact{
+		state:           RegistrationInstalled,
+		definition:      definition,
+		registration:    registration,
+		hasRegistration: true,
+	}
+}
+
+// NoArtifact returns the exact result for an absent owned artifact.
+func NoArtifact() Artifact {
+	return Artifact{state: RegistrationNotInstalled, definition: DefinitionUnknown}
+}
+
+// InvalidArtifact returns the exact result for a present but unverified artifact.
+func InvalidArtifact() Artifact {
+	return Artifact{state: RegistrationInvalid, definition: DefinitionUnknown}
+}
+
+// UnknownArtifact returns the exact result when artifact inspection is inconclusive.
+func UnknownArtifact() Artifact {
+	return Artifact{state: RegistrationUnknown, definition: DefinitionUnknown}
+}
+
+// State returns the exact native artifact state.
+func (a Artifact) State() RegistrationState { return a.state }
+
+// DefinitionState returns the adapter-observed stored definition state.
+func (a Artifact) DefinitionState() DefinitionState { return a.definition }
+
+// Registration returns the verified immutable registration when one exists.
+func (a Artifact) Registration() (Registration, bool) { return a.registration, a.hasRegistration }
+
+// ManagerRegistration is an immutable inspection result for the object loaded
+// by the native manager. It is separate from Artifact by design.
+type ManagerRegistration struct {
+	ownership       ManagerOwnership
+	registration    Registration
+	hasRegistration bool
+}
+
+// OwnedManager returns a loaded native object verified as PowerContext-owned.
+func OwnedManager(registration Registration) ManagerRegistration {
+	return ManagerRegistration{
+		ownership:       ManagerOwnershipOwned,
+		registration:    registration,
+		hasRegistration: true,
+	}
+}
+
+// NotLoadedManager returns the exact result for no loaded manager object.
+func NotLoadedManager() ManagerRegistration {
+	return ManagerRegistration{ownership: ManagerOwnershipNotLoaded}
+}
+
+// ForeignManager returns the exact result for a foreign loaded manager object.
+func ForeignManager() ManagerRegistration {
+	return ManagerRegistration{ownership: ManagerOwnershipForeign}
+}
+
+// UnknownManager returns the exact result when loaded manager ownership is unknown.
+func UnknownManager() ManagerRegistration {
+	return ManagerRegistration{ownership: ManagerOwnershipUnknown}
+}
+
+// Ownership returns the independently observed native manager ownership.
+func (r ManagerRegistration) Ownership() ManagerOwnership { return r.ownership }
+
+// Registration returns the verified registration for an owned manager object.
+func (r ManagerRegistration) Registration() (Registration, bool) {
+	return r.registration, r.hasRegistration
+}
+
+// Adapter isolates every native, filesystem, process, and network operation.
+// Implementations must inspect the artifact and loaded manager object through
+// independent methods; Controller never infers ownership from an endpoint.
+type Adapter interface {
+	Support(context.Context) (Support, error)
+	InspectArtifact(context.Context) (Artifact, error)
+	InspectManager(context.Context) (ManagerRegistration, error)
+	Probe(context.Context, string) (ProbeState, error)
+	Write(context.Context, Registration) error
+	Reload(context.Context) error
+	Enable(context.Context) error
+	Start(context.Context) error
+	Stop(context.Context) error
+	Disable(context.Context) error
+	Remove(context.Context) error
+	ManagerState(context.Context) (ManagerState, error)
+}
+
+// OperationBoundary serializes one complete lifecycle mutation. It is injected
+// so Controller remains pure Go and cannot select a host lock implementation.
+type OperationBoundary interface {
+	Run(context.Context, func(context.Context) error) error
+}

--- a/internal/personalsvc/controller.go
+++ b/internal/personalsvc/controller.go
@@ -1,0 +1,417 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package personalsvc
+
+import (
+	"context"
+	"errors"
+)
+
+// Controller orchestrates one immutable personal-service registration through
+// a supplied native Adapter. It does not read the environment, access storage,
+// open a network connection, start a goroutine, or choose a native manager.
+type Controller struct {
+	adapter  Adapter
+	boundary OperationBoundary
+}
+
+// NewController constructs a pure lifecycle controller from explicit native
+// boundaries. Platform support belongs to the supplied Adapter.
+func NewController(adapter Adapter, boundary OperationBoundary) (*Controller, error) {
+	if adapter == nil || boundary == nil {
+		return nil, newOperationError(ErrorInvalidController, StageNone, emptyStatus())
+	}
+	return &Controller{adapter: adapter, boundary: boundary}, nil
+}
+
+// Install validates and commits an owned registration. A native artifact
+// transaction ends at enablement; later start or liveness failures preserve the
+// committed registration and return RecoveryRetryInstall.
+func (c *Controller) Install(ctx context.Context, desired Registration) (Status, error) {
+	if err := desired.Definition().Validate(); err != nil {
+		return emptyStatus(), newOperationError(ErrorInvalidRegistration, StageNone, emptyStatus())
+	}
+	support, err := c.adapter.Support(ctx)
+	if err != nil {
+		return emptyStatus(), newOperationError(ErrorOperation, StageSupport, emptyStatus())
+	}
+	if support != SupportSupported {
+		return statusForUnsupported(), newOperationError(ErrorUnsupported, StageSupport, statusForUnsupported())
+	}
+	initialProbe, err := c.adapter.Probe(ctx, desired.Definition().Endpoint())
+	if err != nil {
+		return statusForSupportedUnknown(), newOperationError(ErrorOperation, StageProbe, statusForSupportedUnknown())
+	}
+	if initialProbe == ProbeConflict {
+		status := newStatus(
+			SupportSupported, RegistrationNotInstalled, DefinitionUnknown,
+			ManagerOwnershipUnknown, ManagerUnknown, LivenessUnreachable, RecoveryResolveEndpoint,
+		)
+		return status, newOperationError(ErrorEndpointConflict, StageProbe, status)
+	}
+
+	started := false
+	operationErr := c.boundary.Run(ctx, func(operationCtx context.Context) error {
+		var installErr error
+		started, installErr = c.installLocked(operationCtx, desired, initialProbe)
+		return installErr
+	})
+	if operationErr != nil {
+		if operation, found := errors.AsType[*OperationError](operationErr); found {
+			if operation.Kind() != ErrorPostCommit {
+				return operation.Status(), operation
+			}
+			return c.postCommitStatus(ctx, desired, operation.Stage())
+		}
+		return statusForSupportedUnknown(), newOperationError(ErrorOperation, StageLock, statusForSupportedUnknown())
+	}
+
+	status, statusErr := c.Status(ctx, desired)
+	if statusErr != nil {
+		return c.postCommitStatus(ctx, desired, StageProbe)
+	}
+	if started && status.Liveness() != LivenessLive {
+		status = withRecovery(status, RecoveryRetryInstall)
+		return status, newOperationError(ErrorPostCommit, StageProbe, status)
+	}
+	return status, nil
+}
+
+// Uninstall removes only a verified owned registration. Stop happens before
+// disable, remove, and reload; a failure leaves remaining state in place.
+func (c *Controller) Uninstall(ctx context.Context, desired Registration) (Status, error) {
+	if err := desired.Definition().Validate(); err != nil {
+		return emptyStatus(), newOperationError(ErrorInvalidRegistration, StageNone, emptyStatus())
+	}
+	support, err := c.adapter.Support(ctx)
+	if err != nil {
+		return emptyStatus(), newOperationError(ErrorOperation, StageSupport, emptyStatus())
+	}
+	if support != SupportSupported {
+		return statusForUnsupported(), newOperationError(ErrorUnsupported, StageSupport, statusForUnsupported())
+	}
+
+	operationErr := c.boundary.Run(ctx, func(operationCtx context.Context) error {
+		return c.uninstallLocked(operationCtx)
+	})
+	if operationErr != nil {
+		if operation, found := errors.AsType[*OperationError](operationErr); found {
+			if operation.Kind() == ErrorOperation {
+				return c.uninstallFailureStatus(ctx, desired, operation.Stage())
+			}
+			return operation.Status(), operation
+		}
+		return statusForSupportedUnknown(), newOperationError(ErrorOperation, StageLock, statusForSupportedUnknown())
+	}
+	return c.Status(ctx, desired)
+}
+
+// Status independently inspects native support, artifact, loaded ownership,
+// manager state, and the recorded endpoint. It never reuses mutation-time
+// observations as status facts.
+func (c *Controller) Status(ctx context.Context, desired Registration) (Status, error) {
+	support, err := c.adapter.Support(ctx)
+	if err != nil {
+		return emptyStatus(), newOperationError(ErrorOperation, StageSupport, emptyStatus())
+	}
+	if support != SupportSupported {
+		return statusForUnsupported(), nil
+	}
+	artifact, err := c.adapter.InspectArtifact(ctx)
+	if err != nil {
+		return statusForSupportedUnknown(), newOperationError(ErrorOperation, StageInspectArtifact, statusForSupportedUnknown())
+	}
+	managerRegistration, err := c.adapter.InspectManager(ctx)
+	if err != nil {
+		return statusForSupportedUnknown(), newOperationError(ErrorOperation, StageInspectManager, statusForSupportedUnknown())
+	}
+	if artifact.State() != RegistrationInstalled {
+		return newStatus(
+			SupportSupported, artifact.State(), DefinitionUnknown,
+			managerRegistration.Ownership(), managerStateForOwnership(managerRegistration.Ownership()),
+			LivenessUnknown, recoveryForAbsentArtifact(managerRegistration.Ownership()),
+		), nil
+	}
+	stored, found := artifact.Registration()
+	if !found || stored.Definition().Validate() != nil {
+		return newStatus(
+			SupportSupported, RegistrationInvalid, DefinitionUnknown,
+			managerRegistration.Ownership(), ManagerUnknown, LivenessUnknown, RecoveryInspectManager,
+		), nil
+	}
+	ownership := managerRegistration.Ownership()
+	loadedDefinitionStale := false
+	if ownership == ManagerOwnershipOwned {
+		loaded, found := managerRegistration.Registration()
+		if !found || loaded.Definition().Validate() != nil {
+			ownership = ManagerOwnershipUnknown
+		} else {
+			loadedDefinitionStale = loaded != desired
+		}
+	}
+	definition := artifact.DefinitionState()
+	if definition != DefinitionMissingExecutable {
+		if stored == desired && !loadedDefinitionStale {
+			definition = DefinitionCurrent
+		} else {
+			definition = DefinitionStale
+		}
+	}
+
+	manager := managerStateForOwnership(ownership)
+	if ownership == ManagerOwnershipOwned {
+		manager, err = c.adapter.ManagerState(ctx)
+		if err != nil {
+			return statusForSupportedUnknown(), newOperationError(ErrorOperation, StageInspectManager, statusForSupportedUnknown())
+		}
+	}
+	probe, err := c.adapter.Probe(ctx, stored.Definition().Endpoint())
+	if err != nil {
+		return newStatus(
+				SupportSupported, RegistrationInstalled, definition,
+				ownership, manager, LivenessUnknown, RecoveryRetryInstall,
+			), newOperationError(
+				ErrorOperation,
+				StageProbe,
+				newStatus(
+					SupportSupported, RegistrationInstalled, definition,
+					ownership, manager, LivenessUnknown, RecoveryRetryInstall,
+				),
+			)
+	}
+	liveness := livenessForProbe(probe)
+	return newStatus(
+		SupportSupported, RegistrationInstalled, definition,
+		ownership, manager, liveness,
+		recoveryForInstalled(definition, ownership, manager, probe),
+	), nil
+}
+
+func (c *Controller) installLocked(ctx context.Context, desired Registration, initialProbe ProbeState) (bool, error) {
+	artifact, err := c.adapter.InspectArtifact(ctx)
+	if err != nil {
+		return false, newOperationError(ErrorOperation, StageInspectArtifact, statusForSupportedUnknown())
+	}
+	if artifact.State() == RegistrationInvalid || artifact.State() == RegistrationUnknown {
+		return false, newOperationError(ErrorRegistrationConflict, StageInspectArtifact, statusForSupportedUnknown())
+	}
+	if artifact.State() == RegistrationInstalled {
+		stored, found := artifact.Registration()
+		if !found || stored.Definition().Validate() != nil {
+			return false, newOperationError(ErrorRegistrationConflict, StageInspectArtifact, statusForSupportedUnknown())
+		}
+	}
+	managerRegistration, err := c.adapter.InspectManager(ctx)
+	if err != nil {
+		return false, newOperationError(ErrorOperation, StageInspectManager, statusForSupportedUnknown())
+	}
+	if managerRegistration.Ownership() == ManagerOwnershipForeign || managerRegistration.Ownership() == ManagerOwnershipUnknown {
+		return false, newOperationError(ErrorManagerConflict, StageInspectManager, statusForSupportedUnknown())
+	}
+	loadedChanged := false
+	if managerRegistration.Ownership() == ManagerOwnershipOwned {
+		loaded, found := managerRegistration.Registration()
+		if !found || loaded.Definition().Validate() != nil {
+			return false, newOperationError(ErrorManagerConflict, StageInspectManager, statusForSupportedUnknown())
+		}
+		loadedChanged = loaded != desired
+	}
+
+	changed := artifact.State() != RegistrationInstalled || loadedChanged
+	if !changed {
+		stored, _ := artifact.Registration()
+		changed = stored != desired
+	}
+	if changed {
+		if err := c.commit(ctx, desired, artifact); err != nil {
+			return false, err
+		}
+	} else if err := c.adapter.Enable(ctx); err != nil {
+		return false, newOperationError(ErrorOperation, StageEnable, statusForSupportedUnknown())
+	}
+	if initialProbe == ProbeLive {
+		return false, nil
+	}
+	if err := c.adapter.Start(ctx); err != nil {
+		return false, newOperationError(ErrorPostCommit, StageStart, statusForSupportedUnknown())
+	}
+	return true, nil
+}
+
+func (c *Controller) commit(ctx context.Context, desired Registration, previous Artifact) error {
+	if err := c.adapter.Write(ctx, desired); err != nil {
+		c.restore(ctx, previous)
+		return newOperationError(ErrorOperation, StageWrite, statusForSupportedUnknown())
+	}
+	if err := c.adapter.Reload(ctx); err != nil {
+		c.restore(ctx, previous)
+		return newOperationError(ErrorOperation, StageReload, statusForSupportedUnknown())
+	}
+	if err := c.adapter.Enable(ctx); err != nil {
+		c.restore(ctx, previous)
+		return newOperationError(ErrorOperation, StageEnable, statusForSupportedUnknown())
+	}
+	return nil
+}
+
+func (c *Controller) restore(ctx context.Context, previous Artifact) {
+	_ = c.adapter.Disable(ctx)
+	if previous.State() == RegistrationInstalled {
+		registration, found := previous.Registration()
+		if found {
+			_ = c.adapter.Write(ctx, registration)
+			_ = c.adapter.Reload(ctx)
+			_ = c.adapter.Enable(ctx)
+			return
+		}
+	}
+	_ = c.adapter.Remove(ctx)
+	_ = c.adapter.Reload(ctx)
+}
+
+func (c *Controller) uninstallLocked(ctx context.Context) error {
+	artifact, err := c.adapter.InspectArtifact(ctx)
+	if err != nil {
+		return newOperationError(ErrorOperation, StageInspectArtifact, statusForSupportedUnknown())
+	}
+	if artifact.State() == RegistrationInvalid || artifact.State() == RegistrationUnknown {
+		return newOperationError(ErrorRegistrationConflict, StageInspectArtifact, statusForSupportedUnknown())
+	}
+	if artifact.State() == RegistrationInstalled {
+		stored, found := artifact.Registration()
+		if !found || stored.Definition().Validate() != nil {
+			return newOperationError(ErrorRegistrationConflict, StageInspectArtifact, statusForSupportedUnknown())
+		}
+	}
+	managerRegistration, err := c.adapter.InspectManager(ctx)
+	if err != nil {
+		return newOperationError(ErrorOperation, StageInspectManager, statusForSupportedUnknown())
+	}
+	if managerRegistration.Ownership() == ManagerOwnershipForeign || managerRegistration.Ownership() == ManagerOwnershipUnknown {
+		return newOperationError(ErrorManagerConflict, StageInspectManager, statusForSupportedUnknown())
+	}
+	if managerRegistration.Ownership() == ManagerOwnershipOwned {
+		loaded, found := managerRegistration.Registration()
+		if !found || loaded.Definition().Validate() != nil {
+			return newOperationError(ErrorManagerConflict, StageInspectManager, statusForSupportedUnknown())
+		}
+	}
+	if artifact.State() == RegistrationNotInstalled && managerRegistration.Ownership() == ManagerOwnershipNotLoaded {
+		return nil
+	}
+	if err := c.adapter.Stop(ctx); err != nil {
+		return newOperationError(ErrorOperation, StageStop, statusForSupportedUnknown())
+	}
+	if err := c.adapter.Disable(ctx); err != nil {
+		return newOperationError(ErrorOperation, StageDisable, statusForSupportedUnknown())
+	}
+	if artifact.State() == RegistrationInstalled {
+		if err := c.adapter.Remove(ctx); err != nil {
+			return newOperationError(ErrorOperation, StageRemove, statusForSupportedUnknown())
+		}
+	}
+	if err := c.adapter.Reload(ctx); err != nil {
+		return newOperationError(ErrorOperation, StageReload, statusForSupportedUnknown())
+	}
+	return nil
+}
+
+func (c *Controller) postCommitStatus(ctx context.Context, desired Registration, stage OperationStage) (Status, error) {
+	status, err := c.Status(ctx, desired)
+	if err != nil {
+		status = statusForSupportedUnknown()
+	}
+	status = withRecovery(status, RecoveryRetryInstall)
+	return status, newOperationError(ErrorPostCommit, stage, status)
+}
+
+func (c *Controller) uninstallFailureStatus(ctx context.Context, desired Registration, stage OperationStage) (Status, error) {
+	status, err := c.Status(ctx, desired)
+	if err != nil {
+		status = statusForSupportedUnknown()
+	}
+	status = withRecovery(status, RecoveryRetryUninstall)
+	return status, newOperationError(ErrorOperation, stage, status)
+}
+
+func emptyStatus() Status {
+	return newStatus(
+		SupportUnsupported, RegistrationUnknown, DefinitionUnknown,
+		ManagerOwnershipUnknown, ManagerUnknown, LivenessUnknown, RecoveryNone,
+	)
+}
+
+func statusForUnsupported() Status {
+	return newStatus(
+		SupportUnsupported, RegistrationUnknown, DefinitionUnknown,
+		ManagerOwnershipUnknown, ManagerUnknown, LivenessUnknown, RecoveryNone,
+	)
+}
+
+func statusForSupportedUnknown() Status {
+	return newStatus(
+		SupportSupported, RegistrationUnknown, DefinitionUnknown,
+		ManagerOwnershipUnknown, ManagerUnknown, LivenessUnknown, RecoveryNone,
+	)
+}
+
+func withRecovery(status Status, recovery Recovery) Status {
+	return newStatus(
+		status.Support(), status.Registration(), status.Definition(), status.ManagerOwnership(),
+		status.Manager(), status.Liveness(), recovery,
+	)
+}
+
+func managerStateForOwnership(ownership ManagerOwnership) ManagerState {
+	if ownership == ManagerOwnershipNotLoaded {
+		return ManagerInactive
+	}
+	return ManagerUnknown
+}
+
+func livenessForProbe(probe ProbeState) Liveness {
+	if probe == ProbeLive {
+		return LivenessLive
+	}
+	return LivenessUnreachable
+}
+
+func recoveryForAbsentArtifact(ownership ManagerOwnership) Recovery {
+	if ownership == ManagerOwnershipForeign || ownership == ManagerOwnershipUnknown {
+		return RecoveryInspectManager
+	}
+	return RecoveryNone
+}
+
+func recoveryForInstalled(
+	definition DefinitionState,
+	ownership ManagerOwnership,
+	manager ManagerState,
+	probe ProbeState,
+) Recovery {
+	if definition == DefinitionStale || definition == DefinitionMissingExecutable {
+		return RecoveryRetryInstall
+	}
+	if ownership == ManagerOwnershipForeign || ownership == ManagerOwnershipUnknown {
+		return RecoveryInspectManager
+	}
+	if probe == ProbeConflict {
+		return RecoveryResolveEndpoint
+	}
+	if manager == ManagerInactive || manager == ManagerFailed || probe == ProbeUnreachable {
+		return RecoveryRetryInstall
+	}
+	return RecoveryNone
+}

--- a/internal/personalsvc/controller_test.go
+++ b/internal/personalsvc/controller_test.go
@@ -1,0 +1,564 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package personalsvc_test
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/ob-labs/powercontext-go/internal/personalsvc"
+)
+
+func TestControllerInstallIsIdempotentAndReportsIndependentStatus(t *testing.T) {
+	desired := testRegistration(t, "1.2.3")
+	adapter := newFakeAdapter()
+	controller, err := personalsvc.NewController(adapter, fakeBoundary{events: &adapter.events})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	first, installErr := controller.Install(t.Context(), desired)
+	if installErr != nil {
+		t.Fatal(installErr)
+	}
+	if !first.Healthy() || first.Support() != personalsvc.SupportSupported ||
+		first.Registration() != personalsvc.RegistrationInstalled ||
+		first.Definition() != personalsvc.DefinitionCurrent ||
+		first.ManagerOwnership() != personalsvc.ManagerOwnershipOwned ||
+		first.Manager() != personalsvc.ManagerActive ||
+		first.Liveness() != personalsvc.LivenessLive ||
+		first.Recovery() != personalsvc.RecoveryNone {
+		t.Fatalf("first Status = %#v", first)
+	}
+	assertEvents(t, adapter.events, []string{
+		"support", "probe", "lock", "inspect_artifact", "inspect_manager",
+		"write", "reload", "enable", "start", "unlock",
+		"support", "inspect_artifact", "inspect_manager", "manager_state", "probe",
+	})
+
+	adapter.events = nil
+	second, installErr := controller.Install(t.Context(), desired)
+	if installErr != nil {
+		t.Fatal(installErr)
+	}
+	if !second.Healthy() {
+		t.Fatalf("second Status = %#v", second)
+	}
+	assertEvents(t, adapter.events, []string{
+		"support", "probe", "lock", "inspect_artifact", "inspect_manager", "enable", "unlock",
+		"support", "inspect_artifact", "inspect_manager", "manager_state", "probe",
+	})
+}
+
+func TestControllerInstallPrecommitFailureRestoresPreviousOwnedRegistration(t *testing.T) {
+	desired := testRegistration(t, "1.2.3")
+	previous := testRegistration(t, "1.2.2")
+
+	for _, test := range []struct {
+		stage string
+		want  []string
+	}{
+		{
+			stage: "write",
+			want: []string{
+				"support", "probe", "lock", "inspect_artifact", "inspect_manager", "write",
+				"disable", "write", "reload", "enable", "unlock",
+			},
+		},
+		{
+			stage: "reload",
+			want: []string{
+				"support", "probe", "lock", "inspect_artifact", "inspect_manager", "write", "reload",
+				"disable", "write", "reload", "enable", "unlock",
+			},
+		},
+		{
+			stage: "enable",
+			want: []string{
+				"support", "probe", "lock", "inspect_artifact", "inspect_manager", "write", "reload", "enable",
+				"disable", "write", "reload", "enable", "unlock",
+			},
+		},
+	} {
+		t.Run(test.stage, func(t *testing.T) {
+			adapter := newFakeAdapter()
+			adapter.artifact = personalsvc.InstalledArtifact(previous)
+			adapter.failOnce(test.stage)
+			controller, err := personalsvc.NewController(adapter, fakeBoundary{events: &adapter.events})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			_, installErr := controller.Install(t.Context(), desired)
+			_ = assertOperationError(t, installErr, personalsvc.ErrorOperation, personalsvc.OperationStage(test.stage))
+			assertRedacted(t, installErr)
+			assertEvents(t, adapter.events, test.want)
+			stored, found := adapter.artifact.Registration()
+			if !found || stored != previous {
+				t.Fatalf("restored registration = %#v, %t", stored, found)
+			}
+		})
+	}
+}
+
+func TestControllerInstallPostCommitFailurePreservesRegistrationWithRetryRecovery(t *testing.T) {
+	desired := testRegistration(t, "1.2.3")
+	adapter := newFakeAdapter()
+	adapter.failOnce("start")
+	controller, err := personalsvc.NewController(adapter, fakeBoundary{events: &adapter.events})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, installErr := controller.Install(t.Context(), desired)
+	operation := assertOperationError(t, installErr, personalsvc.ErrorPostCommit, personalsvc.StageStart)
+	assertRedacted(t, installErr)
+	if operation.Status().Registration() != personalsvc.RegistrationInstalled ||
+		operation.Status().Recovery() != personalsvc.RecoveryRetryInstall {
+		t.Fatalf("post-commit Status = %#v", operation.Status())
+	}
+	stored, found := adapter.artifact.Registration()
+	if !found || stored != desired {
+		t.Fatalf("preserved registration = %#v, %t", stored, found)
+	}
+	assertEvents(t, adapter.events, []string{
+		"support", "probe", "lock", "inspect_artifact", "inspect_manager",
+		"write", "reload", "enable", "start", "unlock",
+		"support", "inspect_artifact", "inspect_manager", "probe",
+	})
+}
+
+func TestControllerInstallPreservesRegistrationWhenStartedServiceIsStillUnreachable(t *testing.T) {
+	desired := testRegistration(t, "1.2.3")
+	adapter := newFakeAdapter()
+	adapter.leaveEndpointUnreachableAfterStart = true
+	controller, err := personalsvc.NewController(adapter, fakeBoundary{events: &adapter.events})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, installErr := controller.Install(t.Context(), desired)
+	operation := assertOperationError(t, installErr, personalsvc.ErrorPostCommit, personalsvc.StageProbe)
+	if operation.Status().Registration() != personalsvc.RegistrationInstalled ||
+		operation.Status().Manager() != personalsvc.ManagerActive ||
+		operation.Status().Liveness() != personalsvc.LivenessUnreachable ||
+		operation.Status().Recovery() != personalsvc.RecoveryRetryInstall {
+		t.Fatalf("unreachable post-start Status = %#v", operation.Status())
+	}
+	stored, found := adapter.artifact.Registration()
+	if !found || stored != desired {
+		t.Fatalf("preserved registration = %#v, %t", stored, found)
+	}
+	assertEvents(t, adapter.events, []string{
+		"support", "probe", "lock", "inspect_artifact", "inspect_manager",
+		"write", "reload", "enable", "start", "unlock",
+		"support", "inspect_artifact", "inspect_manager", "manager_state", "probe",
+	})
+}
+
+func TestControllerInstallRefusesUnverifiedManagerBeforeArtifactMutation(t *testing.T) {
+	desired := testRegistration(t, "1.2.3")
+	for _, test := range []struct {
+		name    string
+		manager personalsvc.ManagerRegistration
+	}{
+		{name: "foreign", manager: personalsvc.ForeignManager()},
+		{name: "unknown", manager: personalsvc.UnknownManager()},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			adapter := newFakeAdapter()
+			adapter.managerRegistration = test.manager
+			controller, err := personalsvc.NewController(adapter, fakeBoundary{events: &adapter.events})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			_, installErr := controller.Install(t.Context(), desired)
+			_ = assertOperationError(t, installErr, personalsvc.ErrorManagerConflict, personalsvc.StageInspectManager)
+			assertRedacted(t, installErr)
+			assertEvents(t, adapter.events, []string{
+				"support", "probe", "lock", "inspect_artifact", "inspect_manager", "unlock",
+			})
+			if adapter.artifact.State() != personalsvc.RegistrationNotInstalled {
+				t.Fatalf("unverified manager mutation installed artifact: %#v", adapter.artifact)
+			}
+		})
+	}
+}
+
+func TestControllerInstallLeavesExistingLiveEndpointUntouched(t *testing.T) {
+	desired := testRegistration(t, "1.2.3")
+	adapter := newFakeAdapter()
+	adapter.probe = personalsvc.ProbeLive
+	controller, err := personalsvc.NewController(adapter, fakeBoundary{events: &adapter.events})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	status, installErr := controller.Install(t.Context(), desired)
+	if installErr != nil {
+		t.Fatal(installErr)
+	}
+	if status.Liveness() != personalsvc.LivenessLive || status.ManagerOwnership() != personalsvc.ManagerOwnershipNotLoaded ||
+		status.Manager() != personalsvc.ManagerInactive {
+		t.Fatalf("live foreground Status = %#v", status)
+	}
+	assertEvents(t, adapter.events, []string{
+		"support", "probe", "lock", "inspect_artifact", "inspect_manager",
+		"write", "reload", "enable", "unlock",
+		"support", "inspect_artifact", "inspect_manager", "probe",
+	})
+}
+
+func TestControllerReconcilesStaleLoadedManagerDefinition(t *testing.T) {
+	desired := testRegistration(t, "1.2.3")
+	previous := testRegistration(t, "1.2.2")
+	adapter := newFakeAdapter()
+	adapter.artifact = personalsvc.InstalledArtifact(desired)
+	adapter.managerRegistration = personalsvc.OwnedManager(previous)
+	controller, err := personalsvc.NewController(adapter, fakeBoundary{events: &adapter.events})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	before, statusErr := controller.Status(t.Context(), desired)
+	if statusErr != nil || before.Definition() != personalsvc.DefinitionStale {
+		t.Fatalf("pre-install Status = %#v, %v", before, statusErr)
+	}
+	adapter.events = nil
+	status, installErr := controller.Install(t.Context(), desired)
+	if installErr != nil || !status.Healthy() {
+		t.Fatalf("Install() = (%#v, %v)", status, installErr)
+	}
+	assertEvents(t, adapter.events, []string{
+		"support", "probe", "lock", "inspect_artifact", "inspect_manager",
+		"write", "reload", "enable", "start", "unlock",
+		"support", "inspect_artifact", "inspect_manager", "manager_state", "probe",
+	})
+}
+
+func TestControllerInstallRejectsEndpointConflictBeforeArtifactMutation(t *testing.T) {
+	desired := testRegistration(t, "1.2.3")
+	adapter := newFakeAdapter()
+	adapter.probe = personalsvc.ProbeConflict
+	controller, err := personalsvc.NewController(adapter, fakeBoundary{events: &adapter.events})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, installErr := controller.Install(t.Context(), desired)
+	_ = assertOperationError(t, installErr, personalsvc.ErrorEndpointConflict, personalsvc.StageProbe)
+	assertRedacted(t, installErr)
+	assertEvents(t, adapter.events, []string{"support", "probe"})
+}
+
+func TestControllerUninstallDoesNotRemoveRegistrationAfterStopFailure(t *testing.T) {
+	desired := testRegistration(t, "1.2.3")
+	adapter := newFakeAdapter()
+	adapter.artifact = personalsvc.InstalledArtifact(desired)
+	adapter.managerRegistration = personalsvc.OwnedManager(desired)
+	adapter.manager = personalsvc.ManagerActive
+	adapter.failOnce("stop")
+	controller, err := personalsvc.NewController(adapter, fakeBoundary{events: &adapter.events})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, uninstallErr := controller.Uninstall(t.Context(), desired)
+	operation := assertOperationError(t, uninstallErr, personalsvc.ErrorOperation, personalsvc.StageStop)
+	if operation.Status().Registration() != personalsvc.RegistrationInstalled ||
+		operation.Status().Recovery() != personalsvc.RecoveryRetryUninstall {
+		t.Fatalf("stop failure Status = %#v", operation.Status())
+	}
+	if adapter.artifact.State() != personalsvc.RegistrationInstalled {
+		t.Fatal("stop failure removed the registration")
+	}
+	assertEvents(t, adapter.events, []string{
+		"support", "lock", "inspect_artifact", "inspect_manager", "stop", "unlock",
+		"support", "inspect_artifact", "inspect_manager", "manager_state", "probe",
+	})
+}
+
+func TestControllerUninstallRefusesUnverifiedArtifactOrManagerBeforeStop(t *testing.T) {
+	desired := testRegistration(t, "1.2.3")
+	for _, test := range []struct {
+		name       string
+		configure  func(*fakeAdapter)
+		kind       personalsvc.ErrorKind
+		stage      personalsvc.OperationStage
+		wantEvents []string
+	}{
+		{
+			name: "artifact",
+			configure: func(adapter *fakeAdapter) {
+				adapter.artifact = personalsvc.InstalledArtifact(personalsvc.Registration{})
+			},
+			kind:       personalsvc.ErrorRegistrationConflict,
+			stage:      personalsvc.StageInspectArtifact,
+			wantEvents: []string{"support", "lock", "inspect_artifact", "unlock"},
+		},
+		{
+			name: "manager",
+			configure: func(adapter *fakeAdapter) {
+				adapter.artifact = personalsvc.InstalledArtifact(desired)
+				adapter.managerRegistration = personalsvc.OwnedManager(personalsvc.Registration{})
+			},
+			kind:       personalsvc.ErrorManagerConflict,
+			stage:      personalsvc.StageInspectManager,
+			wantEvents: []string{"support", "lock", "inspect_artifact", "inspect_manager", "unlock"},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			adapter := newFakeAdapter()
+			test.configure(adapter)
+			controller, err := personalsvc.NewController(adapter, fakeBoundary{events: &adapter.events})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			_, uninstallErr := controller.Uninstall(t.Context(), desired)
+			_ = assertOperationError(t, uninstallErr, test.kind, test.stage)
+			assertRedacted(t, uninstallErr)
+			assertEvents(t, adapter.events, test.wantEvents)
+		})
+	}
+}
+
+func TestControllerUninstallStopsDisablesRemovesAndReloadsOwnedRegistration(t *testing.T) {
+	desired := testRegistration(t, "1.2.3")
+	adapter := newFakeAdapter()
+	adapter.artifact = personalsvc.InstalledArtifact(desired)
+	adapter.managerRegistration = personalsvc.OwnedManager(desired)
+	adapter.manager = personalsvc.ManagerActive
+	adapter.probe = personalsvc.ProbeLive
+	controller, err := personalsvc.NewController(adapter, fakeBoundary{events: &adapter.events})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	status, uninstallErr := controller.Uninstall(t.Context(), desired)
+	if uninstallErr != nil {
+		t.Fatal(uninstallErr)
+	}
+	if status.Registration() != personalsvc.RegistrationNotInstalled ||
+		status.ManagerOwnership() != personalsvc.ManagerOwnershipNotLoaded {
+		t.Fatalf("uninstall Status = %#v", status)
+	}
+	assertEvents(t, adapter.events, []string{
+		"support", "lock", "inspect_artifact", "inspect_manager", "stop", "disable", "remove", "reload", "unlock",
+		"support", "inspect_artifact", "inspect_manager",
+	})
+}
+
+func TestControllerUninstallIsIdempotentWhenNothingIsInstalledOrLoaded(t *testing.T) {
+	desired := testRegistration(t, "1.2.3")
+	adapter := newFakeAdapter()
+	controller, err := personalsvc.NewController(adapter, fakeBoundary{events: &adapter.events})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	status, uninstallErr := controller.Uninstall(t.Context(), desired)
+	if uninstallErr != nil {
+		t.Fatal(uninstallErr)
+	}
+	if status.Registration() != personalsvc.RegistrationNotInstalled ||
+		status.ManagerOwnership() != personalsvc.ManagerOwnershipNotLoaded ||
+		status.Recovery() != personalsvc.RecoveryNone {
+		t.Fatalf("idempotent uninstall Status = %#v", status)
+	}
+	assertEvents(t, adapter.events, []string{
+		"support", "lock", "inspect_artifact", "inspect_manager", "unlock",
+		"support", "inspect_artifact", "inspect_manager",
+	})
+}
+
+func testRegistration(t *testing.T, packageVersion string) personalsvc.Registration {
+	t.Helper()
+	definition, err := personalsvc.NewDefinition(personalsvc.DefinitionInput{
+		Ownership:         personalsvc.OwnershipMarker,
+		DefinitionVersion: personalsvc.DefinitionVersion,
+		PackageVersion:    packageVersion,
+		Binary:            `C:\\Program Files\\PowerContext\\powercontext.exe`,
+		Endpoint:          "http://127.0.0.1:8123",
+		DataDir:           `C:\\Users\\person\\AppData\\Local\\PowerContext`,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	registration, err := personalsvc.NewRegistration(definition)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return registration
+}
+
+func assertOperationError(
+	t *testing.T, err error, wantKind personalsvc.ErrorKind, wantStage personalsvc.OperationStage,
+) *personalsvc.OperationError {
+	t.Helper()
+	operation, found := errors.AsType[*personalsvc.OperationError](err)
+	if !found {
+		t.Fatalf("error type = %T %v, want *OperationError", err, err)
+	}
+	if operation.Kind() != wantKind || operation.Stage() != wantStage {
+		t.Fatalf("operation error = (%s, %s), want (%s, %s)", operation.Kind(), operation.Stage(), wantKind, wantStage)
+	}
+	return operation
+}
+
+func assertRedacted(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected a redacted error")
+	}
+	for _, forbidden := range []string{"127.0.0.1", "8123", "Program Files", "secret-adapter-detail"} {
+		if strings.Contains(err.Error(), forbidden) {
+			t.Fatalf("error leaked protected definition value %q: %v", forbidden, err)
+		}
+	}
+}
+
+func assertEvents(t *testing.T, got, want []string) {
+	t.Helper()
+	if !slices.Equal(got, want) {
+		t.Fatalf("events = %q, want %q", got, want)
+	}
+}
+
+type fakeBoundary struct{ events *[]string }
+
+func (b fakeBoundary) Run(ctx context.Context, operation func(context.Context) error) error {
+	*b.events = append(*b.events, "lock")
+	err := operation(ctx)
+	*b.events = append(*b.events, "unlock")
+	return err
+}
+
+type fakeAdapter struct {
+	artifact                           personalsvc.Artifact
+	managerRegistration                personalsvc.ManagerRegistration
+	manager                            personalsvc.ManagerState
+	probe                              personalsvc.ProbeState
+	leaveEndpointUnreachableAfterStart bool
+	events                             []string
+	failures                           map[string]int
+}
+
+func newFakeAdapter() *fakeAdapter {
+	return &fakeAdapter{
+		artifact:            personalsvc.NoArtifact(),
+		managerRegistration: personalsvc.NotLoadedManager(),
+		manager:             personalsvc.ManagerInactive,
+		probe:               personalsvc.ProbeUnreachable,
+		failures:            make(map[string]int),
+	}
+}
+
+func (a *fakeAdapter) failOnce(stage string) { a.failures[stage]++ }
+
+func (a *fakeAdapter) Support(context.Context) (personalsvc.Support, error) {
+	a.events = append(a.events, "support")
+	return personalsvc.SupportSupported, nil
+}
+
+func (a *fakeAdapter) InspectArtifact(context.Context) (personalsvc.Artifact, error) {
+	a.events = append(a.events, "inspect_artifact")
+	return a.artifact, a.failure("inspect_artifact")
+}
+
+func (a *fakeAdapter) InspectManager(context.Context) (personalsvc.ManagerRegistration, error) {
+	a.events = append(a.events, "inspect_manager")
+	return a.managerRegistration, a.failure("inspect_manager")
+}
+
+func (a *fakeAdapter) Probe(context.Context, string) (personalsvc.ProbeState, error) {
+	a.events = append(a.events, "probe")
+	return a.probe, a.failure("probe")
+}
+
+func (a *fakeAdapter) Write(_ context.Context, registration personalsvc.Registration) error {
+	a.events = append(a.events, "write")
+	a.artifact = personalsvc.InstalledArtifact(registration)
+	return a.failure("write")
+}
+
+func (a *fakeAdapter) Reload(context.Context) error {
+	a.events = append(a.events, "reload")
+	return a.failure("reload")
+}
+
+func (a *fakeAdapter) Enable(context.Context) error {
+	a.events = append(a.events, "enable")
+	return a.failure("enable")
+}
+
+func (a *fakeAdapter) Start(context.Context) error {
+	a.events = append(a.events, "start")
+	if err := a.failure("start"); err != nil {
+		return err
+	}
+	registration, found := a.artifact.Registration()
+	if !found {
+		return errors.New("secret-adapter-detail")
+	}
+	a.managerRegistration = personalsvc.OwnedManager(registration)
+	a.manager = personalsvc.ManagerActive
+	if !a.leaveEndpointUnreachableAfterStart {
+		a.probe = personalsvc.ProbeLive
+	}
+	return nil
+}
+
+func (a *fakeAdapter) Stop(context.Context) error {
+	a.events = append(a.events, "stop")
+	if err := a.failure("stop"); err != nil {
+		return err
+	}
+	a.managerRegistration = personalsvc.NotLoadedManager()
+	a.manager = personalsvc.ManagerInactive
+	a.probe = personalsvc.ProbeUnreachable
+	return nil
+}
+
+func (a *fakeAdapter) Disable(context.Context) error {
+	a.events = append(a.events, "disable")
+	return a.failure("disable")
+}
+
+func (a *fakeAdapter) Remove(context.Context) error {
+	a.events = append(a.events, "remove")
+	if err := a.failure("remove"); err != nil {
+		return err
+	}
+	a.artifact = personalsvc.NoArtifact()
+	return nil
+}
+
+func (a *fakeAdapter) ManagerState(context.Context) (personalsvc.ManagerState, error) {
+	a.events = append(a.events, "manager_state")
+	return a.manager, a.failure("manager_state")
+}
+
+func (a *fakeAdapter) failure(stage string) error {
+	if a.failures[stage] == 0 {
+		return nil
+	}
+	a.failures[stage]--
+	return errors.New("secret-adapter-detail")
+}

--- a/internal/personalsvc/status.go
+++ b/internal/personalsvc/status.go
@@ -1,0 +1,275 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package personalsvc
+
+// Support describes whether a qualified native personal-service adapter is
+// available on the current host.
+type Support string
+
+const (
+	// SupportSupported means a qualified native adapter is available.
+	SupportSupported Support = "supported"
+	// SupportUnsupported means no qualified native adapter is available.
+	SupportUnsupported Support = "unsupported"
+)
+
+// RegistrationState describes the exact native personal-service artifact.
+type RegistrationState string
+
+const (
+	// RegistrationInstalled means an owned artifact was inspected.
+	RegistrationInstalled RegistrationState = "installed"
+	// RegistrationNotInstalled means no artifact exists at the owned location.
+	RegistrationNotInstalled RegistrationState = "not_installed"
+	// RegistrationInvalid means the artifact cannot be verified as owned.
+	RegistrationInvalid RegistrationState = "invalid"
+	// RegistrationUnknown means the adapter could not determine artifact state.
+	RegistrationUnknown RegistrationState = "unknown"
+)
+
+// DefinitionState compares an installed definition with the desired
+// distribution definition without exposing either definition's contents.
+type DefinitionState string
+
+const (
+	// DefinitionCurrent means the installed definition equals the desired one.
+	DefinitionCurrent DefinitionState = "current"
+	// DefinitionStale means the installed definition differs from the desired one.
+	DefinitionStale DefinitionState = "stale"
+	// DefinitionMissingExecutable means the adapter found a missing executable.
+	DefinitionMissingExecutable DefinitionState = "missing_executable"
+	// DefinitionUnknown means no verified installed definition is available.
+	DefinitionUnknown DefinitionState = "unknown"
+)
+
+// ManagerOwnership describes the loaded native manager object independently
+// from the on-disk artifact.
+type ManagerOwnership string
+
+const (
+	// ManagerOwnershipOwned means the loaded object was independently verified.
+	ManagerOwnershipOwned ManagerOwnership = "owned"
+	// ManagerOwnershipNotLoaded means the native manager has no loaded object.
+	ManagerOwnershipNotLoaded ManagerOwnership = "not_loaded"
+	// ManagerOwnershipForeign means another owner controls the loaded object.
+	ManagerOwnershipForeign ManagerOwnership = "foreign"
+	// ManagerOwnershipUnknown means ownership could not be verified.
+	ManagerOwnershipUnknown ManagerOwnership = "unknown"
+)
+
+// ManagerState describes the native manager state after ownership verification.
+type ManagerState string
+
+const (
+	// ManagerActive means the verified manager object is active.
+	ManagerActive ManagerState = "active"
+	// ManagerInactive means no verified manager object is active.
+	ManagerInactive ManagerState = "inactive"
+	// ManagerFailed means the verified manager object reports a failure.
+	ManagerFailed ManagerState = "failed"
+	// ManagerUnknown means the manager state could not be determined safely.
+	ManagerUnknown ManagerState = "unknown"
+)
+
+// Liveness describes the recorded loopback Server endpoint.
+type Liveness string
+
+const (
+	// LivenessLive means the endpoint returned the PowerContext liveness contract.
+	LivenessLive Liveness = "live"
+	// LivenessUnreachable means the endpoint did not return a valid liveness response.
+	LivenessUnreachable Liveness = "unreachable"
+	// LivenessUnknown means no verified endpoint is available to probe.
+	LivenessUnknown Liveness = "unknown"
+)
+
+// Recovery identifies a fixed, safe next operation. It never contains a
+// definition field, native path, endpoint, or adapter diagnostic.
+type Recovery string
+
+const (
+	// RecoveryNone means no recovery action is required.
+	RecoveryNone Recovery = ""
+	// RecoveryRetryInstall means a committed registration needs an install retry.
+	RecoveryRetryInstall Recovery = "retry_install"
+	// RecoveryRetryUninstall means an uninstall should be retried safely.
+	RecoveryRetryUninstall Recovery = "retry_uninstall"
+	// RecoveryInspectManager means native manager ownership needs manual inspection.
+	RecoveryInspectManager Recovery = "inspect_manager"
+	// RecoveryResolveEndpoint means a conflicting endpoint needs resolution.
+	RecoveryResolveEndpoint Recovery = "resolve_endpoint"
+)
+
+// Status is an immutable observation of one personal-service lifecycle.
+// It intentionally exposes only closed state values and a fixed recovery
+// action, never the underlying Definition or native adapter diagnostics.
+type Status struct {
+	support          Support
+	registration     RegistrationState
+	definition       DefinitionState
+	managerOwnership ManagerOwnership
+	manager          ManagerState
+	liveness         Liveness
+	recovery         Recovery
+}
+
+func newStatus(
+	support Support,
+	registration RegistrationState,
+	definition DefinitionState,
+	managerOwnership ManagerOwnership,
+	manager ManagerState,
+	liveness Liveness,
+	recovery Recovery,
+) Status {
+	return Status{
+		support:          support,
+		registration:     registration,
+		definition:       definition,
+		managerOwnership: managerOwnership,
+		manager:          manager,
+		liveness:         liveness,
+		recovery:         recovery,
+	}
+}
+
+// Support returns the native adapter availability state.
+func (s Status) Support() Support { return s.support }
+
+// Registration returns the exact artifact state.
+func (s Status) Registration() RegistrationState { return s.registration }
+
+// Definition returns the installed-definition comparison state.
+func (s Status) Definition() DefinitionState { return s.definition }
+
+// ManagerOwnership returns the independently inspected manager ownership.
+func (s Status) ManagerOwnership() ManagerOwnership { return s.managerOwnership }
+
+// Manager returns the native manager state after ownership verification.
+func (s Status) Manager() ManagerState { return s.manager }
+
+// Liveness returns the recorded endpoint liveness state.
+func (s Status) Liveness() Liveness { return s.liveness }
+
+// Recovery returns a fixed next action for a degraded lifecycle state.
+func (s Status) Recovery() Recovery { return s.recovery }
+
+// Healthy reports whether every required personal-service state is healthy.
+func (s Status) Healthy() bool {
+	return s.support == SupportSupported &&
+		s.registration == RegistrationInstalled &&
+		s.definition == DefinitionCurrent &&
+		s.managerOwnership == ManagerOwnershipOwned &&
+		s.manager == ManagerActive &&
+		s.liveness == LivenessLive
+}
+
+// ErrorKind identifies a redacted controller failure class.
+type ErrorKind string
+
+const (
+	// ErrorInvalidController means a controller dependency was not supplied.
+	ErrorInvalidController ErrorKind = "invalid_controller"
+	// ErrorInvalidRegistration means the caller supplied an invalid registration.
+	ErrorInvalidRegistration ErrorKind = "invalid_registration"
+	// ErrorUnsupported means no qualified adapter is available.
+	ErrorUnsupported ErrorKind = "unsupported"
+	// ErrorEndpointConflict means another listener owns the intended endpoint.
+	ErrorEndpointConflict ErrorKind = "endpoint_conflict"
+	// ErrorRegistrationConflict means the artifact cannot be safely modified.
+	ErrorRegistrationConflict ErrorKind = "registration_conflict"
+	// ErrorManagerConflict means loaded manager ownership cannot be modified safely.
+	ErrorManagerConflict ErrorKind = "manager_conflict"
+	// ErrorOperation means a pre-commit or uninstall adapter operation failed.
+	ErrorOperation ErrorKind = "operation"
+	// ErrorPostCommit means a registration was committed but requires recovery.
+	ErrorPostCommit ErrorKind = "post_commit"
+)
+
+// OperationStage identifies a safe lifecycle transition. Its closed values
+// are suitable for error classification because none contains caller input.
+type OperationStage string
+
+const (
+	// StageNone means no individual adapter stage applies.
+	StageNone OperationStage = ""
+	// StageSupport inspects adapter availability.
+	StageSupport OperationStage = "support"
+	// StageProbe probes the recorded loopback endpoint.
+	StageProbe OperationStage = "probe"
+	// StageLock enters the injected serialized operation boundary.
+	StageLock OperationStage = "lock"
+	// StageInspectArtifact inspects the native registration artifact.
+	StageInspectArtifact OperationStage = "inspect_artifact"
+	// StageInspectManager inspects native manager ownership.
+	StageInspectManager OperationStage = "inspect_manager"
+	// StageWrite writes an owned registration artifact.
+	StageWrite OperationStage = "write"
+	// StageReload reloads native-manager configuration.
+	StageReload OperationStage = "reload"
+	// StageEnable enables the owned registration.
+	StageEnable OperationStage = "enable"
+	// StageStart starts the registered native service.
+	StageStart OperationStage = "start"
+	// StageStop stops the verified native service.
+	StageStop OperationStage = "stop"
+	// StageDisable disables the owned registration.
+	StageDisable OperationStage = "disable"
+	// StageRemove removes the owned artifact.
+	StageRemove OperationStage = "remove"
+)
+
+// OperationError is a typed, redacted lifecycle failure. It intentionally
+// drops adapter errors because they can carry paths, endpoints, or credentials.
+type OperationError struct {
+	kind   ErrorKind
+	stage  OperationStage
+	status Status
+}
+
+func newOperationError(kind ErrorKind, stage OperationStage, status Status) *OperationError {
+	return &OperationError{kind: kind, stage: stage, status: status}
+}
+
+// Error returns a stable, redacted failure description.
+func (e *OperationError) Error() string {
+	switch e.kind {
+	case ErrorInvalidController:
+		return "invalid personal service controller"
+	case ErrorInvalidRegistration:
+		return "invalid personal service registration"
+	case ErrorUnsupported:
+		return "personal service native adapter is unsupported"
+	case ErrorEndpointConflict:
+		return "personal service endpoint is already occupied"
+	case ErrorRegistrationConflict:
+		return "personal service registration cannot be safely modified"
+	case ErrorManagerConflict:
+		return "personal service native manager ownership cannot be safely modified"
+	case ErrorPostCommit:
+		return "personal service registration is installed but needs recovery"
+	default:
+		return "personal service operation failed during " + string(e.stage)
+	}
+}
+
+// Kind returns the typed failure class.
+func (e *OperationError) Kind() ErrorKind { return e.kind }
+
+// Stage returns the safe lifecycle transition that failed.
+func (e *OperationError) Stage() OperationStage { return e.stage }
+
+// Status returns a content-free lifecycle observation captured for this error.
+func (e *OperationError) Status() Status { return e.status }


### PR DESCRIPTION
Part of #202 Phase 5. Stacked on #248.

Adds a pure personal-service lifecycle controller with explicit artifact/manager/liveness state, ownership fail-closed behavior, pre-commit rollback, post-commit recovery, and idempotent uninstall semantics. The injected adapter and operation boundary are test seams, not native manager implementations.

This PR does not add or claim systemd, launchd, Windows Task Scheduler, CLI/service commands, environment-file handling, Server startup, release packaging, or platform lifecycle support.

Validation uses a deterministic stateful adapter to prove operation ordering, conflicts, rollback, preservation, and redaction.