### PR TITLE
feat(server): compose workload-specific OpenAI providers

### DIFF
--- a/internal/modelprovider/factory.go
+++ b/internal/modelprovider/factory.go
@@ -16,6 +16,7 @@ package modelprovider
 
 import (
 	"context"
+	json "encoding/json/v2"
 	"fmt"
 	"net/http"
 	"os"
@@ -28,6 +29,107 @@ import (
 type EnvLookup func(string) (string, bool)
 
 func ProcessEnvironment(name string) (string, bool) { return os.LookupEnv(name) }
+
+// WorkloadConfig carries one server-owned model workload override. It is
+// copied before a provider client is assembled so callers cannot mutate a
+// live provider configuration through their ProcessConfig value.
+type WorkloadConfig struct {
+	BaseURL       string
+	Headers       http.Header
+	ModelSettings map[string]any
+}
+
+func (c WorkloadConfig) hasOverrides() bool {
+	return c.BaseURL != "" || len(c.Headers) != 0 || len(c.ModelSettings) != 0
+}
+
+func cloneWorkloadConfig(value WorkloadConfig) (WorkloadConfig, error) {
+	result := WorkloadConfig{BaseURL: value.BaseURL, Headers: value.Headers.Clone()}
+	if len(value.ModelSettings) == 0 {
+		return result, nil
+	}
+	encoded, err := json.Marshal(value.ModelSettings)
+	if err != nil {
+		return WorkloadConfig{}, inference.WrapConfigurationError("workload-settings", "", err)
+	}
+	if unmarshalErr := json.Unmarshal(encoded, &result.ModelSettings); unmarshalErr != nil {
+		return WorkloadConfig{}, inference.WrapConfigurationError("workload-settings", "", unmarshalErr)
+	}
+	settings, err := normalizeWorkloadModelSettings(result.ModelSettings)
+	if err != nil {
+		return WorkloadConfig{}, err
+	}
+	result.ModelSettings = settings
+	return result, nil
+}
+
+func normalizeWorkloadModelSettings(settings map[string]any) (map[string]any, error) {
+	if len(settings) == 0 {
+		return nil, nil
+	}
+	result := make(map[string]any, len(settings))
+	extraBody, hasExtraBody := settings["extra_body"]
+	for name, value := range settings {
+		if name == "extra_body" {
+			continue
+		}
+		if err := validateWorkloadSettingName(name); err != nil {
+			return nil, err
+		}
+		result[name] = value
+	}
+	if !hasExtraBody {
+		return result, nil
+	}
+	values, ok := extraBody.(map[string]any)
+	if !ok {
+		return nil, inference.NewConfigurationError("workload-settings", "")
+	}
+	for name, value := range values {
+		if name == "extra_body" {
+			return nil, inference.NewConfigurationError("workload-settings", "")
+		}
+		if err := validateWorkloadSettingName(name); err != nil {
+			return nil, err
+		}
+		if containsNestedExtraBody(value) {
+			return nil, inference.NewConfigurationError("workload-settings", "")
+		}
+		if _, found := result[name]; found {
+			return nil, inference.NewConfigurationError("workload-settings", "")
+		}
+		result[name] = value
+	}
+	return result, nil
+}
+
+func containsNestedExtraBody(value any) bool {
+	switch value := value.(type) {
+	case map[string]any:
+		for name, nested := range value {
+			if name == "extra_body" || containsNestedExtraBody(nested) {
+				return true
+			}
+		}
+	case []any:
+		for _, nested := range value {
+			if containsNestedExtraBody(nested) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func validateWorkloadSettingName(name string) error {
+	if !workloadSettingNamePattern.MatchString(name) {
+		return inference.NewConfigurationError("workload-settings", "")
+	}
+	if _, owned := workloadOwnedRequestFields[name]; owned {
+		return inference.NewConfigurationError("workload-settings", "")
+	}
+	return nil
+}
 
 type Factory struct {
 	milestone  Milestone
@@ -46,6 +148,20 @@ func NewFactory(milestone Milestone, lookup EnvLookup, httpClient *http.Client) 
 }
 
 func (f *Factory) TextModel(modelID string) (inference.TextModel, error) {
+	return f.textModel(modelID, WorkloadConfig{})
+}
+
+// TextModelWithWorkload builds an OpenAI-compatible text client with a
+// workload-local endpoint, headers, and request settings.
+func (f *Factory) TextModelWithWorkload(modelID string, workload WorkloadConfig) (inference.TextModel, error) {
+	return f.textModel(modelID, workload)
+}
+
+func (f *Factory) textModel(modelID string, workload WorkloadConfig) (inference.TextModel, error) {
+	clonedWorkload, err := cloneWorkloadConfig(workload)
+	if err != nil {
+		return nil, err
+	}
 	route, err := Resolve(modelID, Generation)
 	if err != nil {
 		return nil, err
@@ -56,12 +172,16 @@ func (f *Factory) TextModel(modelID string) (inference.TextModel, error) {
 	if err := validateProviderModel(route); err != nil {
 		return nil, err
 	}
+	if clonedWorkload.hasOverrides() && route.protocol != ProtocolOpenAIChat && route.protocol != ProtocolOpenAIResponses {
+		return nil, inference.NewConfigurationError("workload-provider", "workload overrides require OpenAI-compatible model routes")
+	}
 	switch route.protocol {
 	case ProtocolOpenAIChat, ProtocolOpenAIResponses:
 		config, configErr := f.openAIConfig(route)
 		if configErr != nil {
 			return nil, configErr
 		}
+		config = config.withWorkload(clonedWorkload)
 		return NewOpenAITextModel(route, config)
 	case ProtocolAnthropic:
 		config, configErr := f.anthropicConfig(route)
@@ -105,6 +225,23 @@ func (f *Factory) TextModel(modelID string) (inference.TextModel, error) {
 }
 
 func (f *Factory) EmbeddingTransport(modelID string) (inference.EmbeddingTransport, error) {
+	return f.embeddingTransport(modelID, WorkloadConfig{})
+}
+
+// EmbeddingTransportWithWorkload builds an OpenAI-compatible embedding client
+// with workload-local endpoint, headers, and request settings.
+func (f *Factory) EmbeddingTransportWithWorkload(
+	modelID string,
+	workload WorkloadConfig,
+) (inference.EmbeddingTransport, error) {
+	return f.embeddingTransport(modelID, workload)
+}
+
+func (f *Factory) embeddingTransport(modelID string, workload WorkloadConfig) (inference.EmbeddingTransport, error) {
+	clonedWorkload, err := cloneWorkloadConfig(workload)
+	if err != nil {
+		return nil, err
+	}
 	route, err := Resolve(modelID, Embedding)
 	if err != nil {
 		return nil, err
@@ -115,12 +252,16 @@ func (f *Factory) EmbeddingTransport(modelID string) (inference.EmbeddingTranspo
 	if err := validateProviderModel(route); err != nil {
 		return nil, err
 	}
+	if clonedWorkload.hasOverrides() && route.protocol != ProtocolOpenAIEmbedding {
+		return nil, inference.NewConfigurationError("workload-provider", "workload overrides require OpenAI-compatible model routes")
+	}
 	switch route.protocol {
 	case ProtocolOpenAIEmbedding:
 		config, configErr := f.openAIConfig(route)
 		if configErr != nil {
 			return nil, configErr
 		}
+		config = config.withWorkload(clonedWorkload)
 		return NewOpenAIEmbeddingTransport(route, config)
 	case ProtocolGoogle:
 		config, configErr := f.googleConfig(route)
@@ -154,6 +295,13 @@ func (f *Factory) EmbeddingTransport(modelID string) (inference.EmbeddingTranspo
 }
 
 var gatewayKeyPattern = regexp.MustCompile(`^pylf_v[0-9]+_([a-z]+)_[A-Za-z0-9_-]+$`)
+
+var workloadSettingNamePattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
+var workloadOwnedRequestFields = map[string]struct{}{
+	"dimensions": {}, "include": {}, "input": {}, "instructions": {}, "messages": {}, "model": {},
+	"response_format": {}, "stream": {}, "text": {},
+}
 
 func (f *Factory) gatewayCredentials(route Route) (string, string, error) {
 	key, ok := f.firstNonEmpty("PYDANTIC_AI_GATEWAY_API_KEY", "PAIG_API_KEY")

--- a/internal/modelprovider/factory_openai.go
+++ b/internal/modelprovider/factory_openai.go
@@ -111,6 +111,29 @@ func (f *Factory) openAIConfig(route Route) (OpenAIConfig, error) {
 	}
 }
 
+func (c OpenAIConfig) withWorkload(workload WorkloadConfig) OpenAIConfig {
+	if workload.BaseURL != "" {
+		c.BaseURL = workload.BaseURL
+	}
+	if len(workload.Headers) > 0 {
+		if c.Headers == nil {
+			c.Headers = make(http.Header)
+		} else {
+			c.Headers = c.Headers.Clone()
+		}
+		for name, values := range workload.Headers {
+			for existing := range c.Headers {
+				if strings.EqualFold(existing, name) {
+					delete(c.Headers, existing)
+				}
+			}
+			c.Headers[name] = append([]string(nil), values...)
+		}
+	}
+	c.ModelSettings = workload.ModelSettings
+	return c
+}
+
 func (f *Factory) openAIProviderConfig() (OpenAIConfig, error) {
 	baseURL, hasBaseURL := f.nonEmpty("OPENAI_BASE_URL")
 	if !hasBaseURL {

--- a/internal/modelprovider/factory_workload_test.go
+++ b/internal/modelprovider/factory_workload_test.go
@@ -1,0 +1,331 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package modelprovider
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/ob-labs/powercontext-go/inference"
+)
+
+func TestFactoryAppliesWorkloadOverridesWithoutRetainingCallerState(t *testing.T) {
+	fake := &openAIFake{responses: []any{chatResponse("chat_1", `{"value":"stable"}`, 1, 1)}}
+	factory, err := NewFactory(MilestoneB, testEnvironment{"OPENAI_API_KEY": "test-key"}.lookup, fake.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+	nested := map[string]any{"enabled": true}
+	workload := WorkloadConfig{
+		BaseURL: "https://workload.test/v1",
+		Headers: http.Header{"X-Workload": []string{"workload-secret"}},
+		ModelSettings: map[string]any{
+			"top_p": 0.25, "metadata": nested,
+		},
+	}
+	model, err := factory.TextModelWithWorkload("openai-chat:test-model", workload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	workload.BaseURL = "https://mutated.test/v1"
+	workload.Headers.Set("X-Workload", "mutated-secret")
+	nested["enabled"] = false
+	workload.ModelSettings["top_p"] = 0.75
+
+	generator, err := inference.NewPromptedGenerator[openAITestInput, openAITestOutput](
+		model, "Return a value.", openAITestCodec(t), nil, inference.GenerationSettings{},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := generator.Generate(t.Context(), openAITestInput{Value: "bounded"}); err != nil {
+		t.Fatal(err)
+	}
+	requests := fake.Requests()
+	if len(requests) != 1 {
+		t.Fatalf("requests = %#v", requests)
+	}
+	request := requests[0]
+	if request.host != "workload.test" || request.headers.Get("X-Workload") != "workload-secret" || request.body["top_p"] != 0.25 {
+		t.Fatalf("request = %#v", request)
+	}
+	metadata, ok := request.body["metadata"].(map[string]any)
+	if !ok || metadata["enabled"] != true {
+		t.Fatalf("model settings = %#v", request.body)
+	}
+}
+
+func TestFactoryRejectsWorkloadOverrideForNonOpenAIProviderBeforeRequest(t *testing.T) {
+	factory, err := NewFactory(MilestoneB, testEnvironment{"ANTHROPIC_API_KEY": "test-key"}.lookup, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	workload := WorkloadConfig{
+		BaseURL: "https://private-provider.test/v1",
+		Headers: http.Header{"Authorization": []string{"private-secret"}},
+	}
+	for _, factoryCall := range []struct {
+		name string
+		call func() error
+	}{
+		{name: "text", call: func() error {
+			_, callErr := factory.TextModelWithWorkload("anthropic:claude-test", workload)
+			return callErr
+		}},
+		{name: "embedding", call: func() error {
+			_, callErr := factory.EmbeddingTransportWithWorkload("google:gemini-embedding-001", workload)
+			return callErr
+		}},
+	} {
+		t.Run(factoryCall.name, func(t *testing.T) {
+			err := factoryCall.call()
+			var configuration *inference.ConfigurationError
+			if !errors.As(err, &configuration) || configuration.Code() != "workload-provider" {
+				t.Fatalf("error = %v", err)
+			}
+			for _, secret := range []string{"private-provider", "private-secret"} {
+				if strings.Contains(err.Error(), secret) {
+					t.Fatalf("error leaked %q: %v", secret, err)
+				}
+			}
+		})
+	}
+}
+
+func TestFactoryRejectsWorkloadSettingsThatOwnOpenAIRequestShapeBeforeTransport(t *testing.T) {
+	fake := &openAIFake{}
+	factory, err := NewFactory(MilestoneB, testEnvironment{"OPENAI_API_KEY": "test-key"}.lookup, fake.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, test := range []struct {
+		name    string
+		setting string
+		value   any
+		call    func(WorkloadConfig) error
+	}{
+		{
+			name: "chat model", setting: "model", value: "other-model",
+			call: func(workload WorkloadConfig) error {
+				_, callErr := factory.TextModelWithWorkload("openai-chat:test-model", workload)
+				return callErr
+			},
+		},
+		{
+			name: "chat messages", setting: "messages", value: []any{"private prompt"},
+			call: func(workload WorkloadConfig) error {
+				_, callErr := factory.TextModelWithWorkload("openai-chat:test-model", workload)
+				return callErr
+			},
+		},
+		{
+			name: "chat response format", setting: "response_format", value: map[string]any{"type": "text"},
+			call: func(workload WorkloadConfig) error {
+				_, callErr := factory.TextModelWithWorkload("openai-chat:test-model", workload)
+				return callErr
+			},
+		},
+		{
+			name: "responses input", setting: "input", value: "private prompt",
+			call: func(workload WorkloadConfig) error {
+				_, callErr := factory.TextModelWithWorkload("openai-responses:test-model", workload)
+				return callErr
+			},
+		},
+		{
+			name: "responses text format", setting: "text", value: map[string]any{"format": map[string]any{"type": "text"}},
+			call: func(workload WorkloadConfig) error {
+				_, callErr := factory.TextModelWithWorkload("openai-responses:test-model", workload)
+				return callErr
+			},
+		},
+		{
+			name: "responses stream", setting: "stream", value: true,
+			call: func(workload WorkloadConfig) error {
+				_, callErr := factory.TextModelWithWorkload("openai-responses:test-model", workload)
+				return callErr
+			},
+		},
+		{
+			name: "embedding input", setting: "input", value: []any{"private input"},
+			call: func(workload WorkloadConfig) error {
+				_, callErr := factory.EmbeddingTransportWithWorkload("openai:embedding-model", workload)
+				return callErr
+			},
+		},
+		{
+			name: "embedding dimensions", setting: "dimensions", value: 99,
+			call: func(workload WorkloadConfig) error {
+				_, callErr := factory.EmbeddingTransportWithWorkload("openai:embedding-model", workload)
+				return callErr
+			},
+		},
+		{
+			name: "nested messages path", setting: "messages.0.content", value: "private prompt",
+			call: func(workload WorkloadConfig) error {
+				_, callErr := factory.TextModelWithWorkload("openai-chat:test-model", workload)
+				return callErr
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			err := test.call(WorkloadConfig{ModelSettings: map[string]any{test.setting: test.value}})
+			assertWorkloadSettingsRejected(t, err)
+			if requests := fake.Requests(); len(requests) != 0 {
+				t.Fatalf("reserved setting %q reached transport: %#v", test.setting, requests)
+			}
+		})
+	}
+}
+
+func TestFactoryExpandsExtraBodyIntoOpenAIRequests(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		response    any
+		settingName string
+		setting     any
+		invoke      func(*testing.T, *Factory, WorkloadConfig)
+	}{
+		{
+			name: "chat", response: chatResponse("chat_1", `{"value":"stable"}`, 1, 1),
+			settingName: "top_p", setting: 0.25,
+			invoke: func(t *testing.T, factory *Factory, workload WorkloadConfig) {
+				t.Helper()
+				model, err := factory.TextModelWithWorkload("openai-chat:test-model", workload)
+				if err != nil {
+					t.Fatal(err)
+				}
+				generator, err := inference.NewPromptedGenerator[openAITestInput, openAITestOutput](
+					model, "Return a value.", openAITestCodec(t), nil, inference.GenerationSettings{},
+				)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if _, err := generator.Generate(t.Context(), openAITestInput{Value: "bounded"}); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "responses", response: responsesResponse("response_1", "message_1", `{"value":"stable"}`, 1, 1),
+			settingName: "top_p", setting: 0.25,
+			invoke: func(t *testing.T, factory *Factory, workload WorkloadConfig) {
+				t.Helper()
+				model, err := factory.TextModelWithWorkload("openai-responses:test-model", workload)
+				if err != nil {
+					t.Fatal(err)
+				}
+				generator, err := inference.NewPromptedGenerator[openAITestInput, openAITestOutput](
+					model, "Return a value.", openAITestCodec(t), nil, inference.GenerationSettings{},
+				)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if _, err := generator.Generate(t.Context(), openAITestInput{Value: "bounded"}); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "embedding", response: map[string]any{
+				"object": "list", "data": []any{map[string]any{"object": "embedding", "index": 0, "embedding": []float64{1, 0, 0}}},
+				"model": "embedding-model", "usage": map[string]any{"prompt_tokens": 1, "total_tokens": 1},
+			},
+			settingName: "encoding_format", setting: "float",
+			invoke: func(t *testing.T, factory *Factory, workload WorkloadConfig) {
+				t.Helper()
+				transport, err := factory.EmbeddingTransportWithWorkload("openai:embedding-model", workload)
+				if err != nil {
+					t.Fatal(err)
+				}
+				request, err := inference.NewEmbeddingRequest([]string{"bounded"}, inference.EmbeddingDocument, 3)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if _, err := transport.Embed(t.Context(), request); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			fake := &openAIFake{responses: []any{test.response}}
+			factory, err := NewFactory(MilestoneB, testEnvironment{"OPENAI_API_KEY": "test-key"}.lookup, fake.Client())
+			if err != nil {
+				t.Fatal(err)
+			}
+			workload := WorkloadConfig{ModelSettings: map[string]any{
+				test.settingName: test.setting,
+				"extra_body": map[string]any{
+					"route": test.name, "reasoning": map[string]any{"effort": "low"},
+				},
+			}}
+			test.invoke(t, factory, workload)
+			requests := fake.Requests()
+			if len(requests) != 1 {
+				t.Fatalf("requests = %#v", requests)
+			}
+			request := requests[0]
+			if _, found := request.body["extra_body"]; found || request.body["route"] != test.name ||
+				request.body[test.settingName] != test.setting {
+				t.Fatalf("request body = %#v", request.body)
+			}
+			reasoning, ok := request.body["reasoning"].(map[string]any)
+			if !ok || reasoning["effort"] != "low" {
+				t.Fatalf("request reasoning = %#v", request.body)
+			}
+			if test.name == "embedding" && request.body["dimensions"] != float64(3) {
+				t.Fatalf("embedding dimensions = %#v", request.body)
+			}
+		})
+	}
+}
+
+func TestFactoryRejectsInvalidExtraBodyBeforeTransport(t *testing.T) {
+	fake := &openAIFake{}
+	factory, err := NewFactory(MilestoneB, testEnvironment{"OPENAI_API_KEY": "test-key"}.lookup, fake.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, test := range []struct {
+		name     string
+		settings map[string]any
+	}{
+		{name: "scalar", settings: map[string]any{"extra_body": "not-an-object"}},
+		{name: "array", settings: map[string]any{"extra_body": []any{"not-an-object"}}},
+		{name: "recursive", settings: map[string]any{"extra_body": map[string]any{"extra_body": map[string]any{"route": "nested"}}}},
+		{name: "nested recursive", settings: map[string]any{"extra_body": map[string]any{"route": map[string]any{"extra_body": map[string]any{"nested": true}}}}},
+		{name: "reserved", settings: map[string]any{"extra_body": map[string]any{"messages": []any{"private prompt"}}}},
+		{name: "conflicting", settings: map[string]any{"top_p": 0.25, "extra_body": map[string]any{"top_p": 0.75}}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := factory.TextModelWithWorkload("openai-chat:test-model", WorkloadConfig{ModelSettings: test.settings})
+			assertWorkloadSettingsRejected(t, err)
+			if requests := fake.Requests(); len(requests) != 0 {
+				t.Fatalf("invalid extra_body reached transport: %#v", requests)
+			}
+		})
+	}
+}
+
+func assertWorkloadSettingsRejected(t *testing.T, err error) {
+	t.Helper()
+	var configuration *inference.ConfigurationError
+	if !errors.As(err, &configuration) || configuration.Code() != "workload-settings" {
+		t.Fatalf("error = %v", err)
+	}
+}

--- a/internal/modelprovider/openai.go
+++ b/internal/modelprovider/openai.go
@@ -17,6 +17,7 @@ package modelprovider
 import (
 	"context"
 	"errors"
+	"maps"
 	"net/http"
 	"net/url"
 	"slices"
@@ -49,6 +50,7 @@ type OpenAIConfig struct {
 	HTTPClient                *http.Client
 	Headers                   http.Header
 	Query                     url.Values
+	ModelSettings             map[string]any
 	SupportsJSONObject        *bool
 	UseLegacyMaxTokens        *bool
 	DropSampling              *bool
@@ -109,7 +111,7 @@ func (m *OpenAITextModel) completeChat(ctx context.Context, request inference.Te
 			params.MaxCompletionTokens = openai.Int(*value)
 		}
 	}
-	response, err := m.shared.client.Chat.Completions.New(ctx, params, option.WithJSONSet("stream", false))
+	response, err := m.shared.client.Chat.Completions.New(ctx, params, m.shared.textOptions()...)
 	if err != nil {
 		return inference.TextResponse{}, mapOpenAIError(err, "generate")
 	}
@@ -147,7 +149,7 @@ func (m *OpenAITextModel) completeResponses(ctx context.Context, request inferen
 	if value := settings.MaxTokens(); value != nil {
 		params.MaxOutputTokens = openai.Int(*value)
 	}
-	response, err := m.shared.client.Responses.New(ctx, params, option.WithJSONSet("stream", false))
+	response, err := m.shared.client.Responses.New(ctx, params, m.shared.textOptions()...)
 	if err != nil {
 		return inference.TextResponse{}, mapOpenAIError(err, "generate")
 	}
@@ -284,7 +286,7 @@ func (t *OpenAIEmbeddingTransport) Embed(
 		Model:      t.shared.route.model,
 		Input:      openai.EmbeddingNewParamsInputUnion{OfArrayOfStrings: slices.Clone(inputs)},
 		Dimensions: param.NewOpt(int64(request.DimensionCount())),
-	})
+	}, t.shared.embeddingOptions(request)...)
 	if err != nil {
 		return inference.ProviderEmbeddingResult{}, mapOpenAIError(err, "embed")
 	}
@@ -316,6 +318,11 @@ func newOpenAIClient(route Route, config OpenAIConfig) (openAIClient, error) {
 	}
 	config.Headers = config.Headers.Clone()
 	config.Query = cloneURLValues(config.Query)
+	workload, workloadErr := cloneWorkloadConfig(WorkloadConfig{ModelSettings: config.ModelSettings})
+	if workloadErr != nil {
+		return openAIClient{}, workloadErr
+	}
+	config.ModelSettings = workload.ModelSettings
 	opts := []option.RequestOption{
 		option.WithBaseURL(config.BaseURL),
 		option.WithAPIKey(config.APIKey),
@@ -347,6 +354,33 @@ func newOpenAIClient(route Route, config OpenAIConfig) (openAIClient, error) {
 		}
 	}
 	return openAIClient{client: openai.NewClient(opts...), route: route, config: config}, nil
+}
+
+func (c openAIClient) textOptions() []option.RequestOption {
+	options := c.modelSettingOptions()
+	return append(
+		options,
+		option.WithJSONSet("stream", false),
+		option.WithJSONSet("model", c.route.model),
+	)
+}
+
+func (c openAIClient) embeddingOptions(request inference.EmbeddingRequest) []option.RequestOption {
+	options := c.modelSettingOptions()
+	return append(
+		options,
+		option.WithJSONSet("model", c.route.model),
+		option.WithJSONSet("dimensions", request.DimensionCount()),
+	)
+}
+
+func (c openAIClient) modelSettingOptions() []option.RequestOption {
+	keys := slices.Sorted(maps.Keys(c.config.ModelSettings))
+	options := make([]option.RequestOption, 0, len(keys))
+	for _, key := range keys {
+		options = append(options, option.WithJSONSet(key, c.config.ModelSettings[key]))
+	}
+	return options
 }
 
 func mapOpenAIError(err error, operation string) error {

--- a/server/application.go
+++ b/server/application.go
@@ -200,6 +200,7 @@ func configuredReadiness(
 	}{
 		{name: "inference.generation", operation: dependencies.generationReadiness},
 		{name: "inference.embedding", operation: dependencies.embeddingReadiness},
+		{name: "inference.rerank", operation: dependencies.rerankReadiness},
 	} {
 		if configured.operation == nil {
 			continue

--- a/server/application_readiness_test.go
+++ b/server/application_readiness_test.go
@@ -82,6 +82,35 @@ func TestConfiguredReadinessIncludesRuntimeAndConfiguredInference(t *testing.T) 
 	}
 }
 
+func TestConfiguredReadinessAddsRerankOnlyForIndependentRerank(t *testing.T) {
+	withoutRerank, err := configuredReadiness(func(context.Context) error { return nil }, assembledDependencies{}, time.Now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	status, err := withoutRerank.Run(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, found := status.Checks()["inference.rerank"]; found {
+		t.Fatalf("unconfigured checks = %#v", status.Checks())
+	}
+	withRerank, err := configuredReadiness(
+		func(context.Context) error { return nil },
+		assembledDependencies{rerankReadiness: func(context.Context) error { return nil }},
+		time.Now,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	status, err = withRerank.Run(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.Checks()["inference.rerank"] != runtime.CheckReady {
+		t.Fatalf("configured checks = %#v", status.Checks())
+	}
+}
+
 func TestGenerationReadinessUsesRawMinimalProviderRequest(t *testing.T) {
 	t.Setenv("OPENAI_API_KEY", "test-key")
 	t.Setenv("OPENAI_BASE_URL", "https://provider.test/v1")

--- a/server/config_validate.go
+++ b/server/config_validate.go
@@ -106,7 +106,8 @@ func (c ProcessConfig) Validate() error {
 	if err := c.Inference.validate(); err != nil {
 		return err
 	}
-	if c.Runtime.MemoryRerankEnabled && c.Inference.GenerationModel == "" {
+	if c.Runtime.MemoryRerankEnabled && c.Inference.GenerationModel == "" &&
+		(c.Inference.Rerank == nil || c.Inference.Rerank.Model == "") {
 		return errors.New("server: Memory reranking requires a generation model")
 	}
 	if c.Runtime.SourceWindowInterval != nil && c.Inference.GenerationModel == "" {

--- a/server/dependencies.go
+++ b/server/dependencies.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"log/slog"
 	"net/http"
+	"strings"
 	"time"
 
 	"go.opentelemetry.io/otel/trace"
@@ -64,12 +65,18 @@ type assembledDependencies struct {
 	agentSkillTargets    []skill.AgentSkillTarget
 	generationReadiness  pcruntime.DependencyOperation
 	embeddingReadiness   pcruntime.DependencyOperation
+	rerankReadiness      pcruntime.DependencyOperation
 	resources            []pcruntime.Resource
 }
 
 type assembledProviderFactory interface {
 	TextModel(string) (inference.TextModel, error)
 	EmbeddingTransport(string) (inference.EmbeddingTransport, error)
+}
+
+type workloadProviderFactory interface {
+	TextModelWithWorkload(string, modelprovider.WorkloadConfig) (inference.TextModel, error)
+	EmbeddingTransportWithWorkload(string, modelprovider.WorkloadConfig) (inference.EmbeddingTransport, error)
 }
 
 type providerFactoryBuilder func(*http.Client) (assembledProviderFactory, error)
@@ -103,91 +110,16 @@ func assembleDependenciesWithProviderFactory(
 		return result, err
 	}
 	result.agentSkillTargets = configuredTargets
-	needsGenerated := result.memoryCandidates == nil || result.experienceCandidates == nil || result.experienceGenerator == nil ||
-		result.skillGenerator == nil || result.handoffGenerator == nil ||
-		(config.Runtime.MemoryRerankEnabled && result.memoryReranker == nil)
-	if config.Inference.GenerationModel != "" && needsGenerated {
-		factory, err := newProviderFactory(supplied.HTTPClient)
-		if err != nil {
-			return result, err
-		}
-		providerModel, err := factory.TextModel(config.Inference.GenerationModel)
-		if err != nil {
-			return result, err
-		}
-		result.generationReadiness = func(ctx context.Context) error {
-			return inference.ProbeTextModel(ctx, providerModel)
-		}
-		model := inference.TraceTextModel(providerModel, tracerProvider)
-		limits, err := inference.NewLimits(config.Inference.GenerationTimeout, config.Inference.GenerationMaxRequests)
-		if err != nil {
-			return result, err
-		}
-		settings := inference.GenerationSettings{}
-		if result.memoryCandidates == nil {
-			generator, err := memory.NewExtractionPromptedGenerator(model, config.Runtime.MemoryExtractionProfile, &limits, settings)
-			if err != nil {
-				return result, err
-			}
-			result.memoryCandidates, err = memory.NewLLMCandidatePipeline(
-				pcruntime.ReportStructuredUsage(generator), memory.NewContentEvidenceProjector(nil),
-			)
-			if err != nil {
-				return result, err
-			}
-		}
-		if result.experienceGenerator == nil {
-			generator, err := experience.NewPromptedGenerator(model, &limits, settings)
-			if err != nil {
-				return result, err
-			}
-			result.experienceGenerator, err = experience.NewLLMGenerator(pcruntime.ReportStructuredUsage(generator))
-			if err != nil {
-				return result, err
-			}
-		}
-		if result.experienceCandidates == nil {
-			generator, err := experience.NewIncubationPromptedGenerator(model, &limits, settings)
-			if err != nil {
-				return result, err
-			}
-			result.experienceCandidates, err = experience.NewLLMCandidatePipeline(pcruntime.ReportStructuredUsage(generator))
-			if err != nil {
-				return result, err
-			}
-		}
-		if result.skillGenerator == nil {
-			generator, err := skill.NewPromptedGenerator(model, &limits, settings)
-			if err != nil {
-				return result, err
-			}
-			result.skillGenerator, err = skill.NewLLMGenerator(pcruntime.ReportStructuredUsage(generator))
-			if err != nil {
-				return result, err
-			}
-		}
-		if result.handoffGenerator == nil {
-			generator, err := handoff.NewPromptedGenerator(model, &limits, settings)
-			if err != nil {
-				return result, err
-			}
-			result.handoffGenerator, err = handoff.NewLLMGenerationPipeline(
-				pcruntime.ReportStructuredUsage(generator), handoff.NewContentEvidenceProjector(nil),
-			)
-			if err != nil {
-				return result, err
-			}
-		}
-		if config.Runtime.MemoryRerankEnabled && result.memoryReranker == nil {
-			generator, err := memory.NewRerankPromptedGenerator(model, &limits)
-			if err != nil {
-				return result, err
-			}
-			result.memoryReranker, err = memory.NewLLMReranker(pcruntime.ReportStructuredUsage(generator))
-			if err != nil {
-				return result, err
-			}
-		}
+	generationProviderModel, err := assembleGenerationDependencies(
+		config, supplied, tracerProvider, newProviderFactory, &result,
+	)
+	if err != nil {
+		return result, err
+	}
+	if err := assembleMemoryReranker(
+		config, supplied, tracerProvider, newProviderFactory, generationProviderModel, &result,
+	); err != nil {
+		return result, err
 	}
 
 	if result.embeddingModel == nil && config.Inference.EmbeddingModel != "" {
@@ -195,7 +127,7 @@ func assembleDependenciesWithProviderFactory(
 		if err != nil {
 			return result, err
 		}
-		transport, err := factory.EmbeddingTransport(config.Inference.EmbeddingModel)
+		transport, err := embeddingTransportForWorkload(factory, config.Inference.EmbeddingModel, config.Inference.Embedding)
 		if err != nil {
 			return result, err
 		}
@@ -241,6 +173,288 @@ func assembleDependenciesWithProviderFactory(
 		result.externalSkills = provider
 	}
 	return result, nil
+}
+
+func assembleGenerationDependencies(
+	config ProcessConfig,
+	supplied Dependencies,
+	tracerProvider trace.TracerProvider,
+	newProviderFactory providerFactoryBuilder,
+	result *assembledDependencies,
+) (inference.TextModel, error) {
+	needsComponents := result.memoryCandidates == nil || result.experienceCandidates == nil ||
+		result.experienceGenerator == nil || result.skillGenerator == nil || result.handoffGenerator == nil
+	needsModel := needsComponents ||
+		(config.Runtime.MemoryRerankEnabled && result.memoryReranker == nil && config.Inference.Rerank == nil)
+	if config.Inference.GenerationModel == "" || !needsModel {
+		return nil, nil
+	}
+	factory, err := newProviderFactory(supplied.HTTPClient)
+	if err != nil {
+		return nil, err
+	}
+	providerModel, err := textModelForWorkload(factory, config.Inference.GenerationModel, config.Inference.Generation)
+	if err != nil {
+		return nil, err
+	}
+	result.generationReadiness = func(ctx context.Context) error {
+		return inference.ProbeTextModel(ctx, providerModel)
+	}
+	if !needsComponents {
+		return providerModel, nil
+	}
+	model := inference.TraceTextModel(providerModel, tracerProvider)
+	limits, err := inference.NewLimits(config.Inference.GenerationTimeout, config.Inference.GenerationMaxRequests)
+	if err != nil {
+		return nil, err
+	}
+	if err := assembleGenerationComponents(config, model, limits, result); err != nil {
+		return nil, err
+	}
+	return providerModel, nil
+}
+
+func assembleGenerationComponents(
+	config ProcessConfig,
+	model inference.TextModel,
+	limits inference.Limits,
+	result *assembledDependencies,
+) error {
+	settings := inference.GenerationSettings{}
+	if result.memoryCandidates == nil {
+		generator, err := memory.NewExtractionPromptedGenerator(model, config.Runtime.MemoryExtractionProfile, &limits, settings)
+		if err != nil {
+			return err
+		}
+		pipeline, err := memory.NewLLMCandidatePipeline(
+			pcruntime.ReportStructuredUsage(generator), memory.NewContentEvidenceProjector(nil),
+		)
+		if err != nil {
+			return err
+		}
+		result.memoryCandidates = pipeline
+	}
+	if result.experienceGenerator == nil {
+		generator, err := experience.NewPromptedGenerator(model, &limits, settings)
+		if err != nil {
+			return err
+		}
+		output, err := experience.NewLLMGenerator(pcruntime.ReportStructuredUsage(generator))
+		if err != nil {
+			return err
+		}
+		result.experienceGenerator = output
+	}
+	if result.experienceCandidates == nil {
+		generator, err := experience.NewIncubationPromptedGenerator(model, &limits, settings)
+		if err != nil {
+			return err
+		}
+		pipeline, err := experience.NewLLMCandidatePipeline(pcruntime.ReportStructuredUsage(generator))
+		if err != nil {
+			return err
+		}
+		result.experienceCandidates = pipeline
+	}
+	if result.skillGenerator == nil {
+		generator, err := skill.NewPromptedGenerator(model, &limits, settings)
+		if err != nil {
+			return err
+		}
+		output, err := skill.NewLLMGenerator(pcruntime.ReportStructuredUsage(generator))
+		if err != nil {
+			return err
+		}
+		result.skillGenerator = output
+	}
+	if result.handoffGenerator == nil {
+		generator, err := handoff.NewPromptedGenerator(model, &limits, settings)
+		if err != nil {
+			return err
+		}
+		pipeline, err := handoff.NewLLMGenerationPipeline(
+			pcruntime.ReportStructuredUsage(generator), handoff.NewContentEvidenceProjector(nil),
+		)
+		if err != nil {
+			return err
+		}
+		result.handoffGenerator = pipeline
+	}
+	return nil
+}
+
+func assembleMemoryReranker(
+	config ProcessConfig,
+	supplied Dependencies,
+	tracerProvider trace.TracerProvider,
+	newProviderFactory providerFactoryBuilder,
+	generationProviderModel inference.TextModel,
+	result *assembledDependencies,
+) error {
+	if !config.Runtime.MemoryRerankEnabled || result.memoryReranker != nil {
+		return nil
+	}
+	runModel := generationProviderModel
+	timeout, maxRequests := config.Inference.GenerationTimeout, config.Inference.GenerationMaxRequests
+	if rerank := config.Inference.Rerank; rerank != nil {
+		runModelID := rerank.Model
+		if runModelID == "" {
+			runModelID = config.Inference.GenerationModel
+		}
+		factory, err := newProviderFactory(supplied.HTTPClient)
+		if err != nil {
+			return err
+		}
+		model, err := textModelForWorkload(factory, runModelID, resolvedRerankWorkload(config.Inference))
+		if err != nil {
+			return err
+		}
+		runModel = model
+		result.rerankReadiness = func(ctx context.Context) error {
+			return inference.ProbeTextModel(ctx, model)
+		}
+		if rerank.Timeout != nil {
+			timeout = *rerank.Timeout
+		}
+		if rerank.MaxRequests != nil {
+			maxRequests = *rerank.MaxRequests
+		}
+	}
+	if runModel == nil {
+		return inference.NewConfigurationError("model", "rerank model is required")
+	}
+	limits, err := inference.NewLimits(timeout, maxRequests)
+	if err != nil {
+		return err
+	}
+	generator, err := memory.NewRerankPromptedGenerator(inference.TraceTextModel(runModel, tracerProvider), &limits)
+	if err != nil {
+		return err
+	}
+	reranker, err := memory.NewLLMReranker(pcruntime.ReportStructuredUsage(generator))
+	if err != nil {
+		return err
+	}
+	result.memoryReranker = reranker
+	return nil
+}
+
+func textModelForWorkload(
+	factory assembledProviderFactory,
+	modelID string,
+	workload *InferenceWorkloadConfig,
+) (inference.TextModel, error) {
+	if workload == nil {
+		return factory.TextModel(modelID)
+	}
+	configured, ok := factory.(workloadProviderFactory)
+	if !ok {
+		return nil, inference.NewConfigurationError("workload-provider", "provider factory does not support workload overrides")
+	}
+	return configured.TextModelWithWorkload(modelID, modelProviderWorkload(workload))
+}
+
+func embeddingTransportForWorkload(
+	factory assembledProviderFactory,
+	modelID string,
+	workload *InferenceWorkloadConfig,
+) (inference.EmbeddingTransport, error) {
+	if workload == nil {
+		return factory.EmbeddingTransport(modelID)
+	}
+	configured, ok := factory.(workloadProviderFactory)
+	if !ok {
+		return nil, inference.NewConfigurationError("workload-provider", "provider factory does not support workload overrides")
+	}
+	return configured.EmbeddingTransportWithWorkload(modelID, modelProviderWorkload(workload))
+}
+
+func modelProviderWorkload(config *InferenceWorkloadConfig) modelprovider.WorkloadConfig {
+	result := modelprovider.WorkloadConfig{BaseURL: config.BaseURL, Headers: make(http.Header)}
+	for name, value := range config.Headers.Values() {
+		result.Headers.Set(name, value)
+	}
+	if len(config.ModelSettings) == 0 {
+		return result
+	}
+	result.ModelSettings = make(map[string]any, len(config.ModelSettings))
+	for name, value := range config.ModelSettings {
+		result.ModelSettings[name] = value
+	}
+	return result
+}
+
+func resolvedRerankWorkload(config InferenceConfig) *InferenceWorkloadConfig {
+	if config.Rerank == nil {
+		return nil
+	}
+	var result *InferenceWorkloadConfig
+	if config.Rerank.Model == "" {
+		result = cloneInferenceWorkload(config.Generation)
+	}
+	result = overlayInferenceWorkload(result, config.Rerank.Workload)
+	if result == nil || !result.hasOverrides() {
+		return nil
+	}
+	if result.ModelSettings == nil {
+		result.ModelSettings = make(map[string]any)
+	}
+	// The reranker is intentionally deterministic even when the inherited
+	// generation workload supplies a sampling temperature.
+	result.ModelSettings["temperature"] = 0.0
+	return result
+}
+
+func cloneInferenceWorkload(config *InferenceWorkloadConfig) *InferenceWorkloadConfig {
+	if config == nil {
+		return nil
+	}
+	result := &InferenceWorkloadConfig{BaseURL: config.BaseURL, Headers: InferenceHeaders{values: config.Headers.Values()}}
+	if len(config.ModelSettings) > 0 {
+		result.ModelSettings = make(map[string]any, len(config.ModelSettings))
+		for name, value := range config.ModelSettings {
+			result.ModelSettings[name] = value
+		}
+	}
+	return result
+}
+
+func overlayInferenceWorkload(
+	base *InferenceWorkloadConfig,
+	overlay *InferenceWorkloadConfig,
+) *InferenceWorkloadConfig {
+	if overlay == nil {
+		return base
+	}
+	result := cloneInferenceWorkload(base)
+	if result == nil {
+		result = &InferenceWorkloadConfig{}
+	}
+	if overlay.BaseURL != "" {
+		result.BaseURL = overlay.BaseURL
+	}
+	if overlay.HeadersConfigured() {
+		if result.Headers.values == nil {
+			result.Headers.values = make(map[string]string)
+		}
+		for name, value := range overlay.Headers.Values() {
+			for existing := range result.Headers.values {
+				if strings.EqualFold(existing, name) {
+					delete(result.Headers.values, existing)
+				}
+			}
+			result.Headers.values[name] = value
+		}
+	}
+	if len(overlay.ModelSettings) > 0 {
+		if result.ModelSettings == nil {
+			result.ModelSettings = make(map[string]any, len(overlay.ModelSettings))
+		}
+		for name, value := range overlay.ModelSettings {
+			result.ModelSettings[name] = value
+		}
+	}
+	return result
 }
 
 func agentSkillTargets(config ExternalSkillsConfig) ([]skill.AgentSkillTarget, error) {

--- a/server/dependencies_workload_test.go
+++ b/server/dependencies_workload_test.go
@@ -1,0 +1,316 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/otel/trace/noop"
+
+	"github.com/ob-labs/powercontext-go/artifact/memory"
+	"github.com/ob-labs/powercontext-go/inference"
+)
+
+func TestAssembleDependenciesRoutesOpenAIWorkloadOverrides(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "test-key")
+	t.Setenv("OPENAI_BASE_URL", "https://default.test/v1")
+	config := workloadTestConfig(t)
+	config.Inference.Generation = workloadConfig(
+		"https://generation.test/v1", "X-Generation", "generation-secret", map[string]any{"top_p": 0.4},
+	)
+	config.Inference.Embedding = workloadConfig(
+		"https://embedding.test/v1", "X-Embedding", "embedding-secret", map[string]any{"encoding_format": "float"},
+	)
+	rerankTimeout := 200 * time.Millisecond
+	rerankRequests := 2
+	config.Inference.Rerank = &RerankInferenceConfig{
+		Model: "openai-chat:rerank-model",
+		Workload: workloadConfig(
+			"https://rerank.test/v1", "X-Rerank", "rerank-secret", map[string]any{"temperature": 0.9, "top_p": 0.2},
+		),
+		Timeout: &rerankTimeout, MaxRequests: &rerankRequests,
+	}
+	if err := config.Validate(); err != nil {
+		t.Fatal(err)
+	}
+
+	transport := &workloadTransport{}
+	assembled, err := assembleDependencies(
+		config, Dependencies{HTTPClient: &http.Client{Transport: transport}}, noop.NewTracerProvider(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if assembled.generationReadiness == nil || assembled.embeddingReadiness == nil || assembled.rerankReadiness == nil {
+		t.Fatalf("readiness operations = %#v", assembled)
+	}
+	config.Inference.Generation.BaseURL = "https://mutated.test/v1"
+	config.Inference.Generation.Headers.values["X-Generation"] = "mutated-secret"
+	config.Inference.Generation.ModelSettings["top_p"] = 0.9
+	if err := assembled.generationReadiness(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	if err := assembled.embeddingReadiness(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	if err := assembled.rerankReadiness(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+
+	requests := transport.Requests()
+	assertWorkloadRequest(t, requests, "generation-model", "generation.test", "/v1/chat/completions", "X-Generation", "generation-secret", map[string]any{"top_p": 0.4})
+	assertWorkloadRequest(t, requests, "embedding-model", "embedding.test", "/v1/embeddings", "X-Embedding", "embedding-secret", map[string]any{"dimensions": float64(3), "encoding_format": "float"})
+	assertWorkloadRequest(t, requests, "rerank-model", "rerank.test", "/v1/chat/completions", "X-Rerank", "rerank-secret", map[string]any{"temperature": 0.0, "top_p": 0.2})
+	for _, request := range requests {
+		wantHeader := map[string]string{
+			"generation-model": "X-Generation", "embedding-model": "X-Embedding", "rerank-model": "X-Rerank",
+		}[request.model]
+		for _, header := range []string{"X-Generation", "X-Embedding", "X-Rerank"} {
+			if header != wantHeader && request.header.Get(header) != "" {
+				t.Fatalf("request %q unexpectedly crossed workload header %q: %#v", request.model, header, request.header)
+			}
+		}
+	}
+}
+
+func TestRerankWorkloadInheritsGenerationAndOverridesCaseInsensitiveValues(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "test-key")
+	config := workloadTestConfig(t)
+	config.Inference.Generation = &InferenceWorkloadConfig{
+		BaseURL: "https://generation.test/v1",
+		Headers: InferenceHeaders{values: map[string]string{
+			"X-Shared": "generation-secret",
+		}},
+		ModelSettings: map[string]any{"top_p": 0.4, "seed": 7},
+	}
+	config.Inference.Rerank = &RerankInferenceConfig{Workload: &InferenceWorkloadConfig{
+		Headers:       InferenceHeaders{values: map[string]string{"x-shared": "rerank-secret"}},
+		ModelSettings: map[string]any{"top_p": 0.2},
+	}}
+	if err := config.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	transport := &workloadTransport{}
+	assembled, err := assembleDependencies(
+		config, Dependencies{HTTPClient: &http.Client{Transport: transport}}, noop.NewTracerProvider(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if assembled.rerankReadiness == nil {
+		t.Fatal("generation-backed rerank override did not create independent readiness")
+	}
+	if err := assembled.rerankReadiness(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	requests := transport.Requests()
+	if len(requests) != 1 {
+		t.Fatalf("requests = %#v", requests)
+	}
+	request := requests[0]
+	if request.host != "generation.test" || request.model != "generation-model" ||
+		request.header.Get("X-Shared") != "rerank-secret" || request.body["top_p"] != 0.2 ||
+		request.body["seed"] != float64(7) || request.body["temperature"] != 0.0 {
+		t.Fatalf("rerank request = %#v", request)
+	}
+}
+
+func TestIndependentRerankUsesConfiguredRetryAndTimeout(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "test-key")
+	t.Setenv("OPENAI_BASE_URL", "https://default.test/v1")
+	t.Run("retry", func(t *testing.T) {
+		config := workloadTestConfig(t)
+		config.Inference.GenerationModel = ""
+		config.Inference.Generation = nil
+		config.Inference.Rerank = &RerankInferenceConfig{
+			Model:    "openai-chat:rerank-model",
+			Workload: workloadConfig("https://rerank.test/v1", "X-Rerank", "rerank-secret", map[string]any{"temperature": 0.5}),
+		}
+		if err := config.Validate(); err != nil {
+			t.Fatal(err)
+		}
+		transport := &workloadTransport{rerankResponses: []string{`{"unexpected":true}`, `{"selected_ranks":[1]}`}}
+		assembled, err := assembleDependencies(
+			config, Dependencies{HTTPClient: &http.Client{Transport: transport}}, noop.NewTracerProvider(),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if assembled.generationReadiness != nil || assembled.rerankReadiness == nil || assembled.memoryReranker == nil {
+			t.Fatalf("independent rerank assembly = %#v", assembled)
+		}
+		decision, err := assembled.memoryReranker.Rerank(t.Context(), "query", []memory.Hit{{Text: "candidate"}}, 1)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if decision.Usage().Requests != 2 {
+			t.Fatalf("rerank requests = %d, want 2", decision.Usage().Requests)
+		}
+		requests := transport.Requests()
+		if len(requests) != 2 {
+			t.Fatalf("provider calls = %d, want retry", len(requests))
+		}
+		for _, request := range requests {
+			if request.host != "rerank.test" || request.header.Get("X-Rerank") != "rerank-secret" || request.body["temperature"] != 0.0 {
+				t.Fatalf("rerank request = %#v", request)
+			}
+		}
+	})
+	t.Run("timeout", func(t *testing.T) {
+		config := workloadTestConfig(t)
+		config.Inference.GenerationModel = ""
+		config.Inference.Generation = nil
+		timeout := 15 * time.Millisecond
+		config.Inference.Rerank = &RerankInferenceConfig{Model: "openai-chat:rerank-model", Timeout: &timeout}
+		if err := config.Validate(); err != nil {
+			t.Fatal(err)
+		}
+		transport := &workloadTransport{waitForCancellation: true}
+		assembled, err := assembleDependencies(
+			config, Dependencies{HTTPClient: &http.Client{Transport: transport}}, noop.NewTracerProvider(),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, err = assembled.memoryReranker.Rerank(t.Context(), "query", []memory.Hit{{Text: "candidate"}}, 1)
+		var timeoutError *inference.TimeoutError
+		if !errors.As(err, &timeoutError) || timeoutError.Timeout() != timeout {
+			t.Fatalf("rerank error = %v, want timeout %s", err, timeout)
+		}
+	})
+}
+
+func workloadTestConfig(t *testing.T) ProcessConfig {
+	t.Helper()
+	config, err := DefaultConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	config.Runtime.MemoryRerankEnabled = true
+	config.Inference.GenerationModel = "openai-chat:generation-model"
+	config.Inference.EmbeddingModel = "openai:embedding-model"
+	config.Inference.EmbeddingProfileID = "workload-test"
+	config.Inference.EmbeddingDimension = 3
+	config.Inference.EmbeddingNormalization = "none"
+	return config
+}
+
+func workloadConfig(baseURL, header, value string, settings map[string]any) *InferenceWorkloadConfig {
+	return &InferenceWorkloadConfig{
+		BaseURL: baseURL, Headers: InferenceHeaders{values: map[string]string{header: value}}, ModelSettings: settings,
+	}
+}
+
+type workloadRequest struct {
+	host   string
+	path   string
+	model  string
+	header http.Header
+	body   map[string]any
+}
+
+type workloadTransport struct {
+	mu                  sync.Mutex
+	requests            []workloadRequest
+	rerankResponses     []string
+	waitForCancellation bool
+}
+
+func (t *workloadTransport) RoundTrip(request *http.Request) (*http.Response, error) {
+	if t.waitForCancellation {
+		<-request.Context().Done()
+		return nil, request.Context().Err()
+	}
+	body, err := io.ReadAll(request.Body)
+	if err != nil {
+		return nil, err
+	}
+	var decoded map[string]any
+	if decodeErr := json.Unmarshal(body, &decoded); decodeErr != nil {
+		return nil, decodeErr
+	}
+	model, _ := decoded["model"].(string)
+	t.mu.Lock()
+	t.requests = append(t.requests, workloadRequest{
+		host: request.URL.Host, path: request.URL.Path, model: model, header: request.Header.Clone(), body: decoded,
+	})
+	content := `{"selected_ranks":[1]}`
+	if model == "rerank-model" && len(t.rerankResponses) > 0 {
+		content = t.rerankResponses[0]
+		t.rerankResponses = t.rerankResponses[1:]
+	}
+	t.mu.Unlock()
+
+	response := map[string]any{
+		"id": "completion", "object": "chat.completion", "created": 0, "model": model,
+		"choices": []any{map[string]any{
+			"index": 0, "message": map[string]any{"role": "assistant", "content": content}, "finish_reason": "stop",
+		}},
+		"usage": map[string]any{"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+	}
+	if request.URL.Path == "/v1/embeddings" {
+		response = map[string]any{
+			"object": "list", "data": []any{map[string]any{"object": "embedding", "index": 0, "embedding": []float64{1, 0, 0}}},
+			"model": model, "usage": map[string]any{"prompt_tokens": 1, "total_tokens": 1},
+		}
+	}
+	encoded, err := json.Marshal(response)
+	if err != nil {
+		return nil, err
+	}
+	return &http.Response{
+		StatusCode: http.StatusOK, Header: http.Header{"Content-Type": []string{"application/json"}},
+		Body: io.NopCloser(bytes.NewReader(encoded)), Request: request,
+	}, nil
+}
+
+func (t *workloadTransport) Requests() []workloadRequest {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	result := make([]workloadRequest, len(t.requests))
+	copy(result, t.requests)
+	return result
+}
+
+func assertWorkloadRequest(
+	t *testing.T,
+	requests []workloadRequest,
+	model, host, path, header, value string,
+	wantBody map[string]any,
+) {
+	t.Helper()
+	for _, request := range requests {
+		if request.model != model {
+			continue
+		}
+		if request.host != host || request.path != path || request.header.Get(header) != value {
+			t.Fatalf("request for %q = %#v", model, request)
+		}
+		for key, want := range wantBody {
+			if request.body[key] != want {
+				t.Fatalf("request for %q body[%q] = %#v, want %#v", model, key, request.body[key], want)
+			}
+		}
+		return
+	}
+	t.Fatalf("no request for model %q in %#v", model, requests)
+}


### PR DESCRIPTION
Part of #202 Phase 5.

Applies the previously parsed workload configuration to actual OpenAI-compatible generation, embedding, and rerank requests. Each workload has isolated endpoint, headers, settings, and limits; rerank supports explicit or generation-inherited configuration and deterministic temperature.

The OpenAI request boundary now rejects settings that can override PowerContext-owned fields before transport. `extra_body` must be an object and is safely expanded at the request top level. Non-OpenAI workload overrides fail before any request.

No real provider credentials, CLI/host adapter, OpenAPI, database, non-SQLite backend, or new external-agent support is added.

Validation: deterministic fake transport behavior tests, server/modelprovider tests with race, API compatibility, and lint all pass locally.