### PR TITLE
feat(personalsvc): add systemd user adapter contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -585,3 +585,8 @@ source / artifact / trigger / inference
   values with an existing typed redacted error before invoking the native
   boundary. Verify every public lifecycle command fails closed without a
   panic.
+- When a personal-service adapter verifies manager ownership before a mutable
+  operation, derive its fixed artifact path from a composition-provided user
+  root, reject global load roots, and fail closed on missing or nonempty
+  `DropInPaths`. Verify global paths, drop-ins, space-containing command
+  arguments, and zero-value public operations cannot reach a native boundary.

--- a/internal/personalsvc/systemd.go
+++ b/internal/personalsvc/systemd.go
@@ -1,0 +1,628 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package personalsvc
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"path"
+	"slices"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+const (
+	systemdUserUnitName      = "powercontext.service"
+	systemdUserUnitDirectory = "systemd/user"
+	systemdUnitRelativePath  = systemdUserUnitDirectory + "/" + systemdUserUnitName
+)
+
+// SystemdUserCommand is one immutable process invocation requested by the
+// systemd-user adapter. Its fields are intentionally private so the adapter,
+// rather than a caller, selects every executable and argument.
+type SystemdUserCommand struct {
+	program   string
+	arguments []string
+}
+
+// Program returns the exact executable selected by the adapter.
+func (c SystemdUserCommand) Program() string { return c.program }
+
+// Arguments returns an independent copy of the exact argument vector.
+func (c SystemdUserCommand) Arguments() []string { return append([]string(nil), c.arguments...) }
+
+// SystemdUserCommandResult carries a process status and stdout. The boundary
+// never supplies stderr to this package, which prevents native error details
+// from reaching lifecycle errors.
+type SystemdUserCommandResult struct {
+	exitCode int
+	stdout   []byte
+}
+
+// NewSystemdUserCommandResult constructs an immutable result for an explicit
+// systemd-user boundary invocation.
+func NewSystemdUserCommandResult(exitCode int, stdout []byte) SystemdUserCommandResult {
+	return SystemdUserCommandResult{exitCode: exitCode, stdout: bytes.Clone(stdout)}
+}
+
+// ExitCode returns the captured process exit code.
+func (r SystemdUserCommandResult) ExitCode() int { return r.exitCode }
+
+// Stdout returns an independent copy of the captured process stdout.
+func (r SystemdUserCommandResult) Stdout() []byte { return bytes.Clone(r.stdout) }
+
+// SystemdUserExecStart is one structured ExecStart command reported by the
+// composition-owned manager boundary.
+type SystemdUserExecStart struct {
+	path         string
+	arguments    []string
+	ignoreErrors bool
+}
+
+// NewSystemdUserExecStart copies one manager-reported ExecStart command.
+func NewSystemdUserExecStart(path string, arguments []string, ignoreErrors bool) SystemdUserExecStart {
+	return SystemdUserExecStart{
+		path:         strings.Clone(path),
+		arguments:    slices.Clone(arguments),
+		ignoreErrors: ignoreErrors,
+	}
+}
+
+// Path returns the executable path reported by the manager.
+func (c SystemdUserExecStart) Path() string { return c.path }
+
+// Arguments returns an independent copy of the manager-reported argv vector.
+func (c SystemdUserExecStart) Arguments() []string { return slices.Clone(c.arguments) }
+
+// IgnoreErrors reports whether systemd will suppress a command failure.
+func (c SystemdUserExecStart) IgnoreErrors() bool { return c.ignoreErrors }
+
+// SystemdUserManagerUnit is the structured state required to verify one
+// loaded systemd user unit without parsing lossy command-line output.
+type SystemdUserManagerUnit struct {
+	loadState          string
+	fragmentPath       string
+	dropInPathsPresent bool
+	dropInPaths        []string
+	environment        string
+	execStart          []SystemdUserExecStart
+}
+
+// NewSystemdUserManagerUnit copies the manager state returned by the native
+// composition boundary.
+func NewSystemdUserManagerUnit(
+	loadState string,
+	fragmentPath string,
+	dropInPathsPresent bool,
+	dropInPaths []string,
+	environment string,
+	execStart []SystemdUserExecStart,
+) SystemdUserManagerUnit {
+	return SystemdUserManagerUnit{
+		loadState:          strings.Clone(loadState),
+		fragmentPath:       strings.Clone(fragmentPath),
+		dropInPathsPresent: dropInPathsPresent,
+		dropInPaths:        slices.Clone(dropInPaths),
+		environment:        strings.Clone(environment),
+		execStart:          cloneSystemdUserExecStart(execStart),
+	}
+}
+
+// LoadState returns the manager-reported load state.
+func (u SystemdUserManagerUnit) LoadState() string { return u.loadState }
+
+// FragmentPath returns the manager-reported main unit file path.
+func (u SystemdUserManagerUnit) FragmentPath() string { return u.fragmentPath }
+
+// HasDropInPaths reports whether the native boundary read the DropInPaths
+// manager property.
+func (u SystemdUserManagerUnit) HasDropInPaths() bool { return u.dropInPathsPresent }
+
+// DropInPaths returns independent copies of the manager-reported drop-ins.
+func (u SystemdUserManagerUnit) DropInPaths() []string { return slices.Clone(u.dropInPaths) }
+
+// Environment returns the manager-reported environment assignments.
+func (u SystemdUserManagerUnit) Environment() string { return u.environment }
+
+// ExecStart returns independent copies of the manager-reported commands.
+func (u SystemdUserManagerUnit) ExecStart() []SystemdUserExecStart {
+	return cloneSystemdUserExecStart(u.execStart)
+}
+
+func cloneSystemdUserExecStart(commands []SystemdUserExecStart) []SystemdUserExecStart {
+	cloned := make([]SystemdUserExecStart, 0, len(commands))
+	for _, command := range commands {
+		cloned = append(cloned, NewSystemdUserExecStart(command.path, command.arguments, command.ignoreErrors))
+	}
+	return cloned
+}
+
+// SystemdUserBoundary owns every platform interaction required by
+// SystemdUserAdapter. It is deliberately supplied by composition: constructing
+// an adapter neither reads host state nor starts a process.
+type SystemdUserBoundary interface {
+	ReadFile(context.Context, string) ([]byte, bool, error)
+	WriteFile(context.Context, string, []byte) error
+	RemoveFile(context.Context, string) error
+	InspectUnit(context.Context, string) (SystemdUserManagerUnit, error)
+	Run(context.Context, SystemdUserCommand) (SystemdUserCommandResult, error)
+	Probe(context.Context, string) (ProbeState, error)
+}
+
+// SystemdUserLauncher is an immutable command prefix for the future
+// manager-owned personal-service launcher. Registration endpoint and data-dir
+// arguments are appended by the adapter so inspected metadata and ExecStart
+// always describe the same registration.
+type SystemdUserLauncher struct {
+	executable string
+	arguments  []string
+}
+
+// NewSystemdUserLauncher validates a launcher executable and its fixed
+// argument prefix without touching the host filesystem.
+func NewSystemdUserLauncher(executable string, arguments ...string) (SystemdUserLauncher, error) {
+	if !validSystemdArgument(executable, true) {
+		return SystemdUserLauncher{}, newSystemdAdapterError("configuration")
+	}
+	for _, argument := range arguments {
+		if !validSystemdLauncherPrefixArgument(argument) {
+			return SystemdUserLauncher{}, newSystemdAdapterError("configuration")
+		}
+	}
+	return SystemdUserLauncher{executable: executable, arguments: append([]string(nil), arguments...)}, nil
+}
+
+func (l SystemdUserLauncher) command(registration Registration) ([]string, error) {
+	if !validSystemdArgument(l.executable, true) {
+		return nil, newSystemdAdapterError("configuration")
+	}
+	for _, argument := range l.arguments {
+		if !validSystemdLauncherPrefixArgument(argument) {
+			return nil, newSystemdAdapterError("configuration")
+		}
+	}
+	if err := registration.Definition().Validate(); err != nil {
+		return nil, newSystemdAdapterError("configuration")
+	}
+	arguments := make([]string, 0, 1+len(l.arguments)+4)
+	arguments = append(arguments, l.executable)
+	arguments = append(arguments, l.arguments...)
+	arguments = append(arguments,
+		"--endpoint", registration.Definition().Endpoint(),
+		"--data-dir", registration.Definition().DataDir(),
+	)
+	return arguments, nil
+}
+
+// SystemdUserAdapter is the explicit Linux systemd --user contract for one
+// PowerContext registration. It must be constructed with
+// NewSystemdUserAdapter. It does not discover a manager, environment, unit
+// directory, launcher, or host filesystem by itself.
+type SystemdUserAdapter struct {
+	boundary SystemdUserBoundary
+	unitPath string
+	launcher SystemdUserLauncher
+}
+
+var _ Adapter = (*SystemdUserAdapter)(nil)
+
+// NewSystemdUserAdapter constructs a per-user systemd adapter from explicit
+// platform boundaries. The composition-owned user configuration root derives
+// the fixed unit path; known system-wide and root paths are rejected before
+// the boundary is called.
+func NewSystemdUserAdapter(
+	boundary SystemdUserBoundary,
+	userConfigRoot string,
+	launcher SystemdUserLauncher,
+) (*SystemdUserAdapter, error) {
+	if boundary == nil || !validSystemdUserConfigRoot(userConfigRoot) {
+		return nil, newSystemdAdapterError("configuration")
+	}
+	if !validSystemdArgument(launcher.executable, true) {
+		return nil, newSystemdAdapterError("configuration")
+	}
+	for _, argument := range launcher.arguments {
+		if !validSystemdLauncherPrefixArgument(argument) {
+			return nil, newSystemdAdapterError("configuration")
+		}
+	}
+	return &SystemdUserAdapter{
+		boundary: boundary,
+		unitPath: path.Join(userConfigRoot, systemdUnitRelativePath),
+		launcher: launcher,
+	}, nil
+}
+
+// Support classifies a missing or unavailable user manager as unsupported. A
+// platform diagnostic is intentionally not returned because it can disclose
+// manager state, paths, or launch environment.
+func (a *SystemdUserAdapter) Support(ctx context.Context) (Support, error) {
+	result, err := a.run(ctx, "systemctl", "--user", "show-environment")
+	if err != nil || result.ExitCode() != 0 {
+		return SupportUnsupported, nil
+	}
+	return SupportSupported, nil
+}
+
+// InspectArtifact verifies that the stored unit is byte-for-byte the unit
+// rendered from its encoded PowerContext registration.
+func (a *SystemdUserAdapter) InspectArtifact(ctx context.Context) (Artifact, error) {
+	if !a.available() {
+		return UnknownArtifact(), newSystemdAdapterError("inspect artifact")
+	}
+	content, exists, err := a.boundary.ReadFile(ctx, a.unitPath)
+	if err != nil {
+		return UnknownArtifact(), newSystemdAdapterError("inspect artifact")
+	}
+	if !exists {
+		return NoArtifact(), nil
+	}
+	registration, found := a.registrationForUnit(content)
+	if !found {
+		return InvalidArtifact(), nil
+	}
+	return InstalledArtifact(registration), nil
+}
+
+// InspectManager accepts a loaded systemd unit only when its exact fragment,
+// managed metadata, and launcher argument vector all match one registration.
+func (a *SystemdUserAdapter) InspectManager(ctx context.Context) (ManagerRegistration, error) {
+	if !a.available() {
+		return UnknownManager(), newSystemdAdapterError("inspect manager")
+	}
+	unit, err := a.boundary.InspectUnit(ctx, systemdUserUnitName)
+	if err != nil {
+		return UnknownManager(), newSystemdAdapterError("inspect manager")
+	}
+	if unit.LoadState() == "not-found" {
+		return NotLoadedManager(), nil
+	}
+	if unit.LoadState() != "loaded" || !unit.HasDropInPaths() || len(unit.DropInPaths()) != 0 {
+		return ForeignManager(), nil
+	}
+	metadata, owned, found := systemdOwnership(unit.Environment())
+	if !found || !owned {
+		return ForeignManager(), nil
+	}
+	registration, err := DecodeRegistration(metadata)
+	if err != nil {
+		return ForeignManager(), nil
+	}
+	arguments, err := a.launcher.command(registration)
+	if err != nil || unit.FragmentPath() != a.unitPath || !matchesSystemdExecStart(unit.ExecStart(), arguments) {
+		return ForeignManager(), nil
+	}
+	return OwnedManager(registration), nil
+}
+
+// Probe delegates endpoint liveness through the composition-owned boundary.
+func (a *SystemdUserAdapter) Probe(ctx context.Context, endpoint string) (ProbeState, error) {
+	if !a.available() {
+		return ProbeUnreachable, newSystemdAdapterError("probe")
+	}
+	state, err := a.boundary.Probe(ctx, endpoint)
+	if err != nil {
+		return ProbeUnreachable, newSystemdAdapterError("probe")
+	}
+	return state, nil
+}
+
+// Write records a newly rendered unit only when any existing unit has already
+// been verified as PowerContext-owned.
+func (a *SystemdUserAdapter) Write(ctx context.Context, registration Registration) error {
+	artifact, err := a.InspectArtifact(ctx)
+	if err != nil {
+		return err
+	}
+	if artifact.State() == RegistrationInvalid || artifact.State() == RegistrationUnknown {
+		return newSystemdAdapterError("write")
+	}
+	content, err := a.render(registration)
+	if err != nil {
+		return err
+	}
+	if err := a.boundary.WriteFile(ctx, a.unitPath, content); err != nil {
+		return newSystemdAdapterError("write")
+	}
+	return nil
+}
+
+// Reload requests only the systemd --user daemon reload operation.
+func (a *SystemdUserAdapter) Reload(ctx context.Context) error {
+	return a.runRequired(ctx, "reload", "systemctl", "--user", "daemon-reload")
+}
+
+// Enable enables the fixed user unit only after manager ownership is verified.
+func (a *SystemdUserAdapter) Enable(ctx context.Context) error {
+	if err := a.requireMutableManager(ctx); err != nil {
+		return err
+	}
+	return a.runRequired(ctx, "enable", "systemctl", "--user", "enable", systemdUserUnitName)
+}
+
+// Start clears only this unit's failed state and starts only this user unit
+// after manager ownership is verified.
+func (a *SystemdUserAdapter) Start(ctx context.Context) error {
+	if err := a.requireMutableManager(ctx); err != nil {
+		return err
+	}
+	if err := a.runRequired(ctx, "start", "systemctl", "--user", "reset-failed", systemdUserUnitName); err != nil {
+		return err
+	}
+	return a.runRequired(ctx, "start", "systemctl", "--user", "start", systemdUserUnitName)
+}
+
+// Stop stops only the fixed user unit after manager ownership is verified.
+func (a *SystemdUserAdapter) Stop(ctx context.Context) error {
+	if err := a.requireMutableManager(ctx); err != nil {
+		return err
+	}
+	return a.runRequired(ctx, "stop", "systemctl", "--user", "stop", systemdUserUnitName)
+}
+
+// Disable disables only the fixed user unit after manager ownership is verified.
+func (a *SystemdUserAdapter) Disable(ctx context.Context) error {
+	if err := a.requireMutableManager(ctx); err != nil {
+		return err
+	}
+	return a.runRequired(ctx, "disable", "systemctl", "--user", "disable", systemdUserUnitName)
+}
+
+// Remove removes an artifact only after independently verifying that it is
+// PowerContext-owned. An absent artifact is already removed.
+func (a *SystemdUserAdapter) Remove(ctx context.Context) error {
+	artifact, err := a.InspectArtifact(ctx)
+	if err != nil {
+		return err
+	}
+	if artifact.State() == RegistrationNotInstalled {
+		return nil
+	}
+	if artifact.State() != RegistrationInstalled {
+		return newSystemdAdapterError("remove")
+	}
+	if err := a.boundary.RemoveFile(ctx, a.unitPath); err != nil {
+		return newSystemdAdapterError("remove")
+	}
+	return nil
+}
+
+// ManagerState returns a closed manager state without disclosing native
+// command output.
+func (a *SystemdUserAdapter) ManagerState(ctx context.Context) (ManagerState, error) {
+	result, err := a.run(ctx, "systemctl", "--user", "show", "--property=ActiveState", "--value", systemdUserUnitName)
+	if err != nil || result.ExitCode() != 0 {
+		return ManagerUnknown, newSystemdAdapterError("manager state")
+	}
+	switch strings.TrimSpace(string(result.Stdout())) {
+	case "active":
+		return ManagerActive, nil
+	case "inactive":
+		return ManagerInactive, nil
+	case "failed":
+		return ManagerFailed, nil
+	default:
+		return ManagerUnknown, nil
+	}
+}
+
+// RecoveryLogs reads only this unit's journal selector. Callers must decide
+// whether any returned log content is safe to display.
+func (a *SystemdUserAdapter) RecoveryLogs(ctx context.Context) ([]byte, error) {
+	result, err := a.run(ctx, "journalctl", "--user", "--unit", systemdUserUnitName)
+	if err != nil || result.ExitCode() != 0 {
+		return nil, newSystemdAdapterError("recovery logs")
+	}
+	return result.Stdout(), nil
+}
+
+func (a *SystemdUserAdapter) registrationForUnit(content []byte) (Registration, bool) {
+	const marker = "# Managed by PowerContext\n# X-PowerContext-Metadata: "
+	text := string(content)
+	if !strings.HasPrefix(text, marker) {
+		return Registration{}, false
+	}
+	line, remainder, found := strings.Cut(text[len(marker):], "\n")
+	if !found || !validEncodedRegistration(line) {
+		return Registration{}, false
+	}
+	registration, err := DecodeRegistration(line)
+	if err != nil {
+		return Registration{}, false
+	}
+	expected, err := a.render(registration)
+	if err != nil || !bytes.Equal(content, expected) || remainder == "" {
+		return Registration{}, false
+	}
+	return registration, true
+}
+
+func (a *SystemdUserAdapter) render(registration Registration) ([]byte, error) {
+	arguments, err := a.launcher.command(registration)
+	if err != nil {
+		return nil, err
+	}
+	metadata, err := registration.Encode()
+	if err != nil {
+		return nil, newSystemdAdapterError("render")
+	}
+	quoted := make([]string, 0, len(arguments))
+	for _, argument := range arguments {
+		quoted = append(quoted, quoteSystemdArgument(argument))
+	}
+	return []byte("# Managed by PowerContext\n" +
+		"# X-PowerContext-Metadata: " + metadata + "\n" +
+		"[Unit]\n" +
+		"Description=PowerContext personal Server\n" +
+		"After=network.target\n" +
+		"StartLimitIntervalSec=60\n" +
+		"StartLimitBurst=3\n" +
+		"\n" +
+		"[Service]\n" +
+		"Type=simple\n" +
+		"Environment=POWERCONTEXT_SERVICE_OWNED=true\n" +
+		"Environment=POWERCONTEXT_SERVICE_METADATA=" + metadata + "\n" +
+		"ExecStart=" + strings.Join(quoted, " ") + "\n" +
+		"Restart=on-failure\n" +
+		"RestartSec=5s\n" +
+		"TimeoutStopSec=30s\n" +
+		"\n" +
+		"[Install]\n" +
+		"WantedBy=default.target\n"), nil
+}
+
+func (a *SystemdUserAdapter) requireMutableManager(ctx context.Context) error {
+	artifact, err := a.InspectArtifact(ctx)
+	if err != nil {
+		return err
+	}
+	if artifact.State() != RegistrationInstalled {
+		return newSystemdAdapterError("artifact ownership")
+	}
+	manager, err := a.InspectManager(ctx)
+	if err != nil {
+		return err
+	}
+	if manager.Ownership() != ManagerOwnershipOwned && manager.Ownership() != ManagerOwnershipNotLoaded {
+		return newSystemdAdapterError("manager ownership")
+	}
+	return nil
+}
+
+func (a *SystemdUserAdapter) runRequired(ctx context.Context, operation string, program string, arguments ...string) error {
+	result, err := a.run(ctx, program, arguments...)
+	if err != nil || result.ExitCode() != 0 {
+		return newSystemdAdapterError(operation)
+	}
+	return nil
+}
+
+func (a *SystemdUserAdapter) run(ctx context.Context, program string, arguments ...string) (SystemdUserCommandResult, error) {
+	if !a.available() {
+		return SystemdUserCommandResult{}, newSystemdAdapterError("command")
+	}
+	command := SystemdUserCommand{program: program, arguments: append([]string(nil), arguments...)}
+	result, err := a.boundary.Run(ctx, command)
+	if err != nil {
+		return SystemdUserCommandResult{}, err
+	}
+	return result, nil
+}
+
+func (a *SystemdUserAdapter) available() bool {
+	return a != nil && a.boundary != nil
+}
+
+func validSystemdUserConfigRoot(value string) bool {
+	if !validSystemdArgument(value, true) || strings.ContainsRune(value, '\\') || path.Clean(value) != value {
+		return false
+	}
+	if value == "/etc" || value == "/root" || strings.HasPrefix(value, "/etc/") || strings.HasPrefix(value, "/root/") {
+		return false
+	}
+	switch path.Join(value, systemdUserUnitDirectory) {
+	case "/lib/systemd/user", "/run/systemd/user", "/usr/local/lib/systemd/user", "/usr/local/share/systemd/user", "/usr/lib/systemd/user", "/usr/share/systemd/user":
+		return false
+	default:
+		return true
+	}
+}
+
+func validSystemdArgument(value string, absolute bool) bool {
+	if value == "" || !utf8.ValidString(value) || strings.TrimSpace(value) != value {
+		return false
+	}
+	if absolute && !strings.HasPrefix(value, "/") {
+		return false
+	}
+	for _, character := range value {
+		if unicode.IsControl(character) {
+			return false
+		}
+	}
+	return true
+}
+
+func validSystemdLauncherPrefixArgument(value string) bool {
+	if !validSystemdArgument(value, false) {
+		return false
+	}
+	if value == "--" || value == "--endpoint" || value == "--data-dir" {
+		return false
+	}
+	return !strings.HasPrefix(value, "--endpoint=") && !strings.HasPrefix(value, "--data-dir=")
+}
+
+func validEncodedRegistration(value string) bool {
+	if value == "" {
+		return false
+	}
+	for _, character := range value {
+		if !(character >= 'a' && character <= 'z' || character >= 'A' && character <= 'Z' ||
+			character >= '0' && character <= '9' || character == '-' || character == '_') {
+			return false
+		}
+	}
+	return true
+}
+
+func quoteSystemdArgument(value string) string {
+	replacer := strings.NewReplacer("\\", "\\\\", "\"", "\\\"", "%", "%%", "$", "$$")
+	return "\"" + replacer.Replace(value) + "\""
+}
+
+func systemdOwnership(value string) (metadata string, owned bool, found bool) {
+	for item := range strings.FieldsSeq(value) {
+		name, itemValue, hasValue := strings.Cut(item, "=")
+		if !hasValue {
+			continue
+		}
+		switch name {
+		case "POWERCONTEXT_SERVICE_OWNED":
+			if found {
+				return "", false, false
+			}
+			owned = itemValue == "true"
+			found = true
+		case "POWERCONTEXT_SERVICE_METADATA":
+			if metadata != "" || !validEncodedRegistration(itemValue) {
+				return "", false, false
+			}
+			metadata = itemValue
+		}
+	}
+	return metadata, owned, found && metadata != ""
+}
+
+func matchesSystemdExecStart(commands []SystemdUserExecStart, arguments []string) bool {
+	if len(arguments) == 0 || len(commands) != 1 {
+		return false
+	}
+	return commands[0].Path() == arguments[0] &&
+		slices.Equal(commands[0].Arguments(), arguments) &&
+		!commands[0].IgnoreErrors()
+}
+
+type systemdAdapterError struct{ operation string }
+
+func (e *systemdAdapterError) Error() string {
+	return fmt.Sprintf("systemd user service %s failed", e.operation)
+}
+
+func newSystemdAdapterError(operation string) *systemdAdapterError {
+	return &systemdAdapterError{operation: operation}
+}

