### PR TITLE
feat(server): serve canonical Scope sidecar

### DIFF
--- a/internal/endpoint/canonical_scope.go
+++ b/internal/endpoint/canonical_scope.go
@@ -1,0 +1,223 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package endpoint
+
+import (
+	"context"
+
+	canonicalscopec "github.com/ob-labs/powercontext-go/api/canonical/scopes"
+	"github.com/ob-labs/powercontext-go/internal/scope"
+)
+
+// ScopeReadOperations is the consumer-owned read surface required by the
+// canonical Scope sidecar. Runtime owns the operation lifecycle; this adapter
+// only validates transport input and projects immutable domain values.
+type ScopeReadOperations interface {
+	List(context.Context) ([]scope.Descriptor, error)
+	Get(context.Context, string) (scope.Descriptor, error)
+	Default(context.Context) (scope.Descriptor, error)
+	Resolve(context.Context, *string, []scope.BindingKey) (scope.Descriptor, error)
+	ResolveSelection(context.Context, scope.Selection) ([]scope.Descriptor, error)
+}
+
+// CanonicalScopeHandler projects durable Scope reads onto the generated
+// canonical Scope contract. It deliberately does not own Scope mutations.
+type CanonicalScopeHandler struct {
+	operations ScopeReadOperations
+}
+
+var _ canonicalscopec.Handler = (*CanonicalScopeHandler)(nil)
+
+func NewCanonicalScopeHandler(operations ScopeReadOperations) *CanonicalScopeHandler {
+	return &CanonicalScopeHandler{operations: operations}
+}
+
+func (h *CanonicalScopeHandler) ListScopes(ctx context.Context) (canonicalscopec.ListScopesRes, error) {
+	if err := h.available(); err != nil {
+		return nil, err
+	}
+	values, err := h.operations.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return scopePage(values)
+}
+
+func (h *CanonicalScopeHandler) GetScope(
+	ctx context.Context,
+	params canonicalscopec.GetScopeParams,
+) (canonicalscopec.GetScopeRes, error) {
+	if err := h.available(); err != nil {
+		return nil, err
+	}
+	if _, err := scope.NewExactSelection([]string{params.ScopeID}); err != nil {
+		return nil, &scope.ValidationError{}
+	}
+	value, err := h.operations.Get(ctx, params.ScopeID)
+	if err != nil {
+		return nil, err
+	}
+	return scopeDescriptor(value)
+}
+
+func (h *CanonicalScopeHandler) GetDefaultScope(ctx context.Context) (canonicalscopec.GetDefaultScopeRes, error) {
+	if err := h.available(); err != nil {
+		return nil, err
+	}
+	value, err := h.operations.Default(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return scopeDescriptor(value)
+}
+
+func (h *CanonicalScopeHandler) ResolveScopeSelection(
+	ctx context.Context,
+	request *canonicalscopec.ResolveScopeSelectionRequest,
+) (canonicalscopec.ResolveScopeSelectionRes, error) {
+	if err := h.available(); err != nil {
+		return nil, err
+	}
+	if request == nil {
+		return nil, &scope.ValidationError{}
+	}
+	selection, err := canonicalScopeSelection(request.Selection)
+	if err != nil {
+		return nil, err
+	}
+	values, err := h.operations.ResolveSelection(ctx, selection)
+	if err != nil {
+		return nil, err
+	}
+	return scopePage(values)
+}
+
+func (h *CanonicalScopeHandler) ResolveScopeBinding(
+	ctx context.Context,
+	request *canonicalscopec.ResolveScopeBindingRequest,
+) (canonicalscopec.ResolveScopeBindingRes, error) {
+	if err := h.available(); err != nil {
+		return nil, err
+	}
+	if request == nil {
+		return nil, &scope.ValidationError{}
+	}
+	keys, err := canonicalScopeBindingKeys(request.BindingKeys)
+	if err != nil {
+		return nil, err
+	}
+	var explicit *string
+	if value, found := request.ExplicitScopeID.Get(); found {
+		if _, validationErr := scope.NewExactSelection([]string{value}); validationErr != nil {
+			return nil, &scope.ValidationError{}
+		}
+		explicit = new(value)
+	}
+	resolved, err := h.operations.Resolve(ctx, explicit, keys)
+	if err != nil {
+		return nil, err
+	}
+	return scopeDescriptor(resolved)
+}
+
+func (h *CanonicalScopeHandler) available() error {
+	if h == nil || h.operations == nil {
+		return &RuntimeNotReadyError{}
+	}
+	return nil
+}
+
+func canonicalScopeSelection(value canonicalscopec.ScopeSelection) (scope.Selection, error) {
+	switch value.Type {
+	case canonicalscopec.AllScopeSelectionScopeSelection:
+		return scope.AllSelection(), nil
+	case canonicalscopec.ExactScopeSelectionScopeSelection:
+		selection, err := scope.NewExactSelection(value.ExactScopeSelection.ScopeIds)
+		if err != nil {
+			return scope.Selection{}, &scope.ValidationError{}
+		}
+		return selection, nil
+	case canonicalscopec.SubtreeScopeSelectionScopeSelection:
+		selection, err := scope.NewSubtreeSelection(value.SubtreeScopeSelection.RootScopeID)
+		if err != nil {
+			return scope.Selection{}, &scope.ValidationError{}
+		}
+		return selection, nil
+	default:
+		return scope.Selection{}, &scope.ValidationError{}
+	}
+}
+
+func canonicalScopeBindingKeys(values []canonicalscopec.ScopeBindingKey) ([]scope.BindingKey, error) {
+	keys := make([]scope.BindingKey, 0, len(values))
+	for _, value := range values {
+		switch value.Integration {
+		case canonicalscopec.ScopeBindingKeyIntegrationCodex, canonicalscopec.ScopeBindingKeyIntegrationWorkbuddy:
+		default:
+			return nil, &scope.ValidationError{}
+		}
+		key, err := scope.NewBindingKey(string(value.Integration), value.Kind, value.ExternalID)
+		if err != nil {
+			return nil, &scope.ValidationError{}
+		}
+		keys = append(keys, key)
+	}
+	return keys, nil
+}
+
+func scopePage(values []scope.Descriptor) (*canonicalscopec.ScopePage, error) {
+	items := make([]canonicalscopec.ScopeDescriptor, 0, len(values))
+	for _, value := range values {
+		item, err := scopeDescriptorValue(value)
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, item)
+	}
+	return &canonicalscopec.ScopePage{Items: items}, nil
+}
+
+func scopeDescriptor(value scope.Descriptor) (*canonicalscopec.ScopeDescriptor, error) {
+	result, err := scopeDescriptorValue(value)
+	if err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+func scopeDescriptorValue(value scope.Descriptor) (canonicalscopec.ScopeDescriptor, error) {
+	if value.Version() < 1 || int64(int(value.Version())) != value.Version() {
+		return canonicalscopec.ScopeDescriptor{}, &RuntimeNotReadyError{}
+	}
+	external := value.ExternalReferences()
+	externalReferences := make([]canonicalscopec.ScopeExternalReference, 0, len(external))
+	for _, reference := range external {
+		externalReferences = append(externalReferences, canonicalscopec.ScopeExternalReference{
+			Kind: reference.Kind(), Value: reference.Value(),
+		})
+	}
+	result := canonicalscopec.ScopeDescriptor{
+		ContextReferences:  value.ContextReferences(),
+		ExternalReferences: externalReferences,
+		ScopeID:            value.ID(),
+		Summary:            value.Summary(),
+		Title:              value.Title(),
+		Version:            int(value.Version()),
+	}
+	if parent := value.ParentScopeID(); parent != "" {
+		result.ParentScopeID = canonicalscopec.NewOptNilString(parent)
+	}
+	return result, nil
+}

--- a/internal/endpoint/canonical_scope_test.go
+++ b/internal/endpoint/canonical_scope_test.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package endpoint
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	canonicalscopec "github.com/ob-labs/powercontext-go/api/canonical/scopes"
+	"github.com/ob-labs/powercontext-go/internal/scope"
+)
+
+func TestCanonicalScopeHandlerRejectsUnsupportedBindingBeforeResolution(t *testing.T) {
+	operations := &canonicalScopeOperationsStub{}
+	handler := NewCanonicalScopeHandler(operations)
+
+	response, err := handler.ResolveScopeBinding(t.Context(), &canonicalscopec.ResolveScopeBindingRequest{
+		BindingKeys: []canonicalscopec.ScopeBindingKey{{
+			Integration: canonicalscopec.ScopeBindingKeyIntegration("third-agent"),
+			Kind:        "project",
+			ExternalID:  "repository",
+		}},
+	})
+	if response != nil {
+		t.Fatalf("ResolveScopeBinding() response = %T, want nil", response)
+	}
+	if _, ok := errors.AsType[*scope.ValidationError](err); !ok {
+		t.Fatalf("ResolveScopeBinding() error = %T %v, want ValidationError", err, err)
+	}
+	if operations.resolveCalls != 0 {
+		t.Fatalf("Resolve() calls = %d, want no Scope operation", operations.resolveCalls)
+	}
+}
+
+type canonicalScopeOperationsStub struct {
+	resolveCalls int
+}
+
+func (s *canonicalScopeOperationsStub) List(context.Context) ([]scope.Descriptor, error) {
+	return nil, nil
+}
+
+func (s *canonicalScopeOperationsStub) Get(context.Context, string) (scope.Descriptor, error) {
+	return scope.Descriptor{}, nil
+}
+
+func (s *canonicalScopeOperationsStub) Default(context.Context) (scope.Descriptor, error) {
+	return scope.Descriptor{}, nil
+}
+
+func (s *canonicalScopeOperationsStub) Resolve(
+	context.Context,
+	*string,
+	[]scope.BindingKey,
+) (scope.Descriptor, error) {
+	s.resolveCalls++
+	return scope.Descriptor{}, nil
+}
+
+func (s *canonicalScopeOperationsStub) ResolveSelection(
+	context.Context,
+	scope.Selection,
+) ([]scope.Descriptor, error) {
+	return nil, nil
+}

