### PR TITLE
feat(skill): persist package-backed review artifacts

### DIFF
--- a/artifact/skill/model.go
+++ b/artifact/skill/model.go
@@ -79,11 +79,22 @@ func (c PackageContent) Reference() PackageRef { return c.snapshot.Reference() }
 func (c PackageContent) Snapshot() PackageSnapshot { return clonePackageSnapshot(c.snapshot) }
 
 type (
-	Skill = artifact.Artifact[Content]
-	Draft = artifact.Draft[Content]
+	Skill        = artifact.Artifact[Content]
+	Draft        = artifact.Draft[Content]
+	PackageSkill = artifact.Artifact[PackageContent]
+	PackageDraft = artifact.Draft[PackageContent]
 )
 
 func NewDraft(content Content, sources []source.Ref, artifacts []artifact.Ref) (Draft, error) {
+	return artifact.NewDraft(Family, content, sources, artifacts)
+}
+
+// NewPackageDraft creates a v2 package-backed managed Skill draft.
+func NewPackageDraft(
+	content PackageContent,
+	sources []source.Ref,
+	artifacts []artifact.Ref,
+) (PackageDraft, error) {
 	return artifact.NewDraft(Family, content, sources, artifacts)
 }
 

--- a/artifact/skill/package.go
+++ b/artifact/skill/package.go
@@ -73,11 +73,49 @@ type PackageRef struct {
 	archiveSize      int
 }
 
+// NewPackageRef restores a canonical immutable package identity from stored
+// metadata. It validates every indexed field without accepting package bytes.
+func NewPackageRef(
+	treeDigest, archiveDigest string,
+	fileCount, uncompressedSize, archiveSize int,
+) (PackageRef, error) {
+	ref := PackageRef{
+		treeDigest:       treeDigest,
+		archiveDigest:    archiveDigest,
+		fileCount:        fileCount,
+		uncompressedSize: uncompressedSize,
+		archiveSize:      archiveSize,
+	}
+	if err := ref.Validate(); err != nil {
+		return PackageRef{}, err
+	}
+	return ref, nil
+}
+
 func (r PackageRef) TreeDigest() string    { return r.treeDigest }
 func (r PackageRef) ArchiveDigest() string { return r.archiveDigest }
 func (r PackageRef) FileCount() int        { return r.fileCount }
 func (r PackageRef) UncompressedSize() int { return r.uncompressedSize }
 func (r PackageRef) ArchiveSize() int      { return r.archiveSize }
+
+// Validate reports whether r can name a canonical immutable package.
+func (r PackageRef) Validate() error {
+	if !canonicalPackageDigest(r.treeDigest) || !canonicalPackageDigest(r.archiveDigest) ||
+		r.fileCount < 1 || r.fileCount > MaxPackageFiles ||
+		r.uncompressedSize < 1 || r.uncompressedSize > MaxPackageBytes ||
+		r.archiveSize < 1 || r.archiveSize > MaxPackageArchiveBytes {
+		return packageErrorf("managed Skill package reference is not canonical")
+	}
+	return nil
+}
+
+func canonicalPackageDigest(value string) bool {
+	if len(value) != sha256.Size*2 {
+		return false
+	}
+	decoded, err := hex.DecodeString(value)
+	return err == nil && hex.EncodeToString(decoded) == value
+}
 
 // PackageEntry is one regular file retained by an immutable package.
 type PackageEntry struct {

--- a/artifact/skill/package_test.go
+++ b/artifact/skill/package_test.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strconv"
+	"strings"
 	"testing"
 )
 