--- a/internal/personalsvc/systemd_test.go
+++ b/internal/personalsvc/systemd_test.go
@@ -1,0 +1,672 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package personalsvc_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/ob-labs/powercontext-go/internal/personalsvc"
+)
+
+const (
+	systemdUserConfigRoot = "/home/alice/.config"
+	systemdUnitPath       = systemdUserConfigRoot + "/systemd/user/powercontext.service"
+)
+
+func TestSystemdUserAdapterWritesDeterministicOwnedUnit(t *testing.T) {
+	registration := systemdRegistration(t)
+	boundary := newSystemdBoundary()
+	adapter := newSystemdAdapter(t, boundary)
+
+	if err := adapter.Write(t.Context(), registration); err != nil {
+		t.Fatal(err)
+	}
+
+	metadata, err := registration.Encode()
+	if err != nil {
+		t.Fatal(err)
+	}
+	const want = "# Managed by PowerContext\n" +
+		"# X-PowerContext-Metadata: " + "PLACEHOLDER" + "\n" +
+		"[Unit]\n" +
+		"Description=PowerContext personal Server\n" +
+		"After=network.target\n" +
+		"StartLimitIntervalSec=60\n" +
+		"StartLimitBurst=3\n" +
+		"\n" +
+		"[Service]\n" +
+		"Type=simple\n" +
+		"Environment=POWERCONTEXT_SERVICE_OWNED=true\n" +
+		"Environment=POWERCONTEXT_SERVICE_METADATA=" + "PLACEHOLDER" + "\n" +
+		"ExecStart=\"/opt/powercontext/bin/personal-launcher\" \"--foreground\" \"--endpoint\" \"http://127.0.0.1:8123\" \"--data-dir\" \"/home/alice/.local/share/powercontext\"\n" +
+		"Restart=on-failure\n" +
+		"RestartSec=5s\n" +
+		"TimeoutStopSec=30s\n" +
+		"\n" +
+		"[Install]\n" +
+		"WantedBy=default.target\n"
+	expected := strings.ReplaceAll(want, "PLACEHOLDER", metadata)
+	if string(boundary.content) != expected {
+		t.Fatalf("written unit = %q, want %q", boundary.content, expected)
+	}
+	if boundary.writeCount != 1 || boundary.removeCount != 0 {
+		t.Fatalf("mutations = write %d remove %d, want write 1 remove 0", boundary.writeCount, boundary.removeCount)
+	}
+
+	artifact, err := adapter.InspectArtifact(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	stored, found := artifact.Registration()
+	if artifact.State() != personalsvc.RegistrationInstalled || !found || stored != registration {
+		t.Fatalf("artifact = %#v, registration found = %t", artifact, found)
+	}
+}
+
+func TestSystemdUserAdapterRefusesForeignOrMalformedArtifactsWithoutMutation(t *testing.T) {
+	registration := systemdRegistration(t)
+	for _, test := range []struct {
+		name    string
+		content string
+	}{
+		{name: "foreign", content: "[Service]\nExecStart=/foreign/service\n"},
+		{name: "malformed metadata", content: "# Managed by PowerContext\n# X-PowerContext-Metadata: malformed-metadata\n"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			boundary := newSystemdBoundary()
+			boundary.exists = true
+			boundary.content = []byte(test.content)
+			adapter := newSystemdAdapter(t, boundary)
+
+			artifact, err := adapter.InspectArtifact(t.Context())
+			if err != nil {
+				t.Fatal(err)
+			}
+			if artifact.State() != personalsvc.RegistrationInvalid {
+				t.Fatalf("artifact state = %s, want invalid", artifact.State())
+			}
+			if err := adapter.Write(t.Context(), registration); err == nil {
+				t.Fatal("Write succeeded for an unverified artifact")
+			}
+			if err := adapter.Remove(t.Context()); err == nil {
+				t.Fatal("Remove succeeded for an unverified artifact")
+			}
+			if err := adapter.Enable(t.Context()); err == nil {
+				t.Fatal("Enable succeeded for an unverified artifact")
+			}
+			if boundary.writeCount != 0 || boundary.removeCount != 0 {
+				t.Fatalf("unverified artifact mutated: write %d remove %d", boundary.writeCount, boundary.removeCount)
+			}
+			if len(boundary.commands) != 0 {
+				t.Fatalf("unverified artifact reached the manager: %q", boundary.commandArguments())
+			}
+		})
+	}
+}
+
+func TestSystemdUserAdapterRejectsEveryManagerOwnershipMismatchWithoutEnablement(t *testing.T) {
+	registration := systemdRegistration(t)
+	const executable = "/opt/powercontext/bin/personal-launcher"
+	canonical := systemdOwnedManagerFixture(t, registration, []personalsvc.SystemdUserExecStart{
+		personalsvc.NewSystemdUserExecStart(executable, []string{
+			executable, "--foreground", "--endpoint", "http://127.0.0.1:8123", "--data-dir", "/home/alice/.local/share/powercontext",
+		}, false),
+	})
+	ownedBoundary := newSystemdBoundary()
+	ownedAdapter := newSystemdAdapter(t, ownedBoundary)
+	if writeErr := ownedAdapter.Write(t.Context(), registration); writeErr != nil {
+		t.Fatal(writeErr)
+	}
+	ownedBoundary.setManagerUnit(canonical.unit())
+	owned, ownedErr := ownedAdapter.InspectManager(t.Context())
+	if ownedErr != nil || owned.Ownership() != personalsvc.ManagerOwnershipOwned {
+		t.Fatalf("intact manager registration = %s, %v; want owned, nil", owned.Ownership(), ownedErr)
+	}
+
+	for _, test := range []struct {
+		name   string
+		mutate func(systemdManagerFixture) systemdManagerFixture
+	}{
+		{
+			name: "fragment",
+			mutate: func(value systemdManagerFixture) systemdManagerFixture {
+				value.fragmentPath = "/home/alice/.config/systemd/user/foreign.service"
+				return value
+			},
+		},
+		{
+			name: "executable",
+			mutate: func(value systemdManagerFixture) systemdManagerFixture {
+				arguments := value.execStart[0].Arguments()
+				arguments[0] = "/foreign/launcher"
+				value.execStart = []personalsvc.SystemdUserExecStart{personalsvc.NewSystemdUserExecStart("/foreign/launcher", arguments, false)}
+				return value
+			},
+		},
+		{
+			name: "arguments",
+			mutate: func(value systemdManagerFixture) systemdManagerFixture {
+				arguments := value.execStart[0].Arguments()
+				arguments[3] = "http://127.0.0.1:9000"
+				value.execStart = []personalsvc.SystemdUserExecStart{personalsvc.NewSystemdUserExecStart(executable, arguments, false)}
+				return value
+			},
+		},
+		{
+			name: "marker",
+			mutate: func(value systemdManagerFixture) systemdManagerFixture {
+				value.environment = strings.Replace(value.environment, "POWERCONTEXT_SERVICE_OWNED", "FOREIGN_SERVICE_OWNED", 1)
+				return value
+			},
+		},
+		{
+			name: "metadata",
+			mutate: func(value systemdManagerFixture) systemdManagerFixture {
+				value.environment = strings.Replace(value.environment, "POWERCONTEXT_SERVICE_METADATA=", "POWERCONTEXT_SERVICE_METADATA=malformed-", 1)
+				return value
+			},
+		},
+		{
+			name: "ignore errors",
+			mutate: func(value systemdManagerFixture) systemdManagerFixture {
+				command := value.execStart[0]
+				value.execStart = []personalsvc.SystemdUserExecStart{personalsvc.NewSystemdUserExecStart(command.Path(), command.Arguments(), true)}
+				return value
+			},
+		},
+		{
+			name: "drop in",
+			mutate: func(value systemdManagerFixture) systemdManagerFixture {
+				value.dropInPaths = []string{"/home/alice/.config/systemd/user/powercontext.service.d/99-foreign.conf"}
+				return value
+			},
+		},
+		{
+			name: "missing drop in paths",
+			mutate: func(value systemdManagerFixture) systemdManagerFixture {
+				value.dropInPathsPresent = false
+				return value
+			},
+		},
+		{
+			name: "second command",
+			mutate: func(value systemdManagerFixture) systemdManagerFixture {
+				value.execStart = append(value.execStart, personalsvc.NewSystemdUserExecStart("/foreign/launcher", []string{"/foreign/launcher"}, false))
+				return value
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			boundary := newSystemdBoundary()
+			adapter := newSystemdAdapter(t, boundary)
+			if writeErr := adapter.Write(t.Context(), registration); writeErr != nil {
+				t.Fatal(writeErr)
+			}
+			boundary.setManagerUnit(test.mutate(canonical).unit())
+
+			manager, inspectErr := adapter.InspectManager(t.Context())
+			if inspectErr != nil {
+				t.Fatal(inspectErr)
+			}
+			if manager.Ownership() != personalsvc.ManagerOwnershipForeign {
+				t.Fatalf("manager ownership = %s, want foreign", manager.Ownership())
+			}
+			if enableErr := adapter.Enable(t.Context()); enableErr == nil {
+				t.Fatal("Enable succeeded for a foreign manager registration")
+			}
+			if got := boundary.inspectedUnits(); !slices.Equal(got, []string{"powercontext.service", "powercontext.service"}) {
+				t.Fatalf("inspected units = %q, want two fixed-unit inspections", got)
+			}
+		})
+	}
+}
+
+func TestSystemdUserAdapterAcceptsManagerArgumentsContainingSpaces(t *testing.T) {
+	registration := systemdRegistration(t)
+	launcher, err := personalsvc.NewSystemdUserLauncher(
+		"/opt/PowerContext Personal/personal-launcher",
+		"--foreground",
+		"PowerContext personal",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	boundary := newSystemdBoundary()
+	adapter, err := personalsvc.NewSystemdUserAdapter(boundary, systemdUserConfigRoot, launcher)
+	if err != nil {
+		t.Fatal(err)
+	}
+	boundary.setManagerUnit(systemdOwnedManagerFixture(t, registration, []personalsvc.SystemdUserExecStart{
+		personalsvc.NewSystemdUserExecStart(
+			"/opt/PowerContext Personal/personal-launcher",
+			[]string{
+				"/opt/PowerContext Personal/personal-launcher", "--foreground", "PowerContext personal",
+				"--endpoint", "http://127.0.0.1:8123", "--data-dir", "/home/alice/.local/share/powercontext",
+			},
+			false,
+		),
+	}).unit())
+
+	manager, inspectErr := adapter.InspectManager(t.Context())
+	if inspectErr != nil || manager.Ownership() != personalsvc.ManagerOwnershipOwned {
+		t.Fatalf("manager = %s, %v; want owned, nil", manager.Ownership(), inspectErr)
+	}
+}
+
+func TestSystemdUserAdapterRejectsAmbiguousFlattenedManagerArguments(t *testing.T) {
+	registration := systemdRegistration(t)
+	launcher, err := personalsvc.NewSystemdUserLauncher(
+		"/opt/PowerContext Personal/personal-launcher",
+		"--foreground",
+		"PowerContext personal",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	boundary := newSystemdBoundary()
+	adapter, err := personalsvc.NewSystemdUserAdapter(boundary, systemdUserConfigRoot, launcher)
+	if err != nil {
+		t.Fatal(err)
+	}
+	boundary.setManagerUnit(systemdOwnedManagerFixture(t, registration, []personalsvc.SystemdUserExecStart{
+		personalsvc.NewSystemdUserExecStart(
+			"/opt/PowerContext Personal/personal-launcher",
+			[]string{
+				"/opt/PowerContext Personal/personal-launcher", "--foreground", "PowerContext", "personal",
+				"--endpoint", "http://127.0.0.1:8123", "--data-dir", "/home/alice/.local/share/powercontext",
+			},
+			false,
+		),
+	}).unit())
+
+	manager, inspectErr := adapter.InspectManager(t.Context())
+	if inspectErr != nil || manager.Ownership() != personalsvc.ManagerOwnershipForeign {
+		t.Fatalf("manager = %s, %v; want foreign, nil", manager.Ownership(), inspectErr)
+	}
+}
+
+func TestSystemdUserAdapterRejectsManagerWithoutDropInPaths(t *testing.T) {
+	registration := systemdRegistration(t)
+	executable := "/opt/powercontext/bin/personal-launcher"
+	boundary := newSystemdBoundary()
+	adapter := newSystemdAdapter(t, boundary)
+	managerFixture := systemdOwnedManagerFixture(t, registration, []personalsvc.SystemdUserExecStart{
+		personalsvc.NewSystemdUserExecStart(executable, []string{
+			executable, "--foreground", "--endpoint", "http://127.0.0.1:8123", "--data-dir", "/home/alice/.local/share/powercontext",
+		}, false),
+	})
+	managerFixture.dropInPathsPresent = false
+	boundary.setManagerUnit(managerFixture.unit())
+
+	manager, inspectErr := adapter.InspectManager(t.Context())
+	if inspectErr != nil || manager.Ownership() != personalsvc.ManagerOwnershipForeign {
+		t.Fatalf("manager = %s, %v; want foreign, nil", manager.Ownership(), inspectErr)
+	}
+}
+
+func TestSystemdUserAdapterUsesOnlyExactUserManagerCommands(t *testing.T) {
+	registration := systemdRegistration(t)
+	boundary := newSystemdBoundary()
+	adapter := newSystemdAdapter(t, boundary)
+	if err := adapter.Write(t.Context(), registration); err != nil {
+		t.Fatal(err)
+	}
+
+	if support, err := adapter.Support(t.Context()); err != nil || support != personalsvc.SupportSupported {
+		t.Fatalf("Support = %s, %v", support, err)
+	}
+	if err := adapter.Reload(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	if err := adapter.Enable(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	if err := adapter.Start(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	if err := adapter.Stop(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	if err := adapter.Disable(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	if manager, err := adapter.ManagerState(t.Context()); err != nil || manager != personalsvc.ManagerActive {
+		t.Fatalf("ManagerState = %s, %v", manager, err)
+	}
+	if _, err := adapter.RecoveryLogs(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+
+	want := [][]string{
+		{"systemctl", "--user", "show-environment"},
+		{"systemctl", "--user", "daemon-reload"},
+		{"systemctl", "--user", "enable", "powercontext.service"},
+		{"systemctl", "--user", "reset-failed", "powercontext.service"},
+		{"systemctl", "--user", "start", "powercontext.service"},
+		{"systemctl", "--user", "stop", "powercontext.service"},
+		{"systemctl", "--user", "disable", "powercontext.service"},
+		{"systemctl", "--user", "show", "--property=ActiveState", "--value", "powercontext.service"},
+		{"journalctl", "--user", "--unit", "powercontext.service"},
+	}
+	if got := boundary.commandArguments(); !slices.EqualFunc(got, want, slices.Equal) {
+		t.Fatalf("commands = %q, want %q", got, want)
+	}
+	if got := boundary.inspectedUnits(); !slices.Equal(got, []string{
+		"powercontext.service", "powercontext.service", "powercontext.service", "powercontext.service",
+	}) {
+		t.Fatalf("inspected units = %q, want fixed unit before each mutable operation", got)
+	}
+}
+
+func TestSystemdUserAdapterClassifiesUnavailableUserManagerWithoutLeakingCommandError(t *testing.T) {
+	boundary := newSystemdBoundary()
+	boundary.setError(systemdCommand("systemctl", "--user", "show-environment"), errors.New("manager unavailable at /run/user/1000 with secret=abc"))
+	adapter := newSystemdAdapter(t, boundary)
+
+	support, err := adapter.Support(t.Context())
+	if err != nil || support != personalsvc.SupportUnsupported {
+		t.Fatalf("Support = %s, %v; want unsupported, nil", support, err)
+	}
+	boundary.setError(systemdCommand("systemctl", "--user", "daemon-reload"), errors.New("stderr has secret=abc"))
+	err = adapter.Reload(t.Context())
+	if err == nil {
+		t.Fatal("Reload succeeded despite command failure")
+	}
+	if strings.Contains(err.Error(), "secret=abc") || strings.Contains(err.Error(), "/run/user/1000") {
+		t.Fatalf("command error leaked detail: %v", err)
+	}
+}
+
+func TestSystemdUserAdapterZeroValueFailsClosed(t *testing.T) {
+	adapter := &personalsvc.SystemdUserAdapter{}
+	registration := systemdRegistration(t)
+	for _, test := range []struct {
+		name   string
+		invoke func() error
+	}{
+		{
+			name: "inspect artifact",
+			invoke: func() error {
+				_, err := adapter.InspectArtifact(t.Context())
+				return err
+			},
+		},
+		{
+			name: "inspect manager",
+			invoke: func() error {
+				_, err := adapter.InspectManager(t.Context())
+				return err
+			},
+		},
+		{
+			name: "probe",
+			invoke: func() error {
+				_, err := adapter.Probe(t.Context(), "http://127.0.0.1:8123")
+				return err
+			},
+		},
+		{name: "write", invoke: func() error { return adapter.Write(t.Context(), registration) }},
+		{name: "reload", invoke: func() error { return adapter.Reload(t.Context()) }},
+		{name: "enable", invoke: func() error { return adapter.Enable(t.Context()) }},
+		{name: "start", invoke: func() error { return adapter.Start(t.Context()) }},
+		{name: "stop", invoke: func() error { return adapter.Stop(t.Context()) }},
+		{name: "disable", invoke: func() error { return adapter.Disable(t.Context()) }},
+		{name: "remove", invoke: func() error { return adapter.Remove(t.Context()) }},
+		{
+			name: "manager state",
+			invoke: func() error {
+				_, err := adapter.ManagerState(t.Context())
+				return err
+			},
+		},
+		{
+			name: "recovery logs",
+			invoke: func() error {
+				_, err := adapter.RecoveryLogs(t.Context())
+				return err
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			err := test.invoke()
+			if err == nil || strings.Contains(err.Error(), "nil") {
+				t.Fatalf("zero-value error = %v, want redacted failure", err)
+			}
+		})
+	}
+
+	support, err := adapter.Support(t.Context())
+	if err != nil || support != personalsvc.SupportUnsupported {
+		t.Fatalf("zero-value Support = %s, %v; want unsupported, nil", support, err)
+	}
+}
+
+func TestSystemdUserAdapterRejectsNonPrivateUnitPathsWithoutHostAccess(t *testing.T) {
+	launcher, err := personalsvc.NewSystemdUserLauncher("/opt/powercontext/bin/personal-launcher", "--foreground")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, userConfigRoot := range []string{
+		"/etc",
+		"/root/.config",
+		"/usr/lib",
+		"/usr/local/lib",
+		"/usr/share",
+		"/usr/local/share",
+		"/lib",
+		"/run",
+		"relative",
+	} {
+		boundary := newSystemdBoundary()
+		adapter, adapterErr := personalsvc.NewSystemdUserAdapter(boundary, userConfigRoot, launcher)
+		if adapter != nil || adapterErr == nil {
+			t.Fatalf("NewSystemdUserAdapter(%q) = %v, %v; want configuration rejection", userConfigRoot, adapter, adapterErr)
+		}
+		if len(boundary.commands) != 0 || boundary.writeCount != 0 || boundary.removeCount != 0 {
+			t.Fatalf("NewSystemdUserAdapter(%q) accessed its boundary", userConfigRoot)
+		}
+	}
+}
+
+func TestSystemdUserLauncherRejectsRegistrationOverrideArguments(t *testing.T) {
+	for _, arguments := range [][]string{
+		{"--endpoint", "http://127.0.0.1:9000"},
+		{"--endpoint=http://127.0.0.1:9000"},
+		{"--data-dir", "/foreign/data"},
+		{"--data-dir=/foreign/data"},
+		{"--"},
+	} {
+		_, err := personalsvc.NewSystemdUserLauncher("/opt/powercontext/bin/personal-launcher", arguments...)
+		if err == nil {
+			t.Fatalf("NewSystemdUserLauncher(%q) accepted a registration override", arguments)
+		}
+	}
+}
+
+func newSystemdAdapter(t *testing.T, boundary *systemdBoundary) *personalsvc.SystemdUserAdapter {
+	t.Helper()
+	launcher, err := personalsvc.NewSystemdUserLauncher("/opt/powercontext/bin/personal-launcher", "--foreground")
+	if err != nil {
+		t.Fatal(err)
+	}
+	adapter, err := personalsvc.NewSystemdUserAdapter(boundary, systemdUserConfigRoot, launcher)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return adapter
+}
+
+func systemdRegistration(t *testing.T) personalsvc.Registration {
+	t.Helper()
+	definition, err := personalsvc.NewDefinition(personalsvc.DefinitionInput{
+		Ownership:         personalsvc.OwnershipMarker,
+		DefinitionVersion: personalsvc.DefinitionVersion,
+		PackageVersion:    "0.2.0",
+		Binary:            "/opt/powercontext/bin/powercontext",
+		Endpoint:          "http://127.0.0.1:8123",
+		DataDir:           "/home/alice/.local/share/powercontext",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	registration, err := personalsvc.NewRegistration(definition)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return registration
+}
+
+type systemdManagerFixture struct {
+	fragmentPath       string
+	dropInPathsPresent bool
+	dropInPaths        []string
+	environment        string
+	execStart          []personalsvc.SystemdUserExecStart
+}
+
+func systemdOwnedManagerFixture(
+	t *testing.T,
+	registration personalsvc.Registration,
+	execStart []personalsvc.SystemdUserExecStart,
+) systemdManagerFixture {
+	t.Helper()
+	metadata, err := registration.Encode()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return systemdManagerFixture{
+		fragmentPath:       systemdUnitPath,
+		dropInPathsPresent: true,
+		environment:        "POWERCONTEXT_SERVICE_OWNED=true POWERCONTEXT_SERVICE_METADATA=" + metadata,
+		execStart:          execStart,
+	}
+}
+
+func (f systemdManagerFixture) unit() personalsvc.SystemdUserManagerUnit {
+	return personalsvc.NewSystemdUserManagerUnit(
+		"loaded",
+		f.fragmentPath,
+		f.dropInPathsPresent,
+		f.dropInPaths,
+		f.environment,
+		f.execStart,
+	)
+}
+
+type systemdBoundary struct {
+	content     []byte
+	exists      bool
+	readErr     error
+	writeErr    error
+	removeErr   error
+	writeCount  int
+	removeCount int
+	commands    []personalsvc.SystemdUserCommand
+	results     map[string]systemdCommandResponse
+	managerUnit personalsvc.SystemdUserManagerUnit
+	managerErr  error
+	inspections []string
+}
+
+type systemdCommandResponse struct {
+	result personalsvc.SystemdUserCommandResult
+	err    error
+}
+
+func newSystemdBoundary() *systemdBoundary {
+	return &systemdBoundary{results: make(map[string]systemdCommandResponse)}
+}
+
+func (b *systemdBoundary) ReadFile(context.Context, string) ([]byte, bool, error) {
+	if b.readErr != nil {
+		return nil, false, b.readErr
+	}
+	return bytes.Clone(b.content), b.exists, nil
+}
+
+func (b *systemdBoundary) WriteFile(_ context.Context, _ string, content []byte) error {
+	if b.writeErr != nil {
+		return b.writeErr
+	}
+	b.content = bytes.Clone(content)
+	b.exists = true
+	b.writeCount++
+	return nil
+}
+
+func (b *systemdBoundary) RemoveFile(context.Context, string) error {
+	if b.removeErr != nil {
+		return b.removeErr
+	}
+	b.content = nil
+	b.exists = false
+	b.removeCount++
+	return nil
+}
+
+func (b *systemdBoundary) InspectUnit(_ context.Context, unit string) (personalsvc.SystemdUserManagerUnit, error) {
+	b.inspections = append(b.inspections, unit)
+	if b.managerErr != nil {
+		return personalsvc.SystemdUserManagerUnit{}, b.managerErr
+	}
+	if b.managerUnit.LoadState() == "" {
+		return personalsvc.NewSystemdUserManagerUnit("not-found", "", false, nil, "", nil), nil
+	}
+	return b.managerUnit, nil
+}
+
+func (b *systemdBoundary) Run(_ context.Context, command personalsvc.SystemdUserCommand) (personalsvc.SystemdUserCommandResult, error) {
+	b.commands = append(b.commands, command)
+	if response, found := b.results[systemdCommand(command.Program(), command.Arguments()...)]; found {
+		return response.result, response.err
+	}
+	if command.Program() == "systemctl" && slices.Equal(command.Arguments(), []string{"--user", "show", "--property=ActiveState", "--value", "powercontext.service"}) {
+		return personalsvc.NewSystemdUserCommandResult(0, []byte("active\n")), nil
+	}
+	return personalsvc.NewSystemdUserCommandResult(0, nil), nil
+}
+
+func (b *systemdBoundary) Probe(context.Context, string) (personalsvc.ProbeState, error) {
+	return personalsvc.ProbeUnreachable, nil
+}
+
+func (b *systemdBoundary) setError(command string, err error) {
+	b.results[command] = systemdCommandResponse{err: err}
+}
+
+func (b *systemdBoundary) setManagerUnit(unit personalsvc.SystemdUserManagerUnit) {
+	b.managerUnit = unit
+}
+
+func (b *systemdBoundary) inspectedUnits() []string {
+	return slices.Clone(b.inspections)
+}
+
+func (b *systemdBoundary) commandArguments() [][]string {
+	values := make([][]string, 0, len(b.commands))
+	for _, command := range b.commands {
+		values = append(values, append([]string{command.Program()}, command.Arguments()...))
+	}
+	return values
+}
+
+func systemdCommand(program string, arguments ...string) string {
+	return program + "\x00" + strings.Join(arguments, "\x00")
+}


### PR DESCRIPTION
Part of #202 Phase 5.

Adds the pure `systemd --user` adapter contract: deterministic owned unit rendering, exact `systemctl --user` command vectors, fragment/metadata/ExecStart fail-closed inspection, and redacted adapter errors. The parser accepts real systemd status fields only after strictly verifying the unique path/argv/ownership core.

This PR does not execute systemctl, write a real unit, add CLI/service commands, or claim Linux lifecycle/release support. Those require composition-owned OS boundaries and native CI in later slices.