--- a/internal/runtime/scope_application.go
+++ b/internal/runtime/scope_application.go
@@ -111,6 +111,39 @@ func (a *ScopeApplication) Get(ctx context.Context, id string) (result scope.Des
 	return result, err
 }
 
+// List returns durable Scope metadata in stable identity order.
+func (a *ScopeApplication) List(ctx context.Context) (result []scope.Descriptor, err error) {
+	err = a.runtime.Operation(ctx, func(ctx context.Context) error {
+		values, listErr := a.store.List(ctx)
+		if listErr != nil {
+			return listErr
+		}
+		values = slices.Clone(values)
+		slices.SortFunc(values, func(left, right scope.Descriptor) int {
+			return cmp.Compare(left.ID(), right.ID())
+		})
+		result = values
+		return nil
+	})
+	return result, err
+}
+
+// Default returns the durable default Scope without considering external bindings.
+func (a *ScopeApplication) Default(ctx context.Context) (result scope.Descriptor, err error) {
+	err = a.runtime.Operation(ctx, func(ctx context.Context) error {
+		value, found, defaultErr := a.store.Default(ctx)
+		if defaultErr != nil {
+			return defaultErr
+		}
+		if !found {
+			return &scope.NotFoundError{}
+		}
+		result = value
+		return nil
+	})
+	return result, err
+}
+
 func (a *ScopeApplication) SetDefault(ctx context.Context, id string) (result scope.Descriptor, err error) {
 	err = a.runtime.Operation(ctx, func(ctx context.Context) error {
 		value, setErr := a.store.SetDefault(ctx, id)

--- a/internal/runtime/scope_application_test.go
+++ b/internal/runtime/scope_application_test.go
@@ -131,6 +131,40 @@ func TestScopeApplicationClearBindingIsIdempotent(t *testing.T) {
 	}
 }
 
+func TestScopeApplicationListsAndReadsDefaultScopes(t *testing.T) {
+	first, err := scope.NewDescriptor("scope-a", "A", "first", "", nil, nil, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := scope.NewDescriptor("scope-b", "B", "second", "", nil, nil, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store := &memoryScopeStore{
+		scopes:    map[string]scope.Descriptor{second.ID(): second, first.ID(): first},
+		defaultID: second.ID(),
+	}
+	application, err := NewScopeApplication(New(), store, func() string { return "scope-created" })
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	values, err := application.List(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(values) != 2 || values[0].ID() != first.ID() || values[1].ID() != second.ID() {
+		t.Fatalf("List() = %#v, want deterministic identity order", values)
+	}
+	defaultScope, err := application.Default(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if defaultScope.ID() != second.ID() {
+		t.Fatalf("Default() = %#v, want %q", defaultScope, second.ID())
+	}
+}
+
 type memoryScopeStore struct {
 	scopes    map[string]scope.Descriptor
 	defaultID string

--- a/server/application.go
+++ b/server/application.go
@@ -135,9 +135,10 @@ func (a *Application) HTTPHandler() (http.Handler, error) {
 	return NewHTTPHandler(a.endpoint, HTTPOptions{
 		BearerToken: token, HandoffReportRoutes: a.config.HandoffReport.Enabled,
 		metrics: a.metrics, TracerProvider: a.tracing, Logger: a.logger, AccessLog: a.config.Logging.Access,
-		MCP:           MCPOptions{Enabled: a.config.MCP.Enabled, Path: a.config.MCP.Path},
-		webUI:         webOptions,
-		scopeBindings: a.scopes,
+		MCP:             MCPOptions{Enabled: a.config.MCP.Enabled, Path: a.config.MCP.Path},
+		webUI:           webOptions,
+		scopeBindings:   a.scopes,
+		canonicalScopes: endpoint.NewCanonicalScopeHandler(a.scopes),
 	})
 }
 

--- a/server/canonical_scope_http_test.go
+++ b/server/canonical_scope_http_test.go
@@ -1,0 +1,393 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build sqlite_fts5
+
+package server
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"strings"
+	"testing"
+
+	canonicalscopec "github.com/ob-labs/powercontext-go/api/canonical/scopes"
+	v1 "github.com/ob-labs/powercontext-go/api/v1"
+	"github.com/ob-labs/powercontext-go/internal/scope"
+)
+
+func TestOpenApplicationServesCanonicalScopeSidecar(t *testing.T) {
+	config := applicationTestConfig(t)
+	config.Auth.Enabled = true
+	config.Auth.Token = "scope-sidecar-secret"
+	application, err := OpenApplication(t.Context(), config, Dependencies{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { closeScopeReaderApplication(t, application) })
+
+	handler, err := application.HTTPHandler()
+	if err != nil {
+		t.Fatal(err)
+	}
+	root := createScopeForSidecar(t, application, "Root", "root scope", "")
+	child := createScopeForSidecar(t, application, "Child", "child scope", root.ID())
+	defaultScope, err := application.scopes.Default(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, binding := range []struct {
+		integration, target string
+	}{
+		{integration: "codex", target: child.ID()},
+		{integration: "workbuddy", target: root.ID()},
+	} {
+		key, keyErr := scope.NewBindingKey(binding.integration, "project", "repository")
+		if keyErr != nil {
+			t.Fatal(keyErr)
+		}
+		if _, bindErr := application.scopes.Bind(t.Context(), key, binding.target); bindErr != nil {
+			t.Fatal(bindErr)
+		}
+	}
+
+	unauthenticated := newCanonicalScopeClient(t, handler, "")
+	denied, err := unauthenticated.ListScopes(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := denied.(*canonicalscopec.UnauthorizedHeaders); !ok {
+		t.Fatalf("unauthenticated ListScopes() = %T, want UnauthorizedHeaders", denied)
+	}
+	client := newCanonicalScopeClient(t, handler, config.Auth.Token)
+
+	result, err := client.ListScopes(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	page, ok := result.(*canonicalscopec.ScopePage)
+	if !ok {
+		t.Fatalf("ListScopes() = %T, want ScopePage", result)
+	}
+	if len(page.Items) != 3 || page.Items[0].ScopeID == "" {
+		t.Fatalf("ListScopes() = %#v, want default and two created Scopes", page)
+	}
+
+	defaultResult, err := client.GetDefaultScope(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if value, ok := defaultResult.(*canonicalscopec.ScopeDescriptor); !ok || value.ScopeID != defaultScope.ID() {
+		t.Fatalf("GetDefaultScope() = %#v, want %q", defaultResult, defaultScope.ID())
+	}
+	getResult, err := client.GetScope(t.Context(), canonicalscopec.GetScopeParams{ScopeID: child.ID()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if value, ok := getResult.(*canonicalscopec.ScopeDescriptor); !ok || value.ScopeID != child.ID() {
+		t.Fatalf("GetScope() = %#v, want %q", getResult, child.ID())
+	}
+
+	allResult, err := client.ResolveScopeSelection(t.Context(), &canonicalscopec.ResolveScopeSelectionRequest{
+		Selection: canonicalscopec.NewAllScopeSelectionScopeSelection(canonicalscopec.AllScopeSelection{
+			Mode: canonicalscopec.AllScopeSelectionModeAll,
+		}),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	all, ok := allResult.(*canonicalscopec.ScopePage)
+	if !ok || len(all.Items) != len(page.Items) {
+		t.Fatalf("all selection = %#v, want listed Scope page", allResult)
+	}
+	exactResult, err := client.ResolveScopeSelection(t.Context(), &canonicalscopec.ResolveScopeSelectionRequest{
+		Selection: canonicalscopec.NewExactScopeSelectionScopeSelection(canonicalscopec.ExactScopeSelection{
+			Mode: canonicalscopec.ExactScopeSelectionModeExact, ScopeIds: []string{child.ID(), root.ID()},
+		}),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	exactIDs := []string{root.ID(), child.ID()}
+	slices.Sort(exactIDs)
+	assertCanonicalScopeIDs(t, exactResult, exactIDs...)
+	subtreeResult, err := client.ResolveScopeSelection(t.Context(), &canonicalscopec.ResolveScopeSelectionRequest{
+		Selection: canonicalscopec.NewSubtreeScopeSelectionScopeSelection(canonicalscopec.SubtreeScopeSelection{
+			Mode: canonicalscopec.SubtreeScopeSelectionModeSubtree, RootScopeID: root.ID(),
+		}),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertCanonicalScopeIDs(t, subtreeResult, root.ID(), child.ID())
+
+	for _, binding := range []struct {
+		integration, target string
+	}{
+		{integration: "codex", target: child.ID()},
+		{integration: "workbuddy", target: root.ID()},
+	} {
+		result, resolveErr := client.ResolveScopeBinding(t.Context(), &canonicalscopec.ResolveScopeBindingRequest{
+			BindingKeys: []canonicalscopec.ScopeBindingKey{{
+				Integration: canonicalscopec.ScopeBindingKeyIntegration(binding.integration),
+				Kind:        "project",
+				ExternalID:  "repository",
+			}},
+		})
+		if resolveErr != nil {
+			t.Fatal(resolveErr)
+		}
+		if value, ok := result.(*canonicalscopec.ScopeDescriptor); !ok || value.ScopeID != binding.target {
+			t.Fatalf("%s binding = %#v, want %q", binding.integration, result, binding.target)
+		}
+	}
+	explicit := canonicalscopec.NewOptNilString(defaultScope.ID())
+	resolved, err := client.ResolveScopeBinding(t.Context(), &canonicalscopec.ResolveScopeBindingRequest{
+		BindingKeys: []canonicalscopec.ScopeBindingKey{{
+			Integration: canonicalscopec.ScopeBindingKeyIntegrationCodex,
+			Kind:        "project",
+			ExternalID:  "repository",
+		}},
+		ExplicitScopeID: explicit,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if value, ok := resolved.(*canonicalscopec.ScopeDescriptor); !ok || value.ScopeID != defaultScope.ID() {
+		t.Fatalf("explicit Scope binding = %#v, want %q", resolved, defaultScope.ID())
+	}
+}
+
+func TestCanonicalScopeSidecarRejectsMalformedRequestsBeforeLegacyFallback(t *testing.T) {
+	application, err := OpenApplication(t.Context(), applicationTestConfig(t), Dependencies{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { closeScopeReaderApplication(t, application) })
+	handler, err := application.HTTPHandler()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, request := range []struct {
+		name, method, path, body string
+	}{
+		{name: "unknown union", method: http.MethodPost, path: "/v1/scopes/selection/resolve", body: `{"selection":{"mode":"other"}}`},
+		{name: "empty exact", method: http.MethodPost, path: "/v1/scopes/selection/resolve", body: `{"selection":{"mode":"exact","scope_ids":[]}}`},
+		{name: "oversized scope", method: http.MethodGet, path: "/v1/scopes/" + strings.Repeat("x", 257)},
+	} {
+		t.Run(request.name, func(t *testing.T) {
+			response := scopeSidecarRequest(t, handler, request.method, request.path, request.body, "")
+			if response.Code != http.StatusUnprocessableEntity {
+				t.Fatalf("status = %d, want 422: %s", response.Code, response.Body.String())
+			}
+			var envelope struct {
+				Error struct {
+					Code string `json:"code"`
+				} `json:"error"`
+			}
+			if decodeErr := json.Unmarshal(response.Body.Bytes(), &envelope); decodeErr != nil || envelope.Error.Code != "invalid_request" {
+				t.Fatalf("error envelope = %#v, err=%v", envelope, decodeErr)
+			}
+		})
+	}
+}
+
+func TestCanonicalScopeSidecarReservesOnlyExactScopeOperations(t *testing.T) {
+	application, err := OpenApplication(t.Context(), applicationTestConfig(t), Dependencies{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { closeScopeReaderApplication(t, application) })
+	handler, err := application.HTTPHandler()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defaultScope := scopeSidecarRequest(t, handler, http.MethodGet, "/v1/scopes/default", "", "")
+	if defaultScope.Code != http.StatusOK {
+		t.Fatalf("default Scope status = %d: %s", defaultScope.Code, defaultScope.Body.String())
+	}
+	for _, request := range []struct {
+		name, method, path string
+	}{
+		{name: "list wrong method", method: http.MethodPost, path: "/v1/scopes"},
+		{name: "default wrong method", method: http.MethodPost, path: "/v1/scopes/default"},
+		{name: "deferred Scope path", method: http.MethodPost, path: "/v1/scopes/create"},
+		{name: "binding wrong method", method: http.MethodGet, path: "/v1/scope-bindings/resolve"},
+	} {
+		t.Run(request.name, func(t *testing.T) {
+			response := scopeSidecarRequest(t, handler, request.method, request.path, "{}", "")
+			if response.Code != http.StatusNotFound {
+				t.Fatalf("status = %d, want legacy 404: %s", response.Code, response.Body.String())
+			}
+		})
+	}
+
+	legacy, err := v1.NewClient("http://powercontext.test", legacySidecarSecurity{}, v1.WithClient(&http.Client{
+		Transport: scopeSidecarRoundTripper{handler: handler},
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := legacy.GetLiveness(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result == nil || result.Response.Status != "ok" {
+		t.Fatalf("legacy GetLiveness() = %#v", result)
+	}
+}
+
+func TestCanonicalScopeSidecarRedactsMissingScopeAndBindingValues(t *testing.T) {
+	config := applicationTestConfig(t)
+	config.Auth.Enabled = true
+	config.Auth.Token = "scope-sidecar-secret"
+	application, err := OpenApplication(t.Context(), config, Dependencies{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { closeScopeReaderApplication(t, application) })
+	handler, err := application.HTTPHandler()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, request := range []struct {
+		name, method, path, body, private string
+	}{
+		{
+			name: "Scope", method: http.MethodGet, path: "/v1/scopes/private-scope-id", private: "private-scope-id",
+		},
+		{
+			name: "subtree root", method: http.MethodPost, path: "/v1/scopes/selection/resolve",
+			body: `{"selection":{"mode":"subtree","root_scope_id":"private-root-id"}}`, private: "private-root-id",
+		},
+	} {
+		t.Run(request.name, func(t *testing.T) {
+			response := scopeSidecarRequest(t, handler, request.method, request.path, request.body, config.Auth.Token)
+			if response.Code != http.StatusNotFound {
+				t.Fatalf("status = %d, want 404: %s", response.Code, response.Body.String())
+			}
+			if strings.Contains(response.Body.String(), request.private) {
+				t.Fatalf("response leaked %q: %s", request.private, response.Body.String())
+			}
+		})
+	}
+
+	databasePath, err := SQLiteDSN(config.Database.SQLite.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	database, err := sql.Open("sqlite3", databasePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+	if _, err := database.ExecContext(t.Context(), "DELETE FROM pc_scope_settings WHERE name = 'default'"); err != nil {
+		t.Fatal(err)
+	}
+	client := newCanonicalScopeClient(t, handler, config.Auth.Token)
+	result, err := client.ResolveScopeBinding(t.Context(), &canonicalscopec.ResolveScopeBindingRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	missing, ok := result.(*canonicalscopec.NotFoundHeaders)
+	if !ok || missing.Response.Error.Code != "scope_binding_not_found" {
+		t.Fatalf("unbound Scope resolution = %#v, want redacted binding 404", result)
+	}
+}
+
+type scopeSidecarClientSecurity struct {
+	token string
+}
+
+type legacySidecarSecurity struct{}
+
+func (legacySidecarSecurity) BearerAuth(context.Context, v1.OperationName) (v1.BearerAuth, error) {
+	return v1.BearerAuth{}, nil
+}
+
+func (security scopeSidecarClientSecurity) BearerAuth(
+	context.Context,
+	canonicalscopec.OperationName,
+) (canonicalscopec.BearerAuth, error) {
+	return canonicalscopec.BearerAuth{Token: security.token}, nil
+}
+
+type scopeSidecarRoundTripper struct {
+	handler http.Handler
+}
+
+func (transport scopeSidecarRoundTripper) RoundTrip(request *http.Request) (*http.Response, error) {
+	recorder := httptest.NewRecorder()
+	transport.handler.ServeHTTP(recorder, request)
+	return recorder.Result(), nil
+}
+
+func newCanonicalScopeClient(t *testing.T, handler http.Handler, token string) *canonicalscopec.Client {
+	t.Helper()
+	client, err := canonicalscopec.NewClient("http://powercontext.test", scopeSidecarClientSecurity{token: token}, canonicalscopec.WithClient(&http.Client{
+		Transport: scopeSidecarRoundTripper{handler: handler},
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return client
+}
+
+func createScopeForSidecar(t *testing.T, application *Application, title, summary, parent string) scope.Descriptor {
+	t.Helper()
+	draft, err := scope.NewDraft(title, summary, parent, nil, nil, title+"-request")
+	if err != nil {
+		t.Fatal(err)
+	}
+	value, err := application.scopes.Create(t.Context(), draft)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return value
+}
+
+func assertCanonicalScopeIDs(t *testing.T, result canonicalscopec.ResolveScopeSelectionRes, want ...string) {
+	t.Helper()
+	page, ok := result.(*canonicalscopec.ScopePage)
+	if !ok {
+		t.Fatalf("selection = %T, want ScopePage", result)
+	}
+	if len(page.Items) != len(want) {
+		t.Fatalf("selection item count = %d, want %d: %#v", len(page.Items), len(want), page)
+	}
+	for index, id := range want {
+		if page.Items[index].ScopeID != id {
+			t.Fatalf("selection item %d = %q, want %q", index, page.Items[index].ScopeID, id)
+		}
+	}
+}
+
+func scopeSidecarRequest(t *testing.T, handler http.Handler, method, path, body, token string) *httptest.ResponseRecorder {
+	t.Helper()
+	request := httptest.NewRequest(method, path, strings.NewReader(body))
+	request.Header.Set("Content-Type", "application/json")
+	if token != "" {
+		request.Header.Set("Authorization", "Bearer "+token)
+	}
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+	return response
+}

--- a/server/http.go
+++ b/server/http.go
@@ -27,6 +27,7 @@ import (
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
 
+	canonicalscopec "github.com/ob-labs/powercontext-go/api/canonical/scopes"
 	v1 "github.com/ob-labs/powercontext-go/api/v1"
 	"github.com/ob-labs/powercontext-go/internal/endpoint"
 	"github.com/ob-labs/powercontext-go/internal/httpapi"
@@ -48,6 +49,7 @@ type HTTPOptions struct {
 	metrics             *servermetrics.Server
 	webUI               *webui.Options
 	scopeBindings       mcpapi.ScopeBindingOperations
+	canonicalScopes     canonicalscopec.Handler
 }
 
 // MCPOptions controls the optional MCP Streamable HTTP route. Path defaults to
@@ -88,15 +90,16 @@ func NewHTTPHandler(handler v1.Handler, options HTTPOptions) (http.Handler, erro
 	if options.metrics != nil {
 		middlewares = append(middlewares, options.metrics.HTTPMiddleware)
 	}
+	mapApplicationError := func(err error) (int, httpapi.Error, bool) {
+		mapped := endpoint.MapError(err)
+		return mapped.StatusCode, httpapi.Error{
+			Code: mapped.Code, Message: mapped.Message, Details: mapped.Details,
+		}, true
+	}
 	serverOptions := []v1.ServerOption{
 		v1.WithTracerProvider(httpapi.TracerProvider(options.TracerProvider)),
 		v1.WithMiddleware(middlewares...),
-		v1.WithErrorHandler(httpapi.ErrorHandler(func(err error) (int, httpapi.Error, bool) {
-			mapped := endpoint.MapError(err)
-			return mapped.StatusCode, httpapi.Error{
-				Code: mapped.Code, Message: mapped.Message, Details: mapped.Details,
-			}, true
-		})),
+		v1.WithErrorHandler(httpapi.ErrorHandler(mapApplicationError)),
 	}
 	if options.MeterProvider != nil {
 		serverOptions = append(serverOptions, v1.WithMeterProvider(options.MeterProvider))
@@ -105,6 +108,25 @@ func NewHTTPHandler(handler v1.Handler, options HTTPOptions) (http.Handler, erro
 	if err != nil {
 		return nil, err
 	}
+	var canonicalGenerated *canonicalscopec.Server
+	if options.canonicalScopes != nil {
+		canonicalServerOptions := []canonicalscopec.ServerOption{
+			canonicalscopec.WithTracerProvider(httpapi.TracerProvider(options.TracerProvider)),
+			canonicalscopec.WithMiddleware(middlewares...),
+			canonicalscopec.WithErrorHandler(httpapi.ErrorHandler(mapApplicationError)),
+		}
+		if options.MeterProvider != nil {
+			canonicalServerOptions = append(canonicalServerOptions, canonicalscopec.WithMeterProvider(options.MeterProvider))
+		}
+		canonicalGenerated, err = canonicalscopec.NewServer(
+			options.canonicalScopes,
+			canonicalScopeSecurity{},
+			canonicalServerOptions...,
+		)
+		if err != nil {
+			return nil, err
+		}
+	}
 	mcpPath := ""
 	if options.MCP.Enabled {
 		mcpPath, err = normalizeMCPPath(options.MCP.Path)
@@ -112,7 +134,11 @@ func NewHTTPHandler(handler v1.Handler, options HTTPOptions) (http.Handler, erro
 			return nil, err
 		}
 	}
-	validatedOpenAPI := httpapi.ValidateJSONUnicode(generated)
+	var openAPI http.Handler = generated
+	if canonicalGenerated != nil {
+		openAPI = canonicalScopeSidecar{legacy: generated, canonical: canonicalGenerated}
+	}
+	validatedOpenAPI := httpapi.ValidateJSONUnicode(openAPI)
 	var application http.Handler = validatedOpenAPI
 	var mux *http.ServeMux
 	if options.MCP.Enabled || options.metrics != nil || options.webUI != nil {
@@ -166,6 +192,11 @@ func NewHTTPHandler(handler v1.Handler, options HTTPOptions) (http.Handler, erro
 				if !options.HandoffReportRoutes && strings.HasPrefix(request.URL.Path, "/v1/handoff-reports/") {
 					return "unmatched"
 				}
+				if canonicalGenerated != nil {
+					if route, found := canonicalGenerated.FindPath(request.Method, request.URL); found {
+						return route.OperationID()
+					}
+				}
 				route, found := generated.FindPath(request.Method, request.URL)
 				if !found {
 					return "unmatched"
@@ -186,6 +217,33 @@ func NewHTTPHandler(handler v1.Handler, options HTTPOptions) (http.Handler, erro
 		BearerToken: options.BearerToken, HandoffReportRoutes: options.HandoffReportRoutes,
 		Access: access,
 	})
+}
+
+// canonicalScopeSecurity is intentionally permissive: httpapi.Wrap owns the
+// process-wide bearer boundary and runs before this sidecar's generated server.
+type canonicalScopeSecurity struct{}
+
+func (canonicalScopeSecurity) HandleBearerAuth(
+	ctx context.Context,
+	_ canonicalscopec.OperationName,
+	_ canonicalscopec.BearerAuth,
+) (context.Context, error) {
+	return ctx, nil
+}
+
+// canonicalScopeSidecar reserves only exact generated Scope operation paths.
+// All other method/path pairs remain on the frozen legacy handler.
+type canonicalScopeSidecar struct {
+	legacy    http.Handler
+	canonical *canonicalscopec.Server
+}
+
+func (handler canonicalScopeSidecar) ServeHTTP(w http.ResponseWriter, request *http.Request) {
+	if _, found := handler.canonical.FindPath(request.Method, request.URL); found {
+		handler.canonical.ServeHTTP(w, request)
+		return
+	}
+	handler.legacy.ServeHTTP(w, request)
 }
 
 func normalizeMCPPath(value string) (string, error) {


### PR DESCRIPTION
Part of #202 Phase 3.

Serves exactly five canonical Scope read/resolve operations through the generated `api/canonical/scopes` sidecar while preserving the frozen legacy v1 Handler/Invoker/client. The dispatcher sends only generated exact method/path matches to the sidecar; every other/deferred path remains legacy fallback.

The canonical endpoint uses the runtime Scope application, accepts only Codex/WorkBuddy binding integrations before runtime/SQLite access, and maps failures through the same redacted process-wide HTTP policy. It uses the existing outer auth/request-ID/body/trace/log/metrics wrapper once, and adds no generated MCP tool or Scope mutation route.

Validation includes real file SQLite/OpenApplication/generated-client behavior, binding/selection priority, malformed/missing redaction, zero-side-effect unsupported agent rejection, and legacy fallback checks.