@@ -311,6 +312,58 @@ func TestPackageSnapshotOperationsRejectArchiveMismatch(t *testing.T) {
 			var packageErr *PackageError
 			if err := operation.run(); !errors.As(err, &packageErr) {
 				t.Fatalf("operation error = %T %v, want PackageError", err, err)
+			}
+		})
+	}
+}
+
+func TestPackageRefRestoresOnlyCanonicalIdentity(t *testing.T) {
+	snapshot, err := CapturePackageArchive(zipEntries(t, []zipEntry{{
+		name:    "SKILL.md",
+		content: []byte("---\nname: restore-ref\ndescription: Restore a canonical reference.\n---\n"),
+	}}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := snapshot.Reference()
+
+	restored, err := NewPackageRef(
+		want.TreeDigest(), want.ArchiveDigest(), want.FileCount(), want.UncompressedSize(), want.ArchiveSize(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if restored != want {
+		t.Fatalf("restored reference = %#v, want %#v", restored, want)
+	}
+
+	for _, test := range []struct {
+		name string
+		ref  PackageRef
+	}{
+		{
+			name: "noncanonical digest",
+			ref: PackageRef{
+				treeDigest: strings.ToUpper(want.TreeDigest()), archiveDigest: want.ArchiveDigest(),
+				fileCount: want.FileCount(), uncompressedSize: want.UncompressedSize(), archiveSize: want.ArchiveSize(),
+			},
+		},
+		{
+			name: "impossible file count",
+			ref: PackageRef{
+				treeDigest: want.TreeDigest(), archiveDigest: want.ArchiveDigest(),
+				fileCount: 0, uncompressedSize: want.UncompressedSize(), archiveSize: want.ArchiveSize(),
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			_, restoreErr := NewPackageRef(
+				test.ref.TreeDigest(), test.ref.ArchiveDigest(),
+				test.ref.FileCount(), test.ref.UncompressedSize(), test.ref.ArchiveSize(),
+			)
+			var packageErr *PackageError
+			if !errors.As(restoreErr, &packageErr) {
+				t.Fatalf("NewPackageRef() error = %T %v, want PackageError", restoreErr, restoreErr)
 			}
 		})
 	}

--- a/internal/review/service.go
+++ b/internal/review/service.go
@@ -99,6 +99,22 @@ func (s *Service) ProposeSkill(
 	return skillCandidate(value)
 }
 
+// ProposePackageSkill submits a v2 package-backed managed Skill for review.
+func (s *Service) ProposePackageSkill(
+	ctx context.Context,
+	proposal skill.PackageContent,
+	sources []source.Ref,
+	artifacts []artifact.Ref,
+	target *artifact.Ref,
+	reason *string,
+) (Candidate[skill.PackageContent], error) {
+	value, err := s.propose(ctx, skill.Family, proposal, sources, artifacts, target, reason)
+	if err != nil {
+		return Candidate[skill.PackageContent]{}, err
+	}
+	return packageSkillCandidate(value)
+}
+
 func (s *Service) propose(
 	ctx context.Context,
 	family string,
@@ -210,6 +226,22 @@ func (s *Service) GetSkill(ctx context.Context, ref artifact.Ref) (skill.Skill, 
 	return result, nil
 }
 
+// GetPackageSkill returns one package-backed managed Skill revision.
+func (s *Service) GetPackageSkill(ctx context.Context, ref artifact.Ref) (skill.PackageSkill, error) {
+	if ref.Family() != skill.Family {
+		return skill.PackageSkill{}, &artifact.NotFoundError{Ref: ref}
+	}
+	value, err := s.backend.GetArtifact(ctx, ref)
+	if err != nil {
+		return skill.PackageSkill{}, err
+	}
+	result, ok := value.(skill.PackageSkill)
+	if !ok {
+		return skill.PackageSkill{}, &artifact.NotFoundError{Ref: ref}
+	}
+	return result, nil
+}
+
 func experienceCandidate(value Snapshot) (Candidate[experience.Content], error) {
 	proposal, ok := value.ProposalValue().(experience.Content)
 	if !ok || value.Family() != experience.Family {
@@ -226,6 +258,18 @@ func skillCandidate(value Snapshot) (Candidate[skill.Content], error) {
 	proposal, ok := value.ProposalValue().(skill.Content)
 	if !ok || value.Family() != skill.Family {
 		return Candidate[skill.Content]{}, &InvalidCandidateError{Field: "family", Detail: value.Family()}
+	}
+	return NewCandidate(
+		value.ID(), value.Version(), value.Family(), value.Status(), proposal,
+		value.Sources(), value.Artifacts(), value.Target(), value.Reason(),
+		value.ResultArtifact(), value.DecisionReason(),
+	)
+}
+
+func packageSkillCandidate(value Snapshot) (Candidate[skill.PackageContent], error) {
+	proposal, ok := value.ProposalValue().(skill.PackageContent)
+	if !ok || value.Family() != skill.Family {
+		return Candidate[skill.PackageContent]{}, &InvalidCandidateError{Field: "family", Detail: value.Family()}
 	}
 	return NewCandidate(
 		value.ID(), value.Version(), value.Family(), value.Status(), proposal,

--- a/internal/runtime/review_application.go
+++ b/internal/runtime/review_application.go
@@ -81,6 +81,29 @@ func (a *ReviewApplication) ProposeSkill(
 	return result, err
 }
 
+// ProposePackageSkill serializes a v2 package-backed managed Skill proposal
+// through the resolved scope's review service.
+func (a *ReviewApplication) ProposePackageSkill(
+	ctx context.Context,
+	scopeID string,
+	proposal skill.PackageContent,
+	sources []source.Ref,
+	artifacts []artifact.Ref,
+	target *artifact.Ref,
+	reason *string,
+) (review.Snapshot, error) {
+	var result review.Snapshot
+	err := a.runtime.ScopedWrite(ctx, scopeID, func(ctx context.Context, scope string) error {
+		service, err := a.service(scope)
+		if err != nil {
+			return err
+		}
+		result, err = service.ProposePackageSkill(ctx, proposal, sources, artifacts, target, reason)
+		return err
+	})
+	return result, err
+}
+
 func (a *ReviewApplication) GetCandidate(ctx context.Context, scopeID, candidateID string) (review.Snapshot, error) {
 	var result review.Snapshot
 	err := a.runtime.ScopedRead(ctx, scopeID, func(ctx context.Context, scope string) error {
@@ -180,6 +203,24 @@ func (a *ReviewApplication) GetSkill(
 			return err
 		}
 		result, err = service.GetSkill(ctx, ref)
+		return err
+	})
+	return result, err
+}
+
+// GetPackageSkill reads one v2 package-backed managed Skill revision.
+func (a *ReviewApplication) GetPackageSkill(
+	ctx context.Context,
+	scopeID string,
+	ref artifact.Ref,
+) (skill.PackageSkill, error) {
+	var result skill.PackageSkill
+	err := a.runtime.ScopedRead(ctx, scopeID, func(ctx context.Context, scope string) error {
+		service, err := a.service(scope)
+		if err != nil {
+			return err
+		}
+		result, err = service.GetPackageSkill(ctx, ref)
 		return err
 	})
 	return result, err

--- a/internal/sqlstore/artifact_codec.go
+++ b/internal/sqlstore/artifact_codec.go
@@ -15,20 +15,22 @@
 package sqlstore
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 
 	"github.com/ob-labs/powercontext-go/artifact"
 )
 
-// ArtifactCodec is an exact family/content route for one persisted Artifact
-// schema. It is immutable after construction.
+// ArtifactCodec is an exact family route with a finite set of persisted
+// content schemas. It is immutable after construction.
 type ArtifactCodec struct {
 	family        string
-	contentType   reflect.Type
+	contentTypes  map[reflect.Type]struct{}
 	encode        func(any) ([]byte, error)
 	decodeContent func([]byte) (any, error)
-	decode        func(artifact.Ref, artifact.Lineage, []byte) (artifact.Snapshot, error)
+	decodeScoped  func(context.Context, DBTX, string, []byte) (any, error)
+	decode        func(context.Context, DBTX, string, artifact.Ref, artifact.Lineage, []byte) (artifact.Snapshot, error)
 }
 
 // NewArtifactCodec constructs an exact concrete content codec.
@@ -48,8 +50,8 @@ func NewArtifactCodec[T any](
 		return ArtifactCodec{}, fmt.Errorf("sqlstore: Artifact codec functions must not be nil")
 	}
 	return ArtifactCodec{
-		family:      family,
-		contentType: contentType,
+		family:       family,
+		contentTypes: map[reflect.Type]struct{}{contentType: {}},
 		encode: func(value any) ([]byte, error) {
 			if reflect.TypeOf(value) != contentType {
 				return nil, fmt.Errorf("sqlstore: Artifact codec %q expected %s, got %T", family, contentType, value)
@@ -59,7 +61,10 @@ func NewArtifactCodec[T any](
 		decodeContent: func(payload []byte) (any, error) {
 			return decode(payload)
 		},
-		decode: func(ref artifact.Ref, lineage artifact.Lineage, payload []byte) (artifact.Snapshot, error) {
+		decodeScoped: func(_ context.Context, _ DBTX, _ string, payload []byte) (any, error) {
+			return decode(payload)
+		},
+		decode: func(_ context.Context, _ DBTX, _ string, ref artifact.Ref, lineage artifact.Lineage, payload []byte) (artifact.Snapshot, error) {
 			content, err := decode(payload)
 			if err != nil {
 				return nil, err
@@ -67,4 +72,9 @@ func NewArtifactCodec[T any](
 			return artifact.Restore(ref, content, lineage)
 		},
 	}, nil
+}
+
+func (c ArtifactCodec) supportsContent(value any) bool {
+	_, ok := c.contentTypes[reflect.TypeOf(value)]
+	return ok
 }

--- a/internal/sqlstore/artifact_codecs.go
+++ b/internal/sqlstore/artifact_codecs.go
@@ -15,9 +15,14 @@
 package sqlstore
 
 import (
+	"context"
 	"encoding/json"
+	"encoding/json/jsontext"
+	jsonv2 "encoding/json/v2"
 	"fmt"
+	"reflect"
 
+	"github.com/ob-labs/powercontext-go/artifact"
 	"github.com/ob-labs/powercontext-go/artifact/experience"
 	"github.com/ob-labs/powercontext-go/artifact/memory"
 	"github.com/ob-labs/powercontext-go/artifact/skill"
@@ -32,13 +37,44 @@ func ExperienceArtifactCodec() ArtifactCodec {
 	return codec
 }
 
-// SkillArtifactCodec returns the Python-compatible managed Skill route.
+// SkillArtifactCodec returns the legacy Python-compatible managed Skill route
+// together with the Go-only package-backed v2 variant.
 func SkillArtifactCodec() ArtifactCodec {
-	codec, err := NewArtifactCodec(skill.Family, encodeSkill, decodeSkill)
-	if err != nil {
-		panic(err)
+	return ArtifactCodec{
+		family: skill.Family,
+		contentTypes: map[reflect.Type]struct{}{
+			reflect.TypeFor[skill.Content]():        {},
+			reflect.TypeFor[skill.PackageContent](): {},
+		},
+		encode: encodeSkillVariant,
+		decodeContent: func(payload []byte) (any, error) {
+			return decodeSkill(payload)
+		},
+		decodeScoped: func(ctx context.Context, db DBTX, scopeID string, payload []byte) (any, error) {
+			return decodeSkillVariant(ctx, db, scopeID, payload)
+		},
+		decode: func(
+			ctx context.Context,
+			db DBTX,
+			scopeID string,
+			ref artifact.Ref,
+			lineage artifact.Lineage,
+			payload []byte,
+		) (artifact.Snapshot, error) {
+			content, err := decodeSkillVariant(ctx, db, scopeID, payload)
+			if err != nil {
+				return nil, err
+			}
+			switch value := content.(type) {
+			case skill.Content:
+				return artifact.Restore(ref, value, lineage)
+			case skill.PackageContent:
+				return artifact.Restore(ref, value, lineage)
+			default:
+				return nil, fmt.Errorf("unsupported managed Skill content type %T", content)
+			}
+		},
 	}
-	return codec
 }
 
 // MemoryArtifactCodec returns the authoritative Memory manifest route.
@@ -96,6 +132,68 @@ func decodeSkill(payload []byte) (skill.Content, error) {
 		return skill.Content{}, err
 	}
 	return skill.NewContent(value.Name, value.Description, value.Instructions, value.Validation)
+}
+
+type skillPackageContentJSON struct {
+	PackageRef skillPackageRefJSON `json:"package_ref"`
+}
+
+type skillPackageRefJSON struct {
+	TreeDigest       string `json:"tree_digest"`
+	ArchiveDigest    string `json:"archive_digest"`
+	FileCount        int    `json:"file_count"`
+	UncompressedSize int    `json:"uncompressed_size"`
+	ArchiveSize      int    `json:"archive_size"`
+}
+
+func encodeSkillVariant(value any) ([]byte, error) {
+	switch content := value.(type) {
+	case skill.Content:
+		return encodeSkill(content)
+	case skill.PackageContent:
+		ref := content.Reference()
+		if err := ref.Validate(); err != nil {
+			return nil, err
+		}
+		return jsonv2.Marshal(skillPackageContentJSON{PackageRef: skillPackageRefJSON{
+			TreeDigest:       ref.TreeDigest(),
+			ArchiveDigest:    ref.ArchiveDigest(),
+			FileCount:        ref.FileCount(),
+			UncompressedSize: ref.UncompressedSize(),
+			ArchiveSize:      ref.ArchiveSize(),
+		}})
+	default:
+		return nil, fmt.Errorf("unsupported managed Skill content type %T", value)
+	}
+}
+
+func decodeSkillVariant(ctx context.Context, db DBTX, scopeID string, payload []byte) (any, error) {
+	var fields map[string]jsontext.Value
+	if err := jsonv2.Unmarshal(payload, &fields); err != nil {
+		return nil, err
+	}
+	if _, packageBacked := fields["package_ref"]; !packageBacked {
+		return decodeSkill(payload)
+	}
+	var encoded skillPackageContentJSON
+	if err := jsonv2.Unmarshal(payload, &encoded, jsonv2.RejectUnknownMembers(true)); err != nil {
+		return nil, err
+	}
+	ref, err := skill.NewPackageRef(
+		encoded.PackageRef.TreeDigest,
+		encoded.PackageRef.ArchiveDigest,
+		encoded.PackageRef.FileCount,
+		encoded.PackageRef.UncompressedSize,
+		encoded.PackageRef.ArchiveSize,
+	)
+	if err != nil {
+		return nil, err
+	}
+	snapshot, err := (SkillPackageRepository{}).Get(ctx, db, scopeID, ref)
+	if err != nil {
+		return nil, err
+	}
+	return skill.NewPackageContent(snapshot)
 }
 
 type memoryContentJSON struct {

--- a/internal/sqlstore/artifacts.go
+++ b/internal/sqlstore/artifacts.go
@@ -153,7 +153,8 @@ func (r *ArtifactRepository) Revise(
 	if err != nil {
 		return nil, err
 	}
-	if reflect.TypeOf(current.ContentValue()) != codec.contentType {
+	if !codec.supportsContent(current.ContentValue()) || !codec.supportsContent(draft.ContentValue()) ||
+		reflect.TypeOf(current.ContentValue()) != reflect.TypeOf(draft.ContentValue()) {
 		return nil, &artifact.FamilyMismatchError{
 			ArtifactFamily: current.Ref().Family(),
 			DraftFamily:    draft.Family(),
@@ -297,7 +298,7 @@ func (r *ArtifactRepository) codecForDraft(draft artifact.DraftSnapshot) (Artifa
 	if !ok {
 		return ArtifactCodec{}, &RepositoryNotFoundError{Kind: "artifact-family", Identity: draft.Family()}
 	}
-	if reflect.TypeOf(draft.ContentValue()) != codec.contentType {
+	if !codec.supportsContent(draft.ContentValue()) {
 		return ArtifactCodec{}, &artifact.FamilyMismatchError{
 			ArtifactFamily: codec.family,
 			DraftFamily:    draft.Family(),
@@ -341,7 +342,7 @@ func (r *ArtifactRepository) insertRevision(
 			return nil, artifactErr
 		}
 	}
-	created, err := codec.decode(ref, lineage, payload)
+	created, err := codec.decode(ctx, db, scopeID, ref, lineage, payload)
 	if err != nil {
 		return nil, &InvalidStoredPayloadError{Kind: "artifact", Name: codec.family, Issue: "payload does not match the model"}
 	}
@@ -410,7 +411,7 @@ func (r *ArtifactRepository) decode(
 	if err != nil {
 		return nil, err
 	}
-	decoded, err := codec.decode(ref, lineage, row.content)
+	decoded, err := codec.decode(ctx, db, row.scopeID, ref, lineage, row.content)
 	if err != nil {
 		return nil, &InvalidStoredPayloadError{Kind: "artifact", Name: row.family, Issue: "payload does not match the model"}
 	}

--- a/internal/sqlstore/candidates.go
+++ b/internal/sqlstore/candidates.go
@@ -19,7 +19,6 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"reflect"
 
 	"github.com/ob-labs/powercontext-go/artifact"
 	"github.com/ob-labs/powercontext-go/internal/review"
@@ -154,7 +153,7 @@ func (r *CandidateRepository) List(
 	defer func() { returnErr = errors.Join(returnErr, rows.Close()) }()
 	values := make([]review.Snapshot, 0, limit+1)
 	for rows.Next() {
-		candidate, err := r.scanAndDecode(rows)
+		candidate, err := r.scanAndDecode(ctx, db, scopeID, rows)
 		if err != nil {
 			return review.Page{}, err
 		}
@@ -354,14 +353,19 @@ func (r *CandidateRepository) findCurrent(
 	if locked && r.dialect == MySQLDialect {
 		query += " FOR UPDATE"
 	}
-	candidate, err := r.scanAndDecode(db.QueryRowContext(ctx, query, scopeID, candidateID))
+	candidate, err := r.scanAndDecode(ctx, db, scopeID, db.QueryRowContext(ctx, query, scopeID, candidateID))
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, false, nil
 	}
 	return candidate, err == nil, err
 }
 
-func (r *CandidateRepository) scanAndDecode(value scanner) (review.Snapshot, error) {
+func (r *CandidateRepository) scanAndDecode(
+	ctx context.Context,
+	db DBTX,
+	scopeID string,
+	value scanner,
+) (review.Snapshot, error) {
 	var candidateID, family, status string
 	var version, resultFamily, resultID, resultRevision, decisionReason any
 	var proposalPayload, sourcePayload, artifactPayload any
@@ -386,7 +390,7 @@ func (r *CandidateRepository) scanAndDecode(value scanner) (review.Snapshot, err
 	if err != nil {
 		return nil, err
 	}
-	proposal, err := codec.decodeContent(proposalBytes)
+	proposal, err := codec.decodeScoped(ctx, db, scopeID, proposalBytes)
 	if err != nil {
 		return nil, &InvalidStoredPayloadError{Kind: "candidate-proposal", Name: family, Issue: "payload does not match the model"}
 	}
@@ -433,9 +437,9 @@ func (r *CandidateRepository) requireProposal(family string, proposal any) error
 	if !ok {
 		return &review.InvalidCandidateError{Field: "family", Detail: family}
 	}
-	if reflect.TypeOf(proposal) != codec.contentType {
+	if !codec.supportsContent(proposal) {
 		return &review.InvalidCandidateError{
-			Field: "proposal", Detail: fmt.Sprintf("expected %s", codec.contentType.Name()),
+			Field: "proposal", Detail: "must match a registered exact content type",
 		}
 	}
 	return nil

--- a/internal/sqlstore/review.go
+++ b/internal/sqlstore/review.go
@@ -36,6 +36,7 @@ type ReviewBackend struct {
 	artifacts       *ArtifactRepository
 	sources         *SourceRepository
 	experienceIndex ExperienceIndex
+	skillPackages   SkillPackageRepository
 }
 
 func NewReviewBackend(
@@ -58,6 +59,7 @@ func NewReviewBackend(
 	return &ReviewBackend{
 		database: database, scopeID: scopeID, candidates: candidates,
 		artifacts: artifacts, sources: sources, experienceIndex: experienceIndex,
+		skillPackages: SkillPackageRepository{},
 	}, nil
 }
 
@@ -78,6 +80,9 @@ func (r *ReviewBackend) Propose(
 ) (review.Snapshot, error) {
 	var result review.Snapshot
 	err := r.database.Transaction(ctx, func(tx DBTX) error {
+		if err := r.persistPackageProposal(ctx, tx, family, proposal); err != nil {
+			return err
+		}
 		if err := r.validateEvidence(ctx, tx, sources, artifacts); err != nil {
 			return err
 		}
@@ -150,8 +155,11 @@ func (r *ReviewBackend) Revise(
 		if err != nil {
 			return err
 		}
-		if proposalErr := validateReviewedProposal(current.Family(), proposal); proposalErr != nil {
+		if proposalErr := validateReviewedProposal(current.Family(), current.ProposalValue(), proposal); proposalErr != nil {
 			return proposalErr
+		}
+		if packageErr := r.persistPackageProposal(ctx, tx, current.Family(), proposal); packageErr != nil {
+			return packageErr
 		}
 		if !equalOptionalRef(target, current.Target()) {
 			return &review.InvalidCandidateError{Field: "target", Detail: "cannot change across Candidate versions"}
@@ -197,6 +205,9 @@ func (r *ReviewBackend) Approve(
 		candidate, err := r.candidates.LockPending(ctx, tx, r.scopeID, candidateID, expectedVersion)
 		if err != nil {
 			return err
+		}
+		if packageErr := r.revalidatePackageProposal(ctx, tx, candidate); packageErr != nil {
+			return packageErr
 		}
 		if lineageErr := validateApprovalLineage(candidate); lineageErr != nil {
 			return lineageErr
@@ -324,15 +335,22 @@ func (r *ReviewBackend) validateTarget(
 	return nil
 }
 
-func validateReviewedProposal(family string, proposal any) error {
-	expected := map[string]reflect.Type{
-		experience.Family: reflect.TypeFor[experience.Content](),
-		skill.Family:      reflect.TypeFor[skill.Content](),
-	}[family]
-	if expected == nil || reflect.TypeOf(proposal) != expected {
+func validateReviewedProposal(family string, current, proposal any) error {
+	if reflect.TypeOf(current) != reflect.TypeOf(proposal) {
 		return &review.InvalidCandidateError{Field: "family", Detail: family}
 	}
-	return nil
+	switch family {
+	case experience.Family:
+		if _, ok := proposal.(experience.Content); ok {
+			return nil
+		}
+	case skill.Family:
+		switch proposal.(type) {
+		case skill.Content, skill.PackageContent:
+			return nil
+		}
+	}
+	return &review.InvalidCandidateError{Field: "family", Detail: family}
 }
 
 func validateApprovalLineage(candidate review.Snapshot) error {
@@ -372,8 +390,46 @@ func candidateDraft(candidate review.Snapshot) (artifact.DraftSnapshot, error) {
 			break
 		}
 		return skill.NewDraft(proposal, candidate.Sources(), candidate.Artifacts())
+	case skill.PackageContent:
+		if candidate.Family() != skill.Family {
+			break
+		}
+		return skill.NewPackageDraft(proposal, candidate.Sources(), candidate.Artifacts())
 	}
 	return nil, &review.InvalidCandidateError{Field: "family", Detail: candidate.Family()}
+}
+
+func (r *ReviewBackend) persistPackageProposal(
+	ctx context.Context,
+	tx DBTX,
+	family string,
+	proposal any,
+) error {
+	if family != skill.Family {
+		return nil
+	}
+	content, packageBacked := proposal.(skill.PackageContent)
+	if !packageBacked {
+		return nil
+	}
+	_, err := r.skillPackages.Add(ctx, tx, r.scopeID, content.Snapshot())
+	return err
+}
+
+func (r *ReviewBackend) revalidatePackageProposal(
+	ctx context.Context,
+	tx DBTX,
+	candidate review.Snapshot,
+) error {
+	if candidate.Family() != skill.Family {
+		return nil
+	}
+	content, packageBacked := candidate.ProposalValue().(skill.PackageContent)
+	if !packageBacked {
+		return nil
+	}
+	_, err := r.skillPackages.Get(ctx, tx, r.scopeID, content.Reference())
+	return err
 }
 
 func equalOptionalRef(left, right *artifact.Ref) bool {

--- a/internal/sqlstore/review_contract_test.go
+++ b/internal/sqlstore/review_contract_test.go
@@ -15,8 +15,11 @@
 package sqlstore_test
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/ob-labs/powercontext-go/artifact"
@@ -206,6 +209,451 @@ func TestManagedSkillApprovalValidatesLineageBeforeArtifactWrite(t *testing.T) {
 	}
 	if got := lineage.Artifacts(); len(got) != 1 || got[0] != *initialRef {
 		t.Fatalf("replacement Artifact lineage = %#v", got)
+	}
+}
+
+func TestPackageBackedSkillReviewPersistsOnlyCanonicalReference(t *testing.T) {
+	fixture := newReviewFixture(t, "package-review", (&sequenceIDs{}).New)
+	evidence := fixture.capture(t, "package-evidence", "reviewed package evidence")
+	snapshot := skillPackageSnapshot(t, "package-review-skill")
+	proposal, err := skill.NewPackageContent(snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	candidate, err := fixture.service.ProposePackageSkill(
+		fixture.ctx, proposal, []source.Ref{evidence}, nil, nil, nil,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if candidate.Proposal().Reference() != snapshot.Reference() {
+		t.Fatalf("candidate package reference = %#v, want %#v", candidate.Proposal().Reference(), snapshot.Reference())
+	}
+	assertPackageReviewPayload(t, fixture, candidate.ID(), "proposal", snapshot)
+	assertPackageReviewRow(t, fixture, snapshot, 1)
+
+	approved, err := fixture.service.Approve(fixture.ctx, candidate.ID(), candidate.Version())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if approved.ResultArtifact() == nil {
+		t.Fatal("approved package Candidate has no Artifact")
+	}
+	stored, err := fixture.service.GetPackageSkill(fixture.ctx, *approved.ResultArtifact())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stored.Content().Reference() != snapshot.Reference() {
+		t.Fatalf("stored package Artifact reference = %#v, want %#v", stored.Content().Reference(), snapshot.Reference())
+	}
+	assertPackageArtifactPayload(t, fixture, *approved.ResultArtifact(), snapshot)
+
+	legacy := reviewSkill(t, "Keep legacy skill JSON unchanged.")
+	legacyCandidate, err := fixture.service.ProposeSkill(
+		fixture.ctx, legacy, []source.Ref{evidence}, nil, nil, nil,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var legacyPayload []byte
+	if err := fixture.database.SQLDB().QueryRowContext(fixture.ctx, `SELECT proposal
+        FROM pc_artifact_candidate_versions WHERE scope_id = ? AND candidate_id = ?`,
+		fixture.scope, legacyCandidate.ID()).Scan(&legacyPayload); err != nil {
+		t.Fatal(err)
+	}
+	wantLegacy := `{"name":"powercontext-review","description":"Use for reviewed changes.","instructions":"Keep legacy skill JSON unchanged.","validation":["tests pass"]}`
+	if string(legacyPayload) != wantLegacy {
+		t.Fatalf("legacy Skill proposal JSON changed: %s", legacyPayload)
+	}
+}
+
+func TestPackageSkillProposalRollsBackPackageWhenCandidateWriteFails(t *testing.T) {
+	fixedID := func(kind string) (string, error) { return kind + "-package", nil }
+	fixture := newReviewFixture(t, "package-rollback", fixedID)
+	evidence := fixture.capture(t, "package-evidence", "reviewed package evidence")
+	snapshot := skillPackageSnapshot(t, "package-rollback-skill")
+	proposal, err := skill.NewPackageContent(snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, triggerErr := fixture.database.SQLDB().ExecContext(fixture.ctx, `CREATE TRIGGER pc_test_fail_package_candidate
+        BEFORE INSERT ON pc_artifact_candidate_heads
+		BEGIN SELECT RAISE(ABORT, 'injected package Candidate failure'); END`); triggerErr != nil {
+		t.Fatal(triggerErr)
+	}
+
+	_, err = fixture.service.ProposePackageSkill(fixture.ctx, proposal, []source.Ref{evidence}, nil, nil, nil)
+	if err == nil {
+		t.Fatal("package proposal unexpectedly survived Candidate failure")
+	}
+	assertPackageReviewRow(t, fixture, snapshot, 0)
+}
+
+func TestPackageSkillRevisionPersistsExactReferenceAndRollsBackOnCandidateFailure(t *testing.T) {
+	fixture := newReviewFixture(t, "package-revision", (&sequenceIDs{}).New)
+	evidence := fixture.capture(t, "package-evidence", "reviewed package evidence")
+	initialSnapshot := skillPackageSnapshot(t, "package-revision-initial")
+	initialContent, err := skill.NewPackageContent(initialSnapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	initial, err := fixture.service.ProposePackageSkill(
+		fixture.ctx, initialContent, []source.Ref{evidence}, nil, nil, nil,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	initialApproval, err := fixture.service.Approve(fixture.ctx, initial.ID(), initial.Version())
+	if err != nil {
+		t.Fatal(err)
+	}
+	initialRef := initialApproval.ResultArtifact()
+	if initialRef == nil {
+		t.Fatal("initial package Skill has no Artifact")
+	}
+
+	revisedSnapshot := skillPackageSnapshot(t, "package-revision-revised")
+	revisedContent, err := skill.NewPackageContent(revisedSnapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	replacement, err := fixture.service.ProposePackageSkill(
+		fixture.ctx, revisedContent, []source.Ref{evidence}, []artifact.Ref{*initialRef}, initialRef, nil,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	replacementApproval, err := fixture.service.Approve(fixture.ctx, replacement.ID(), replacement.Version())
+	if err != nil {
+		t.Fatal(err)
+	}
+	revisedRef := replacementApproval.ResultArtifact()
+	if revisedRef == nil || revisedRef.ID() != initialRef.ID() || revisedRef.Revision() != 2 {
+		t.Fatalf("revised package Artifact = %#v, want revision 2 of %#v", revisedRef, initialRef)
+	}
+	stored, err := fixture.service.GetPackageSkill(fixture.ctx, *revisedRef)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stored.Content().Reference() != revisedSnapshot.Reference() {
+		t.Fatalf("revised package reference = %#v, want %#v", stored.Content().Reference(), revisedSnapshot.Reference())
+	}
+	if lineage := stored.Lineage(); len(lineage.Sources()) != 1 || lineage.Sources()[0] != evidence ||
+		len(lineage.Artifacts()) != 1 || lineage.Artifacts()[0] != *initialRef {
+		t.Fatalf("revised package lineage = %#v", lineage)
+	}
+	assertPackageArtifactPayload(t, fixture, *revisedRef, revisedSnapshot)
+
+	rollbackSnapshot := skillPackageSnapshot(t, "package-revision-rollback")
+	rollbackContent, err := skill.NewPackageContent(rollbackSnapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pending, err := fixture.service.ProposePackageSkill(
+		fixture.ctx, initialContent, []source.Ref{evidence}, nil, nil, nil,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, triggerErr := fixture.database.SQLDB().ExecContext(fixture.ctx, `CREATE TRIGGER pc_test_fail_package_revision
+        BEFORE UPDATE OF version ON pc_artifact_candidate_heads
+		BEGIN SELECT RAISE(ABORT, 'injected package Candidate revision failure'); END`); triggerErr != nil {
+		t.Fatal(triggerErr)
+	}
+	_, err = fixture.service.Revise(
+		fixture.ctx, pending.ID(), pending.Version(), rollbackContent, []source.Ref{evidence}, nil, nil, nil,
+	)
+	if err == nil {
+		t.Fatal("package revision unexpectedly survived Candidate failure")
+	}
+	assertPackageReviewRow(t, fixture, rollbackSnapshot, 0)
+	assertPendingCandidate(t, fixture.service, pending.ID())
+}
+
+func TestPackageSkillCandidateRevisionRejectsCrossVariant(t *testing.T) {
+	fixture := newReviewFixture(t, "package-cross-variant", (&sequenceIDs{}).New)
+	evidence := fixture.capture(t, "package-evidence", "reviewed package evidence")
+	snapshot := skillPackageSnapshot(t, "package-cross-variant-skill")
+	packageContent, err := skill.NewPackageContent(snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	candidate, err := fixture.service.ProposePackageSkill(
+		fixture.ctx, packageContent, []source.Ref{evidence}, nil, nil, nil,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	legacy := reviewSkill(t, "Do not cross Skill content variants.")
+	_, err = fixture.service.Revise(
+		fixture.ctx, candidate.ID(), candidate.Version(), legacy, []source.Ref{evidence}, nil, nil, nil,
+	)
+	assertReviewInvalidField(t, err, "family")
+	current, err := fixture.service.Get(fixture.ctx, candidate.ID())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if current.Version() != candidate.Version() {
+		t.Fatalf("cross-variant Candidate changed to version %d", current.Version())
+	}
+}
+
+func TestPackageSkillApprovalRollsBackArtifactAndCandidateForEveryWriteFailure(t *testing.T) {
+	tests := []struct {
+		name       string
+		triggerSQL string
+	}{
+		{
+			name: "artifact insert",
+			triggerSQL: `CREATE TRIGGER pc_test_fail_package_artifact
+                BEFORE INSERT ON pc_artifacts
+                BEGIN SELECT RAISE(ABORT, 'injected package Artifact failure'); END`,
+		},
+		{
+			name: "source lineage insert",
+			triggerSQL: `CREATE TRIGGER pc_test_fail_package_lineage
+                BEFORE INSERT ON pc_artifact_lineage_sources
+                BEGIN SELECT RAISE(ABORT, 'injected package lineage failure'); END`,
+		},
+		{
+			name: "candidate terminal update",
+			triggerSQL: `CREATE TRIGGER pc_test_fail_package_terminal
+                BEFORE UPDATE OF status ON pc_artifact_candidate_heads
+                WHEN NEW.status = 'approved'
+                BEGIN SELECT RAISE(ABORT, 'injected package terminal failure'); END`,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newReviewFixture(t, "package-approval-rollback", (&sequenceIDs{}).New)
+			evidence := fixture.capture(t, "package-evidence", "reviewed package evidence")
+			snapshot := skillPackageSnapshot(t, "package-approval-rollback-skill")
+			proposal, err := skill.NewPackageContent(snapshot)
+			if err != nil {
+				t.Fatal(err)
+			}
+			candidate, err := fixture.service.ProposePackageSkill(
+				fixture.ctx, proposal, []source.Ref{evidence}, nil, nil, nil,
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := fixture.database.SQLDB().ExecContext(fixture.ctx, test.triggerSQL); err != nil {
+				t.Fatal(err)
+			}
+
+			if _, err := fixture.service.Approve(fixture.ctx, candidate.ID(), candidate.Version()); err == nil {
+				t.Fatal("package approval unexpectedly survived injected write failure")
+			}
+			assertPendingCandidate(t, fixture.service, candidate.ID())
+			assertArtifactCount(t, fixture.database, fixture.scope, skill.Family, 0)
+			assertPackageReviewRow(t, fixture, snapshot, 1)
+		})
+	}
+}
+
+func TestPackageSkillApprovalRejectsCorruptCanonicalArchiveBeforeArtifactWrite(t *testing.T) {
+	fixture := newReviewFixture(t, "package-approval-corrupt", (&sequenceIDs{}).New)
+	evidence := fixture.capture(t, "package-evidence", "reviewed package evidence")
+	snapshot := skillPackageSnapshot(t, "package-approval-corrupt-skill")
+	proposal, err := skill.NewPackageContent(snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	candidate, err := fixture.service.ProposePackageSkill(
+		fixture.ctx, proposal, []source.Ref{evidence}, nil, nil, nil,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, corruptErr := fixture.database.SQLDB().ExecContext(fixture.ctx, `UPDATE pc_skill_packages SET archive = ?
+        WHERE scope_id = ? AND tree_digest = ?`, []byte("approval-corrupt-package-secret"), fixture.scope, snapshot.Reference().TreeDigest()); corruptErr != nil {
+		t.Fatal(corruptErr)
+	}
+
+	_, err = fixture.service.Approve(fixture.ctx, candidate.ID(), candidate.Version())
+	assertPackageReadFailureRedacted(t, err, fixture, snapshot, "approval-corrupt-package-secret")
+	assertPendingCandidateHead(t, fixture.database, fixture.scope, candidate.ID())
+	assertArtifactCount(t, fixture.database, fixture.scope, skill.Family, 0)
+}
+
+func TestPackageSkillArtifactReadRevalidatesCanonicalArchive(t *testing.T) {
+	fixture := newReviewFixture(t, "package-artifact-corrupt", (&sequenceIDs{}).New)
+	evidence := fixture.capture(t, "package-evidence", "reviewed package evidence")
+	snapshot := skillPackageSnapshot(t, "package-artifact-corrupt-skill")
+	proposal, err := skill.NewPackageContent(snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	candidate, err := fixture.service.ProposePackageSkill(
+		fixture.ctx, proposal, []source.Ref{evidence}, nil, nil, nil,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	approved, err := fixture.service.Approve(fixture.ctx, candidate.ID(), candidate.Version())
+	if err != nil {
+		t.Fatal(err)
+	}
+	ref := approved.ResultArtifact()
+	if ref == nil {
+		t.Fatal("approved package Skill has no Artifact")
+	}
+	if _, corruptErr := fixture.database.SQLDB().ExecContext(fixture.ctx, `UPDATE pc_skill_packages SET archive = ?
+        WHERE scope_id = ? AND tree_digest = ?`, []byte("artifact-read-corrupt-package-secret"), fixture.scope, snapshot.Reference().TreeDigest()); corruptErr != nil {
+		t.Fatal(corruptErr)
+	}
+
+	_, err = fixture.service.GetPackageSkill(fixture.ctx, *ref)
+	assertPackageReadFailureRedacted(t, err, fixture, snapshot, "artifact-read-corrupt-package-secret")
+}
+
+func TestPackageSkillReadRejectsMissingOrCorruptCanonicalPackageWithoutLeakingIdentity(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*testing.T, reviewFixture, skill.PackageSnapshot, string)
+	}{
+		{
+			name: "scope mismatch",
+			mutate: func(t *testing.T, fixture reviewFixture, snapshot skill.PackageSnapshot, candidateID string) {
+				t.Helper()
+				var proposal, sourceRefs, artifactRefs []byte
+				if err := fixture.database.SQLDB().QueryRowContext(fixture.ctx, `SELECT proposal, source_refs, artifact_refs
+                    FROM pc_artifact_candidate_versions WHERE scope_id = ? AND candidate_id = ?`, fixture.scope, candidateID).Scan(
+					&proposal, &sourceRefs, &artifactRefs,
+				); err != nil {
+					t.Fatal(err)
+				}
+				const otherScope = "package-other-scope-secret"
+				if _, err := fixture.database.SQLDB().ExecContext(fixture.ctx, `INSERT INTO pc_artifact_candidate_versions
+                    (scope_id, candidate_id, version, family, proposal, source_refs, artifact_refs, reason)
+                    VALUES (?, ?, 1, ?, ?, ?, ?, NULL)`, otherScope, "package-mismatched-candidate", skill.Family,
+					proposal, sourceRefs, artifactRefs,
+				); err != nil {
+					t.Fatal(err)
+				}
+				if _, err := fixture.database.SQLDB().ExecContext(fixture.ctx, `INSERT INTO pc_artifact_candidate_heads
+                    (scope_id, candidate_id, family, version, status)
+                    VALUES (?, ?, ?, 1, 'pending')`, otherScope, "package-mismatched-candidate", skill.Family); err != nil {
+					t.Fatal(err)
+				}
+				candidateRepository := reviewCandidateRepository(t)
+				err := fixture.database.Transaction(fixture.ctx, func(tx sqlstore.DBTX) error {
+					_, getErr := candidateRepository.Get(fixture.ctx, tx, otherScope, "package-mismatched-candidate")
+					return getErr
+				})
+				assertPackageReadFailureRedacted(t, err, fixture, snapshot, otherScope)
+			},
+		},
+		{
+			name: "corrupt archive",
+			mutate: func(t *testing.T, fixture reviewFixture, snapshot skill.PackageSnapshot, candidateID string) {
+				t.Helper()
+				if _, err := fixture.database.SQLDB().ExecContext(fixture.ctx, `UPDATE pc_skill_packages SET archive = ?
+                    WHERE scope_id = ? AND tree_digest = ?`, []byte("stored-package-secret"), fixture.scope, snapshot.Reference().TreeDigest()); err != nil {
+					t.Fatal(err)
+				}
+				_, err := fixture.service.Get(fixture.ctx, candidateID)
+				assertPackageReadFailureRedacted(t, err, fixture, snapshot, "stored-package-secret")
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newReviewFixture(t, "package-read-secret", (&sequenceIDs{}).New)
+			evidence := fixture.capture(t, "package-evidence", "reviewed package evidence")
+			snapshot := skillPackageSnapshot(t, "package-read-skill")
+			proposal, err := skill.NewPackageContent(snapshot)
+			if err != nil {
+				t.Fatal(err)
+			}
+			candidate, err := fixture.service.ProposePackageSkill(
+				fixture.ctx, proposal, []source.Ref{evidence}, nil, nil, nil,
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			test.mutate(t, fixture, snapshot, candidate.ID())
+		})
+	}
+}
+
+func assertPackageReadFailureRedacted(
+	t *testing.T,
+	err error,
+	fixture reviewFixture,
+	snapshot skill.PackageSnapshot,
+	extraSecret string,
+) {
+	t.Helper()
+	if _, invalid := errors.AsType[*sqlstore.InvalidStoredPayloadError](err); !invalid {
+		t.Fatalf("package read error = %T %v, want InvalidStoredPayloadError", err, err)
+	}
+	for _, secret := range []string{fixture.scope, snapshot.Metadata().Name(), snapshot.Reference().TreeDigest(), snapshot.Reference().ArchiveDigest(), extraSecret} {
+		if strings.Contains(err.Error(), secret) {
+			t.Fatalf("package read error leaked %q: %v", secret, err)
+		}
+	}
+}
+
+func assertPendingCandidateHead(t *testing.T, database *sqlstore.Database, scopeID, candidateID string) {
+	t.Helper()
+	var status string
+	if err := database.SQLDB().QueryRowContext(t.Context(), `SELECT status
+        FROM pc_artifact_candidate_heads WHERE scope_id = ? AND candidate_id = ?`, scopeID, candidateID).Scan(&status); err != nil {
+		t.Fatal(err)
+	}
+	if status != string(review.Pending) {
+		t.Fatalf("Candidate head status = %q, want pending", status)
+	}
+}
+
+func assertPackageReviewPayload(t *testing.T, fixture reviewFixture, candidateID, column string, snapshot skill.PackageSnapshot) {
+	t.Helper()
+	var payload []byte
+	query := fmt.Sprintf(`SELECT %s FROM pc_artifact_candidate_versions WHERE scope_id = ? AND candidate_id = ?`, column)
+	if err := fixture.database.SQLDB().QueryRowContext(fixture.ctx, query, fixture.scope, candidateID).Scan(&payload); err != nil {
+		t.Fatal(err)
+	}
+	assertPackageReferencePayload(t, payload, snapshot)
+}
+
+func assertPackageArtifactPayload(t *testing.T, fixture reviewFixture, ref artifact.Ref, snapshot skill.PackageSnapshot) {
+	t.Helper()
+	var payload []byte
+	if err := fixture.database.SQLDB().QueryRowContext(fixture.ctx, `SELECT content FROM pc_artifacts
+        WHERE scope_id = ? AND family = ? AND artifact_id = ? AND revision = ?`,
+		fixture.scope, ref.Family(), ref.ID(), ref.Revision()).Scan(&payload); err != nil {
+		t.Fatal(err)
+	}
+	assertPackageReferencePayload(t, payload, snapshot)
+}
+
+func assertPackageReferencePayload(t *testing.T, payload []byte, snapshot skill.PackageSnapshot) {
+	t.Helper()
+	ref := snapshot.Reference()
+	want := fmt.Sprintf(`{"package_ref":{"tree_digest":"%s","archive_digest":"%s","file_count":%d,"uncompressed_size":%d,"archive_size":%d}}`,
+		ref.TreeDigest(), ref.ArchiveDigest(), ref.FileCount(), ref.UncompressedSize(), ref.ArchiveSize())
+	if string(payload) != want {
+		t.Fatalf("package reference payload = %s, want %s", payload, want)
+	}
+	for _, forbidden := range [][]byte{snapshot.Archive(), snapshot.Manifest(), []byte(snapshot.Instructions())} {
+		if bytes.Contains(payload, forbidden) {
+			t.Fatalf("package reference payload duplicated package bytes: %q", payload)
+		}
+	}
+}
+
+func assertPackageReviewRow(t *testing.T, fixture reviewFixture, snapshot skill.PackageSnapshot, want int) {
+	t.Helper()
+	var count int
+	if err := fixture.database.SQLDB().QueryRowContext(fixture.ctx, `SELECT COUNT(*) FROM pc_skill_packages
+        WHERE scope_id = ? AND tree_digest = ?`, fixture.scope, snapshot.Reference().TreeDigest()).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != want {
+		t.Fatalf("stored package rows = %d, want %d", count, want)
 	}
 }
 

--- a/internal/sqlstore/skill_packages.go
+++ b/internal/sqlstore/skill_packages.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
-	"encoding/hex"
 	"errors"
 
 	"github.com/ob-labs/powercontext-go/artifact/skill"
@@ -204,20 +203,10 @@ func sameSkillPackageRecord(record skillPackageRecord, snapshot skill.PackageSna
 }
 
 func validateSkillPackageReference(ref skill.PackageRef) error {
-	if !validSkillPackageDigest(ref.TreeDigest()) || !validSkillPackageDigest(ref.ArchiveDigest()) ||
-		ref.FileCount() < 1 || ref.FileCount() > skill.MaxPackageFiles || ref.UncompressedSize() < 0 ||
-		ref.UncompressedSize() > skill.MaxPackageBytes || ref.ArchiveSize() < 1 || ref.ArchiveSize() > skill.MaxPackageArchiveBytes {
+	if err := ref.Validate(); err != nil {
 		return &InvalidRepositoryArgumentError{Field: "package_ref", Detail: "must be a canonical managed Skill package reference"}
 	}
 	return nil
-}
-
-func validSkillPackageDigest(value string) bool {
-	if len(value) != 64 {
-		return false
-	}
-	_, err := hex.DecodeString(value)
-	return err == nil
 }
 
 func storedSkillPackageString(value any, column string) (string, error) {

--- a/internal/sqlstore/skill_packages_test.go
+++ b/internal/sqlstore/skill_packages_test.go
@@ -20,6 +20,7 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -264,7 +265,7 @@ func TestSkillPackageRepositoryPreservesNonConstraintDatabaseError(t *testing.T)
 	}
 }
 
-func TestLegacyArtifactCodecRejectsPackageContentBeforeWrite(t *testing.T) {
+func TestSkillArtifactCodecPersistsPackageReferenceWithoutPackageBytes(t *testing.T) {
 	database := openTestDatabase(t)
 	snapshot := skillPackageSnapshot(t, "v2-package-skill")
 	packageContent, err := skill.NewPackageContent(snapshot)
@@ -275,23 +276,88 @@ func TestLegacyArtifactCodecRejectsPackageContentBeforeWrite(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	legacy, err := sqlstore.NewArtifactRepository(sqlstore.SQLiteDialect, sqlstore.SkillArtifactCodec())
+	repository, err := sqlstore.NewArtifactRepository(sqlstore.SQLiteDialect, sqlstore.SkillArtifactCodec())
 	if err != nil {
 		t.Fatal(err)
 	}
+	packageRepository := sqlstore.SkillPackageRepository{}
+	const scopeID = "scope-package-codec"
+	var stored artifact.Snapshot
 	err = database.Transaction(t.Context(), func(tx sqlstore.DBTX) error {
-		_, createErr := legacy.Create(t.Context(), tx, "scope-package-codec", "legacy-artifact", packageDraft)
+		if _, addErr := packageRepository.Add(t.Context(), tx, scopeID, snapshot); addErr != nil {
+			return addErr
+		}
+		var createErr error
+		stored, createErr = repository.Create(t.Context(), tx, scopeID, "package-artifact", packageDraft)
 		return createErr
 	})
-	if _, ok := errors.AsType[*artifact.FamilyMismatchError](err); !ok {
-		t.Fatalf("legacy codec package write = %T %v", err, err)
-	}
-	var artifactRows int
-	if err := database.SQLDB().QueryRowContext(t.Context(), "SELECT COUNT(*) FROM pc_artifacts").Scan(&artifactRows); err != nil {
+	if err != nil {
 		t.Fatal(err)
 	}
-	if artifactRows != 0 {
-		t.Fatalf("package-backed value wrote %d legacy artifact rows", artifactRows)
+	packageArtifact, ok := stored.(skill.PackageSkill)
+	if !ok || packageArtifact.Content().Reference() != snapshot.Reference() {
+		t.Fatalf("stored package Artifact = %#v", stored)
+	}
+	var payload []byte
+	if err := database.SQLDB().QueryRowContext(t.Context(), `SELECT content FROM pc_artifacts
+        WHERE scope_id = ? AND family = ? AND artifact_id = ?`, scopeID, skill.Family, "package-artifact").Scan(&payload); err != nil {
+		t.Fatal(err)
+	}
+	ref := snapshot.Reference()
+	want := fmt.Sprintf(`{"package_ref":{"tree_digest":"%s","archive_digest":"%s","file_count":%d,"uncompressed_size":%d,"archive_size":%d}}`,
+		ref.TreeDigest(), ref.ArchiveDigest(), ref.FileCount(), ref.UncompressedSize(), ref.ArchiveSize())
+	if string(payload) != want || bytes.Contains(payload, snapshot.Archive()) || bytes.Contains(payload, snapshot.Manifest()) ||
+		bytes.Contains(payload, []byte(snapshot.Instructions())) {
+		t.Fatalf("package Artifact payload = %q, want reference-only %q", payload, want)
+	}
+}
+
+func TestSkillArtifactCodecRejectsCrossVariantRevision(t *testing.T) {
+	database := openTestDatabase(t)
+	repository, err := sqlstore.NewArtifactRepository(sqlstore.SQLiteDialect, sqlstore.SkillArtifactCodec())
+	if err != nil {
+		t.Fatal(err)
+	}
+	legacyContent, err := skill.NewContent("legacy-skill", "Preserve legacy Skill.", "Keep legacy behavior.", []string{"tests pass"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	legacyDraft, err := skill.NewDraft(legacyContent, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshot := skillPackageSnapshot(t, "cross-variant-skill")
+	packageContent, err := skill.NewPackageContent(snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	packageDraft, err := skill.NewPackageDraft(packageContent, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const scopeID = "scope-cross-variant"
+	var created artifact.Snapshot
+	if createErr := database.Transaction(t.Context(), func(tx sqlstore.DBTX) error {
+		var artifactCreateErr error
+		created, artifactCreateErr = repository.Create(t.Context(), tx, scopeID, "skill-artifact", legacyDraft)
+		return artifactCreateErr
+	}); createErr != nil {
+		t.Fatal(createErr)
+	}
+	err = database.Transaction(t.Context(), func(tx sqlstore.DBTX) error {
+		_, reviseErr := repository.Revise(t.Context(), tx, scopeID, created, packageDraft)
+		return reviseErr
+	})
+	if _, mismatch := errors.AsType[*artifact.FamilyMismatchError](err); !mismatch {
+		t.Fatalf("cross-variant revision error = %T %v, want FamilyMismatchError", err, err)
+	}
+	var revisions int
+	if err := database.SQLDB().QueryRowContext(t.Context(), `SELECT COUNT(*) FROM pc_artifacts
+        WHERE scope_id = ? AND family = ? AND artifact_id = ?`, scopeID, skill.Family, "skill-artifact").Scan(&revisions); err != nil {
+		t.Fatal(err)
+	}
+	if revisions != 1 {
+		t.Fatalf("cross-variant revision wrote %d rows", revisions)
 	}
 }
 


### PR DESCRIPTION
Part of #202 Phase 4.

Adds package-backed managed Skill review and immutable artifact revisions while retaining every legacy Skill content/API/JSON path. Package candidates and artifacts carry only a strict immutable reference; canonical archive bytes stay solely in the scope-local package repository and are revalidated on every read.

Review proposal, revise, approval, artifact revision, lineage, and candidate terminal state are transactional. Cross-variant legacy/package revisions, scope mismatches, and corrupted package records are rejected with redacted errors.

This PR does not add HTTP/MCP routes, publication, installation, target enrollment, remote distribution, a new external agent, or non-SQLite behavior.