### PR TITLE
feat(service): run Linux personal server lifecycle

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -296,6 +296,64 @@ jobs:
             exit 1
           fi
 
+  linux-personal-service-consumer:
+    name: Linux personal service release consumer
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    permissions:
+      contents: read
+    env:
+      GOTOOLCHAIN: local
+      GOFLAGS: -mod=readonly
+    steps:
+      - name: Check out
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Install native build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes --no-install-recommends libsqlite3-dev
+
+      - name: Set up the environment
+        uses: ./.github/actions/setup-go-env
+
+      - name: Build Standard Linux archive for personal-service consumer
+        shell: bash
+        run: |
+          version=0.0.0-ci
+          epoch="$(git show -s --format=%ct)"
+          build_date="$(date -u -d "@$epoch" +%Y-%m-%dT%H:%M:%SZ)"
+          syft_version="$(go run ./tools/release asset -component syft -field version)"
+          mkdir -p "$RUNNER_TEMP/tools"
+          GOBIN="$RUNNER_TEMP/tools" go install "github.com/anchore/syft/cmd/syft@v$syft_version"
+          make package-standard \
+            VERSION="$version" COMMIT="$GITHUB_SHA" BUILD_DATE="$build_date" \
+            SYFT="$RUNNER_TEMP/tools/syft"
+
+      - name: Build Linux personal-service consumer
+        shell: bash
+        run: |
+          go test -c -tags systemd_user_consumer \
+            -o "$RUNNER_TEMP/powercontext-systemd-user-consumer.test" ./tools/release
+
+      - name: Exercise Standard Linux personal-service archive
+        shell: bash
+        run: |
+          version=0.0.0-ci
+          archive="$(realpath "dist/powercontext-${version}-linux-amd64.tar.gz")"
+          test/systemd-user-consumer/run.sh \
+            --archive "$archive" \
+            --test-binary "$RUNNER_TEMP/powercontext-systemd-user-consumer.test"
+
+      - name: Upload bounded personal-service consumer diagnostics
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: linux-personal-service-consumer-${{ github.sha }}
+          path: ${{ runner.temp }}/powercontext-systemd-user-consumer.*/summary.json
+          if-no-files-found: warn
+          retention-days: 14
+
   check-docs:
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -188,6 +188,29 @@ jobs:
         run: |
           cmp --silent <(jq -S '.redistributed_integrations' "${{ steps.archives.outputs.standard_root }}/DEPENDENCIES.json") <(jq -S '.redistributed_integrations' "${{ steps.archives.outputs.full_root }}/DEPENDENCIES.json")
 
+      - name: Exercise published Linux personal-service archive
+        id: personal_service
+        shell: bash
+        env:
+          ASSET_DIR: ${{ runner.temp }}/powercontext-release-assets
+          VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          go test -c -tags systemd_user_consumer \
+            -o "$RUNNER_TEMP/powercontext-systemd-user-consumer.test" ./tools/release
+          archive="$ASSET_DIR/powercontext-${VERSION}-linux-amd64.tar.gz"
+          test/systemd-user-consumer/run.sh \
+            --archive "$archive" \
+            --test-binary "$RUNNER_TEMP/powercontext-systemd-user-consumer.test"
+
+      - name: Upload bounded published personal-service consumer diagnostics
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: published-linux-personal-service-consumer-${{ github.sha }}
+          path: ${{ runner.temp }}/powercontext-systemd-user-consumer.*/summary.json
+          if-no-files-found: warn
+          retention-days: 14
+
       - name: Exercise the released standard binary
         id: standard_smoke
         env:
@@ -330,6 +353,7 @@ jobs:
           FULL_SMOKE: ${{ steps.full_smoke.outcome }}
           FULL_IMAGE_RUNTIME: ${{ steps.full_image_runtime.outcome }}
           IMAGES: ${{ steps.images.outcome }}
+          PERSONAL_SERVICE: ${{ steps.personal_service.outcome }}
           RELEASE_TAG: ${{ inputs.release_tag }}
           VERSION: ${{ steps.release.outputs.version }}
           STANDARD_SMOKE: ${{ steps.standard_smoke.outcome }}
@@ -345,6 +369,7 @@ jobs:
             echo "- Standard process contract: **$STANDARD_SMOKE**"
             echo "- Full process contract: **$FULL_SMOKE**"
             echo "- Immutable GHCR manifests: **$IMAGES**"
+            echo "- Linux personal-service archive consumer: **$PERSONAL_SERVICE**"
             echo "- Published standard image runtime: **$STANDARD_IMAGE_RUNTIME**"
             echo "- Published Full image runtime: **$FULL_IMAGE_RUNTIME**"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,6 +158,33 @@ jobs:
           make package-standard
           make package-full
 
+      - name: Build Linux personal-service consumer
+        if: matrix.target == 'linux-amd64'
+        shell: bash
+        run: |
+          go test -c -tags systemd_user_consumer \
+            -o "$RUNNER_TEMP/powercontext-systemd-user-consumer.test" ./tools/release
+
+      - name: Exercise Standard Linux personal-service archive
+        if: matrix.target == 'linux-amd64'
+        shell: bash
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          archive="$(realpath "dist/powercontext-${VERSION}-linux-amd64.tar.gz")"
+          test/systemd-user-consumer/run.sh \
+            --archive "$archive" \
+            --test-binary "$RUNNER_TEMP/powercontext-systemd-user-consumer.test"
+
+      - name: Upload bounded personal-service consumer diagnostics
+        if: failure() && matrix.target == 'linux-amd64'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: release-linux-personal-service-consumer-${{ github.sha }}
+          path: ${{ runner.temp }}/powercontext-systemd-user-consumer.*/summary.json
+          if-no-files-found: warn
+          retention-days: 14
+
       - name: Smoke test both released process surfaces
         env:
           POWERCONTEXT_ONNXRUNTIME_LIBRARY_DIR: ${{ steps.native.outputs.onnxruntime-lib-dir }}

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -50,6 +50,7 @@ header:
     - '**/*.yaml'
     - '**/*.yml'
     - 'Dockerfile'
+    - 'test/systemd-user-consumer/Dockerfile'
 
   paths-ignore:
     # Workflows are supply-chain configuration rather than shipped source.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -626,3 +626,11 @@ source / artifact / trigger / inference
   root, reject global load roots, and fail closed on missing or nonempty
   `DropInPaths`. Verify global paths, drop-ins, space-containing command
   arguments, and zero-value public operations cannot reach a native boundary.
+- When a Linux personal-service boundary accesses an owned artifact or
+  credential-bearing environment file, resolve every directory component from
+  a trusted descriptor with `O_DIRECTORY|O_NOFOLLOW` and perform leaf reads,
+  writes, renames, and deletes relative to that descriptor. Preserve D-Bus
+  environment entries as individual assignments and require each ownership
+  marker exactly once. Verify a middle-directory symlink to an owner-private
+  target, concurrent parent replacement, and a whitespace-combined marker
+  assignment cannot substitute a trusted artifact or manager registration.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -202,6 +202,9 @@ source / artifact / trigger / inference
   merge only `Rows.Close`; do not call a helper that reads `Rows.Err` again.
   Verify injected iteration and close failures remain matchable while each
   root error appears only once.
+- When a health probe consumes an HTTP response but its outcome intentionally
+  does not model close failure, explicitly discard `Body.Close` in a deferred
+  function. Verify the probe outcome and the pinned `errcheck` policy.
 - When a CI end-to-end test starts a compiled Go service under a readiness
   deadline, build the binary once before the deadline and pass its absolute
   path to every test worker. Verify the workflow with empty `GOMODCACHE` and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -634,3 +634,9 @@ source / artifact / trigger / inference
   marker exactly once. Verify a middle-directory symlink to an owner-private
   target, concurrent parent replacement, and a whitespace-combined marker
   assignment cannot substitute a trusted artifact or manager registration.
+
+- When a hidden service command forwards persistent paths or endpoints into a
+  managed unit, reject a changed flag value with leading or trailing whitespace
+  as a usage error before any platform boundary. Render and parse the exact
+  supported systemd service type, and verify legacy type variants remain
+  unowned artifacts.

--- a/internal/cli/server_command.go
+++ b/internal/cli/server_command.go
@@ -42,6 +42,11 @@ type serverEnvironmentValue struct {
 	present bool
 }
 
+type serviceFlagRequirement struct {
+	name  string
+	value *string
+}
+
 func newServerCommand(state *commandState) *cobra.Command {
 	command := &cobra.Command{Use: "server", Short: "Run a configured PowerContext service."}
 	command.AddCommand(
@@ -58,11 +63,9 @@ func newServerInstallCommand() *cobra.Command {
 	var envFile string
 	var dataDir string
 	command := &cobra.Command{
-		Use: "install", Short: "Install the Linux personal Server service.", Args: cobra.NoArgs,
+		Use: "install", Short: "Install the Linux personal Server service.",
+		Args: requiredServiceArgs(serviceFlagRequirement{name: "env-file", value: &envFile}),
 		RunE: func(command *cobra.Command, _ []string) error {
-			if err := requireServiceFlag(command, "env-file", envFile); err != nil {
-				return err
-			}
 			if command.Flags().Changed("data-dir") {
 				if err := requireServiceFlag(command, "data-dir", dataDir); err != nil {
 					return err
@@ -100,20 +103,13 @@ func newServerServiceRunCommand() *cobra.Command {
 	var endpoint string
 	var dataDir string
 	command := &cobra.Command{
-		Use: "_service-run", Hidden: true, Args: cobra.NoArgs,
+		Use: "_service-run", Hidden: true,
+		Args: requiredServiceArgs(
+			serviceFlagRequirement{name: "env-file", value: &envFile},
+			serviceFlagRequirement{name: "endpoint", value: &endpoint},
+			serviceFlagRequirement{name: "data-dir", value: &dataDir},
+		),
 		RunE: func(command *cobra.Command, _ []string) error {
-			for _, flag := range []struct {
-				name  string
-				value string
-			}{
-				{name: "env-file", value: envFile},
-				{name: "endpoint", value: endpoint},
-				{name: "data-dir", value: dataDir},
-			} {
-				if err := requireServiceFlag(command, flag.name, flag.value); err != nil {
-					return err
-				}
-			}
 			return unsupportedPersonalService()
 		},
 	}
@@ -124,6 +120,23 @@ func newServerServiceRunCommand() *cobra.Command {
 		_ = command.MarkFlagRequired(name)
 	}
 	return command
+}
+
+func requiredServiceArgs(requirements ...serviceFlagRequirement) cobra.PositionalArgs {
+	return func(command *cobra.Command, arguments []string) error {
+		if err := cobra.NoArgs(command, arguments); err != nil {
+			return err
+		}
+		for _, requirement := range requirements {
+			if !command.Flags().Changed(requirement.name) {
+				return usageError(fmt.Errorf("server: --%s is required", requirement.name))
+			}
+			if err := requireServiceFlag(command, requirement.name, *requirement.value); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
 }
 
 func requireServiceFlag(command *cobra.Command, name, value string) error {

--- a/internal/cli/server_command.go
+++ b/internal/cli/server_command.go
@@ -140,7 +140,7 @@ func requiredServiceArgs(requirements ...serviceFlagRequirement) cobra.Positiona
 }
 
 func requireServiceFlag(command *cobra.Command, name, value string) error {
-	if command.Flags().Changed(name) && strings.TrimSpace(value) == "" {
+	if command.Flags().Changed(name) && (strings.TrimSpace(value) == "" || strings.TrimSpace(value) != value) {
 		return usageError(fmt.Errorf("server: --%s must be a non-empty trimmed value", name))
 	}
 	return nil

--- a/internal/cli/server_command.go
+++ b/internal/cli/server_command.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"slices"
 	"strings"
 	"sync"
 	"syscall"
@@ -51,15 +52,15 @@ func newServerCommand(state *commandState) *cobra.Command {
 	command := &cobra.Command{Use: "server", Short: "Run a configured PowerContext service."}
 	command.AddCommand(
 		newServerRunCommand(state),
-		newServerInstallCommand(),
-		newServerStatusCommand(),
-		newServerUninstallCommand(),
-		newServerServiceRunCommand(),
+		newServerInstallCommand(state),
+		newServerStatusCommand(state),
+		newServerUninstallCommand(state),
+		newServerServiceRunCommand(state),
 	)
 	return command
 }
 
-func newServerInstallCommand() *cobra.Command {
+func newServerInstallCommand(state *commandState) *cobra.Command {
 	var envFile string
 	var dataDir string
 	command := &cobra.Command{
@@ -71,7 +72,7 @@ func newServerInstallCommand() *cobra.Command {
 					return err
 				}
 			}
-			return unsupportedPersonalService()
+			return runPersonalServiceInstall(command.Context(), state, envFile, dataDir)
 		},
 	}
 	command.Flags().StringVar(&envFile, "env-file", "", "Absolute environment file used by the personal Server service.")
@@ -80,25 +81,25 @@ func newServerInstallCommand() *cobra.Command {
 	return command
 }
 
-func newServerStatusCommand() *cobra.Command {
+func newServerStatusCommand(state *commandState) *cobra.Command {
 	return &cobra.Command{
 		Use: "status", Short: "Inspect the Linux personal Server service.", Args: cobra.NoArgs,
-		RunE: func(*cobra.Command, []string) error {
-			return unsupportedPersonalService()
+		RunE: func(command *cobra.Command, _ []string) error {
+			return runPersonalServiceStatus(command.Context(), state)
 		},
 	}
 }
 
-func newServerUninstallCommand() *cobra.Command {
+func newServerUninstallCommand(state *commandState) *cobra.Command {
 	return &cobra.Command{
 		Use: "uninstall", Short: "Remove the Linux personal Server service.", Args: cobra.NoArgs,
-		RunE: func(*cobra.Command, []string) error {
-			return unsupportedPersonalService()
+		RunE: func(command *cobra.Command, _ []string) error {
+			return runPersonalServiceUninstall(command.Context(), state)
 		},
 	}
 }
 
-func newServerServiceRunCommand() *cobra.Command {
+func newServerServiceRunCommand(state *commandState) *cobra.Command {
 	var envFile string
 	var endpoint string
 	var dataDir string
@@ -110,7 +111,7 @@ func newServerServiceRunCommand() *cobra.Command {
 			serviceFlagRequirement{name: "data-dir", value: &dataDir},
 		),
 		RunE: func(command *cobra.Command, _ []string) error {
-			return unsupportedPersonalService()
+			return runPersonalServiceLauncher(command.Context(), state, envFile, endpoint, dataDir)
 		},
 	}
 	command.Flags().StringVar(&envFile, "env-file", "", "Registered environment file.")
@@ -249,6 +250,35 @@ func withServerEnvironment(values map[string]string, run func() error) (err erro
 	for name, value := range values {
 		if setErr := os.Setenv(name, value); setErr != nil {
 			return fmt.Errorf("server: load environment: %w", setErr)
+		}
+	}
+	return run()
+}
+
+// withIsolatedServerEnvironment starts a foreground service with exactly the
+// values recorded in its private environment file plus service-owned overrides.
+// A systemd user manager may retain arbitrary inherited values, so selectively
+// replacing POWERCONTEXT_SERVER_* variables would permit stale provider
+// credentials or configuration to reach the managed process.
+func withIsolatedServerEnvironment(values map[string]string, run func() error) (err error) {
+	serverEnvironmentScopeMu.Lock()
+	defer serverEnvironmentScopeMu.Unlock()
+
+	before := slices.Clone(os.Environ())
+	os.Clearenv()
+	defer func() {
+		os.Clearenv()
+		for _, item := range before {
+			name, value, found := strings.Cut(item, "=")
+			if !found {
+				continue
+			}
+			err = errors.Join(err, os.Setenv(name, value))
+		}
+	}()
+	for name, value := range values {
+		if setErr := os.Setenv(name, value); setErr != nil {
+			return fmt.Errorf("server: load isolated environment: %w", setErr)
 		}
 	}
 	return run()

--- a/internal/cli/server_command.go
+++ b/internal/cli/server_command.go
@@ -44,8 +44,93 @@ type serverEnvironmentValue struct {
 
 func newServerCommand(state *commandState) *cobra.Command {
 	command := &cobra.Command{Use: "server", Short: "Run a configured PowerContext service."}
-	command.AddCommand(newServerRunCommand(state))
+	command.AddCommand(
+		newServerRunCommand(state),
+		newServerInstallCommand(),
+		newServerStatusCommand(),
+		newServerUninstallCommand(),
+		newServerServiceRunCommand(),
+	)
 	return command
+}
+
+func newServerInstallCommand() *cobra.Command {
+	var envFile string
+	var dataDir string
+	command := &cobra.Command{
+		Use: "install", Short: "Install the Linux personal Server service.", Args: cobra.NoArgs,
+		RunE: func(command *cobra.Command, _ []string) error {
+			if err := requireServiceFlag(command, "env-file", envFile); err != nil {
+				return err
+			}
+			if command.Flags().Changed("data-dir") {
+				if err := requireServiceFlag(command, "data-dir", dataDir); err != nil {
+					return err
+				}
+			}
+			return unsupportedPersonalService()
+		},
+	}
+	command.Flags().StringVar(&envFile, "env-file", "", "Absolute environment file used by the personal Server service.")
+	command.Flags().StringVar(&dataDir, "data-dir", "", "Absolute Server data directory override.")
+	_ = command.MarkFlagRequired("env-file")
+	return command
+}
+
+func newServerStatusCommand() *cobra.Command {
+	return &cobra.Command{
+		Use: "status", Short: "Inspect the Linux personal Server service.", Args: cobra.NoArgs,
+		RunE: func(*cobra.Command, []string) error {
+			return unsupportedPersonalService()
+		},
+	}
+}
+
+func newServerUninstallCommand() *cobra.Command {
+	return &cobra.Command{
+		Use: "uninstall", Short: "Remove the Linux personal Server service.", Args: cobra.NoArgs,
+		RunE: func(*cobra.Command, []string) error {
+			return unsupportedPersonalService()
+		},
+	}
+}
+
+func newServerServiceRunCommand() *cobra.Command {
+	var envFile string
+	var endpoint string
+	var dataDir string
+	command := &cobra.Command{
+		Use: "_service-run", Hidden: true, Args: cobra.NoArgs,
+		RunE: func(command *cobra.Command, _ []string) error {
+			for _, flag := range []struct {
+				name  string
+				value string
+			}{
+				{name: "env-file", value: envFile},
+				{name: "endpoint", value: endpoint},
+				{name: "data-dir", value: dataDir},
+			} {
+				if err := requireServiceFlag(command, flag.name, flag.value); err != nil {
+					return err
+				}
+			}
+			return unsupportedPersonalService()
+		},
+	}
+	command.Flags().StringVar(&envFile, "env-file", "", "Registered environment file.")
+	command.Flags().StringVar(&endpoint, "endpoint", "", "Registered loopback endpoint.")
+	command.Flags().StringVar(&dataDir, "data-dir", "", "Registered Server data directory.")
+	for _, name := range []string{"env-file", "endpoint", "data-dir"} {
+		_ = command.MarkFlagRequired(name)
+	}
+	return command
+}
+
+func requireServiceFlag(command *cobra.Command, name, value string) error {
+	if command.Flags().Changed(name) && strings.TrimSpace(value) == "" {
+		return usageError(fmt.Errorf("server: --%s must be a non-empty trimmed value", name))
+	}
+	return nil
 }
 
 func newServerRunCommand(state *commandState) *cobra.Command {

--- a/internal/cli/server_personal_service.go
+++ b/internal/cli/server_personal_service.go
@@ -27,5 +27,3 @@ func (*UnsupportedPersonalServiceError) Error() string {
 	}
 	return "personal Server service is supported only on Linux"
 }
-
-func unsupportedPersonalService() error { return &UnsupportedPersonalServiceError{} }

--- a/internal/cli/server_personal_service.go
+++ b/internal/cli/server_personal_service.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import "runtime"
+
+// UnsupportedPersonalServiceError reports a personal Server service command
+// that cannot use a native lifecycle manager. It has no caller-controlled
+// fields so diagnostics cannot expose paths, endpoints, or credentials.
+type UnsupportedPersonalServiceError struct{}
+
+func (*UnsupportedPersonalServiceError) Error() string {
+	if runtime.GOOS == "linux" {
+		return "personal Server service lifecycle is not available in this build"
+	}
+	return "personal Server service is supported only on Linux"
+}
+
+func unsupportedPersonalService() error { return &UnsupportedPersonalServiceError{} }

--- a/internal/cli/server_personal_service_lifecycle.go
+++ b/internal/cli/server_personal_service_lifecycle.go
@@ -1,0 +1,329 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/ob-labs/powercontext-go/internal/personalsvc"
+	"github.com/ob-labs/powercontext-go/server"
+)
+
+var (
+	personalServiceBoundaryFactory = newCurrentLinuxSystemdBoundary
+	personalServiceExecutable      = currentPersonalServiceExecutable
+)
+
+type personalServiceRuntime struct {
+	boundary   *linuxSystemdBoundary
+	adapter    *personalsvc.SystemdUserAdapter
+	controller *personalsvc.Controller
+}
+
+type personalServiceStatusView struct {
+	Support          personalsvc.Support           `json:"support"`
+	Registration     personalsvc.RegistrationState `json:"registration"`
+	Definition       personalsvc.DefinitionState   `json:"definition"`
+	ManagerOwnership personalsvc.ManagerOwnership  `json:"manager_ownership"`
+	Manager          personalsvc.ManagerState      `json:"manager"`
+	Liveness         personalsvc.Liveness          `json:"liveness"`
+	Recovery         personalsvc.Recovery          `json:"recovery"`
+}
+
+func runPersonalServiceInstall(ctx context.Context, state *commandState, envFile, dataDir string) error {
+	runtime, err := newPersonalServiceRuntime()
+	if err != nil {
+		return err
+	}
+	registration, err := newPersonalServiceRegistration(ctx, state, runtime.boundary, envFile, dataDir)
+	if err != nil {
+		return err
+	}
+	status, err := runtime.controller.Install(ctx, registration)
+	if err != nil {
+		return err
+	}
+	return writePersonalServiceStatus(state, status)
+}
+
+func runPersonalServiceStatus(ctx context.Context, state *commandState) error {
+	runtime, err := newPersonalServiceRuntime()
+	if err != nil {
+		return err
+	}
+	registration, found, err := installedPersonalServiceRegistration(ctx, runtime.adapter)
+	if err != nil {
+		return err
+	}
+	if !found {
+		status, statusErr := runtime.controller.Status(ctx, personalsvc.Registration{})
+		if statusErr != nil {
+			return statusErr
+		}
+		return writePersonalServiceStatus(state, status)
+	}
+	status, err := runtime.controller.Status(ctx, registration)
+	if err != nil {
+		return err
+	}
+	return writePersonalServiceStatus(state, status)
+}
+
+func runPersonalServiceUninstall(ctx context.Context, state *commandState) error {
+	runtime, err := newPersonalServiceRuntime()
+	if err != nil {
+		return err
+	}
+	registration, found, err := installedPersonalServiceRegistration(ctx, runtime.adapter)
+	if err != nil {
+		return err
+	}
+	if !found {
+		status, statusErr := runtime.controller.Status(ctx, personalsvc.Registration{})
+		if statusErr != nil {
+			return statusErr
+		}
+		return writePersonalServiceStatus(state, status)
+	}
+	status, err := runtime.controller.Uninstall(ctx, registration)
+	if err != nil {
+		return err
+	}
+	return writePersonalServiceStatus(state, status)
+}
+
+func runPersonalServiceLauncher(ctx context.Context, state *commandState, envFile, endpoint, dataDir string) error {
+	runtime, err := newPersonalServiceRuntime()
+	if err != nil {
+		return err
+	}
+	registration, found, err := installedPersonalServiceRegistration(ctx, runtime.adapter)
+	if err != nil || !found {
+		return newPersonalServicePlatformError("launcher identity")
+	}
+	expected, err := newPersonalServiceRegistrationFromIdentity(state, envFile, endpoint, dataDir)
+	if err != nil || registration != expected {
+		return newPersonalServicePlatformError("launcher identity")
+	}
+	values, err := runtime.boundary.LoadEnvironmentFile(ctx, registration.Definition().EnvFile())
+	if err != nil {
+		return err
+	}
+	override, err := personalServiceHTTPOverride(registration.Definition().Endpoint())
+	if err != nil {
+		return newPersonalServicePlatformError("launcher identity")
+	}
+	return withIsolatedServerEnvironment(personalServiceEnvironment(values, registration.Definition().DataDir()), func() error {
+		config, configErr := server.LoadConfigWithHTTPOverride(override)
+		if configErr != nil || config.Database.Kind != "sqlite" {
+			return newPersonalServicePlatformError("configuration")
+		}
+		runner := state.serverRun
+		if runner == nil {
+			runner = runServer
+		}
+		return runner(ctx, state, config)
+	})
+}
+
+func newPersonalServiceRuntime() (personalServiceRuntime, error) {
+	boundary, err := personalServiceBoundaryFactory()
+	if err != nil {
+		return personalServiceRuntime{}, err
+	}
+	launcher, err := personalsvc.NewSystemdUserLauncher("server", "_service-run")
+	if err != nil {
+		return personalServiceRuntime{}, newPersonalServicePlatformError("configuration")
+	}
+	adapter, err := personalsvc.NewSystemdUserAdapter(boundary, boundary.roots.configRoot, launcher)
+	if err != nil {
+		return personalServiceRuntime{}, newPersonalServicePlatformError("configuration")
+	}
+	controller, err := personalsvc.NewController(adapter, boundary.OperationBoundary())
+	if err != nil {
+		return personalServiceRuntime{}, newPersonalServicePlatformError("configuration")
+	}
+	return personalServiceRuntime{boundary: boundary, adapter: adapter, controller: controller}, nil
+}
+
+func newPersonalServiceRegistration(
+	ctx context.Context,
+	state *commandState,
+	boundary *linuxSystemdBoundary,
+	envFile, dataDir string,
+) (personalsvc.Registration, error) {
+	envFile, err := personalServiceEnvironmentPath(envFile)
+	if err != nil {
+		return personalsvc.Registration{}, newPersonalServicePlatformError("environment file")
+	}
+	dataDir, err = personalServiceDataDir(dataDir)
+	if err != nil {
+		return personalsvc.Registration{}, newPersonalServicePlatformError("data directory")
+	}
+	values, err := boundary.LoadEnvironmentFile(ctx, envFile)
+	if err != nil {
+		return personalsvc.Registration{}, err
+	}
+	var config server.ProcessConfig
+	if err := withIsolatedServerEnvironment(personalServiceEnvironment(values, dataDir), func() error {
+		var configErr error
+		config, configErr = server.LoadConfig()
+		return configErr
+	}); err != nil || config.Database.Kind != "sqlite" {
+		return personalsvc.Registration{}, newPersonalServicePlatformError("configuration")
+	}
+	return newPersonalServiceRegistrationFromIdentity(state, envFile, "http://"+config.HTTP.Address(), dataDir)
+}
+
+func newPersonalServiceRegistrationFromIdentity(
+	state *commandState,
+	envFile, endpoint, dataDir string,
+) (personalsvc.Registration, error) {
+	envFile, err := personalServiceEnvironmentPath(envFile)
+	if err != nil {
+		return personalsvc.Registration{}, err
+	}
+	dataDir, err = personalServiceDataDir(dataDir)
+	if err != nil {
+		return personalsvc.Registration{}, err
+	}
+	binary, err := personalServiceExecutable()
+	if err != nil {
+		return personalsvc.Registration{}, err
+	}
+	definition, err := personalsvc.NewDefinition(personalsvc.DefinitionInput{
+		Ownership:         personalsvc.OwnershipMarker,
+		DefinitionVersion: personalsvc.DefinitionVersion,
+		PackageVersion:    personalServiceVersion(state),
+		Binary:            binary,
+		Endpoint:          endpoint,
+		DataDir:           dataDir,
+		EnvFile:           envFile,
+	})
+	if err != nil {
+		return personalsvc.Registration{}, err
+	}
+	return personalsvc.NewRegistration(definition)
+}
+
+func installedPersonalServiceRegistration(ctx context.Context, adapter *personalsvc.SystemdUserAdapter) (personalsvc.Registration, bool, error) {
+	artifact, err := adapter.InspectArtifact(ctx)
+	if err != nil {
+		return personalsvc.Registration{}, false, newPersonalServicePlatformError("registration")
+	}
+	if artifact.State() != personalsvc.RegistrationInstalled {
+		if artifact.State() == personalsvc.RegistrationNotInstalled {
+			return personalsvc.Registration{}, false, nil
+		}
+		return personalsvc.Registration{}, false, newPersonalServicePlatformError("registration")
+	}
+	registration, found := artifact.Registration()
+	if !found || registration.Definition().Validate() != nil {
+		return personalsvc.Registration{}, false, newPersonalServicePlatformError("registration")
+	}
+	return registration, true, nil
+}
+
+func personalServiceEnvironment(values map[string]string, dataDir string) map[string]string {
+	result := maps.Clone(values)
+	result[server.PowerContextHomeEnv] = dataDir
+	result["POWERCONTEXT_SERVER_DATABASE_KIND"] = "sqlite"
+	result["POWERCONTEXT_SERVER_DATABASE_URL"] = "sqlite+aiosqlite:///" + filepath.ToSlash(filepath.Join(dataDir, "powercontext.db"))
+	return result
+}
+
+func personalServiceEnvironmentPath(value string) (string, error) {
+	if !filepath.IsAbs(value) {
+		return "", fmt.Errorf("personal-service environment file must be absolute")
+	}
+	absolute, err := filepath.Abs(value)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Clean(absolute), nil
+}
+
+func personalServiceDataDir(value string) (string, error) {
+	if value == "" {
+		return server.PowerContextDataDir()
+	}
+	if !filepath.IsAbs(value) {
+		return "", fmt.Errorf("personal-service data directory must be absolute")
+	}
+	return resolvePath(value)
+}
+
+func personalServiceHTTPOverride(endpoint string) (server.HTTPConfigOverride, error) {
+	parsed, err := url.Parse(endpoint)
+	if err != nil || parsed.Scheme != "http" || parsed.User != nil || parsed.Path != "" || parsed.RawQuery != "" || parsed.Fragment != "" {
+		return server.HTTPConfigOverride{}, fmt.Errorf("invalid personal-service endpoint")
+	}
+	port, err := strconv.Atoi(parsed.Port())
+	if err != nil || port < 1 || port > 65535 || parsed.Hostname() == "" {
+		return server.HTTPConfigOverride{}, fmt.Errorf("invalid personal-service endpoint")
+	}
+	host := parsed.Hostname()
+	return server.HTTPConfigOverride{Host: new(host), Port: new(port)}, nil
+}
+
+func currentPersonalServiceExecutable() (string, error) {
+	executable, err := os.Executable()
+	if err != nil {
+		return "", err
+	}
+	resolved, err := filepath.EvalSymlinks(executable)
+	if err != nil {
+		return "", err
+	}
+	info, err := os.Stat(resolved)
+	if err != nil || !info.Mode().IsRegular() {
+		return "", fmt.Errorf("invalid personal-service executable")
+	}
+	return filepath.Clean(resolved), nil
+}
+
+func personalServiceVersion(state *commandState) string {
+	if state == nil || strings.TrimSpace(state.version.Version) == "" {
+		return "devel"
+	}
+	return state.version.Version
+}
+
+func writePersonalServiceStatus(state *commandState, status personalsvc.Status) error {
+	view := personalServiceStatusView{
+		Support:          status.Support(),
+		Registration:     status.Registration(),
+		Definition:       status.Definition(),
+		ManagerOwnership: status.ManagerOwnership(),
+		Manager:          status.Manager(),
+		Liveness:         status.Liveness(),
+		Recovery:         status.Recovery(),
+	}
+	if state.json {
+		return writeJSON(state.stdout, view)
+	}
+	_, err := fmt.Fprintf(state.stdout,
+		"Support: %s\nRegistration: %s\nDefinition: %s\nManager ownership: %s\nManager: %s\nLiveness: %s\nRecovery: %s\n",
+		view.Support, view.Registration, view.Definition, view.ManagerOwnership, view.Manager, view.Liveness, view.Recovery,
+	)
+	return err
+}

--- a/internal/cli/server_personal_service_lifecycle_test.go
+++ b/internal/cli/server_personal_service_lifecycle_test.go
@@ -284,7 +284,8 @@ func (r *lifecycleSystemdRunner) Run(_ context.Context, program string, argument
 					"POWERCONTEXT_SERVICE_OWNED=true", "POWERCONTEXT_SERVICE_METADATA=" + metadata,
 				}},
 				"ExecStart": map[string]any{"type": "a(sasbttttuii)", "data": []any{[]any{
-					lifecycleBinary, []any{lifecycleBinary, "server", "_service-run", "--env-file", lifecycleEnvFile, "--endpoint", lifecycleURL, "--data-dir", lifecycleDataDir},
+					lifecycleBinary,
+					[]any{lifecycleBinary, "server", "_service-run", "--env-file", lifecycleEnvFile, "--endpoint", lifecycleURL, "--data-dir", lifecycleDataDir},
 					false, 0, 0, 0, 0, 0, 0, 0,
 				}}},
 			},

--- a/internal/cli/server_personal_service_lifecycle_test.go
+++ b/internal/cli/server_personal_service_lifecycle_test.go
@@ -1,0 +1,315 @@
+//go:build linux
+
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"bytes"
+	"context"
+	json "encoding/json/v2"
+	"errors"
+	"io"
+	"net/http"
+	"os"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/ob-labs/powercontext-go/internal/personalsvc"
+	"github.com/ob-labs/powercontext-go/server"
+)
+
+const (
+	lifecycleBinary  = "/opt/powercontext/powercontext"
+	lifecycleEnvFile = "/home/alice/.config/powercontext/server.env"
+	lifecycleDataDir = "/home/alice/.local/share/powercontext-service"
+	lifecycleURL     = "http://127.0.0.1:8123"
+)
+
+func TestServerPersonalServiceInstallAndLauncherUseOnlyVerifiedIdentity(t *testing.T) {
+	registration := lifecycleRegistration(t)
+	files := &lifecyclePrivateFiles{content: map[string][]byte{
+		lifecycleEnvFile: []byte("OPENAI_API_KEY=from-file\nPOWERCONTEXT_SERVER_HTTP_PORT=8123\n"),
+	}}
+	runner := &lifecycleSystemdRunner{files: files, registration: registration}
+	boundary, err := newLinuxSystemdBoundary(
+		linuxPersonalServiceRoots{configRoot: "/home/alice/.config", stateRoot: "/home/alice/.local/state/powercontext"},
+		runner,
+		files,
+		&testLinuxOperationLock{},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	boundary.probeClient = &lifecycleHealthClient{}
+
+	originalBoundaryFactory := personalServiceBoundaryFactory
+	originalExecutable := personalServiceExecutable
+	personalServiceBoundaryFactory = func() (*linuxSystemdBoundary, error) { return boundary, nil }
+	personalServiceExecutable = func() (string, error) { return lifecycleBinary, nil }
+	t.Cleanup(func() {
+		personalServiceBoundaryFactory = originalBoundaryFactory
+		personalServiceExecutable = originalExecutable
+	})
+
+	t.Setenv("OPENAI_API_KEY", "inherited-secret")
+	t.Setenv("POWERCONTEXT_SERVER_HTTP_PORT", "9123")
+	var runs int
+	serverRun := func(_ context.Context, _ *commandState, config server.ProcessConfig) error {
+		runs++
+		if config.HTTP.Host != "127.0.0.1" || config.HTTP.Port != 8123 {
+			t.Fatalf("service HTTP config = %#v", config.HTTP)
+		}
+		if config.Database.Kind != "sqlite" || config.Database.SQLite.URL != "sqlite+aiosqlite:////home/alice/.local/share/powercontext-service/powercontext.db" {
+			t.Fatalf("service database config = %#v", config.Database)
+		}
+		if got := environmentValue("OPENAI_API_KEY"); got != "from-file" {
+			t.Fatalf("OPENAI_API_KEY = %q, want environment file value", got)
+		}
+		if got := environmentValue("LEAKED_PROVIDER_SECRET"); got != "" {
+			t.Fatalf("LEAKED_PROVIDER_SECRET = %q, want cleared", got)
+		}
+		return nil
+	}
+
+	command := newCommandWithDependencies(VersionInfo{Version: "1.2.3"}, io.Discard, io.Discard, nil, serverRun)
+	command.SetArgs([]string{"server", "install", "--env-file", lifecycleEnvFile, "--data-dir", lifecycleDataDir})
+	if err := command.ExecuteContext(t.Context()); err != nil {
+		t.Fatalf("install = %v", err)
+	}
+	unit, found := files.content[boundary.unitPath()]
+	if !found || !bytes.Contains(unit, []byte("Type=exec\n")) || bytes.Contains(unit, []byte("from-file")) || bytes.Contains(unit, []byte("inherited-secret")) {
+		t.Fatalf("managed unit = %q", unit)
+	}
+	if !slices.ContainsFunc(runner.calls, func(arguments []string) bool {
+		return slices.Equal(arguments, []string{"systemctl", "--user", "start", "powercontext.service"})
+	}) {
+		t.Fatalf("install did not start the owned user unit: %q", runner.calls)
+	}
+	for _, arguments := range runner.calls {
+		if slices.Contains(arguments, "--system") || slices.Contains(arguments, "--global") || slices.Contains(arguments, "enable-linger") {
+			t.Fatalf("install issued a forbidden manager command: %q", arguments)
+		}
+	}
+
+	t.Setenv("LEAKED_PROVIDER_SECRET", "stale-manager-value")
+	command = newCommandWithDependencies(VersionInfo{Version: "1.2.3"}, io.Discard, io.Discard, nil, serverRun)
+	command.SetArgs([]string{"server", "_service-run", "--env-file", lifecycleEnvFile, "--endpoint", lifecycleURL, "--data-dir", lifecycleDataDir})
+	if err := command.ExecuteContext(t.Context()); err != nil {
+		t.Fatalf("service-run = %v", err)
+	}
+	if runs != 1 {
+		t.Fatalf("foreground runner calls = %d, want 1", runs)
+	}
+}
+
+func TestServerPersonalServiceLauncherRejectsAnUnregisteredIdentityBeforeEnvironmentLoad(t *testing.T) {
+	registration := lifecycleRegistration(t)
+	files := &lifecyclePrivateFiles{content: map[string][]byte{
+		lifecycleEnvFile: []byte("OPENAI_API_KEY=from-file\n"),
+	}}
+	runner := &lifecycleSystemdRunner{files: files, registration: registration}
+	boundary, err := newLinuxSystemdBoundary(
+		linuxPersonalServiceRoots{configRoot: "/home/alice/.config", stateRoot: "/home/alice/.local/state/powercontext"},
+		runner,
+		files,
+		&testLinuxOperationLock{},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	launcher, err := personalsvc.NewSystemdUserLauncher("server", "_service-run")
+	if err != nil {
+		t.Fatal(err)
+	}
+	adapter, err := personalsvc.NewSystemdUserAdapter(boundary, "/home/alice/.config", launcher)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := adapter.Write(t.Context(), registration); err != nil {
+		t.Fatal(err)
+	}
+
+	originalBoundaryFactory := personalServiceBoundaryFactory
+	originalExecutable := personalServiceExecutable
+	personalServiceBoundaryFactory = func() (*linuxSystemdBoundary, error) { return boundary, nil }
+	personalServiceExecutable = func() (string, error) { return lifecycleBinary, nil }
+	t.Cleanup(func() {
+		personalServiceBoundaryFactory = originalBoundaryFactory
+		personalServiceExecutable = originalExecutable
+	})
+
+	command := newCommandWithDependencies(VersionInfo{Version: "1.2.3"}, io.Discard, io.Discard, nil,
+		func(context.Context, *commandState, server.ProcessConfig) error {
+			t.Fatal("unregistered launcher reached foreground server")
+			return nil
+		},
+	)
+	command.SetArgs([]string{"server", "_service-run", "--env-file", lifecycleEnvFile, "--endpoint", "http://127.0.0.1:8124", "--data-dir", lifecycleDataDir})
+	if err := command.ExecuteContext(t.Context()); err == nil || strings.Contains(err.Error(), lifecycleEnvFile) || strings.Contains(err.Error(), "8124") {
+		t.Fatalf("service-run refusal = %v", err)
+	}
+	if files.reads[lifecycleEnvFile] != 0 {
+		t.Fatalf("unregistered launcher read the environment file %d times", files.reads[lifecycleEnvFile])
+	}
+}
+
+func TestPersonalServiceRegistrationRequiresAbsoluteEnvironmentAndDataPaths(t *testing.T) {
+	originalExecutable := personalServiceExecutable
+	personalServiceExecutable = func() (string, error) { return lifecycleBinary, nil }
+	t.Cleanup(func() { personalServiceExecutable = originalExecutable })
+
+	for _, test := range []struct {
+		name    string
+		envFile string
+		dataDir string
+	}{
+		{name: "relative environment", envFile: "server.env", dataDir: lifecycleDataDir},
+		{name: "relative data directory", envFile: lifecycleEnvFile, dataDir: "powercontext-data"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if _, err := newPersonalServiceRegistrationFromIdentity(
+				&commandState{version: VersionInfo{Version: "1.2.3"}}, test.envFile, lifecycleURL, test.dataDir,
+			); err == nil {
+				t.Fatal("relative personal-service identity was accepted")
+			}
+		})
+	}
+}
+
+func lifecycleRegistration(t *testing.T) personalsvc.Registration {
+	t.Helper()
+	definition, err := personalsvc.NewDefinition(personalsvc.DefinitionInput{
+		Ownership:         personalsvc.OwnershipMarker,
+		DefinitionVersion: personalsvc.DefinitionVersion,
+		PackageVersion:    "1.2.3",
+		Binary:            lifecycleBinary,
+		Endpoint:          lifecycleURL,
+		DataDir:           lifecycleDataDir,
+		EnvFile:           lifecycleEnvFile,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	registration, err := personalsvc.NewRegistration(definition)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return registration
+}
+
+func environmentValue(name string) string {
+	value, _ := os.LookupEnv(name)
+	return value
+}
+
+type lifecyclePrivateFiles struct {
+	content map[string][]byte
+	reads   map[string]int
+}
+
+func (f *lifecyclePrivateFiles) Read(_ context.Context, name string) ([]byte, bool, error) {
+	if f.reads == nil {
+		f.reads = make(map[string]int)
+	}
+	f.reads[name]++
+	value, found := f.content[name]
+	return bytes.Clone(value), found, nil
+}
+
+func (f *lifecyclePrivateFiles) Write(_ context.Context, name string, value []byte) error {
+	if f.content == nil {
+		f.content = make(map[string][]byte)
+	}
+	f.content[name] = bytes.Clone(value)
+	return nil
+}
+
+func (f *lifecyclePrivateFiles) Remove(_ context.Context, name string) error {
+	delete(f.content, name)
+	return nil
+}
+
+func (*lifecyclePrivateFiles) Validate(context.Context, string) error { return nil }
+
+type lifecycleSystemdRunner struct {
+	files        *lifecyclePrivateFiles
+	registration personalsvc.Registration
+	calls        [][]string
+}
+
+func (r *lifecycleSystemdRunner) Run(_ context.Context, program string, arguments ...string) (linuxSystemdProcessResult, error) {
+	call := append([]string{program}, arguments...)
+	r.calls = append(r.calls, call)
+	switch {
+	case slices.Equal(call, []string{"systemctl", "--user", "show-environment"}):
+		return linuxSystemdProcessResult{}, nil
+	case slices.Equal(call, []string{"busctl", "--user", "--json=short", "call", personalServiceManagerName, personalServiceManagerPath, personalServiceManagerName + ".Manager", "LoadUnit", "s", personalServiceUnitName}):
+		if _, found := r.files.content["/home/alice/.config/systemd/user/powercontext.service"]; !found {
+			return linuxSystemdProcessResult{exitCode: 1}, nil
+		}
+		return linuxSystemdProcessResult{stdout: []byte(`{"type":"o","data":"/org/freedesktop/systemd1/unit/powercontext_2eservice"}`)}, nil
+	case slices.Equal(call, []string{"busctl", "--user", "--json=short", "call", personalServiceManagerName, personalServiceUnitObjectPath, "org.freedesktop.DBus.Properties", "GetAll", "s", personalServiceUnitInterface}):
+		value, err := json.Marshal(map[string]any{
+			"type": "a{sv}",
+			"data": map[string]any{
+				"LoadState":    map[string]any{"type": "s", "data": "loaded"},
+				"FragmentPath": map[string]any{"type": "s", "data": "/home/alice/.config/systemd/user/powercontext.service"},
+				"DropInPaths":  map[string]any{"type": "as", "data": []string{}},
+			},
+		})
+		return linuxSystemdProcessResult{stdout: value}, err
+	case slices.Equal(call, []string{"busctl", "--user", "--json=short", "call", personalServiceManagerName, personalServiceUnitObjectPath, "org.freedesktop.DBus.Properties", "GetAll", "s", personalServiceServiceInterface}):
+		metadata, err := r.registration.Encode()
+		if err != nil {
+			return linuxSystemdProcessResult{}, err
+		}
+		value, marshalErr := json.Marshal(map[string]any{
+			"type": "a{sv}",
+			"data": map[string]any{
+				"Environment": map[string]any{"type": "as", "data": []string{
+					"POWERCONTEXT_SERVICE_OWNED=true", "POWERCONTEXT_SERVICE_METADATA=" + metadata,
+				}},
+				"ExecStart": map[string]any{"type": "a(sasbttttuii)", "data": []any{[]any{
+					lifecycleBinary, []any{lifecycleBinary, "server", "_service-run", "--env-file", lifecycleEnvFile, "--endpoint", lifecycleURL, "--data-dir", lifecycleDataDir},
+					false, 0, 0, 0, 0, 0, 0, 0,
+				}}},
+			},
+		})
+		return linuxSystemdProcessResult{stdout: value}, marshalErr
+	case slices.Equal(call, []string{"systemctl", "--user", "show", "--property=ActiveState", "--value", personalServiceUnitName}):
+		return linuxSystemdProcessResult{stdout: []byte("active\n")}, nil
+	default:
+		return linuxSystemdProcessResult{}, nil
+	}
+}
+
+type lifecycleHealthClient struct{ calls int }
+
+func (c *lifecycleHealthClient) Do(request *http.Request) (*http.Response, error) {
+	if request.URL.String() != lifecycleURL+"/health/live" {
+		return nil, errors.New("unexpected health URL")
+	}
+	c.calls++
+	if c.calls == 1 {
+		return nil, errors.New("listener is absent")
+	}
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(`{"status":"ok"}`)),
+		Request:    request,
+	}, nil
+}

--- a/internal/cli/server_personal_service_linux.go
+++ b/internal/cli/server_personal_service_linux.go
@@ -19,6 +19,8 @@ package cli
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"errors"
 	"io"
 	"io/fs"
@@ -64,7 +66,13 @@ type linuxPrivateFiles struct {
 func newLinuxPrivateFiles(roots linuxPersonalServiceRoots) (*linuxPrivateFiles, error) {
 	home := filepath.FromSlash(filepath.Dir(roots.configRoot))
 	owner := uint32(os.Geteuid())
-	if owner == 0 || !safeLinuxUserHome(home, owner) {
+	descriptor, err := openAbsoluteDirectoryNoSymlink(home)
+	if err != nil {
+		return nil, newPersonalServicePlatformError("configuration")
+	}
+	defer unix.Close(descriptor)
+	var stat unix.Stat_t
+	if owner == 0 || unix.Fstat(descriptor, &stat) != nil || !safeLinuxUserHomeStat(stat, owner) {
 		return nil, newPersonalServicePlatformError("configuration")
 	}
 	return &linuxPrivateFiles{home: home, owner: owner}, nil
@@ -104,23 +112,23 @@ func (f *linuxPrivateFiles) Write(ctx context.Context, name string, content []by
 	if err := contextError(ctx); err != nil {
 		return err
 	}
-	parent := filepath.Dir(name)
-	if err := f.ensurePrivateDirectories(parent); err != nil {
-		return err
-	}
-	if existing, err := f.openPrivate(name); err == nil {
-		if closeErr := existing.Close(); closeErr != nil {
-			return closeErr
-		}
-	} else if !errors.Is(err, os.ErrNotExist) {
-		return err
-	}
-	temporary, err := os.CreateTemp(parent, ".powercontext.service-")
+	parent, base, err := f.openPrivateParent(name, true)
 	if err != nil {
 		return err
 	}
-	temporaryName := temporary.Name()
-	defer func() { _ = os.Remove(temporaryName) }()
+	defer unix.Close(parent)
+	before, exists, err := f.privateAt(parent, base)
+	if err != nil {
+		return err
+	}
+	if exists && !validLinuxPrivateFileObservation(before, f.owner) {
+		return errors.New("unsafe private file")
+	}
+	temporary, temporaryName, err := createPrivateTemporaryFile(parent)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = unix.Unlinkat(parent, temporaryName, 0) }()
 	if err := temporary.Chmod(0o600); err != nil {
 		_ = temporary.Close()
 		return err
@@ -139,38 +147,51 @@ func (f *linuxPrivateFiles) Write(ctx context.Context, name string, content []by
 	if err := contextError(ctx); err != nil {
 		return err
 	}
-	if err := os.Rename(temporaryName, name); err != nil {
+	if err := unix.Renameat(parent, temporaryName, parent, base); err != nil {
 		return err
 	}
-	return os.Chmod(name, 0o600)
+	return nil
 }
 
 func (f *linuxPrivateFiles) Remove(ctx context.Context, name string) error {
 	if err := contextError(ctx); err != nil {
 		return err
 	}
-	file, err := f.openPrivate(name)
+	parent, base, err := f.openPrivateParent(name, false)
 	if errors.Is(err, os.ErrNotExist) {
 		return nil
 	}
 	if err != nil {
 		return err
 	}
-	if closeErr := file.Close(); closeErr != nil {
-		return closeErr
+	defer unix.Close(parent)
+	identity, exists, err := f.privateAt(parent, base)
+	if err != nil || !exists {
+		return err
 	}
-	return os.Remove(name)
+	if !validLinuxPrivateFileObservation(identity, f.owner) {
+		return errors.New("unsafe private file")
+	}
+	return unix.Unlinkat(parent, base, 0)
 }
 
 func (f *linuxPrivateFiles) openPrivate(name string) (*os.File, error) {
-	before, err := linuxPrivateIdentity(name)
+	parent, base, err := f.openPrivateParent(name, false)
 	if err != nil {
 		return nil, err
+	}
+	defer unix.Close(parent)
+	before, exists, err := f.privateAt(parent, base)
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return nil, os.ErrNotExist
 	}
 	if !validLinuxPrivateFileObservation(before, f.owner) {
 		return nil, errors.New("unsafe private file")
 	}
-	descriptor, err := unix.Open(name, unix.O_RDONLY|unix.O_NONBLOCK|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
+	descriptor, err := unix.Openat(parent, base, unix.O_RDONLY|unix.O_NONBLOCK|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -184,59 +205,175 @@ func (f *linuxPrivateFiles) openPrivate(name string) (*os.File, error) {
 		_ = unix.Close(descriptor)
 		return nil, errors.New("private file changed during open")
 	}
-	return os.NewFile(uintptr(descriptor), filepath.Base(name)), nil
+	return os.NewFile(uintptr(descriptor), base), nil
 }
 
-func (f *linuxPrivateFiles) ensurePrivateDirectories(target string) error {
+func (f *linuxPrivateFiles) openOrCreatePrivate(name string, flags int) (*os.File, error) {
+	parent, base, err := f.openPrivateParent(name, true)
+	if err != nil {
+		return nil, err
+	}
+	defer unix.Close(parent)
+	before, existed, err := f.privateAt(parent, base)
+	if err != nil {
+		return nil, err
+	}
+	if existed && !validLinuxPrivateFileObservation(before, f.owner) {
+		return nil, errors.New("unsafe private file")
+	}
+	descriptor, err := unix.Openat(parent, base, flags|unix.O_CREAT|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	var stat unix.Stat_t
+	if err := unix.Fstat(descriptor, &stat); err != nil {
+		_ = unix.Close(descriptor)
+		return nil, err
+	}
+	after := linuxPrivateIdentityFromStat(stat)
+	if !validLinuxPrivateFileObservation(after, f.owner) || existed && !validLinuxPrivateFile(before, after, f.owner) {
+		_ = unix.Close(descriptor)
+		return nil, errors.New("private file changed during open")
+	}
+	return os.NewFile(uintptr(descriptor), base), nil
+}
+
+func (f *linuxPrivateFiles) openPrivateParent(name string, create bool) (int, string, error) {
+	if name != filepath.Clean(name) || !filepath.IsAbs(name) {
+		return -1, "", errors.New("invalid private file path")
+	}
+	base := filepath.Base(name)
+	if base == "." || base == string(filepath.Separator) || base == ".." {
+		return -1, "", errors.New("invalid private file path")
+	}
+	parent := filepath.Dir(name)
+	if create {
+		descriptor, err := f.ensurePrivateDirectories(parent)
+		return descriptor, base, err
+	}
+	descriptor, err := f.openOwnedPrivateDirectory(parent)
+	return descriptor, base, err
+}
+
+func (f *linuxPrivateFiles) ensurePrivateDirectories(target string) (int, error) {
 	relative, err := filepath.Rel(f.home, target)
 	if err != nil || relative == ".." || filepath.IsAbs(relative) || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
-		return errors.New("private path escaped current user root")
+		return -1, errors.New("private path escaped current user root")
 	}
-	current := f.home
+	descriptor, err := openAbsoluteDirectoryNoSymlink(f.home)
+	if err != nil {
+		return -1, err
+	}
+	var home unix.Stat_t
+	if err := unix.Fstat(descriptor, &home); err != nil || !safeLinuxUserHomeStat(home, f.owner) {
+		_ = unix.Close(descriptor)
+		return -1, errors.New("unsafe current user root")
+	}
 	for _, element := range strings.Split(relative, string(filepath.Separator)) {
 		if element == "" || element == "." {
 			continue
 		}
-		current = filepath.Join(current, element)
-		if err := mkdirPrivateDirectory(current, f.owner); err != nil {
-			return err
+		next, openErr := unix.Openat(descriptor, element, unix.O_PATH|unix.O_DIRECTORY|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
+		if errors.Is(openErr, unix.ENOENT) {
+			if mkdirErr := unix.Mkdirat(descriptor, element, 0o700); mkdirErr != nil && !errors.Is(mkdirErr, unix.EEXIST) {
+				_ = unix.Close(descriptor)
+				return -1, mkdirErr
+			}
+			next, openErr = unix.Openat(descriptor, element, unix.O_PATH|unix.O_DIRECTORY|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
+		}
+		if openErr != nil {
+			_ = unix.Close(descriptor)
+			return -1, openErr
+		}
+		_ = unix.Close(descriptor)
+		descriptor = next
+		var stat unix.Stat_t
+		if err := unix.Fstat(descriptor, &stat); err != nil || !safeLinuxDirectoryStat(stat, f.owner) {
+			_ = unix.Close(descriptor)
+			return -1, errors.New("unsafe private directory")
 		}
 	}
-	return nil
+	if relative == "." {
+		var stat unix.Stat_t
+		if err := unix.Fstat(descriptor, &stat); err != nil || !safeLinuxDirectoryStat(stat, f.owner) {
+			_ = unix.Close(descriptor)
+			return -1, errors.New("unsafe private directory")
+		}
+	}
+	return descriptor, nil
 }
 
-func mkdirPrivateDirectory(name string, owner uint32) error {
-	if err := os.Mkdir(name, 0o700); err != nil && !errors.Is(err, os.ErrExist) {
-		return err
+func (f *linuxPrivateFiles) openOwnedPrivateDirectory(name string) (int, error) {
+	descriptor, err := openAbsoluteDirectoryNoSymlink(name)
+	if err != nil {
+		return -1, err
 	}
-	if !safeLinuxDirectory(name, owner) {
-		return errors.New("unsafe private directory")
-	}
-	return nil
-}
-
-func safeLinuxDirectory(name string, owner uint32) bool {
 	var stat unix.Stat_t
-	if unix.Lstat(name, &stat) != nil {
-		return false
+	if err := unix.Fstat(descriptor, &stat); err != nil || !safeLinuxDirectoryStat(stat, f.owner) {
+		_ = unix.Close(descriptor)
+		return -1, errors.New("unsafe private directory")
 	}
+	return descriptor, nil
+}
+
+func (f *linuxPrivateFiles) privateAt(parent int, base string) (linuxPrivateFileIdentity, bool, error) {
+	var stat unix.Stat_t
+	if err := unix.Fstatat(parent, base, &stat, unix.AT_SYMLINK_NOFOLLOW); err != nil {
+		if errors.Is(err, unix.ENOENT) {
+			return linuxPrivateFileIdentity{}, false, nil
+		}
+		return linuxPrivateFileIdentity{}, false, err
+	}
+	return linuxPrivateIdentityFromStat(stat), true, nil
+}
+
+func createPrivateTemporaryFile(parent int) (*os.File, string, error) {
+	for range 128 {
+		var nonce [12]byte
+		if _, err := rand.Read(nonce[:]); err != nil {
+			return nil, "", err
+		}
+		name := ".powercontext.service-" + hex.EncodeToString(nonce[:])
+		descriptor, err := unix.Openat(parent, name, unix.O_WRONLY|unix.O_CREAT|unix.O_EXCL|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0o600)
+		if errors.Is(err, unix.EEXIST) {
+			continue
+		}
+		if err != nil {
+			return nil, "", err
+		}
+		return os.NewFile(uintptr(descriptor), name), name, nil
+	}
+	return nil, "", errors.New("cannot create private temporary file")
+}
+
+func openAbsoluteDirectoryNoSymlink(name string) (int, error) {
+	if name != filepath.Clean(name) || !filepath.IsAbs(name) {
+		return -1, errors.New("invalid directory path")
+	}
+	descriptor, err := unix.Open(string(filepath.Separator), unix.O_PATH|unix.O_DIRECTORY|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return -1, err
+	}
+	for _, element := range strings.Split(strings.TrimPrefix(name, string(filepath.Separator)), string(filepath.Separator)) {
+		if element == "" {
+			continue
+		}
+		next, openErr := unix.Openat(descriptor, element, unix.O_PATH|unix.O_DIRECTORY|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
+		_ = unix.Close(descriptor)
+		if openErr != nil {
+			return -1, openErr
+		}
+		descriptor = next
+	}
+	return descriptor, nil
+}
+
+func safeLinuxDirectoryStat(stat unix.Stat_t, owner uint32) bool {
 	return stat.Uid == owner && stat.Mode&unix.S_IFMT == unix.S_IFDIR && stat.Mode&0o077 == 0
 }
 
-func safeLinuxUserHome(name string, owner uint32) bool {
-	var stat unix.Stat_t
-	if unix.Lstat(name, &stat) != nil {
-		return false
-	}
+func safeLinuxUserHomeStat(stat unix.Stat_t, owner uint32) bool {
 	return stat.Uid == owner && stat.Mode&unix.S_IFMT == unix.S_IFDIR
-}
-
-func linuxPrivateIdentity(name string) (linuxPrivateFileIdentity, error) {
-	var stat unix.Stat_t
-	if err := unix.Lstat(name, &stat); err != nil {
-		return linuxPrivateFileIdentity{}, err
-	}
-	return linuxPrivateIdentityFromStat(stat), nil
 }
 
 func linuxPrivateIdentityFromStat(stat unix.Stat_t) linuxPrivateFileIdentity {
@@ -267,15 +404,12 @@ func (l *linuxOperationFileLock) WithLock(ctx context.Context, operation func(co
 	if err := contextError(ctx); err != nil {
 		return err
 	}
-	if err := l.files.ensurePrivateDirectories(filepath.Dir(l.path)); err != nil {
-		return err
-	}
-	descriptor, err := unix.Open(l.path, unix.O_RDWR|unix.O_CREAT|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0o600)
+	file, err := l.files.openOrCreatePrivate(l.path, unix.O_RDWR)
 	if err != nil {
 		return err
 	}
-	file := os.NewFile(uintptr(descriptor), filepath.Base(l.path))
 	defer file.Close()
+	descriptor := int(file.Fd())
 	var stat unix.Stat_t
 	if err := unix.Fstat(descriptor, &stat); err != nil || !validLinuxPrivateFileObservation(linuxPrivateIdentityFromStat(stat), l.files.owner) {
 		return errors.New("unsafe operation lock")

--- a/internal/cli/server_personal_service_linux.go
+++ b/internal/cli/server_personal_service_linux.go
@@ -70,7 +70,7 @@ func newLinuxPrivateFiles(roots linuxPersonalServiceRoots) (*linuxPrivateFiles, 
 	if err != nil {
 		return nil, newPersonalServicePlatformError("configuration")
 	}
-	defer unix.Close(descriptor)
+	defer func() { _ = unix.Close(descriptor) }()
 	var stat unix.Stat_t
 	if owner == 0 || unix.Fstat(descriptor, &stat) != nil || !safeLinuxUserHomeStat(stat, owner) {
 		return nil, newPersonalServicePlatformError("configuration")
@@ -89,7 +89,7 @@ func (f *linuxPrivateFiles) Read(ctx context.Context, name string) ([]byte, bool
 	if err != nil {
 		return nil, false, err
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 	content, err := io.ReadAll(io.LimitReader(file, maximumPersonalServiceFileSize+1))
 	if err != nil || len(content) > maximumPersonalServiceFileSize {
 		return nil, false, errors.New("private file cannot be read")
@@ -116,7 +116,7 @@ func (f *linuxPrivateFiles) Write(ctx context.Context, name string, content []by
 	if err != nil {
 		return err
 	}
-	defer unix.Close(parent)
+	defer func() { _ = unix.Close(parent) }()
 	before, exists, err := f.privateAt(parent, base)
 	if err != nil {
 		return err
@@ -164,7 +164,7 @@ func (f *linuxPrivateFiles) Remove(ctx context.Context, name string) error {
 	if err != nil {
 		return err
 	}
-	defer unix.Close(parent)
+	defer func() { _ = unix.Close(parent) }()
 	identity, exists, err := f.privateAt(parent, base)
 	if err != nil || !exists {
 		return err
@@ -408,7 +408,7 @@ func (l *linuxOperationFileLock) WithLock(ctx context.Context, operation func(co
 	if err != nil {
 		return err
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 	descriptor := int(file.Fd())
 	var stat unix.Stat_t
 	if err := unix.Fstat(descriptor, &stat); err != nil || !validLinuxPrivateFileObservation(linuxPrivateIdentityFromStat(stat), l.files.owner) {

--- a/internal/cli/server_personal_service_linux.go
+++ b/internal/cli/server_personal_service_linux.go
@@ -36,8 +36,8 @@ import (
 const maximumPersonalServiceFileSize = 1 << 20
 
 // newCurrentLinuxSystemdBoundary performs current-user discovery only when a
-// later lifecycle command asks for it. Task 2 does not wire this constructor
-// into a CLI command, so it cannot mutate a host service by itself.
+// personal-service lifecycle command asks for it. Constructing the boundary
+// itself does not inspect a user manager or mutate a host service.
 func newCurrentLinuxSystemdBoundary() (*linuxSystemdBoundary, error) {
 	if os.Geteuid() == 0 {
 		return nil, newPersonalServicePlatformError("configuration")

--- a/internal/cli/server_personal_service_linux.go
+++ b/internal/cli/server_personal_service_linux.go
@@ -1,0 +1,335 @@
+//go:build linux
+
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/sys/unix"
+)
+
+const maximumPersonalServiceFileSize = 1 << 20
+
+// newCurrentLinuxSystemdBoundary performs current-user discovery only when a
+// later lifecycle command asks for it. Task 2 does not wire this constructor
+// into a CLI command, so it cannot mutate a host service by itself.
+func newCurrentLinuxSystemdBoundary() (*linuxSystemdBoundary, error) {
+	if os.Geteuid() == 0 {
+		return nil, newPersonalServicePlatformError("configuration")
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, newPersonalServicePlatformError("configuration")
+	}
+	roots, err := newLinuxPersonalServiceRoots(filepath.ToSlash(home))
+	if err != nil {
+		return nil, err
+	}
+	files, err := newLinuxPrivateFiles(roots)
+	if err != nil {
+		return nil, err
+	}
+	locker := &linuxOperationFileLock{files: files, path: filepath.FromSlash(path.Join(roots.stateRoot, "personal-service.lock"))}
+	return newLinuxSystemdBoundary(roots, linuxSystemdProcessRunner{}, files, locker)
+}
+
+type linuxPrivateFiles struct {
+	home  string
+	owner uint32
+}
+
+func newLinuxPrivateFiles(roots linuxPersonalServiceRoots) (*linuxPrivateFiles, error) {
+	home := filepath.FromSlash(filepath.Dir(roots.configRoot))
+	owner := uint32(os.Geteuid())
+	if owner == 0 || !safeLinuxUserHome(home, owner) {
+		return nil, newPersonalServicePlatformError("configuration")
+	}
+	return &linuxPrivateFiles{home: home, owner: owner}, nil
+}
+
+func (f *linuxPrivateFiles) Read(ctx context.Context, name string) ([]byte, bool, error) {
+	if err := contextError(ctx); err != nil {
+		return nil, false, err
+	}
+	file, err := f.openPrivate(name)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	defer file.Close()
+	content, err := io.ReadAll(io.LimitReader(file, maximumPersonalServiceFileSize+1))
+	if err != nil || len(content) > maximumPersonalServiceFileSize {
+		return nil, false, errors.New("private file cannot be read")
+	}
+	return bytes.Clone(content), true, nil
+}
+
+func (f *linuxPrivateFiles) Validate(ctx context.Context, name string) error {
+	if err := contextError(ctx); err != nil {
+		return err
+	}
+	file, err := f.openPrivate(name)
+	if err != nil {
+		return err
+	}
+	return file.Close()
+}
+
+func (f *linuxPrivateFiles) Write(ctx context.Context, name string, content []byte) error {
+	if err := contextError(ctx); err != nil {
+		return err
+	}
+	parent := filepath.Dir(name)
+	if err := f.ensurePrivateDirectories(parent); err != nil {
+		return err
+	}
+	if existing, err := f.openPrivate(name); err == nil {
+		if closeErr := existing.Close(); closeErr != nil {
+			return closeErr
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	temporary, err := os.CreateTemp(parent, ".powercontext.service-")
+	if err != nil {
+		return err
+	}
+	temporaryName := temporary.Name()
+	defer func() { _ = os.Remove(temporaryName) }()
+	if err := temporary.Chmod(0o600); err != nil {
+		_ = temporary.Close()
+		return err
+	}
+	if _, err := temporary.Write(content); err != nil {
+		_ = temporary.Close()
+		return err
+	}
+	if err := temporary.Sync(); err != nil {
+		_ = temporary.Close()
+		return err
+	}
+	if err := temporary.Close(); err != nil {
+		return err
+	}
+	if err := contextError(ctx); err != nil {
+		return err
+	}
+	if err := os.Rename(temporaryName, name); err != nil {
+		return err
+	}
+	return os.Chmod(name, 0o600)
+}
+
+func (f *linuxPrivateFiles) Remove(ctx context.Context, name string) error {
+	if err := contextError(ctx); err != nil {
+		return err
+	}
+	file, err := f.openPrivate(name)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if closeErr := file.Close(); closeErr != nil {
+		return closeErr
+	}
+	return os.Remove(name)
+}
+
+func (f *linuxPrivateFiles) openPrivate(name string) (*os.File, error) {
+	before, err := linuxPrivateIdentity(name)
+	if err != nil {
+		return nil, err
+	}
+	if !validLinuxPrivateFileObservation(before, f.owner) {
+		return nil, errors.New("unsafe private file")
+	}
+	descriptor, err := unix.Open(name, unix.O_RDONLY|unix.O_NONBLOCK|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return nil, err
+	}
+	var stat unix.Stat_t
+	if err := unix.Fstat(descriptor, &stat); err != nil {
+		_ = unix.Close(descriptor)
+		return nil, err
+	}
+	after := linuxPrivateIdentityFromStat(stat)
+	if !validLinuxPrivateFile(before, after, f.owner) {
+		_ = unix.Close(descriptor)
+		return nil, errors.New("private file changed during open")
+	}
+	return os.NewFile(uintptr(descriptor), filepath.Base(name)), nil
+}
+
+func (f *linuxPrivateFiles) ensurePrivateDirectories(target string) error {
+	relative, err := filepath.Rel(f.home, target)
+	if err != nil || relative == ".." || filepath.IsAbs(relative) || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+		return errors.New("private path escaped current user root")
+	}
+	current := f.home
+	for _, element := range strings.Split(relative, string(filepath.Separator)) {
+		if element == "" || element == "." {
+			continue
+		}
+		current = filepath.Join(current, element)
+		if err := mkdirPrivateDirectory(current, f.owner); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func mkdirPrivateDirectory(name string, owner uint32) error {
+	if err := os.Mkdir(name, 0o700); err != nil && !errors.Is(err, os.ErrExist) {
+		return err
+	}
+	if !safeLinuxDirectory(name, owner) {
+		return errors.New("unsafe private directory")
+	}
+	return nil
+}
+
+func safeLinuxDirectory(name string, owner uint32) bool {
+	var stat unix.Stat_t
+	if unix.Lstat(name, &stat) != nil {
+		return false
+	}
+	return stat.Uid == owner && stat.Mode&unix.S_IFMT == unix.S_IFDIR && stat.Mode&0o077 == 0
+}
+
+func safeLinuxUserHome(name string, owner uint32) bool {
+	var stat unix.Stat_t
+	if unix.Lstat(name, &stat) != nil {
+		return false
+	}
+	return stat.Uid == owner && stat.Mode&unix.S_IFMT == unix.S_IFDIR
+}
+
+func linuxPrivateIdentity(name string) (linuxPrivateFileIdentity, error) {
+	var stat unix.Stat_t
+	if err := unix.Lstat(name, &stat); err != nil {
+		return linuxPrivateFileIdentity{}, err
+	}
+	return linuxPrivateIdentityFromStat(stat), nil
+}
+
+func linuxPrivateIdentityFromStat(stat unix.Stat_t) linuxPrivateFileIdentity {
+	mode := fs.FileMode(stat.Mode & 0o777)
+	switch stat.Mode & unix.S_IFMT {
+	case unix.S_IFREG:
+	case unix.S_IFLNK:
+		mode |= fs.ModeSymlink
+	case unix.S_IFIFO:
+		mode |= fs.ModeNamedPipe
+	case unix.S_IFDIR:
+		mode |= fs.ModeDir
+	default:
+		mode |= fs.ModeIrregular
+	}
+	return linuxPrivateFileIdentity{device: uint64(stat.Dev), inode: stat.Ino, mode: mode, uid: stat.Uid}
+}
+
+type linuxOperationFileLock struct {
+	files *linuxPrivateFiles
+	path  string
+}
+
+func (l *linuxOperationFileLock) WithLock(ctx context.Context, operation func(context.Context) error) error {
+	if l == nil || l.files == nil || operation == nil {
+		return errors.New("invalid operation lock")
+	}
+	if err := contextError(ctx); err != nil {
+		return err
+	}
+	if err := l.files.ensurePrivateDirectories(filepath.Dir(l.path)); err != nil {
+		return err
+	}
+	descriptor, err := unix.Open(l.path, unix.O_RDWR|unix.O_CREAT|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0o600)
+	if err != nil {
+		return err
+	}
+	file := os.NewFile(uintptr(descriptor), filepath.Base(l.path))
+	defer file.Close()
+	var stat unix.Stat_t
+	if err := unix.Fstat(descriptor, &stat); err != nil || !validLinuxPrivateFileObservation(linuxPrivateIdentityFromStat(stat), l.files.owner) {
+		return errors.New("unsafe operation lock")
+	}
+	if err := unix.Flock(descriptor, unix.LOCK_EX|unix.LOCK_NB); err != nil {
+		return err
+	}
+	defer func() { _ = unix.Flock(descriptor, unix.LOCK_UN) }()
+	return operation(ctx)
+}
+
+type linuxSystemdProcessRunner struct{}
+
+func (linuxSystemdProcessRunner) Run(ctx context.Context, program string, arguments ...string) (linuxSystemdProcessResult, error) {
+	if err := contextError(ctx); err != nil {
+		return linuxSystemdProcessResult{}, err
+	}
+	command := exec.CommandContext(ctx, program, arguments...)
+	output := &linuxSystemdOutput{limit: maximumPersonalServiceFileSize}
+	command.Stdout = output
+	command.Stderr = io.Discard
+	err := command.Run()
+	if contextErr := contextError(ctx); contextErr != nil {
+		return linuxSystemdProcessResult{}, contextErr
+	}
+	if output.exceeded {
+		return linuxSystemdProcessResult{}, errors.New("systemd command output exceeded limit")
+	}
+	if exitError, found := errors.AsType[*exec.ExitError](err); found {
+		return linuxSystemdProcessResult{exitCode: exitError.ExitCode(), stdout: bytes.Clone(output.buffer.Bytes())}, nil
+	}
+	if err != nil {
+		return linuxSystemdProcessResult{}, err
+	}
+	return linuxSystemdProcessResult{stdout: bytes.Clone(output.buffer.Bytes())}, nil
+}
+
+type linuxSystemdOutput struct {
+	buffer   bytes.Buffer
+	limit    int
+	exceeded bool
+}
+
+func (b *linuxSystemdOutput) Write(value []byte) (int, error) {
+	original := len(value)
+	remaining := b.limit - b.buffer.Len()
+	if remaining <= 0 {
+		b.exceeded = true
+		return original, nil
+	}
+	if len(value) > remaining {
+		b.exceeded = true
+		value = value[:remaining]
+	}
+	_, _ = b.buffer.Write(value)
+	return original, nil
+}

--- a/internal/cli/server_personal_service_linux.go
+++ b/internal/cli/server_personal_service_linux.go
@@ -180,7 +180,7 @@ func (f *linuxPrivateFiles) openPrivate(name string) (*os.File, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer unix.Close(parent)
+	defer func() { _ = unix.Close(parent) }()
 	before, exists, err := f.privateAt(parent, base)
 	if err != nil {
 		return nil, err
@@ -213,7 +213,7 @@ func (f *linuxPrivateFiles) openOrCreatePrivate(name string, flags int) (*os.Fil
 	if err != nil {
 		return nil, err
 	}
-	defer unix.Close(parent)
+	defer func() { _ = unix.Close(parent) }()
 	before, existed, err := f.privateAt(parent, base)
 	if err != nil {
 		return nil, err

--- a/internal/cli/server_personal_service_linux_test.go
+++ b/internal/cli/server_personal_service_linux_test.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	"golang.org/x/sys/unix"
@@ -102,6 +103,115 @@ func TestLinuxPrivateFilesReplaceOnlyThePrivateUnitAtomically(t *testing.T) {
 			t.Fatalf("temporary unit %q remains", entry.Name())
 		}
 	}
+}
+
+func TestLinuxPrivateFilesRejectMiddleDirectorySymlinksToPrivateTargets(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("personal user service refuses root execution")
+	}
+	files, home := newTestLinuxPrivateFiles(t)
+	config := filepath.Join(home, ".config")
+	target := filepath.Join(home, ".private-target")
+	if err := os.Mkdir(config, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(target, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	envFile := filepath.Join(target, "server.env")
+	if err := os.WriteFile(envFile, []byte("OPENAI_API_KEY=secret\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	linked := filepath.Join(config, "service")
+	if err := os.Symlink(target, linked); err != nil {
+		t.Fatal(err)
+	}
+	if err := files.Validate(t.Context(), filepath.Join(linked, "server.env")); err == nil {
+		t.Fatal("Validate followed a middle-directory symbolic link")
+	}
+	if _, _, err := files.Read(t.Context(), filepath.Join(linked, "server.env")); err == nil {
+		t.Fatal("Read followed a middle-directory symbolic link")
+	}
+	if err := files.Write(t.Context(), filepath.Join(linked, "powercontext.service"), []byte("foreign")); err == nil {
+		t.Fatal("Write followed a middle-directory symbolic link")
+	}
+	if err := files.Remove(t.Context(), filepath.Join(linked, "server.env")); err == nil {
+		t.Fatal("Remove followed a middle-directory symbolic link")
+	}
+	if content, err := os.ReadFile(envFile); err != nil || !strings.Contains(string(content), "secret") {
+		t.Fatalf("private target changed: content = %q, error = %v", content, err)
+	}
+}
+
+func TestLinuxPrivateFilesRejectConcurrentParentReplacement(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("personal user service refuses root execution")
+	}
+	files, home := newTestLinuxPrivateFiles(t)
+	config := filepath.Join(home, ".config")
+	systemd := filepath.Join(config, "systemd")
+	user := filepath.Join(systemd, "user")
+	foreignSystemd := filepath.Join(home, ".foreign-systemd")
+	if err := os.Mkdir(config, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(systemd, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(user, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(user, "powercontext.service"), []byte("owned"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(foreignSystemd, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(foreignSystemd, "user"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(foreignSystemd, "user", "powercontext.service"), []byte("foreign"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	stop := make(chan struct{})
+	var replacements sync.WaitGroup
+	replacements.Add(1)
+	go func() {
+		defer replacements.Done()
+		hold := filepath.Join(config, "systemd.hold")
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			if err := os.Rename(systemd, hold); err != nil {
+				continue
+			}
+			if err := os.Symlink(foreignSystemd, systemd); err != nil {
+				_ = os.Rename(hold, systemd)
+				continue
+			}
+			_ = os.Remove(systemd)
+			_ = os.Rename(hold, systemd)
+		}
+	}()
+
+	unit := filepath.Join(user, "powercontext.service")
+	for range 1000 {
+		content, exists, err := files.Read(t.Context(), unit)
+		if err != nil || !exists {
+			continue
+		}
+		if string(content) != "owned" {
+			close(stop)
+			replacements.Wait()
+			t.Fatalf("Read followed a concurrently replaced parent: %q", content)
+		}
+	}
+	close(stop)
+	replacements.Wait()
 }
 
 func newTestLinuxPrivateFiles(t *testing.T) (*linuxPrivateFiles, string) {

--- a/internal/cli/server_personal_service_linux_test.go
+++ b/internal/cli/server_personal_service_linux_test.go
@@ -1,0 +1,122 @@
+//go:build linux
+
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestLinuxPrivateFilesRejectUnsafeEnvironmentObjectsWithoutBlocking(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("personal user service refuses root execution")
+	}
+	files, home := newTestLinuxPrivateFiles(t)
+	envFile := filepath.Join(home, "server.env")
+	if err := os.WriteFile(envFile, []byte("OPENAI_API_KEY=secret\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := files.Validate(t.Context(), envFile); err != nil {
+		t.Fatalf("Validate regular private file: %v", err)
+	}
+	if err := os.Remove(envFile); err != nil {
+		t.Fatal(err)
+	}
+	if err := unix.Mkfifo(envFile, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := files.Validate(t.Context(), envFile); err == nil {
+		t.Fatal("Validate accepted a FIFO")
+	}
+	if err := os.Remove(envFile); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join(home, "outside.env"), envFile); err != nil {
+		t.Fatal(err)
+	}
+	if err := files.Validate(t.Context(), envFile); err == nil {
+		t.Fatal("Validate accepted a symbolic link")
+	}
+}
+
+func TestLinuxOperationFileLockRefusesNestedContention(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("personal user service refuses root execution")
+	}
+	files, home := newTestLinuxPrivateFiles(t)
+	lock := &linuxOperationFileLock{files: files, path: filepath.Join(home, ".local", "state", "powercontext", "personal-service.lock")}
+	err := lock.WithLock(t.Context(), func(ctx context.Context) error {
+		return lock.WithLock(ctx, func(context.Context) error { return nil })
+	})
+	if err == nil || errors.Is(err, context.Canceled) {
+		t.Fatalf("nested lock error = %v", err)
+	}
+}
+
+func TestLinuxPrivateFilesReplaceOnlyThePrivateUnitAtomically(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("personal user service refuses root execution")
+	}
+	files, home := newTestLinuxPrivateFiles(t)
+	unit := filepath.Join(home, ".config", "systemd", "user", "powercontext.service")
+	if err := files.Write(t.Context(), unit, []byte("first")); err != nil {
+		t.Fatal(err)
+	}
+	if err := files.Write(t.Context(), unit, []byte("second")); err != nil {
+		t.Fatal(err)
+	}
+	content, err := os.ReadFile(unit)
+	if err != nil || string(content) != "second" {
+		t.Fatalf("unit content = %q, %v", content, err)
+	}
+	info, err := os.Lstat(unit)
+	if err != nil || !info.Mode().IsRegular() || info.Mode().Perm()&0o077 != 0 {
+		t.Fatalf("unit mode = %v, %v", info.Mode(), err)
+	}
+	entries, err := os.ReadDir(filepath.Dir(unit))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), ".powercontext.service-") {
+			t.Fatalf("temporary unit %q remains", entry.Name())
+		}
+	}
+}
+
+func newTestLinuxPrivateFiles(t *testing.T) (*linuxPrivateFiles, string) {
+	t.Helper()
+	home := filepath.Join(t.TempDir(), "home")
+	if err := os.Mkdir(home, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	roots, err := newLinuxPersonalServiceRoots(filepath.ToSlash(home))
+	if err != nil {
+		t.Fatal(err)
+	}
+	files, err := newLinuxPrivateFiles(roots)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return files, home
+}

--- a/internal/cli/server_personal_service_other.go
+++ b/internal/cli/server_personal_service_other.go
@@ -1,0 +1,24 @@
+//go:build !linux
+
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+// newCurrentLinuxSystemdBoundary is a non-Linux no-side-effect stub. Public
+// commands remain typed unsupported until the Linux lifecycle composition is
+// deliberately wired in the next task.
+func newCurrentLinuxSystemdBoundary() (*linuxSystemdBoundary, error) {
+	return nil, unsupportedPersonalService()
+}

--- a/internal/cli/server_personal_service_other.go
+++ b/internal/cli/server_personal_service_other.go
@@ -17,8 +17,7 @@
 package cli
 
 // newCurrentLinuxSystemdBoundary is a non-Linux no-side-effect stub. Public
-// commands remain typed unsupported until the Linux lifecycle composition is
-// deliberately wired in the next task.
+// personal-service commands remain typed unsupported outside Linux.
 func newCurrentLinuxSystemdBoundary() (*linuxSystemdBoundary, error) {
 	return nil, unsupportedPersonalService()
 }

--- a/internal/cli/server_personal_service_other.go
+++ b/internal/cli/server_personal_service_other.go
@@ -19,5 +19,5 @@ package cli
 // newCurrentLinuxSystemdBoundary is a non-Linux no-side-effect stub. Public
 // personal-service commands remain typed unsupported outside Linux.
 func newCurrentLinuxSystemdBoundary() (*linuxSystemdBoundary, error) {
-	return nil, unsupportedPersonalService()
+	return nil, &UnsupportedPersonalServiceError{}
 }

--- a/internal/cli/server_personal_service_systemd.go
+++ b/internal/cli/server_personal_service_systemd.go
@@ -320,6 +320,9 @@ func (b *linuxSystemdBoundary) InspectUnit(ctx context.Context, name string) (pe
 		return personalsvc.NewSystemdUserManagerUnit("not-found", "", false, nil, nil, nil), nil
 	}
 	if parseErr := parseBusctlObjectPath(objectResult.stdout); parseErr != nil {
+		if b.systemctlShowNotFound(ctx) {
+			return personalsvc.NewSystemdUserManagerUnit("not-found", "", false, nil, nil, nil), nil
+		}
 		return personalsvc.SystemdUserManagerUnit{}, newPersonalServicePlatformError("unit inspect")
 	}
 	unitProperties, err := b.busctl(ctx,
@@ -330,10 +333,16 @@ func (b *linuxSystemdBoundary) InspectUnit(ctx context.Context, name string) (pe
 	}
 	unitValues, err := parseBusctlProperties(unitProperties)
 	if err != nil {
+		if b.systemctlShowNotFound(ctx) {
+			return personalsvc.NewSystemdUserManagerUnit("not-found", "", false, nil, nil, nil), nil
+		}
 		return personalsvc.SystemdUserManagerUnit{}, newPersonalServicePlatformError("unit inspect")
 	}
 	loadState, err := busctlRequiredString(unitValues, "LoadState", "s")
 	if err != nil {
+		if b.systemctlShowNotFound(ctx) {
+			return personalsvc.NewSystemdUserManagerUnit("not-found", "", false, nil, nil, nil), nil
+		}
 		return personalsvc.SystemdUserManagerUnit{}, newPersonalServicePlatformError("unit inspect")
 	}
 	if loadState == "not-found" {
@@ -347,6 +356,9 @@ func (b *linuxSystemdBoundary) InspectUnit(ctx context.Context, name string) (pe
 	}
 	unit, err := parseBusctlUnit(unitValues, serviceProperties)
 	if err != nil {
+		if b.systemctlShowNotFound(ctx) {
+			return personalsvc.NewSystemdUserManagerUnit("not-found", "", false, nil, nil, nil), nil
+		}
 		return personalsvc.SystemdUserManagerUnit{}, newPersonalServicePlatformError("unit inspect")
 	}
 	return unit, nil
@@ -450,6 +462,48 @@ func (b *linuxSystemdBoundary) busctlResult(ctx context.Context, arguments ...st
 		return linuxSystemdProcessResult{}, newPersonalServicePlatformError("user bus")
 	}
 	return linuxSystemdProcessResult{exitCode: result.exitCode, stdout: bytes.Clone(result.stdout)}, nil
+}
+
+// systemctlShowNotFound preserves a strict user-bus inspection for loaded
+// units while using the upstream adapter's stable absent-unit classification
+// when a systemd version emits an unrecognized D-Bus property envelope.
+func (b *linuxSystemdBoundary) systemctlShowNotFound(ctx context.Context) bool {
+	if err := contextError(ctx); err != nil {
+		return false
+	}
+	result, err := b.runner.Run(ctx,
+		"systemctl",
+		"--user",
+		"show",
+		"--property=LoadState",
+		"--property=FragmentPath",
+		"--property=DropInPaths",
+		"--property=Environment",
+		"--property=ExecStart",
+		personalServiceUnitName,
+	)
+	if err != nil || result.exitCode != 0 || contextError(ctx) != nil {
+		return false
+	}
+	loadState, found := systemctlShowProperty(result.stdout, "LoadState")
+	return !found || loadState == "not-found"
+}
+
+func systemctlShowProperty(payload []byte, name string) (string, bool) {
+	var value string
+	found := false
+	for line := range strings.Lines(string(payload)) {
+		key, candidate, ok := strings.Cut(strings.TrimRight(line, "\r\n"), "=")
+		if !ok || key != name {
+			continue
+		}
+		if found {
+			return "", false
+		}
+		value = candidate
+		found = true
+	}
+	return value, found
 }
 
 func (b *linuxSystemdBoundary) available() bool {

--- a/internal/cli/server_personal_service_systemd.go
+++ b/internal/cli/server_personal_service_systemd.go
@@ -307,6 +307,12 @@ func (b *linuxSystemdBoundary) InspectUnit(ctx context.Context, name string) (pe
 	if !b.available() || name != personalServiceUnitName {
 		return personalsvc.SystemdUserManagerUnit{}, newPersonalServicePlatformError("unit inspect")
 	}
+	// systemctl show is the upstream-stable absent-unit classifier. It must run
+	// before the strict D-Bus ownership inspection because systemd can expose an
+	// unloaded unit through a property envelope the latter intentionally rejects.
+	if b.systemctlShowNotFound(ctx) {
+		return personalsvc.NewSystemdUserManagerUnit("not-found", "", false, nil, nil, nil), nil
+	}
 	objectResult, err := b.busctlResult(ctx,
 		"call", personalServiceManagerName, personalServiceManagerPath, personalServiceManagerName+".Manager", "LoadUnit", "s", personalServiceUnitName,
 	)

--- a/internal/cli/server_personal_service_systemd.go
+++ b/internal/cli/server_personal_service_systemd.go
@@ -319,7 +319,7 @@ func (b *linuxSystemdBoundary) InspectUnit(ctx context.Context, name string) (pe
 	if objectResult.exitCode != 0 {
 		return personalsvc.NewSystemdUserManagerUnit("not-found", "", false, nil, nil, nil), nil
 	}
-	if err := parseBusctlObjectPath(objectResult.stdout); err != nil {
+	if parseErr := parseBusctlObjectPath(objectResult.stdout); parseErr != nil {
 		return personalsvc.SystemdUserManagerUnit{}, newPersonalServicePlatformError("unit inspect")
 	}
 	unitProperties, err := b.busctl(ctx,
@@ -386,7 +386,7 @@ func (b *linuxSystemdBoundary) Probe(ctx context.Context, endpoint string) (pers
 		}
 		return personalsvc.ProbeUnreachable, nil
 	}
-	defer response.Body.Close()
+	defer func() { _ = response.Body.Close() }()
 	content, readErr := io.ReadAll(io.LimitReader(response.Body, 4<<10))
 	if response.StatusCode != http.StatusOK || readErr != nil {
 		return personalsvc.ProbeConflict, nil

--- a/internal/cli/server_personal_service_systemd.go
+++ b/internal/cli/server_personal_service_systemd.go
@@ -20,12 +20,18 @@ import (
 	"encoding/json/jsontext"
 	json "encoding/json/v2"
 	"errors"
+	"io"
 	"io/fs"
+	"maps"
+	"net/http"
+	"net/url"
 	"path"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/ob-labs/powercontext-go/internal/personalsvc"
+	"github.com/ob-labs/powercontext-go/internal/transportpolicy"
 )
 
 const (
@@ -35,6 +41,7 @@ const (
 	personalServiceUnitObjectPath   = "/org/freedesktop/systemd1/unit/powercontext_2eservice"
 	personalServiceUnitInterface    = "org.freedesktop.systemd1.Unit"
 	personalServiceServiceInterface = "org.freedesktop.systemd1.Service"
+	personalServiceProbeTimeout     = 5 * time.Second
 )
 
 // linuxPersonalServiceRoots are derived from the current user's home rather
@@ -93,6 +100,10 @@ type linuxOperationLocker interface {
 	WithLock(context.Context, func(context.Context) error) error
 }
 
+type linuxSystemdHTTPClient interface {
+	Do(*http.Request) (*http.Response, error)
+}
+
 // linuxPrivateFileIdentity records the two observations around a no-follow
 // open. A changed identity, non-regular type, loose mode, or foreign owner is
 // always unsafe.
@@ -118,10 +129,11 @@ func validLinuxPrivateFileObservation(value linuxPrivateFileIdentity, owner uint
 // It is inert until a caller invokes one of its methods; constructing it does
 // not inspect a bus, file, process, or service lifecycle.
 type linuxSystemdBoundary struct {
-	roots  linuxPersonalServiceRoots
-	runner linuxSystemdRunner
-	files  linuxPrivateFileStore
-	locker linuxOperationLocker
+	roots       linuxPersonalServiceRoots
+	runner      linuxSystemdRunner
+	files       linuxPrivateFileStore
+	locker      linuxOperationLocker
+	probeClient linuxSystemdHTTPClient
 }
 
 var _ personalsvc.SystemdUserBoundary = (*linuxSystemdBoundary)(nil)
@@ -137,7 +149,16 @@ func newLinuxSystemdBoundary(
 		roots.stateRoot != path.Join(home, ".local", "state", "powercontext") || runner == nil || files == nil || locker == nil {
 		return nil, newPersonalServicePlatformError("configuration")
 	}
-	return &linuxSystemdBoundary{roots: roots, runner: runner, files: files, locker: locker}, nil
+	return &linuxSystemdBoundary{
+		roots: roots, runner: runner, files: files, locker: locker,
+		probeClient: &http.Client{
+			Timeout:   personalServiceProbeTimeout,
+			Transport: &http.Transport{Proxy: nil},
+			CheckRedirect: func(*http.Request, []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		},
+	}, nil
 }
 
 func (b *linuxSystemdBoundary) unitPath() string {
@@ -206,6 +227,29 @@ func (b *linuxSystemdBoundary) VerifyEnvironmentFile(ctx context.Context, envFil
 		return newPersonalServicePlatformError("environment file")
 	}
 	return nil
+}
+
+// LoadEnvironmentFile reads and parses a private environment file through the
+// same no-follow identity validation used by install and launcher execution.
+func (b *linuxSystemdBoundary) LoadEnvironmentFile(ctx context.Context, envFile string) (map[string]string, error) {
+	if !b.available() || !validLinuxPrivatePath(envFile) {
+		return nil, newPersonalServicePlatformError("environment file")
+	}
+	if err := contextError(ctx); err != nil {
+		return nil, err
+	}
+	content, exists, err := b.files.Read(ctx, envFile)
+	if err != nil || !exists {
+		if contextErr := contextError(ctx); contextErr != nil {
+			return nil, contextErr
+		}
+		return nil, newPersonalServicePlatformError("environment file")
+	}
+	values, err := parseConfigEnvironment(string(content))
+	if err != nil {
+		return nil, newPersonalServicePlatformError("environment file")
+	}
+	return maps.Clone(values), nil
 }
 
 func (b *linuxSystemdBoundary) ReadFile(ctx context.Context, name string) ([]byte, bool, error) {
@@ -314,11 +358,61 @@ func (b *linuxSystemdBoundary) Run(ctx context.Context, command personalsvc.Syst
 	return personalsvc.NewSystemdUserCommandResult(result.exitCode, result.stdout), nil
 }
 
-// Probe is deliberately withheld until the launcher/liveness slice owns a
-// bounded loopback client. A status command cannot infer lifecycle success
-// from a systemd state alone.
-func (*linuxSystemdBoundary) Probe(context.Context, string) (personalsvc.ProbeState, error) {
-	return personalsvc.ProbeUnreachable, newPersonalServicePlatformError("liveness probe")
+// Probe requests only the exact public liveness route through a proxy-free,
+// bounded loopback client. A valid liveness response identifies an existing
+// PowerContext process; every other response proves that the endpoint is busy
+// but cannot be used as the managed service's liveness evidence.
+func (b *linuxSystemdBoundary) Probe(ctx context.Context, endpoint string) (personalsvc.ProbeState, error) {
+	if !b.available() || b.probeClient == nil {
+		return personalsvc.ProbeUnreachable, newPersonalServicePlatformError("liveness probe")
+	}
+	if err := contextError(ctx); err != nil {
+		return personalsvc.ProbeUnreachable, err
+	}
+	target, err := personalServiceHealthURL(endpoint)
+	if err != nil {
+		return personalsvc.ProbeUnreachable, newPersonalServicePlatformError("liveness probe")
+	}
+	requestCtx, cancel := context.WithTimeout(ctx, personalServiceProbeTimeout)
+	defer cancel()
+	request, err := http.NewRequestWithContext(requestCtx, http.MethodGet, target.String(), nil)
+	if err != nil {
+		return personalsvc.ProbeUnreachable, newPersonalServicePlatformError("liveness probe")
+	}
+	response, err := b.probeClient.Do(request)
+	if err != nil {
+		if ctx.Err() != nil {
+			return personalsvc.ProbeUnreachable, ctx.Err()
+		}
+		return personalsvc.ProbeUnreachable, nil
+	}
+	defer response.Body.Close()
+	content, readErr := io.ReadAll(io.LimitReader(response.Body, 4<<10))
+	if response.StatusCode != http.StatusOK || readErr != nil {
+		return personalsvc.ProbeConflict, nil
+	}
+	var health struct {
+		Status string `json:"status"`
+	}
+	if json.Unmarshal(content, &health) != nil || health.Status != "ok" {
+		return personalsvc.ProbeConflict, nil
+	}
+	return personalsvc.ProbeLive, nil
+}
+
+func personalServiceHealthURL(endpoint string) (*url.URL, error) {
+	parsed, err := url.Parse(endpoint)
+	if err != nil || parsed.Scheme != "http" || parsed.User != nil || parsed.Hostname() == "" ||
+		!transportpolicy.IsLoopbackHost(parsed.Hostname()) || parsed.Path != "" || parsed.RawQuery != "" || parsed.Fragment != "" {
+		return nil, errors.New("invalid liveness endpoint")
+	}
+	target := parsed.Clone()
+	target.Path = "/health/live"
+	target.RawPath = ""
+	target.RawQuery = ""
+	target.ForceQuery = false
+	target.Fragment = ""
+	return target, nil
 }
 
 func (b *linuxSystemdBoundary) busctl(ctx context.Context, arguments ...string) ([]byte, error) {

--- a/internal/cli/server_personal_service_systemd.go
+++ b/internal/cli/server_personal_service_systemd.go
@@ -482,34 +482,13 @@ func (b *linuxSystemdBoundary) systemctlShowNotFound(ctx context.Context) bool {
 		"--user",
 		"show",
 		"--property=LoadState",
-		"--property=FragmentPath",
-		"--property=DropInPaths",
-		"--property=Environment",
-		"--property=ExecStart",
+		"--value",
 		personalServiceUnitName,
 	)
 	if err != nil || result.exitCode != 0 || contextError(ctx) != nil {
 		return false
 	}
-	loadState, found := systemctlShowProperty(result.stdout, "LoadState")
-	return !found || loadState == "not-found"
-}
-
-func systemctlShowProperty(payload []byte, name string) (string, bool) {
-	var value string
-	found := false
-	for line := range strings.Lines(string(payload)) {
-		key, candidate, ok := strings.Cut(strings.TrimRight(line, "\r\n"), "=")
-		if !ok || key != name {
-			continue
-		}
-		if found {
-			return "", false
-		}
-		value = candidate
-		found = true
-	}
-	return value, found
+	return strings.TrimSpace(string(result.stdout)) == "not-found"
 }
 
 func (b *linuxSystemdBoundary) available() bool {

--- a/internal/cli/server_personal_service_systemd.go
+++ b/internal/cli/server_personal_service_systemd.go
@@ -1,0 +1,553 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json/jsontext"
+	json "encoding/json/v2"
+	"errors"
+	"io/fs"
+	"path"
+	"slices"
+	"strings"
+
+	"github.com/ob-labs/powercontext-go/internal/personalsvc"
+)
+
+const (
+	personalServiceUnitName         = "powercontext.service"
+	personalServiceManagerName      = "org.freedesktop.systemd1"
+	personalServiceManagerPath      = "/org/freedesktop/systemd1"
+	personalServiceUnitObjectPath   = "/org/freedesktop/systemd1/unit/powercontext_2eservice"
+	personalServiceUnitInterface    = "org.freedesktop.systemd1.Unit"
+	personalServiceServiceInterface = "org.freedesktop.systemd1.Service"
+)
+
+// linuxPersonalServiceRoots are derived from the current user's home rather
+// than from caller-selected systemd roots. They are kept in CLI composition so
+// personalsvc remains platform and filesystem independent.
+type linuxPersonalServiceRoots struct {
+	configRoot string
+	stateRoot  string
+}
+
+func newLinuxPersonalServiceRoots(home string) (linuxPersonalServiceRoots, error) {
+	if !validLinuxUserRoot(home) {
+		return linuxPersonalServiceRoots{}, newPersonalServicePlatformError("configuration")
+	}
+	return linuxPersonalServiceRoots{
+		configRoot: path.Join(home, ".config"),
+		stateRoot:  path.Join(home, ".local", "state", "powercontext"),
+	}, nil
+}
+
+func validLinuxUserRoot(value string) bool {
+	if !path.IsAbs(value) || path.Clean(value) != value || value == "/" || strings.ContainsRune(value, '\\') {
+		return false
+	}
+	for _, global := range []string{"/etc", "/root", "/usr", "/lib", "/run", "/var"} {
+		if value == global || strings.HasPrefix(value, global+"/") {
+			return false
+		}
+	}
+	return true
+}
+
+type linuxSystemdProcessResult struct {
+	exitCode int
+	stdout   []byte
+}
+
+// linuxSystemdRunner is injected so the fixed native argv contract can
+// be tested without starting a user manager.
+type linuxSystemdRunner interface {
+	Run(context.Context, string, ...string) (linuxSystemdProcessResult, error)
+}
+
+// linuxPrivateFileStore owns the no-follow, nonblocking filesystem operations
+// used for the private unit and credential-bearing environment file.
+type linuxPrivateFileStore interface {
+	Read(context.Context, string) ([]byte, bool, error)
+	Write(context.Context, string, []byte) error
+	Remove(context.Context, string) error
+	Validate(context.Context, string) error
+}
+
+// linuxOperationLocker serializes an entire native inspect/mutate sequence
+// across processes. It is separate from the controller's in-process mutex.
+type linuxOperationLocker interface {
+	WithLock(context.Context, func(context.Context) error) error
+}
+
+// linuxPrivateFileIdentity records the two observations around a no-follow
+// open. A changed identity, non-regular type, loose mode, or foreign owner is
+// always unsafe.
+type linuxPrivateFileIdentity struct {
+	device uint64
+	inode  uint64
+	mode   fs.FileMode
+	uid    uint32
+}
+
+func validLinuxPrivateFile(before, after linuxPrivateFileIdentity, owner uint32) bool {
+	return validLinuxPrivateFileObservation(before, owner) &&
+		validLinuxPrivateFileObservation(after, owner) &&
+		before.device == after.device && before.inode == after.inode
+}
+
+func validLinuxPrivateFileObservation(value linuxPrivateFileIdentity, owner uint32) bool {
+	return value.device != 0 && value.inode != 0 && value.uid == owner && value.mode.IsRegular() &&
+		value.mode&fs.ModeSymlink == 0 && value.mode.Perm()&0o077 == 0
+}
+
+// linuxSystemdBoundary is the composition-owned Linux systemd-user boundary.
+// It is inert until a caller invokes one of its methods; constructing it does
+// not inspect a bus, file, process, or service lifecycle.
+type linuxSystemdBoundary struct {
+	roots  linuxPersonalServiceRoots
+	runner linuxSystemdRunner
+	files  linuxPrivateFileStore
+	locker linuxOperationLocker
+}
+
+var _ personalsvc.SystemdUserBoundary = (*linuxSystemdBoundary)(nil)
+
+func newLinuxSystemdBoundary(
+	roots linuxPersonalServiceRoots,
+	runner linuxSystemdRunner,
+	files linuxPrivateFileStore,
+	locker linuxOperationLocker,
+) (*linuxSystemdBoundary, error) {
+	home := path.Dir(roots.configRoot)
+	if !validLinuxUserRoot(home) || roots.configRoot != path.Join(home, ".config") ||
+		roots.stateRoot != path.Join(home, ".local", "state", "powercontext") || runner == nil || files == nil || locker == nil {
+		return nil, newPersonalServicePlatformError("configuration")
+	}
+	return &linuxSystemdBoundary{roots: roots, runner: runner, files: files, locker: locker}, nil
+}
+
+func (b *linuxSystemdBoundary) unitPath() string {
+	if b == nil {
+		return ""
+	}
+	return path.Join(b.roots.configRoot, "systemd", "user", personalServiceUnitName)
+}
+
+func (b *linuxSystemdBoundary) lockPath() string {
+	if b == nil {
+		return ""
+	}
+	return path.Join(b.roots.stateRoot, "personal-service.lock")
+}
+
+// OperationBoundary exposes the private cross-process lock through the pure
+// controller's lifecycle boundary without importing filesystem concerns into
+// personalsvc.
+func (b *linuxSystemdBoundary) OperationBoundary() personalsvc.OperationBoundary {
+	return linuxSystemdOperationBoundary{boundary: b}
+}
+
+type linuxSystemdOperationBoundary struct{ boundary *linuxSystemdBoundary }
+
+var _ personalsvc.OperationBoundary = linuxSystemdOperationBoundary{}
+
+func (b linuxSystemdOperationBoundary) Run(ctx context.Context, operation func(context.Context) error) error {
+	if b.boundary == nil {
+		return newPersonalServicePlatformError("operation lock")
+	}
+	return b.boundary.WithOperationLock(ctx, operation)
+}
+
+// WithOperationLock must wrap every inspect, registration, unit mutation,
+// manager mutation, and final inspection performed by the CLI lifecycle.
+func (b *linuxSystemdBoundary) WithOperationLock(ctx context.Context, operation func(context.Context) error) error {
+	if !b.available() || operation == nil {
+		return newPersonalServicePlatformError("operation lock")
+	}
+	if err := contextError(ctx); err != nil {
+		return err
+	}
+	if err := b.locker.WithLock(ctx, operation); err != nil {
+		if contextErr := contextError(ctx); contextErr != nil {
+			return contextErr
+		}
+		return newPersonalServicePlatformError("operation lock")
+	}
+	return nil
+}
+
+// VerifyEnvironmentFile validates a registered file through the Linux secure
+// open boundary without retaining or rendering its contents.
+func (b *linuxSystemdBoundary) VerifyEnvironmentFile(ctx context.Context, envFile string) error {
+	if !b.available() || !validLinuxPrivatePath(envFile) {
+		return newPersonalServicePlatformError("environment file")
+	}
+	if err := contextError(ctx); err != nil {
+		return err
+	}
+	if err := b.files.Validate(ctx, envFile); err != nil {
+		if contextErr := contextError(ctx); contextErr != nil {
+			return contextErr
+		}
+		return newPersonalServicePlatformError("environment file")
+	}
+	return nil
+}
+
+func (b *linuxSystemdBoundary) ReadFile(ctx context.Context, name string) ([]byte, bool, error) {
+	if !b.available() || name != b.unitPath() {
+		return nil, false, newPersonalServicePlatformError("unit path")
+	}
+	if err := contextError(ctx); err != nil {
+		return nil, false, err
+	}
+	content, exists, err := b.files.Read(ctx, name)
+	if err != nil {
+		if contextErr := contextError(ctx); contextErr != nil {
+			return nil, false, contextErr
+		}
+		return nil, false, newPersonalServicePlatformError("unit read")
+	}
+	return bytes.Clone(content), exists, nil
+}
+
+func (b *linuxSystemdBoundary) WriteFile(ctx context.Context, name string, content []byte) error {
+	if !b.available() || name != b.unitPath() {
+		return newPersonalServicePlatformError("unit path")
+	}
+	if err := contextError(ctx); err != nil {
+		return err
+	}
+	if err := b.files.Write(ctx, name, bytes.Clone(content)); err != nil {
+		if contextErr := contextError(ctx); contextErr != nil {
+			return contextErr
+		}
+		return newPersonalServicePlatformError("unit write")
+	}
+	return nil
+}
+
+func (b *linuxSystemdBoundary) RemoveFile(ctx context.Context, name string) error {
+	if !b.available() || name != b.unitPath() {
+		return newPersonalServicePlatformError("unit path")
+	}
+	if err := contextError(ctx); err != nil {
+		return err
+	}
+	if err := b.files.Remove(ctx, name); err != nil {
+		if contextErr := contextError(ctx); contextErr != nil {
+			return contextErr
+		}
+		return newPersonalServicePlatformError("unit remove")
+	}
+	return nil
+}
+
+// InspectUnit reads typed D-Bus properties instead of parsing presentation
+// output. The object path, destination, interfaces, and unit name are fixed.
+func (b *linuxSystemdBoundary) InspectUnit(ctx context.Context, name string) (personalsvc.SystemdUserManagerUnit, error) {
+	if !b.available() || name != personalServiceUnitName {
+		return personalsvc.SystemdUserManagerUnit{}, newPersonalServicePlatformError("unit inspect")
+	}
+	objectResult, err := b.busctlResult(ctx,
+		"call", personalServiceManagerName, personalServiceManagerPath, personalServiceManagerName+".Manager", "LoadUnit", "s", personalServiceUnitName,
+	)
+	if err != nil {
+		return personalsvc.SystemdUserManagerUnit{}, err
+	}
+	// Controller methods establish user-manager support before inspection. Once
+	// that support check succeeded, LoadUnit's nonzero result is the exact
+	// unregistered-unit state needed for a first install or completed uninstall.
+	if objectResult.exitCode != 0 {
+		return personalsvc.NewSystemdUserManagerUnit("not-found", "", false, nil, "", nil), nil
+	}
+	if err := parseBusctlObjectPath(objectResult.stdout); err != nil {
+		return personalsvc.SystemdUserManagerUnit{}, newPersonalServicePlatformError("unit inspect")
+	}
+	unitProperties, err := b.busctl(ctx,
+		"call", personalServiceManagerName, personalServiceUnitObjectPath, "org.freedesktop.DBus.Properties", "GetAll", "s", personalServiceUnitInterface,
+	)
+	if err != nil {
+		return personalsvc.SystemdUserManagerUnit{}, err
+	}
+	serviceProperties, err := b.busctl(ctx,
+		"call", personalServiceManagerName, personalServiceUnitObjectPath, "org.freedesktop.DBus.Properties", "GetAll", "s", personalServiceServiceInterface,
+	)
+	if err != nil {
+		return personalsvc.SystemdUserManagerUnit{}, err
+	}
+	unit, err := parseBusctlUnit(unitProperties, serviceProperties)
+	if err != nil {
+		return personalsvc.SystemdUserManagerUnit{}, newPersonalServicePlatformError("unit inspect")
+	}
+	return unit, nil
+}
+
+func (b *linuxSystemdBoundary) Run(ctx context.Context, command personalsvc.SystemdUserCommand) (personalsvc.SystemdUserCommandResult, error) {
+	if !b.available() || !allowedLinuxSystemdCommand(command) {
+		return personalsvc.SystemdUserCommandResult{}, newPersonalServicePlatformError("manager command")
+	}
+	if err := contextError(ctx); err != nil {
+		return personalsvc.SystemdUserCommandResult{}, err
+	}
+	result, err := b.runner.Run(ctx, command.Program(), command.Arguments()...)
+	if err != nil {
+		if contextErr := contextError(ctx); contextErr != nil {
+			return personalsvc.SystemdUserCommandResult{}, contextErr
+		}
+		return personalsvc.SystemdUserCommandResult{}, newPersonalServicePlatformError("manager command")
+	}
+	return personalsvc.NewSystemdUserCommandResult(result.exitCode, result.stdout), nil
+}
+
+// Probe is deliberately withheld until the launcher/liveness slice owns a
+// bounded loopback client. A status command cannot infer lifecycle success
+// from a systemd state alone.
+func (*linuxSystemdBoundary) Probe(context.Context, string) (personalsvc.ProbeState, error) {
+	return personalsvc.ProbeUnreachable, newPersonalServicePlatformError("liveness probe")
+}
+
+func (b *linuxSystemdBoundary) busctl(ctx context.Context, arguments ...string) ([]byte, error) {
+	result, err := b.busctlResult(ctx, arguments...)
+	if err != nil || result.exitCode != 0 {
+		if contextErr := contextError(ctx); contextErr != nil {
+			return nil, contextErr
+		}
+		return nil, newPersonalServicePlatformError("user bus")
+	}
+	return bytes.Clone(result.stdout), nil
+}
+
+func (b *linuxSystemdBoundary) busctlResult(ctx context.Context, arguments ...string) (linuxSystemdProcessResult, error) {
+	if err := contextError(ctx); err != nil {
+		return linuxSystemdProcessResult{}, err
+	}
+	command := append([]string{"--user", "--json=short"}, arguments...)
+	result, err := b.runner.Run(ctx, "busctl", command...)
+	if err != nil {
+		if contextErr := contextError(ctx); contextErr != nil {
+			return linuxSystemdProcessResult{}, contextErr
+		}
+		return linuxSystemdProcessResult{}, newPersonalServicePlatformError("user bus")
+	}
+	return linuxSystemdProcessResult{exitCode: result.exitCode, stdout: bytes.Clone(result.stdout)}, nil
+}
+
+func (b *linuxSystemdBoundary) available() bool {
+	return b != nil && b.runner != nil && b.files != nil && b.locker != nil && b.unitPath() != "" && b.lockPath() != ""
+}
+
+func contextError(ctx context.Context) error {
+	if ctx == nil {
+		return errors.New("missing context")
+	}
+	return ctx.Err()
+}
+
+func validLinuxPrivatePath(value string) bool {
+	return path.IsAbs(value) && path.Clean(value) == value && value != "/" && !strings.ContainsRune(value, '\\')
+}
+
+func allowedLinuxSystemdCommand(command personalsvc.SystemdUserCommand) bool {
+	arguments := command.Arguments()
+	switch command.Program() {
+	case "systemctl":
+		return slices.ContainsFunc([][]string{
+			{"--user", "show-environment"},
+			{"--user", "daemon-reload"},
+			{"--user", "enable", personalServiceUnitName},
+			{"--user", "reset-failed", personalServiceUnitName},
+			{"--user", "start", personalServiceUnitName},
+			{"--user", "stop", personalServiceUnitName},
+			{"--user", "disable", personalServiceUnitName},
+			{"--user", "show", "--property=ActiveState", "--value", personalServiceUnitName},
+		}, func(candidate []string) bool { return slices.Equal(arguments, candidate) })
+	case "journalctl":
+		return slices.Equal(arguments, []string{"--user", "--unit", personalServiceUnitName})
+	default:
+		return false
+	}
+}
+
+type busctlValue struct {
+	typeName string
+	data     jsontext.Value
+}
+
+func parseBusctlObjectPath(payload []byte) error {
+	value, err := parseBusctlEnvelope(payload)
+	if err != nil || value.typeName != "o" {
+		return errors.New("invalid user-bus object")
+	}
+	object, err := busctlString(value.data)
+	if err != nil || object != personalServiceUnitObjectPath {
+		return errors.New("unexpected user-bus object")
+	}
+	return nil
+}
+
+func parseBusctlUnit(unitPayload, servicePayload []byte) (personalsvc.SystemdUserManagerUnit, error) {
+	unitValues, err := parseBusctlProperties(unitPayload)
+	if err != nil {
+		return personalsvc.SystemdUserManagerUnit{}, err
+	}
+	serviceValues, err := parseBusctlProperties(servicePayload)
+	if err != nil {
+		return personalsvc.SystemdUserManagerUnit{}, err
+	}
+	loadState, err := busctlRequiredString(unitValues, "LoadState", "s")
+	if err != nil {
+		return personalsvc.SystemdUserManagerUnit{}, err
+	}
+	fragmentPath, err := busctlRequiredString(unitValues, "FragmentPath", "s")
+	if err != nil {
+		return personalsvc.SystemdUserManagerUnit{}, err
+	}
+	dropIns, err := busctlRequiredStrings(unitValues, "DropInPaths", "as")
+	if err != nil {
+		return personalsvc.SystemdUserManagerUnit{}, err
+	}
+	environment, err := busctlRequiredStrings(serviceValues, "Environment", "as")
+	if err != nil {
+		return personalsvc.SystemdUserManagerUnit{}, err
+	}
+	execStart, err := busctlExecStart(serviceValues["ExecStart"])
+	if err != nil {
+		return personalsvc.SystemdUserManagerUnit{}, err
+	}
+	return personalsvc.NewSystemdUserManagerUnit(
+		loadState, fragmentPath, true, dropIns, strings.Join(environment, " "), execStart,
+	), nil
+}
+
+func parseBusctlProperties(payload []byte) (map[string]busctlValue, error) {
+	envelope, err := parseBusctlEnvelope(payload)
+	if err != nil || envelope.typeName != "a{sv}" || envelope.data.Kind() != '{' {
+		return nil, errors.New("invalid user-bus properties")
+	}
+	var members map[string]jsontext.Value
+	if err := json.Unmarshal(envelope.data, &members); err != nil || members == nil {
+		return nil, errors.New("invalid user-bus properties")
+	}
+	result := make(map[string]busctlValue, len(members))
+	for name, member := range members {
+		value, err := parseBusctlEnvelope(member)
+		if err != nil {
+			return nil, errors.New("invalid user-bus properties")
+		}
+		result[name] = value
+	}
+	return result, nil
+}
+
+func parseBusctlEnvelope(payload []byte) (busctlValue, error) {
+	if jsontext.Value(payload).Kind() != '{' {
+		return busctlValue{}, errors.New("invalid user-bus JSON")
+	}
+	var object map[string]jsontext.Value
+	if err := json.Unmarshal(payload, &object); err != nil || len(object) != 2 {
+		return busctlValue{}, errors.New("invalid user-bus JSON")
+	}
+	typeValue, found := object["type"]
+	if !found {
+		return busctlValue{}, errors.New("invalid user-bus JSON")
+	}
+	typeName, err := busctlString(typeValue)
+	if err != nil || typeName == "" {
+		return busctlValue{}, errors.New("invalid user-bus JSON")
+	}
+	data, found := object["data"]
+	if !found {
+		return busctlValue{}, errors.New("invalid user-bus JSON")
+	}
+	return busctlValue{typeName: typeName, data: data}, nil
+}
+
+func busctlRequiredString(values map[string]busctlValue, name, typeName string) (string, error) {
+	value, found := values[name]
+	if !found || value.typeName != typeName {
+		return "", errors.New("missing user-bus property")
+	}
+	return busctlString(value.data)
+}
+
+func busctlRequiredStrings(values map[string]busctlValue, name, typeName string) ([]string, error) {
+	value, found := values[name]
+	if !found || value.typeName != typeName || value.data.Kind() != '[' {
+		return nil, errors.New("missing user-bus property")
+	}
+	var result []string
+	if err := json.Unmarshal(value.data, &result); err != nil {
+		return nil, errors.New("invalid user-bus property")
+	}
+	return slices.Clone(result), nil
+}
+
+func busctlExecStart(value busctlValue) ([]personalsvc.SystemdUserExecStart, error) {
+	if value.typeName != "a(sasbttttuii)" || value.data.Kind() != '[' {
+		return nil, errors.New("invalid ExecStart")
+	}
+	var rows []jsontext.Value
+	if err := json.Unmarshal(value.data, &rows); err != nil {
+		return nil, errors.New("invalid ExecStart")
+	}
+	commands := make([]personalsvc.SystemdUserExecStart, 0, len(rows))
+	for _, row := range rows {
+		var fields []jsontext.Value
+		if row.Kind() != '[' || json.Unmarshal(row, &fields) != nil || len(fields) != 10 {
+			return nil, errors.New("invalid ExecStart")
+		}
+		commandPath, err := busctlString(fields[0])
+		if err != nil || commandPath == "" {
+			return nil, errors.New("invalid ExecStart")
+		}
+		var arguments []string
+		if fields[1].Kind() != '[' || json.Unmarshal(fields[1], &arguments) != nil || len(arguments) == 0 {
+			return nil, errors.New("invalid ExecStart")
+		}
+		var ignoreErrors bool
+		if fields[2].Kind() != 'f' && fields[2].Kind() != 't' || json.Unmarshal(fields[2], &ignoreErrors) != nil {
+			return nil, errors.New("invalid ExecStart")
+		}
+		commands = append(commands, personalsvc.NewSystemdUserExecStart(commandPath, arguments, ignoreErrors))
+	}
+	return commands, nil
+}
+
+func busctlString(value jsontext.Value) (string, error) {
+	if value.Kind() != '"' {
+		return "", errors.New("invalid user-bus string")
+	}
+	var result string
+	if err := json.Unmarshal(value, &result); err != nil {
+		return "", errors.New("invalid user-bus string")
+	}
+	return result, nil
+}
+
+type personalServicePlatformError struct{ operation string }
+
+func (e *personalServicePlatformError) Error() string {
+	if e == nil || e.operation == "" {
+		return "personal Server service platform operation failed"
+	}
+	return "personal Server service " + e.operation + " failed"
+}
+
+func newPersonalServicePlatformError(operation string) error {
+	return &personalServicePlatformError{operation: operation}
+}

--- a/internal/cli/server_personal_service_systemd.go
+++ b/internal/cli/server_personal_service_systemd.go
@@ -328,13 +328,24 @@ func (b *linuxSystemdBoundary) InspectUnit(ctx context.Context, name string) (pe
 	if err != nil {
 		return personalsvc.SystemdUserManagerUnit{}, err
 	}
+	unitValues, err := parseBusctlProperties(unitProperties)
+	if err != nil {
+		return personalsvc.SystemdUserManagerUnit{}, newPersonalServicePlatformError("unit inspect")
+	}
+	loadState, err := busctlRequiredString(unitValues, "LoadState", "s")
+	if err != nil {
+		return personalsvc.SystemdUserManagerUnit{}, newPersonalServicePlatformError("unit inspect")
+	}
+	if loadState == "not-found" {
+		return personalsvc.NewSystemdUserManagerUnit("not-found", "", false, nil, nil, nil), nil
+	}
 	serviceProperties, err := b.busctl(ctx,
 		"call", personalServiceManagerName, personalServiceUnitObjectPath, "org.freedesktop.DBus.Properties", "GetAll", "s", personalServiceServiceInterface,
 	)
 	if err != nil {
 		return personalsvc.SystemdUserManagerUnit{}, err
 	}
-	unit, err := parseBusctlUnit(unitProperties, serviceProperties)
+	unit, err := parseBusctlUnit(unitValues, serviceProperties)
 	if err != nil {
 		return personalsvc.SystemdUserManagerUnit{}, newPersonalServicePlatformError("unit inspect")
 	}
@@ -494,11 +505,7 @@ func parseBusctlObjectPath(payload []byte) error {
 	return nil
 }
 
-func parseBusctlUnit(unitPayload, servicePayload []byte) (personalsvc.SystemdUserManagerUnit, error) {
-	unitValues, err := parseBusctlProperties(unitPayload)
-	if err != nil {
-		return personalsvc.SystemdUserManagerUnit{}, err
-	}
+func parseBusctlUnit(unitValues map[string]busctlValue, servicePayload []byte) (personalsvc.SystemdUserManagerUnit, error) {
 	serviceValues, err := parseBusctlProperties(servicePayload)
 	if err != nil {
 		return personalsvc.SystemdUserManagerUnit{}, err

--- a/internal/cli/server_personal_service_systemd.go
+++ b/internal/cli/server_personal_service_systemd.go
@@ -273,7 +273,7 @@ func (b *linuxSystemdBoundary) InspectUnit(ctx context.Context, name string) (pe
 	// that support check succeeded, LoadUnit's nonzero result is the exact
 	// unregistered-unit state needed for a first install or completed uninstall.
 	if objectResult.exitCode != 0 {
-		return personalsvc.NewSystemdUserManagerUnit("not-found", "", false, nil, "", nil), nil
+		return personalsvc.NewSystemdUserManagerUnit("not-found", "", false, nil, nil, nil), nil
 	}
 	if err := parseBusctlObjectPath(objectResult.stdout); err != nil {
 		return personalsvc.SystemdUserManagerUnit{}, newPersonalServicePlatformError("unit inspect")
@@ -430,7 +430,7 @@ func parseBusctlUnit(unitPayload, servicePayload []byte) (personalsvc.SystemdUse
 		return personalsvc.SystemdUserManagerUnit{}, err
 	}
 	return personalsvc.NewSystemdUserManagerUnit(
-		loadState, fragmentPath, true, dropIns, strings.Join(environment, " "), execStart,
+		loadState, fragmentPath, true, dropIns, environment, execStart,
 	), nil
 }
 

--- a/internal/cli/server_personal_service_systemd_test.go
+++ b/internal/cli/server_personal_service_systemd_test.go
@@ -50,7 +50,7 @@ func TestLinuxSystemdBoundaryUsesFixedStructuredUserBusCommands(t *testing.T) {
 		t.Fatalf("InspectUnit() = %#v", unit)
 	}
 	want := [][]string{
-		{"systemctl", "--user", "show", "--property=LoadState", "--property=FragmentPath", "--property=DropInPaths", "--property=Environment", "--property=ExecStart", "powercontext.service"},
+		{"systemctl", "--user", "show", "--property=LoadState", "--value", "powercontext.service"},
 		{"busctl", "--user", "--json=short", "call", "org.freedesktop.systemd1", "/org/freedesktop/systemd1", "org.freedesktop.systemd1.Manager", "LoadUnit", "s", "powercontext.service"},
 		{"busctl", "--user", "--json=short", "call", "org.freedesktop.systemd1", "/org/freedesktop/systemd1/unit/powercontext_2eservice", "org.freedesktop.DBus.Properties", "GetAll", "s", "org.freedesktop.systemd1.Unit"},
 		{"busctl", "--user", "--json=short", "call", "org.freedesktop.systemd1", "/org/freedesktop/systemd1/unit/powercontext_2eservice", "org.freedesktop.DBus.Properties", "GetAll", "s", "org.freedesktop.systemd1.Service"},
@@ -88,7 +88,7 @@ func TestLinuxSystemdBoundaryClassifiesAbsentUnitAfterSupportAsNotLoaded(t *test
 		t.Fatalf("InspectUnit() = %#v, %v; want not-found, nil", unit, err)
 	}
 	if got := runner.arguments(); !slices.EqualFunc(got, [][]string{
-		{"systemctl", "--user", "show", "--property=LoadState", "--property=FragmentPath", "--property=DropInPaths", "--property=Environment", "--property=ExecStart", "powercontext.service"},
+		{"systemctl", "--user", "show", "--property=LoadState", "--value", "powercontext.service"},
 		{"busctl", "--user", "--json=short", "call", "org.freedesktop.systemd1", "/org/freedesktop/systemd1", "org.freedesktop.systemd1.Manager", "LoadUnit", "s", "powercontext.service"},
 	}, slices.Equal) {
 		t.Fatalf("absent-unit command = %q", got)
@@ -107,7 +107,7 @@ func TestLinuxSystemdBoundaryClassifiesLoadedAbsentUnitAsNotLoaded(t *testing.T)
 		t.Fatalf("InspectUnit() = %#v, %v; want not-found, nil", unit, err)
 	}
 	want := [][]string{
-		{"systemctl", "--user", "show", "--property=LoadState", "--property=FragmentPath", "--property=DropInPaths", "--property=Environment", "--property=ExecStart", "powercontext.service"},
+		{"systemctl", "--user", "show", "--property=LoadState", "--value", "powercontext.service"},
 		{"busctl", "--user", "--json=short", "call", "org.freedesktop.systemd1", "/org/freedesktop/systemd1", "org.freedesktop.systemd1.Manager", "LoadUnit", "s", "powercontext.service"},
 		{"busctl", "--user", "--json=short", "call", "org.freedesktop.systemd1", "/org/freedesktop/systemd1/unit/powercontext_2eservice", "org.freedesktop.DBus.Properties", "GetAll", "s", "org.freedesktop.systemd1.Unit"},
 	}
@@ -118,13 +118,13 @@ func TestLinuxSystemdBoundaryClassifiesLoadedAbsentUnitAsNotLoaded(t *testing.T)
 
 func TestLinuxSystemdBoundaryClassifiesSystemctlShowNotFoundAsNotLoaded(t *testing.T) {
 	boundary, runner, _ := newTestLinuxSystemdBoundary(t)
-	runner.responses = []linuxSystemdCommandResult{{stdout: []byte("LoadState=not-found\nFragmentPath=\nDropInPaths=\nEnvironment=\nExecStart=\n")}}
+	runner.responses = []linuxSystemdCommandResult{{stdout: []byte("not-found\n")}}
 
 	unit, err := boundary.InspectUnit(t.Context(), "powercontext.service")
 	if err != nil || unit.LoadState() != "not-found" {
 		t.Fatalf("InspectUnit() = %#v, %v; want not-found, nil", unit, err)
 	}
-	want := [][]string{{"systemctl", "--user", "show", "--property=LoadState", "--property=FragmentPath", "--property=DropInPaths", "--property=Environment", "--property=ExecStart", personalServiceUnitName}}
+	want := [][]string{{"systemctl", "--user", "show", "--property=LoadState", "--value", personalServiceUnitName}}
 	if got := runner.arguments(); !slices.EqualFunc(got, want, slices.Equal) {
 		t.Fatalf("fallback command = %q, want %q", got, want)
 	}
@@ -356,10 +356,9 @@ func (c *testLinuxSystemdHTTPClient) Do(request *http.Request) (*http.Response, 
 func (r *testLinuxSystemdRunner) Run(_ context.Context, program string, arguments ...string) (linuxSystemdProcessResult, error) {
 	r.calls = append(r.calls, append([]string{program}, arguments...))
 	if program == "systemctl" && slices.Equal(arguments, []string{
-		"--user", "show", "--property=LoadState", "--property=FragmentPath", "--property=DropInPaths",
-		"--property=Environment", "--property=ExecStart", "powercontext.service",
-	}) && (len(r.responses) == 0 || !bytes.Contains(r.responses[0].stdout, []byte("LoadState="))) {
-		return linuxSystemdProcessResult{stdout: []byte("LoadState=loaded\n")}, nil
+		"--user", "show", "--property=LoadState", "--value", "powercontext.service",
+	}) && (len(r.responses) == 0 || !bytes.Equal(bytes.TrimSpace(r.responses[0].stdout), []byte("not-found"))) {
+		return linuxSystemdProcessResult{stdout: []byte("loaded\n")}, nil
 	}
 	if len(r.responses) == 0 {
 		return linuxSystemdProcessResult{}, errors.New("unexpected process")

--- a/internal/cli/server_personal_service_systemd_test.go
+++ b/internal/cli/server_personal_service_systemd_test.go
@@ -91,6 +91,26 @@ func TestLinuxSystemdBoundaryClassifiesAbsentUnitAfterSupportAsNotLoaded(t *test
 	}
 }
 
+func TestLinuxSystemdBoundaryClassifiesLoadedAbsentUnitAsNotLoaded(t *testing.T) {
+	boundary, runner, _ := newTestLinuxSystemdBoundary(t)
+	runner.responses = []linuxSystemdCommandResult{
+		{stdout: []byte(`{"type":"o","data":"/org/freedesktop/systemd1/unit/powercontext_2eservice"}`)},
+		{stdout: unitPropertiesJSON(t, "not-found", "", nil)},
+	}
+
+	unit, err := boundary.InspectUnit(t.Context(), "powercontext.service")
+	if err != nil || unit.LoadState() != "not-found" {
+		t.Fatalf("InspectUnit() = %#v, %v; want not-found, nil", unit, err)
+	}
+	want := [][]string{
+		{"busctl", "--user", "--json=short", "call", "org.freedesktop.systemd1", "/org/freedesktop/systemd1", "org.freedesktop.systemd1.Manager", "LoadUnit", "s", "powercontext.service"},
+		{"busctl", "--user", "--json=short", "call", "org.freedesktop.systemd1", "/org/freedesktop/systemd1/unit/powercontext_2eservice", "org.freedesktop.DBus.Properties", "GetAll", "s", "org.freedesktop.systemd1.Unit"},
+	}
+	if got := runner.arguments(); !slices.EqualFunc(got, want, slices.Equal) {
+		t.Fatalf("absent loaded-unit command = %q, want %q", got, want)
+	}
+}
+
 func TestLinuxSystemdBoundaryRejectsGlobalRootsAndForeignDropIns(t *testing.T) {
 	for _, home := range []string{"/", "/etc", "/root", "/usr/local", "/run/user/1000", "/home/alice/../bob", "relative"} {
 		if _, err := newLinuxPersonalServiceRoots(home); err == nil {

--- a/internal/cli/server_personal_service_systemd_test.go
+++ b/internal/cli/server_personal_service_systemd_test.go
@@ -50,6 +50,7 @@ func TestLinuxSystemdBoundaryUsesFixedStructuredUserBusCommands(t *testing.T) {
 		t.Fatalf("InspectUnit() = %#v", unit)
 	}
 	want := [][]string{
+		{"systemctl", "--user", "show", "--property=LoadState", "--property=FragmentPath", "--property=DropInPaths", "--property=Environment", "--property=ExecStart", "powercontext.service"},
 		{"busctl", "--user", "--json=short", "call", "org.freedesktop.systemd1", "/org/freedesktop/systemd1", "org.freedesktop.systemd1.Manager", "LoadUnit", "s", "powercontext.service"},
 		{"busctl", "--user", "--json=short", "call", "org.freedesktop.systemd1", "/org/freedesktop/systemd1/unit/powercontext_2eservice", "org.freedesktop.DBus.Properties", "GetAll", "s", "org.freedesktop.systemd1.Unit"},
 		{"busctl", "--user", "--json=short", "call", "org.freedesktop.systemd1", "/org/freedesktop/systemd1/unit/powercontext_2eservice", "org.freedesktop.DBus.Properties", "GetAll", "s", "org.freedesktop.systemd1.Service"},
@@ -86,7 +87,10 @@ func TestLinuxSystemdBoundaryClassifiesAbsentUnitAfterSupportAsNotLoaded(t *test
 	if err != nil || unit.LoadState() != "not-found" {
 		t.Fatalf("InspectUnit() = %#v, %v; want not-found, nil", unit, err)
 	}
-	if got := runner.arguments(); !slices.EqualFunc(got, [][]string{{"busctl", "--user", "--json=short", "call", "org.freedesktop.systemd1", "/org/freedesktop/systemd1", "org.freedesktop.systemd1.Manager", "LoadUnit", "s", "powercontext.service"}}, slices.Equal) {
+	if got := runner.arguments(); !slices.EqualFunc(got, [][]string{
+		{"systemctl", "--user", "show", "--property=LoadState", "--property=FragmentPath", "--property=DropInPaths", "--property=Environment", "--property=ExecStart", "powercontext.service"},
+		{"busctl", "--user", "--json=short", "call", "org.freedesktop.systemd1", "/org/freedesktop/systemd1", "org.freedesktop.systemd1.Manager", "LoadUnit", "s", "powercontext.service"},
+	}, slices.Equal) {
 		t.Fatalf("absent-unit command = %q", got)
 	}
 }
@@ -103,6 +107,7 @@ func TestLinuxSystemdBoundaryClassifiesLoadedAbsentUnitAsNotLoaded(t *testing.T)
 		t.Fatalf("InspectUnit() = %#v, %v; want not-found, nil", unit, err)
 	}
 	want := [][]string{
+		{"systemctl", "--user", "show", "--property=LoadState", "--property=FragmentPath", "--property=DropInPaths", "--property=Environment", "--property=ExecStart", "powercontext.service"},
 		{"busctl", "--user", "--json=short", "call", "org.freedesktop.systemd1", "/org/freedesktop/systemd1", "org.freedesktop.systemd1.Manager", "LoadUnit", "s", "powercontext.service"},
 		{"busctl", "--user", "--json=short", "call", "org.freedesktop.systemd1", "/org/freedesktop/systemd1/unit/powercontext_2eservice", "org.freedesktop.DBus.Properties", "GetAll", "s", "org.freedesktop.systemd1.Unit"},
 	}
@@ -113,19 +118,13 @@ func TestLinuxSystemdBoundaryClassifiesLoadedAbsentUnitAsNotLoaded(t *testing.T)
 
 func TestLinuxSystemdBoundaryClassifiesSystemctlShowNotFoundAsNotLoaded(t *testing.T) {
 	boundary, runner, _ := newTestLinuxSystemdBoundary(t)
-	runner.responses = []linuxSystemdCommandResult{
-		{stdout: []byte("unrecognized user-bus envelope")},
-		{stdout: []byte("LoadState=not-found\nFragmentPath=\nDropInPaths=\nEnvironment=\nExecStart=\n")},
-	}
+	runner.responses = []linuxSystemdCommandResult{{stdout: []byte("LoadState=not-found\nFragmentPath=\nDropInPaths=\nEnvironment=\nExecStart=\n")}}
 
 	unit, err := boundary.InspectUnit(t.Context(), "powercontext.service")
 	if err != nil || unit.LoadState() != "not-found" {
 		t.Fatalf("InspectUnit() = %#v, %v; want not-found, nil", unit, err)
 	}
-	want := [][]string{
-		{"busctl", "--user", "--json=short", "call", "org.freedesktop.systemd1", "/org/freedesktop/systemd1", "org.freedesktop.systemd1.Manager", "LoadUnit", "s", "powercontext.service"},
-		{"systemctl", "--user", "show", "--property=LoadState", "--property=FragmentPath", "--property=DropInPaths", "--property=Environment", "--property=ExecStart", personalServiceUnitName},
-	}
+	want := [][]string{{"systemctl", "--user", "show", "--property=LoadState", "--property=FragmentPath", "--property=DropInPaths", "--property=Environment", "--property=ExecStart", personalServiceUnitName}}
 	if got := runner.arguments(); !slices.EqualFunc(got, want, slices.Equal) {
 		t.Fatalf("fallback command = %q, want %q", got, want)
 	}
@@ -356,6 +355,12 @@ func (c *testLinuxSystemdHTTPClient) Do(request *http.Request) (*http.Response, 
 
 func (r *testLinuxSystemdRunner) Run(_ context.Context, program string, arguments ...string) (linuxSystemdProcessResult, error) {
 	r.calls = append(r.calls, append([]string{program}, arguments...))
+	if program == "systemctl" && slices.Equal(arguments, []string{
+		"--user", "show", "--property=LoadState", "--property=FragmentPath", "--property=DropInPaths",
+		"--property=Environment", "--property=ExecStart", "powercontext.service",
+	}) && (len(r.responses) == 0 || !bytes.Contains(r.responses[0].stdout, []byte("LoadState="))) {
+		return linuxSystemdProcessResult{stdout: []byte("LoadState=loaded\n")}, nil
+	}
 	if len(r.responses) == 0 {
 		return linuxSystemdProcessResult{}, errors.New("unexpected process")
 	}

--- a/internal/cli/server_personal_service_systemd_test.go
+++ b/internal/cli/server_personal_service_systemd_test.go
@@ -111,6 +111,26 @@ func TestLinuxSystemdBoundaryClassifiesLoadedAbsentUnitAsNotLoaded(t *testing.T)
 	}
 }
 
+func TestLinuxSystemdBoundaryClassifiesSystemctlShowNotFoundAsNotLoaded(t *testing.T) {
+	boundary, runner, _ := newTestLinuxSystemdBoundary(t)
+	runner.responses = []linuxSystemdCommandResult{
+		{stdout: []byte("unrecognized user-bus envelope")},
+		{stdout: []byte("LoadState=not-found\nFragmentPath=\nDropInPaths=\nEnvironment=\nExecStart=\n")},
+	}
+
+	unit, err := boundary.InspectUnit(t.Context(), "powercontext.service")
+	if err != nil || unit.LoadState() != "not-found" {
+		t.Fatalf("InspectUnit() = %#v, %v; want not-found, nil", unit, err)
+	}
+	want := [][]string{
+		{"busctl", "--user", "--json=short", "call", "org.freedesktop.systemd1", "/org/freedesktop/systemd1", "org.freedesktop.systemd1.Manager", "LoadUnit", "s", "powercontext.service"},
+		{"systemctl", "--user", "show", "--property=LoadState", "--property=FragmentPath", "--property=DropInPaths", "--property=Environment", "--property=ExecStart", personalServiceUnitName},
+	}
+	if got := runner.arguments(); !slices.EqualFunc(got, want, slices.Equal) {
+		t.Fatalf("fallback command = %q, want %q", got, want)
+	}
+}
+
 func TestLinuxSystemdBoundaryRejectsGlobalRootsAndForeignDropIns(t *testing.T) {
 	for _, home := range []string{"/", "/etc", "/root", "/usr/local", "/run/user/1000", "/home/alice/../bob", "relative"} {
 		if _, err := newLinuxPersonalServiceRoots(home); err == nil {

--- a/internal/cli/server_personal_service_systemd_test.go
+++ b/internal/cli/server_personal_service_systemd_test.go
@@ -163,6 +163,20 @@ func TestLinuxSystemdBoundaryRejectsForeignOrMalformedStructuredBusData(t *testi
 	}
 }
 
+func TestLinuxSystemdBoundaryPreservesEachEnvironmentAssignment(t *testing.T) {
+	assignments := []string{"POWERCONTEXT_SERVICE_OWNED=true POWERCONTEXT_SERVICE_METADATA=not-a-separate-assignment"}
+	boundary, runner, _ := newTestLinuxSystemdBoundary(t)
+	runner.responses = []linuxSystemdCommandResult{
+		{stdout: []byte(`{"type":"o","data":"/org/freedesktop/systemd1/unit/powercontext_2eservice"}`)},
+		{stdout: unitPropertiesJSON(t, "loaded", "/home/alice/.config/systemd/user/powercontext.service", nil)},
+		{stdout: servicePropertiesJSON(t, assignments, nil)},
+	}
+	unit, err := boundary.InspectUnit(t.Context(), "powercontext.service")
+	if err != nil || !slices.Equal(unit.Environment(), assignments) {
+		t.Fatalf("InspectUnit() Environment = %q, error = %v", unit.Environment(), err)
+	}
+}
+
 func TestLinuxSystemdBoundaryReportsAVerifiedStaleRunningDefinition(t *testing.T) {
 	desired := newTestPersonalServiceRegistration(t, "1.0.0")
 	stale := newTestPersonalServiceRegistration(t, "0.9.0")

--- a/internal/cli/server_personal_service_systemd_test.go
+++ b/internal/cli/server_personal_service_systemd_test.go
@@ -19,7 +19,9 @@ import (
 	"context"
 	json "encoding/json/v2"
 	"errors"
+	"io"
 	"io/fs"
+	"net/http"
 	"slices"
 	"strings"
 	"testing"
@@ -259,6 +261,31 @@ func TestLinuxSystemdBoundaryValidatesEnvironmentAndSerializesOperations(t *test
 	}
 }
 
+func TestLinuxSystemdBoundaryProbesOnlyExactLoopbackLiveness(t *testing.T) {
+	boundary, _, _ := newTestLinuxSystemdBoundary(t)
+	client := &testLinuxSystemdHTTPClient{}
+	boundary.probeClient = client
+
+	state, err := boundary.Probe(t.Context(), "http://127.0.0.1:8123")
+	if err != nil || state != personalsvc.ProbeLive {
+		t.Fatalf("Probe() = %s, %v; want live, nil", state, err)
+	}
+	if client.url != "http://127.0.0.1:8123/health/live" || client.method != http.MethodGet {
+		t.Fatalf("liveness request = %s %s", client.method, client.url)
+	}
+
+	state, err = boundary.Probe(t.Context(), "http://service.example:8123")
+	if err == nil || state != personalsvc.ProbeUnreachable || client.calls != 1 {
+		t.Fatalf("non-loopback Probe() = %s, %v; calls = %d", state, err, client.calls)
+	}
+	canceled, cancel := context.WithCancel(t.Context())
+	cancel()
+	state, err = boundary.Probe(canceled, "http://127.0.0.1:8123")
+	if !errors.Is(err, context.Canceled) || state != personalsvc.ProbeUnreachable || client.calls != 1 {
+		t.Fatalf("canceled Probe() = %s, %v; calls = %d", state, err, client.calls)
+	}
+}
+
 type linuxSystemdCommandResult struct {
 	exitCode int
 	stdout   []byte
@@ -268,6 +295,23 @@ type linuxSystemdCommandResult struct {
 type testLinuxSystemdRunner struct {
 	responses []linuxSystemdCommandResult
 	calls     [][]string
+}
+
+type testLinuxSystemdHTTPClient struct {
+	calls  int
+	method string
+	url    string
+}
+
+func (c *testLinuxSystemdHTTPClient) Do(request *http.Request) (*http.Response, error) {
+	c.calls++
+	c.method = request.Method
+	c.url = request.URL.String()
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(`{"status":"ok"}`)),
+		Request:    request,
+	}, nil
 }
 
 func (r *testLinuxSystemdRunner) Run(_ context.Context, program string, arguments ...string) (linuxSystemdProcessResult, error) {

--- a/internal/cli/server_personal_service_systemd_test.go
+++ b/internal/cli/server_personal_service_systemd_test.go
@@ -1,0 +1,365 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"bytes"
+	"context"
+	json "encoding/json/v2"
+	"errors"
+	"io/fs"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/ob-labs/powercontext-go/internal/personalsvc"
+)
+
+func TestLinuxSystemdBoundaryUsesFixedStructuredUserBusCommands(t *testing.T) {
+	boundary, runner, _ := newTestLinuxSystemdBoundary(t)
+	runner.responses = []linuxSystemdCommandResult{
+		{stdout: []byte(`{"type":"o","data":"/org/freedesktop/systemd1/unit/powercontext_2eservice"}`)},
+		{stdout: unitPropertiesJSON(t, "loaded", "/home/alice/.config/systemd/user/powercontext.service", nil)},
+		{stdout: servicePropertiesJSON(t, nil, []any{[]any{
+			"/opt/powercontext/powercontext",
+			[]any{"/opt/powercontext/powercontext", "server", "_service-run", "--env-file", "/home/alice/.config/powercontext/server.env", "--endpoint", "http://127.0.0.1:8123", "--data-dir", "/home/alice/.local/share/powercontext"},
+			false, 0, 0, 0, 0, 0, 0, 0,
+		}})},
+	}
+
+	unit, err := boundary.InspectUnit(t.Context(), "powercontext.service")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if unit.LoadState() != "loaded" || unit.FragmentPath() != "/home/alice/.config/systemd/user/powercontext.service" ||
+		!unit.HasDropInPaths() || len(unit.DropInPaths()) != 0 || len(unit.ExecStart()) != 1 {
+		t.Fatalf("InspectUnit() = %#v", unit)
+	}
+	want := [][]string{
+		{"busctl", "--user", "--json=short", "call", "org.freedesktop.systemd1", "/org/freedesktop/systemd1", "org.freedesktop.systemd1.Manager", "LoadUnit", "s", "powercontext.service"},
+		{"busctl", "--user", "--json=short", "call", "org.freedesktop.systemd1", "/org/freedesktop/systemd1/unit/powercontext_2eservice", "org.freedesktop.DBus.Properties", "GetAll", "s", "org.freedesktop.systemd1.Unit"},
+		{"busctl", "--user", "--json=short", "call", "org.freedesktop.systemd1", "/org/freedesktop/systemd1/unit/powercontext_2eservice", "org.freedesktop.DBus.Properties", "GetAll", "s", "org.freedesktop.systemd1.Service"},
+	}
+	if !slices.EqualFunc(runner.arguments(), want, slices.Equal) {
+		t.Fatalf("user-bus argv = %q, want %q", runner.arguments(), want)
+	}
+}
+
+func TestLinuxSystemdBoundaryClassifiesAbsentUserBusWithoutLeakingOutput(t *testing.T) {
+	boundary, runner, _ := newTestLinuxSystemdBoundary(t)
+	runner.responses = []linuxSystemdCommandResult{{exitCode: 1, stdout: []byte("user bus at /run/user/1000 token=secret")}}
+	launcher, err := personalsvc.NewSystemdUserLauncher("server", "_service-run")
+	if err != nil {
+		t.Fatal(err)
+	}
+	adapter, err := personalsvc.NewSystemdUserAdapter(boundary, "/home/alice/.config", launcher)
+	if err != nil {
+		t.Fatal(err)
+	}
+	support, supportErr := adapter.Support(t.Context())
+	if supportErr != nil || support != personalsvc.SupportUnsupported {
+		t.Fatalf("Support() = %s, %v; want unsupported, nil", support, supportErr)
+	}
+	if got := runner.arguments(); !slices.EqualFunc(got, [][]string{{"systemctl", "--user", "show-environment"}}, slices.Equal) {
+		t.Fatalf("user-bus command = %q", got)
+	}
+}
+
+func TestLinuxSystemdBoundaryClassifiesAbsentUnitAfterSupportAsNotLoaded(t *testing.T) {
+	boundary, runner, _ := newTestLinuxSystemdBoundary(t)
+	runner.responses = []linuxSystemdCommandResult{{exitCode: 1, stdout: []byte("unit path=/home/alice/.config token=secret")}}
+	unit, err := boundary.InspectUnit(t.Context(), "powercontext.service")
+	if err != nil || unit.LoadState() != "not-found" {
+		t.Fatalf("InspectUnit() = %#v, %v; want not-found, nil", unit, err)
+	}
+	if got := runner.arguments(); !slices.EqualFunc(got, [][]string{{"busctl", "--user", "--json=short", "call", "org.freedesktop.systemd1", "/org/freedesktop/systemd1", "org.freedesktop.systemd1.Manager", "LoadUnit", "s", "powercontext.service"}}, slices.Equal) {
+		t.Fatalf("absent-unit command = %q", got)
+	}
+}
+
+func TestLinuxSystemdBoundaryRejectsGlobalRootsAndForeignDropIns(t *testing.T) {
+	for _, home := range []string{"/", "/etc", "/root", "/usr/local", "/run/user/1000", "/home/alice/../bob", "relative"} {
+		if _, err := newLinuxPersonalServiceRoots(home); err == nil {
+			t.Fatalf("newLinuxPersonalServiceRoots(%q) succeeded", home)
+		}
+	}
+	roots, err := newLinuxPersonalServiceRoots("/home/alice")
+	if err != nil {
+		t.Fatal(err)
+	}
+	roots.stateRoot = "/home/bob/.local/state/powercontext"
+	if boundary, boundaryErr := newLinuxSystemdBoundary(roots, &testLinuxSystemdRunner{}, &testLinuxPrivateFiles{}, &testLinuxOperationLock{}); boundary != nil || boundaryErr == nil {
+		t.Fatalf("newLinuxSystemdBoundary accepted split current-user roots: %v, %v", boundary, boundaryErr)
+	}
+
+	boundary, runner, _ := newTestLinuxSystemdBoundary(t)
+	runner.responses = []linuxSystemdCommandResult{
+		{stdout: []byte(`{"type":"o","data":"/org/freedesktop/systemd1/unit/powercontext_2eservice"}`)},
+		{stdout: unitPropertiesJSON(t, "loaded", "/home/alice/.config/systemd/user/powercontext.service", []string{"/home/alice/.config/systemd/user/powercontext.service.d/foreign.conf"})},
+		{stdout: servicePropertiesJSON(t, nil, nil)},
+	}
+	unit, err := boundary.InspectUnit(t.Context(), "powercontext.service")
+	if err != nil || len(unit.DropInPaths()) != 1 {
+		t.Fatalf("InspectUnit() = %#v, %v", unit, err)
+	}
+	launcher, err := personalsvc.NewSystemdUserLauncher("server", "_service-run")
+	if err != nil {
+		t.Fatal(err)
+	}
+	adapter, err := personalsvc.NewSystemdUserAdapter(boundary, "/home/alice/.config", launcher)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runner.responses = []linuxSystemdCommandResult{
+		{stdout: []byte(`{"type":"o","data":"/org/freedesktop/systemd1/unit/powercontext_2eservice"}`)},
+		{stdout: unitPropertiesJSON(t, "loaded", "/home/alice/.config/systemd/user/powercontext.service", []string{"/home/alice/.config/systemd/user/powercontext.service.d/foreign.conf"})},
+		{stdout: servicePropertiesJSON(t, nil, nil)},
+	}
+	manager, err := adapter.InspectManager(t.Context())
+	if err != nil || manager.Ownership() != personalsvc.ManagerOwnershipForeign {
+		t.Fatalf("InspectManager() = %s, %v; want foreign, nil", manager.Ownership(), err)
+	}
+}
+
+func TestLinuxSystemdBoundaryRejectsForeignOrMalformedStructuredBusData(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		responses []linuxSystemdCommandResult
+	}{
+		{
+			name: "foreign unit object",
+			responses: []linuxSystemdCommandResult{
+				{stdout: []byte(`{"type":"o","data":"/org/freedesktop/systemd1/unit/foreign_2eservice"}`)},
+			},
+		},
+		{
+			name: "malformed ExecStart tuple",
+			responses: []linuxSystemdCommandResult{
+				{stdout: []byte(`{"type":"o","data":"/org/freedesktop/systemd1/unit/powercontext_2eservice"}`)},
+				{stdout: unitPropertiesJSON(t, "loaded", "/home/alice/.config/systemd/user/powercontext.service", nil)},
+				{stdout: servicePropertiesJSON(t, nil, []any{[]any{"/opt/powercontext/powercontext", []any{"/opt/powercontext/powercontext"}, false}})},
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			boundary, runner, _ := newTestLinuxSystemdBoundary(t)
+			runner.responses = test.responses
+			if _, err := boundary.InspectUnit(t.Context(), "powercontext.service"); err == nil {
+				t.Fatal("InspectUnit accepted unverified user-bus data")
+			}
+		})
+	}
+}
+
+func TestLinuxSystemdBoundaryReportsAVerifiedStaleRunningDefinition(t *testing.T) {
+	desired := newTestPersonalServiceRegistration(t, "1.0.0")
+	stale := newTestPersonalServiceRegistration(t, "0.9.0")
+	metadata, err := stale.Encode()
+	if err != nil {
+		t.Fatal(err)
+	}
+	boundary, runner, _ := newTestLinuxSystemdBoundary(t)
+	runner.responses = []linuxSystemdCommandResult{
+		{stdout: []byte(`{"type":"o","data":"/org/freedesktop/systemd1/unit/powercontext_2eservice"}`)},
+		{stdout: unitPropertiesJSON(t, "loaded", "/home/alice/.config/systemd/user/powercontext.service", nil)},
+		{stdout: servicePropertiesJSON(t, []string{
+			"POWERCONTEXT_SERVICE_OWNED=true", "POWERCONTEXT_SERVICE_METADATA=" + metadata,
+		}, []any{[]any{
+			"/opt/powercontext/powercontext",
+			[]any{"/opt/powercontext/powercontext", "server", "_service-run", "--env-file", "/home/alice/.config/powercontext/server.env", "--endpoint", "http://127.0.0.1:8123", "--data-dir", "/home/alice/.local/share/powercontext"},
+			false, 0, 0, 0, 0, 0, 0, 0,
+		}})},
+	}
+	launcher, err := personalsvc.NewSystemdUserLauncher("server", "_service-run")
+	if err != nil {
+		t.Fatal(err)
+	}
+	adapter, err := personalsvc.NewSystemdUserAdapter(boundary, "/home/alice/.config", launcher)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manager, err := adapter.InspectManager(t.Context())
+	loaded, found := manager.Registration()
+	if err != nil || manager.Ownership() != personalsvc.ManagerOwnershipOwned || !found || loaded == desired || loaded != stale {
+		t.Fatalf("InspectManager() = ownership %s registration %v %t error %v", manager.Ownership(), loaded, found, err)
+	}
+}
+
+func TestLinuxPrivateFileValidationRejectsSymlinkFIFOInsecureModeAndIdentityChanges(t *testing.T) {
+	private := linuxPrivateFileIdentity{device: 1, inode: 2, mode: 0o600, uid: 1000}
+	if !validLinuxPrivateFile(private, private, 1000) {
+		t.Fatal("valid private file was rejected")
+	}
+	for _, test := range []struct {
+		name   string
+		before linuxPrivateFileIdentity
+		after  linuxPrivateFileIdentity
+	}{
+		{name: "symlink", before: linuxPrivateFileIdentity{device: 1, inode: 2, mode: fs.ModeSymlink | 0o600, uid: 1000}, after: private},
+		{name: "fifo", before: linuxPrivateFileIdentity{device: 1, inode: 2, mode: fs.ModeNamedPipe | 0o600, uid: 1000}, after: private},
+		{name: "group readable", before: linuxPrivateFileIdentity{device: 1, inode: 2, mode: 0o640, uid: 1000}, after: private},
+		{name: "foreign owner", before: linuxPrivateFileIdentity{device: 1, inode: 2, mode: 0o600, uid: 1001}, after: private},
+		{name: "identity changed", before: private, after: linuxPrivateFileIdentity{device: 1, inode: 3, mode: 0o600, uid: 1000}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if validLinuxPrivateFile(test.before, test.after, 1000) {
+				t.Fatal("unsafe private file was accepted")
+			}
+		})
+	}
+}
+
+func TestLinuxSystemdBoundaryValidatesEnvironmentAndSerializesOperations(t *testing.T) {
+	boundary, _, files := newTestLinuxSystemdBoundary(t)
+	if err := boundary.VerifyEnvironmentFile(t.Context(), "/home/alice/.config/powercontext/server.env"); err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Equal(files.validated, []string{"/home/alice/.config/powercontext/server.env"}) {
+		t.Fatalf("validated files = %q", files.validated)
+	}
+	files.validateErr = errors.New("fifo at /home/alice/.config/powercontext/server.env token=secret")
+	err := boundary.VerifyEnvironmentFile(t.Context(), "/home/alice/.config/powercontext/server.env")
+	if err == nil || strings.Contains(err.Error(), "secret") || strings.Contains(err.Error(), "/home") {
+		t.Fatalf("environment refusal = %v", err)
+	}
+
+	started := false
+	err = boundary.OperationBoundary().Run(t.Context(), func(context.Context) error {
+		started = true
+		return boundary.OperationBoundary().Run(t.Context(), func(context.Context) error { return nil })
+	})
+	if !started || err == nil {
+		t.Fatalf("nested lock error = %v, started = %t", err, started)
+	}
+}
+
+type linuxSystemdCommandResult struct {
+	exitCode int
+	stdout   []byte
+	err      error
+}
+
+type testLinuxSystemdRunner struct {
+	responses []linuxSystemdCommandResult
+	calls     [][]string
+}
+
+func (r *testLinuxSystemdRunner) Run(_ context.Context, program string, arguments ...string) (linuxSystemdProcessResult, error) {
+	r.calls = append(r.calls, append([]string{program}, arguments...))
+	if len(r.responses) == 0 {
+		return linuxSystemdProcessResult{}, errors.New("unexpected process")
+	}
+	result := r.responses[0]
+	r.responses = r.responses[1:]
+	return linuxSystemdProcessResult{exitCode: result.exitCode, stdout: bytes.Clone(result.stdout)}, result.err
+}
+
+func (r *testLinuxSystemdRunner) arguments() [][]string {
+	return slices.Clone(r.calls)
+}
+
+type testLinuxPrivateFiles struct {
+	validated   []string
+	validateErr error
+}
+
+func (f *testLinuxPrivateFiles) Read(context.Context, string) ([]byte, bool, error) {
+	return nil, false, nil
+}
+func (f *testLinuxPrivateFiles) Write(context.Context, string, []byte) error { return nil }
+func (f *testLinuxPrivateFiles) Remove(context.Context, string) error        { return nil }
+func (f *testLinuxPrivateFiles) Validate(_ context.Context, name string) error {
+	f.validated = append(f.validated, name)
+	return f.validateErr
+}
+
+type testLinuxOperationLock struct{ held bool }
+
+func (l *testLinuxOperationLock) WithLock(ctx context.Context, operation func(context.Context) error) error {
+	if l.held {
+		return errors.New("operation lock held")
+	}
+	l.held = true
+	defer func() { l.held = false }()
+	return operation(ctx)
+}
+
+func newTestLinuxSystemdBoundary(t *testing.T) (*linuxSystemdBoundary, *testLinuxSystemdRunner, *testLinuxPrivateFiles) {
+	t.Helper()
+	roots, err := newLinuxPersonalServiceRoots("/home/alice")
+	if err != nil {
+		t.Fatal(err)
+	}
+	runner := &testLinuxSystemdRunner{}
+	files := &testLinuxPrivateFiles{}
+	boundary, err := newLinuxSystemdBoundary(roots, runner, files, &testLinuxOperationLock{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return boundary, runner, files
+}
+
+func unitPropertiesJSON(t *testing.T, loadState, fragmentPath string, dropIns []string) []byte {
+	t.Helper()
+	return mustBusctlJSON(t, map[string]any{
+		"type": "a{sv}",
+		"data": map[string]any{
+			"LoadState":    map[string]any{"type": "s", "data": loadState},
+			"FragmentPath": map[string]any{"type": "s", "data": fragmentPath},
+			"DropInPaths":  map[string]any{"type": "as", "data": dropIns},
+		},
+	})
+}
+
+func servicePropertiesJSON(t *testing.T, environment []string, execStart []any) []byte {
+	t.Helper()
+	return mustBusctlJSON(t, map[string]any{
+		"type": "a{sv}",
+		"data": map[string]any{
+			"Environment": map[string]any{"type": "as", "data": environment},
+			"ExecStart":   map[string]any{"type": "a(sasbttttuii)", "data": execStart},
+		},
+	})
+}
+
+func mustBusctlJSON(t *testing.T, value any) []byte {
+	t.Helper()
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return encoded
+}
+
+func newTestPersonalServiceRegistration(t *testing.T, packageVersion string) personalsvc.Registration {
+	t.Helper()
+	definition, err := personalsvc.NewDefinition(personalsvc.DefinitionInput{
+		Ownership:         personalsvc.OwnershipMarker,
+		DefinitionVersion: personalsvc.DefinitionVersion,
+		PackageVersion:    packageVersion,
+		Binary:            "/opt/powercontext/powercontext",
+		Endpoint:          "http://127.0.0.1:8123",
+		DataDir:           "/home/alice/.local/share/powercontext",
+		EnvFile:           "/home/alice/.config/powercontext/server.env",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	registration, err := personalsvc.NewRegistration(definition)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return registration
+}

--- a/internal/cli/server_personal_service_test.go
+++ b/internal/cli/server_personal_service_test.go
@@ -1,0 +1,106 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"errors"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestServerPersonalServiceCommandsExposeThePortableContract(t *testing.T) {
+	command := newCommand(VersionInfo{}, nil, nil)
+	server, _, err := command.Find([]string{"server"})
+	if err != nil {
+		t.Fatalf("server command = %v", err)
+	}
+	for _, test := range []struct {
+		name     string
+		hidden   bool
+		required []string
+		optional []string
+	}{
+		{name: "install", required: []string{"env-file"}, optional: []string{"data-dir"}},
+		{name: "status", optional: []string{"json"}},
+		{name: "uninstall", optional: []string{"json"}},
+		{name: "_service-run", hidden: true, required: []string{"env-file", "endpoint", "data-dir"}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			child, _, findErr := server.Find([]string{test.name})
+			if findErr != nil || child.Name() != test.name {
+				t.Fatalf("server %s command = %v, %v", test.name, child, findErr)
+			}
+			if child.Hidden != test.hidden {
+				t.Fatalf("server %s Hidden = %t, want %t", test.name, child.Hidden, test.hidden)
+			}
+			for _, name := range test.required {
+				flag := child.Flags().Lookup(name)
+				if flag == nil || flag.Annotations["cobra_annotation_bash_completion_one_required_flag"] == nil {
+					t.Fatalf("server %s --%s is not required", test.name, name)
+				}
+			}
+			for _, name := range test.optional {
+				if child.Flags().Lookup(name) == nil && child.InheritedFlags().Lookup(name) == nil {
+					t.Fatalf("server %s --%s is missing", test.name, name)
+				}
+			}
+		})
+	}
+}
+
+func TestServerPersonalServiceCommandsRejectExplicitBlankValues(t *testing.T) {
+	for _, arguments := range [][]string{
+		{"server", "install", "--env-file="},
+		{"server", "install", "--env-file", "/etc/powercontext/server.env", "--data-dir="},
+		{"server", "_service-run", "--env-file=", "--endpoint", "http://127.0.0.1:7614", "--data-dir", "/var/lib/powercontext"},
+		{"server", "_service-run", "--env-file", "/etc/powercontext/server.env", "--endpoint=", "--data-dir", "/var/lib/powercontext"},
+		{"server", "_service-run", "--env-file", "/etc/powercontext/server.env", "--endpoint", "http://127.0.0.1:7614", "--data-dir="},
+	} {
+		t.Run(strings.Join(arguments[1:], " "), func(t *testing.T) {
+			command := newCommand(VersionInfo{}, nil, nil)
+			command.SetArgs(arguments)
+			err := command.ExecuteContext(t.Context())
+			if _, found := errors.AsType[*UsageError](err); !found || ExitCode(err) != 2 {
+				t.Fatalf("ExecuteContext() error = %T %v, want typed usage error", err, err)
+			}
+		})
+	}
+}
+
+func TestServerPersonalServiceCommandsAreTypedUnsupportedWithoutNativeEffectsOnNonLinux(t *testing.T) {
+	if runtime.GOOS == "linux" {
+		t.Skip("non-Linux unsupported behavior")
+	}
+	for _, arguments := range [][]string{
+		{"server", "install", "--env-file", "/etc/powercontext/server.env"},
+		{"server", "status", "--json"},
+		{"server", "uninstall", "--json"},
+		{"server", "_service-run", "--env-file", "/etc/powercontext/server.env", "--endpoint", "http://127.0.0.1:7614", "--data-dir", "/var/lib/powercontext"},
+	} {
+		t.Run(strings.Join(arguments[1:], " "), func(t *testing.T) {
+			system := &scriptedSystemCommands{t: t}
+			command := newCommandWithAllDependencies(VersionInfo{}, nil, nil, nil, nil, system)
+			command.SetArgs(arguments)
+			err := command.ExecuteContext(t.Context())
+			if _, found := errors.AsType[*UnsupportedPersonalServiceError](err); !found || ExitCode(err) != 1 {
+				t.Fatalf("ExecuteContext() error = %T %v, want typed unsupported error", err, err)
+			}
+			if len(system.calls) != 0 || len(system.lookups) != 0 {
+				t.Fatalf("unsupported command reached native boundary: calls=%v lookups=%v", system.calls, system.lookups)
+			}
+		})
+	}
+}

--- a/internal/cli/server_personal_service_test.go
+++ b/internal/cli/server_personal_service_test.go
@@ -65,12 +65,15 @@ func TestServerPersonalServiceCommandsRejectMissingOrBlankValuesBeforeNativeEffe
 	for _, arguments := range [][]string{
 		{"server", "install"},
 		{"server", "install", "--env-file="},
+		{"server", "install", "--env-file", " /etc/powercontext/server.env"},
 		{"server", "install", "--env-file", "/etc/powercontext/server.env", "--data-dir="},
+		{"server", "install", "--env-file", "/etc/powercontext/server.env", "--data-dir", "/var/lib/powercontext "},
 		{"server", "_service-run", "--endpoint", "http://127.0.0.1:7614", "--data-dir", "/var/lib/powercontext"},
 		{"server", "_service-run", "--env-file", "/etc/powercontext/server.env", "--data-dir", "/var/lib/powercontext"},
 		{"server", "_service-run", "--env-file", "/etc/powercontext/server.env", "--endpoint", "http://127.0.0.1:7614"},
 		{"server", "_service-run", "--env-file=", "--endpoint", "http://127.0.0.1:7614", "--data-dir", "/var/lib/powercontext"},
 		{"server", "_service-run", "--env-file", "/etc/powercontext/server.env", "--endpoint=", "--data-dir", "/var/lib/powercontext"},
+		{"server", "_service-run", "--env-file", "/etc/powercontext/server.env", "--endpoint", " http://127.0.0.1:7614", "--data-dir", "/var/lib/powercontext"},
 		{"server", "_service-run", "--env-file", "/etc/powercontext/server.env", "--endpoint", "http://127.0.0.1:7614", "--data-dir="},
 	} {
 		t.Run(strings.Join(arguments[1:], " "), func(t *testing.T) {

--- a/internal/cli/server_personal_service_test.go
+++ b/internal/cli/server_personal_service_test.go
@@ -61,20 +61,28 @@ func TestServerPersonalServiceCommandsExposeThePortableContract(t *testing.T) {
 	}
 }
 
-func TestServerPersonalServiceCommandsRejectExplicitBlankValues(t *testing.T) {
+func TestServerPersonalServiceCommandsRejectMissingOrBlankValuesBeforeNativeEffects(t *testing.T) {
 	for _, arguments := range [][]string{
+		{"server", "install"},
 		{"server", "install", "--env-file="},
 		{"server", "install", "--env-file", "/etc/powercontext/server.env", "--data-dir="},
+		{"server", "_service-run", "--endpoint", "http://127.0.0.1:7614", "--data-dir", "/var/lib/powercontext"},
+		{"server", "_service-run", "--env-file", "/etc/powercontext/server.env", "--data-dir", "/var/lib/powercontext"},
+		{"server", "_service-run", "--env-file", "/etc/powercontext/server.env", "--endpoint", "http://127.0.0.1:7614"},
 		{"server", "_service-run", "--env-file=", "--endpoint", "http://127.0.0.1:7614", "--data-dir", "/var/lib/powercontext"},
 		{"server", "_service-run", "--env-file", "/etc/powercontext/server.env", "--endpoint=", "--data-dir", "/var/lib/powercontext"},
 		{"server", "_service-run", "--env-file", "/etc/powercontext/server.env", "--endpoint", "http://127.0.0.1:7614", "--data-dir="},
 	} {
 		t.Run(strings.Join(arguments[1:], " "), func(t *testing.T) {
-			command := newCommand(VersionInfo{}, nil, nil)
+			system := &scriptedSystemCommands{t: t}
+			command := newCommandWithAllDependencies(VersionInfo{}, nil, nil, nil, nil, system)
 			command.SetArgs(arguments)
 			err := command.ExecuteContext(t.Context())
 			if _, found := errors.AsType[*UsageError](err); !found || ExitCode(err) != 2 {
 				t.Fatalf("ExecuteContext() error = %T %v, want typed usage error", err, err)
+			}
+			if len(system.calls) != 0 || len(system.lookups) != 0 {
+				t.Fatalf("invalid command reached native boundary: calls=%v lookups=%v", system.calls, system.lookups)
 			}
 		})
 	}

--- a/internal/personalsvc/controller_test.go
+++ b/internal/personalsvc/controller_test.go
@@ -397,6 +397,7 @@ func testRegistration(t *testing.T, packageVersion string) personalsvc.Registrat
 		Binary:            `C:\\Program Files\\PowerContext\\powercontext.exe`,
 		Endpoint:          "http://127.0.0.1:8123",
 		DataDir:           `C:\\Users\\person\\AppData\\Local\\PowerContext`,
+		EnvFile:           `C:\Users\person\AppData\Local\PowerContext\server.env`,
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/internal/personalsvc/definition.go
+++ b/internal/personalsvc/definition.go
@@ -36,13 +36,14 @@ const (
 	// DefinitionVersion is the currently supported registration metadata
 	// format. A newer value must be deliberately introduced with a parser and
 	// migration decision rather than silently accepted.
-	DefinitionVersion uint = 2
+	DefinitionVersion uint = 3
 
 	MaxOwnershipLength      = 128
 	MaxPackageVersionLength = 128
 	MaxBinaryLength         = 4096
 	MaxEndpointLength       = 2048
 	MaxDataDirLength        = 4096
+	MaxEnvFileLength        = 4096
 
 	maxDecodedRegistrationLength = 12 * 1024
 	maxEncodedRegistrationLength = 16 * 1024
@@ -69,6 +70,7 @@ type DefinitionInput struct {
 	Binary            string
 	Endpoint          string
 	DataDir           string
+	EnvFile           string
 }
 
 // Definition is an immutable, side-effect-free declaration that a native
@@ -80,6 +82,7 @@ type Definition struct {
 	binary            string
 	endpoint          string
 	dataDir           string
+	envFile           string
 }
 
 // NewDefinition validates an owned personal-service declaration.
@@ -91,6 +94,7 @@ func NewDefinition(input DefinitionInput) (Definition, error) {
 		binary:            input.Binary,
 		endpoint:          input.Endpoint,
 		dataDir:           input.DataDir,
+		envFile:           input.EnvFile,
 	}
 	if err := definition.Validate(); err != nil {
 		return Definition{}, err
@@ -104,6 +108,7 @@ func (d Definition) PackageVersion() string { return d.packageVersion }
 func (d Definition) Binary() string         { return d.binary }
 func (d Definition) Endpoint() string       { return d.endpoint }
 func (d Definition) DataDir() string        { return d.dataDir }
+func (d Definition) EnvFile() string        { return d.envFile }
 
 // Validate rejects zero-value, unsupported, and unsafe definitions.
 func (d Definition) Validate() error {
@@ -125,7 +130,10 @@ func (d Definition) Validate() error {
 	if err := validateEndpoint(d.endpoint); err != nil {
 		return err
 	}
-	return validateAbsolutePath("data_dir", d.dataDir, MaxDataDirLength)
+	if err := validateAbsolutePath("data_dir", d.dataDir, MaxDataDirLength); err != nil {
+		return err
+	}
+	return validateNormalizedAbsolutePath("env_file", d.envFile, MaxEnvFileLength)
 }
 
 // CanonicalJSON returns the RFC 8785 canonical registration definition.
@@ -140,6 +148,7 @@ func (d Definition) CanonicalJSON() ([]byte, error) {
 		Binary:            d.binary,
 		Endpoint:          d.endpoint,
 		DataDir:           d.dataDir,
+		EnvFile:           d.envFile,
 	})
 	if err != nil {
 		return nil, invalidMetadata("payload", "cannot be encoded")
@@ -219,6 +228,7 @@ type definitionWire struct {
 	Binary            string `json:"binary"`
 	Endpoint          string `json:"endpoint"`
 	DataDir           string `json:"data_dir"`
+	EnvFile           string `json:"env_file"`
 }
 
 func decodeDefinition(payload []byte) (Definition, error) {
@@ -229,7 +239,7 @@ func decodeDefinition(payload []byte) (Definition, error) {
 	if err := json.Unmarshal(payload, &object); err != nil {
 		return Definition{}, invalidMetadata("payload", "must be valid JSON without duplicate members or trailing data")
 	}
-	if len(object) != 6 {
+	if len(object) != 7 {
 		for name := range object {
 			if !definitionField(name) && sensitiveMetadataName(name) {
 				return Definition{}, invalidMetadata("metadata", "must not contain sensitive members")
@@ -270,6 +280,10 @@ func decodeDefinition(payload []byte) (Definition, error) {
 	if err != nil {
 		return Definition{}, err
 	}
+	envFile, err := requiredString(object["env_file"], "env_file")
+	if err != nil {
+		return Definition{}, err
+	}
 	return NewDefinition(DefinitionInput{
 		Ownership:         ownership,
 		DefinitionVersion: version,
@@ -277,6 +291,7 @@ func decodeDefinition(payload []byte) (Definition, error) {
 		Binary:            binary,
 		Endpoint:          endpoint,
 		DataDir:           dataDir,
+		EnvFile:           envFile,
 	})
 }
 
@@ -353,6 +368,16 @@ func validateAbsolutePath(field, value string, maximum int) error {
 	return nil
 }
 
+func validateNormalizedAbsolutePath(field, value string, maximum int) error {
+	if err := validateAbsolutePath(field, value, maximum); err != nil {
+		return err
+	}
+	if !normalizedAbsolutePath(value) {
+		return invalidMetadata(field, "must be normalized")
+	}
+	return nil
+}
+
 // absolutePath accepts a portable POSIX absolute path and the stable Windows
 // drive and UNC forms. It deliberately does not inspect the host filesystem.
 func absolutePath(value string) bool {
@@ -362,13 +387,45 @@ func absolutePath(value string) bool {
 	return len(value) >= 3 && asciiLetter(value[0]) && value[1] == ':' && (value[2] == '/' || value[2] == '\\')
 }
 
+func normalizedAbsolutePath(value string) bool {
+	separator := "/"
+	remainder := ""
+	switch {
+	case strings.HasPrefix(value, "/"):
+		if strings.HasPrefix(value, "//") {
+			return false
+		}
+		remainder = value[1:]
+	case strings.HasPrefix(value, `\\`):
+		separator = `\`
+		remainder = value[2:]
+	case len(value) >= 3 && asciiLetter(value[0]) && value[1] == ':' && (value[2] == '/' || value[2] == '\\'):
+		separator = value[2:3]
+		remainder = value[3:]
+	default:
+		return false
+	}
+	if remainder == "" || strings.Contains(remainder, separator+separator) {
+		return false
+	}
+	if separator == "/" && strings.ContainsRune(remainder, '\\') || separator == `\` && strings.ContainsRune(remainder, '/') {
+		return false
+	}
+	for segment := range strings.SplitSeq(remainder, separator) {
+		if segment == "" || segment == "." || segment == ".." {
+			return false
+		}
+	}
+	return true
+}
+
 func asciiLetter(value byte) bool {
 	return value >= 'a' && value <= 'z' || value >= 'A' && value <= 'Z'
 }
 
 func definitionField(name string) bool {
 	switch name {
-	case "ownership", "definition_version", "package_version", "binary", "endpoint", "data_dir":
+	case "ownership", "definition_version", "package_version", "binary", "endpoint", "data_dir", "env_file":
 		return true
 	default:
 		return false

--- a/internal/personalsvc/definition.go
+++ b/internal/personalsvc/definition.go
@@ -389,7 +389,7 @@ func absolutePath(value string) bool {
 
 func normalizedAbsolutePath(value string) bool {
 	separator := "/"
-	remainder := ""
+	var remainder string
 	switch {
 	case strings.HasPrefix(value, "/"):
 		if strings.HasPrefix(value, "//") {

--- a/internal/personalsvc/definition_test.go
+++ b/internal/personalsvc/definition_test.go
@@ -42,7 +42,7 @@ func TestRegistrationEncodesAnImmutableCanonicalDefinition(t *testing.T) {
 	if decodeErr != nil {
 		t.Fatalf("DecodeString() error = %v", decodeErr)
 	}
-	const want = `{"binary":"/opt/powercontext/bin/powercontext","data_dir":"/var/lib/powercontext","definition_version":2,"endpoint":"http://127.0.0.1:7614","ownership":"powercontext.personal-server","package_version":"0.2.0"}`
+	const want = `{"binary":"/opt/powercontext/bin/powercontext","data_dir":"/var/lib/powercontext","definition_version":3,"endpoint":"http://127.0.0.1:7614","env_file":"/etc/powercontext/server.env","ownership":"powercontext.personal-server","package_version":"0.2.0"}`
 	if string(payload) != want {
 		t.Fatalf("canonical payload = %q, want %q", payload, want)
 	}
@@ -164,6 +164,49 @@ func TestDefinitionAcceptsTransportPolicyLoopbackEndpoints(t *testing.T) {
 	}
 }
 
+func TestDefinitionRequiresANormalizedAbsoluteEnvironmentFileIdentity(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		envFile string
+		wantErr bool
+	}{
+		{name: "POSIX", envFile: "/etc/powercontext/server.env"},
+		{name: "Windows drive", envFile: `C:\ProgramData\PowerContext\server.env`},
+		{name: "UNC", envFile: `\\server\share\server.env`},
+		{name: "relative", envFile: "config/server.env", wantErr: true},
+		{name: "empty", envFile: "", wantErr: true},
+		{name: "POSIX dot", envFile: "/etc/./powercontext/server.env", wantErr: true},
+		{name: "POSIX parent", envFile: "/etc/powercontext/../server.env", wantErr: true},
+		{name: "POSIX repeated separator", envFile: "/etc//powercontext/server.env", wantErr: true},
+		{name: "Windows dot", envFile: `C:\ProgramData\.\server.env`, wantErr: true},
+		{name: "Windows repeated separator", envFile: `C:\ProgramData\\server.env`, wantErr: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			input := testDefinitionInput()
+			input.EnvFile = test.envFile
+			definition, err := personalsvc.NewDefinition(input)
+			if test.wantErr {
+				if err == nil {
+					t.Fatal("NewDefinition() accepted an invalid environment file identity")
+				}
+				if _, ok := errors.AsType[*personalsvc.InvalidMetadataError](err); !ok {
+					t.Fatalf("NewDefinition() error type = %T, want *InvalidMetadataError", err)
+				}
+				if test.envFile != "" && strings.Contains(err.Error(), test.envFile) {
+					t.Fatalf("NewDefinition() error exposed environment file: %q", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("NewDefinition() error = %v", err)
+			}
+			if definition.EnvFile() != test.envFile {
+				t.Fatalf("EnvFile() = %q, want %q", definition.EnvFile(), test.envFile)
+			}
+		})
+	}
+}
+
 func TestDecodeRegistrationRejectsNonCanonicalUnknownDuplicateAndSensitiveMetadata(t *testing.T) {
 	cases := []struct {
 		name    string
@@ -203,6 +246,17 @@ func TestDecodeRegistrationRejectsNonCanonicalUnknownDuplicateAndSensitiveMetada
 				t.Fatalf("DecodeRegistration() error exposed sensitive value: %q", err)
 			}
 		})
+	}
+}
+
+func TestDecodeRegistrationRejectsLegacyV2WithoutEnvironmentFile(t *testing.T) {
+	payload := `{"binary":"/opt/powercontext/bin/powercontext","data_dir":"/var/lib/powercontext","definition_version":2,"endpoint":"http://127.0.0.1:7614","ownership":"powercontext.personal-server","package_version":"0.2.0"}`
+	_, err := personalsvc.DecodeRegistration(base64.RawURLEncoding.EncodeToString([]byte(payload)))
+	if err == nil {
+		t.Fatal("DecodeRegistration() accepted a legacy v2 registration")
+	}
+	if _, ok := errors.AsType[*personalsvc.InvalidMetadataError](err); !ok {
+		t.Fatalf("DecodeRegistration() error type = %T, want *InvalidMetadataError", err)
 	}
 }
 
@@ -255,5 +309,6 @@ func testDefinitionInput() personalsvc.DefinitionInput {
 		Binary:            "/opt/powercontext/bin/powercontext",
 		Endpoint:          "http://127.0.0.1:7614",
 		DataDir:           "/var/lib/powercontext",
+		EnvFile:           "/etc/powercontext/server.env",
 	}
 }

--- a/internal/personalsvc/launchd_test.go
+++ b/internal/personalsvc/launchd_test.go
@@ -246,6 +246,7 @@ func launchdRegistration(t *testing.T) personalsvc.Registration {
 		Binary:            "/opt/powercontext/bin/powercontext",
 		Endpoint:          "http://127.0.0.1:7614",
 		DataDir:           "/var/lib/powercontext",
+		EnvFile:           "/etc/powercontext/server.env",
 	})
 	if err != nil {
 		t.Fatalf("NewDefinition() error = %v", err)

--- a/internal/personalsvc/systemd.go
+++ b/internal/personalsvc/systemd.go
@@ -163,45 +163,34 @@ type SystemdUserBoundary interface {
 	Probe(context.Context, string) (ProbeState, error)
 }
 
-// SystemdUserLauncher is an immutable command prefix for the future
-// manager-owned personal-service launcher. Registration endpoint and data-dir
-// arguments are appended by the adapter so inspected metadata and ExecStart
-// always describe the same registration.
+// SystemdUserLauncher is the fixed command prefix for the manager-owned
+// personal-service launcher. The executable and all mutable values belong to
+// the registration, so the unit can be compared directly with its definition.
 type SystemdUserLauncher struct {
-	executable string
-	arguments  []string
+	arguments []string
 }
 
-// NewSystemdUserLauncher validates a launcher executable and its fixed
-// argument prefix without touching the host filesystem.
-func NewSystemdUserLauncher(executable string, arguments ...string) (SystemdUserLauncher, error) {
-	if !validSystemdArgument(executable, true) {
+// NewSystemdUserLauncher accepts only the release binary's hidden service
+// command. It does not inspect the executable or filesystem.
+func NewSystemdUserLauncher(arguments ...string) (SystemdUserLauncher, error) {
+	if !slices.Equal(arguments, []string{"server", "_service-run"}) {
 		return SystemdUserLauncher{}, newSystemdAdapterError("configuration")
 	}
-	for _, argument := range arguments {
-		if !validSystemdLauncherPrefixArgument(argument) {
-			return SystemdUserLauncher{}, newSystemdAdapterError("configuration")
-		}
-	}
-	return SystemdUserLauncher{executable: executable, arguments: append([]string(nil), arguments...)}, nil
+	return SystemdUserLauncher{arguments: slices.Clone(arguments)}, nil
 }
 
 func (l SystemdUserLauncher) command(registration Registration) ([]string, error) {
-	if !validSystemdArgument(l.executable, true) {
+	if !slices.Equal(l.arguments, []string{"server", "_service-run"}) {
 		return nil, newSystemdAdapterError("configuration")
-	}
-	for _, argument := range l.arguments {
-		if !validSystemdLauncherPrefixArgument(argument) {
-			return nil, newSystemdAdapterError("configuration")
-		}
 	}
 	if err := registration.Definition().Validate(); err != nil {
 		return nil, newSystemdAdapterError("configuration")
 	}
-	arguments := make([]string, 0, 1+len(l.arguments)+4)
-	arguments = append(arguments, l.executable)
+	arguments := make([]string, 0, 1+len(l.arguments)+6)
+	arguments = append(arguments, registration.Definition().Binary())
 	arguments = append(arguments, l.arguments...)
 	arguments = append(arguments,
+		"--env-file", registration.Definition().EnvFile(),
 		"--endpoint", registration.Definition().Endpoint(),
 		"--data-dir", registration.Definition().DataDir(),
 	)
@@ -232,13 +221,8 @@ func NewSystemdUserAdapter(
 	if boundary == nil || !validSystemdUserConfigRoot(userConfigRoot) {
 		return nil, newSystemdAdapterError("configuration")
 	}
-	if !validSystemdArgument(launcher.executable, true) {
+	if !slices.Equal(launcher.arguments, []string{"server", "_service-run"}) {
 		return nil, newSystemdAdapterError("configuration")
-	}
-	for _, argument := range launcher.arguments {
-		if !validSystemdLauncherPrefixArgument(argument) {
-			return nil, newSystemdAdapterError("configuration")
-		}
 	}
 	return &SystemdUserAdapter{
 		boundary: boundary,
@@ -555,16 +539,6 @@ func validSystemdArgument(value string, absolute bool) bool {
 		}
 	}
 	return true
-}
-
-func validSystemdLauncherPrefixArgument(value string) bool {
-	if !validSystemdArgument(value, false) {
-		return false
-	}
-	if value == "--" || value == "--endpoint" || value == "--data-dir" {
-		return false
-	}
-	return !strings.HasPrefix(value, "--endpoint=") && !strings.HasPrefix(value, "--data-dir=")
 }
 
 func validEncodedRegistration(value string) bool {

--- a/internal/personalsvc/systemd.go
+++ b/internal/personalsvc/systemd.go
@@ -459,7 +459,7 @@ func (a *SystemdUserAdapter) render(registration Registration) ([]byte, error) {
 		"StartLimitBurst=3\n" +
 		"\n" +
 		"[Service]\n" +
-		"Type=simple\n" +
+		"Type=exec\n" +
 		"Environment=POWERCONTEXT_SERVICE_OWNED=true\n" +
 		"Environment=POWERCONTEXT_SERVICE_METADATA=" + metadata + "\n" +
 		"ExecStart=" + strings.Join(quoted, " ") + "\n" +

--- a/internal/personalsvc/systemd.go
+++ b/internal/personalsvc/systemd.go
@@ -98,7 +98,7 @@ type SystemdUserManagerUnit struct {
 	fragmentPath       string
 	dropInPathsPresent bool
 	dropInPaths        []string
-	environment        string
+	environment        []string
 	execStart          []SystemdUserExecStart
 }
 
@@ -109,7 +109,7 @@ func NewSystemdUserManagerUnit(
 	fragmentPath string,
 	dropInPathsPresent bool,
 	dropInPaths []string,
-	environment string,
+	environment []string,
 	execStart []SystemdUserExecStart,
 ) SystemdUserManagerUnit {
 	return SystemdUserManagerUnit{
@@ -117,7 +117,7 @@ func NewSystemdUserManagerUnit(
 		fragmentPath:       strings.Clone(fragmentPath),
 		dropInPathsPresent: dropInPathsPresent,
 		dropInPaths:        slices.Clone(dropInPaths),
-		environment:        strings.Clone(environment),
+		environment:        slices.Clone(environment),
 		execStart:          cloneSystemdUserExecStart(execStart),
 	}
 }
@@ -135,8 +135,10 @@ func (u SystemdUserManagerUnit) HasDropInPaths() bool { return u.dropInPathsPres
 // DropInPaths returns independent copies of the manager-reported drop-ins.
 func (u SystemdUserManagerUnit) DropInPaths() []string { return slices.Clone(u.dropInPaths) }
 
-// Environment returns the manager-reported environment assignments.
-func (u SystemdUserManagerUnit) Environment() string { return u.environment }
+// Environment returns independent copies of the manager-reported environment
+// assignments. Each string remains one D-Bus assignment; callers must not
+// split a value on whitespace because values may themselves contain spaces.
+func (u SystemdUserManagerUnit) Environment() []string { return slices.Clone(u.environment) }
 
 // ExecStart returns independent copies of the manager-reported commands.
 func (u SystemdUserManagerUnit) ExecStart() []SystemdUserExecStart {
@@ -559,8 +561,8 @@ func quoteSystemdArgument(value string) string {
 	return "\"" + replacer.Replace(value) + "\""
 }
 
-func systemdOwnership(value string) (metadata string, owned bool, found bool) {
-	for item := range strings.FieldsSeq(value) {
+func systemdOwnership(values []string) (metadata string, owned bool, found bool) {
+	for _, item := range values {
 		name, itemValue, hasValue := strings.Cut(item, "=")
 		if !hasValue {
 			continue

--- a/internal/personalsvc/systemd_test.go
+++ b/internal/personalsvc/systemd_test.go
@@ -55,7 +55,7 @@ func TestSystemdUserAdapterWritesDeterministicOwnedUnit(t *testing.T) {
 		"Type=simple\n" +
 		"Environment=POWERCONTEXT_SERVICE_OWNED=true\n" +
 		"Environment=POWERCONTEXT_SERVICE_METADATA=" + "PLACEHOLDER" + "\n" +
-		"ExecStart=\"/opt/powercontext/bin/personal-launcher\" \"--foreground\" \"--endpoint\" \"http://127.0.0.1:8123\" \"--data-dir\" \"/home/alice/.local/share/powercontext\"\n" +
+		"ExecStart=\"/opt/powercontext/bin/powercontext\" \"server\" \"_service-run\" \"--env-file\" \"/home/alice/.config/powercontext/server.env\" \"--endpoint\" \"http://127.0.0.1:8123\" \"--data-dir\" \"/home/alice/.local/share/powercontext\"\n" +
 		"Restart=on-failure\n" +
 		"RestartSec=5s\n" +
 		"TimeoutStopSec=30s\n" +
@@ -123,10 +123,11 @@ func TestSystemdUserAdapterRefusesForeignOrMalformedArtifactsWithoutMutation(t *
 
 func TestSystemdUserAdapterRejectsEveryManagerOwnershipMismatchWithoutEnablement(t *testing.T) {
 	registration := systemdRegistration(t)
-	const executable = "/opt/powercontext/bin/personal-launcher"
+	const executable = "/opt/powercontext/bin/powercontext"
 	canonical := systemdOwnedManagerFixture(t, registration, []personalsvc.SystemdUserExecStart{
 		personalsvc.NewSystemdUserExecStart(executable, []string{
-			executable, "--foreground", "--endpoint", "http://127.0.0.1:8123", "--data-dir", "/home/alice/.local/share/powercontext",
+			executable, "server", "_service-run", "--env-file", "/home/alice/.config/powercontext/server.env",
+			"--endpoint", "http://127.0.0.1:8123", "--data-dir", "/home/alice/.local/share/powercontext",
 		}, false),
 	})
 	ownedBoundary := newSystemdBoundary()
@@ -164,7 +165,7 @@ func TestSystemdUserAdapterRejectsEveryManagerOwnershipMismatchWithoutEnablement
 			name: "arguments",
 			mutate: func(value systemdManagerFixture) systemdManagerFixture {
 				arguments := value.execStart[0].Arguments()
-				arguments[3] = "http://127.0.0.1:9000"
+				arguments[6] = "http://127.0.0.1:9000"
 				value.execStart = []personalsvc.SystemdUserExecStart{personalsvc.NewSystemdUserExecStart(executable, arguments, false)}
 				return value
 			},
@@ -239,12 +240,8 @@ func TestSystemdUserAdapterRejectsEveryManagerOwnershipMismatchWithoutEnablement
 }
 
 func TestSystemdUserAdapterAcceptsManagerArgumentsContainingSpaces(t *testing.T) {
-	registration := systemdRegistration(t)
-	launcher, err := personalsvc.NewSystemdUserLauncher(
-		"/opt/PowerContext Personal/personal-launcher",
-		"--foreground",
-		"PowerContext personal",
-	)
+	registration := systemdRegistrationWithBinary(t, "/opt/PowerContext Personal/powercontext")
+	launcher, err := personalsvc.NewSystemdUserLauncher("server", "_service-run")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -255,9 +252,9 @@ func TestSystemdUserAdapterAcceptsManagerArgumentsContainingSpaces(t *testing.T)
 	}
 	boundary.setManagerUnit(systemdOwnedManagerFixture(t, registration, []personalsvc.SystemdUserExecStart{
 		personalsvc.NewSystemdUserExecStart(
-			"/opt/PowerContext Personal/personal-launcher",
+			"/opt/PowerContext Personal/powercontext",
 			[]string{
-				"/opt/PowerContext Personal/personal-launcher", "--foreground", "PowerContext personal",
+				"/opt/PowerContext Personal/powercontext", "server", "_service-run", "--env-file", "/home/alice/.config/powercontext/server.env",
 				"--endpoint", "http://127.0.0.1:8123", "--data-dir", "/home/alice/.local/share/powercontext",
 			},
 			false,
@@ -271,12 +268,8 @@ func TestSystemdUserAdapterAcceptsManagerArgumentsContainingSpaces(t *testing.T)
 }
 
 func TestSystemdUserAdapterRejectsAmbiguousFlattenedManagerArguments(t *testing.T) {
-	registration := systemdRegistration(t)
-	launcher, err := personalsvc.NewSystemdUserLauncher(
-		"/opt/PowerContext Personal/personal-launcher",
-		"--foreground",
-		"PowerContext personal",
-	)
+	registration := systemdRegistrationWithBinary(t, "/opt/PowerContext Personal/powercontext")
+	launcher, err := personalsvc.NewSystemdUserLauncher("server", "_service-run")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -287,10 +280,10 @@ func TestSystemdUserAdapterRejectsAmbiguousFlattenedManagerArguments(t *testing.
 	}
 	boundary.setManagerUnit(systemdOwnedManagerFixture(t, registration, []personalsvc.SystemdUserExecStart{
 		personalsvc.NewSystemdUserExecStart(
-			"/opt/PowerContext Personal/personal-launcher",
+			"/opt/PowerContext Personal/powercontext",
 			[]string{
-				"/opt/PowerContext Personal/personal-launcher", "--foreground", "PowerContext", "personal",
-				"--endpoint", "http://127.0.0.1:8123", "--data-dir", "/home/alice/.local/share/powercontext",
+				"/opt/PowerContext Personal/powercontext", "server", "_service-run", "--env-file", "/home/alice/.config/powercontext/server.env",
+				"--endpoint", "http://127.0.0.1:8123", "--data-dir", "/home/alice/.local", "share/powercontext",
 			},
 			false,
 		),
@@ -304,12 +297,13 @@ func TestSystemdUserAdapterRejectsAmbiguousFlattenedManagerArguments(t *testing.
 
 func TestSystemdUserAdapterRejectsManagerWithoutDropInPaths(t *testing.T) {
 	registration := systemdRegistration(t)
-	executable := "/opt/powercontext/bin/personal-launcher"
+	executable := "/opt/powercontext/bin/powercontext"
 	boundary := newSystemdBoundary()
 	adapter := newSystemdAdapter(t, boundary)
 	managerFixture := systemdOwnedManagerFixture(t, registration, []personalsvc.SystemdUserExecStart{
 		personalsvc.NewSystemdUserExecStart(executable, []string{
-			executable, "--foreground", "--endpoint", "http://127.0.0.1:8123", "--data-dir", "/home/alice/.local/share/powercontext",
+			executable, "server", "_service-run", "--env-file", "/home/alice/.config/powercontext/server.env",
+			"--endpoint", "http://127.0.0.1:8123", "--data-dir", "/home/alice/.local/share/powercontext",
 		}, false),
 	})
 	managerFixture.dropInPathsPresent = false
@@ -459,7 +453,7 @@ func TestSystemdUserAdapterZeroValueFailsClosed(t *testing.T) {
 }
 
 func TestSystemdUserAdapterRejectsNonPrivateUnitPathsWithoutHostAccess(t *testing.T) {
-	launcher, err := personalsvc.NewSystemdUserLauncher("/opt/powercontext/bin/personal-launcher", "--foreground")
+	launcher, err := personalsvc.NewSystemdUserLauncher("server", "_service-run")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -485,24 +479,27 @@ func TestSystemdUserAdapterRejectsNonPrivateUnitPathsWithoutHostAccess(t *testin
 	}
 }
 
-func TestSystemdUserLauncherRejectsRegistrationOverrideArguments(t *testing.T) {
+func TestSystemdUserLauncherAcceptsOnlyTheFixedServiceRunPrefix(t *testing.T) {
 	for _, arguments := range [][]string{
+		nil,
+		{"server"},
+		{"_service-run"},
 		{"--endpoint", "http://127.0.0.1:9000"},
 		{"--endpoint=http://127.0.0.1:9000"},
 		{"--data-dir", "/foreign/data"},
 		{"--data-dir=/foreign/data"},
 		{"--"},
 	} {
-		_, err := personalsvc.NewSystemdUserLauncher("/opt/powercontext/bin/personal-launcher", arguments...)
+		_, err := personalsvc.NewSystemdUserLauncher(arguments...)
 		if err == nil {
-			t.Fatalf("NewSystemdUserLauncher(%q) accepted a registration override", arguments)
+			t.Fatalf("NewSystemdUserLauncher(%q) accepted a non-fixed prefix", arguments)
 		}
 	}
 }
 
 func newSystemdAdapter(t *testing.T, boundary *systemdBoundary) *personalsvc.SystemdUserAdapter {
 	t.Helper()
-	launcher, err := personalsvc.NewSystemdUserLauncher("/opt/powercontext/bin/personal-launcher", "--foreground")
+	launcher, err := personalsvc.NewSystemdUserLauncher("server", "_service-run")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -514,12 +511,16 @@ func newSystemdAdapter(t *testing.T, boundary *systemdBoundary) *personalsvc.Sys
 }
 
 func systemdRegistration(t *testing.T) personalsvc.Registration {
+	return systemdRegistrationWithBinary(t, "/opt/powercontext/bin/powercontext")
+}
+
+func systemdRegistrationWithBinary(t *testing.T, binary string) personalsvc.Registration {
 	t.Helper()
 	definition, err := personalsvc.NewDefinition(personalsvc.DefinitionInput{
 		Ownership:         personalsvc.OwnershipMarker,
 		DefinitionVersion: personalsvc.DefinitionVersion,
 		PackageVersion:    "0.2.0",
-		Binary:            "/opt/powercontext/bin/powercontext",
+		Binary:            binary,
 		Endpoint:          "http://127.0.0.1:8123",
 		DataDir:           "/home/alice/.local/share/powercontext",
 		EnvFile:           "/home/alice/.config/powercontext/server.env",

--- a/internal/personalsvc/systemd_test.go
+++ b/internal/personalsvc/systemd_test.go
@@ -522,6 +522,7 @@ func systemdRegistration(t *testing.T) personalsvc.Registration {
 		Binary:            "/opt/powercontext/bin/powercontext",
 		Endpoint:          "http://127.0.0.1:8123",
 		DataDir:           "/home/alice/.local/share/powercontext",
+		EnvFile:           "/home/alice/.config/powercontext/server.env",
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/internal/personalsvc/systemd_test.go
+++ b/internal/personalsvc/systemd_test.go
@@ -52,7 +52,7 @@ func TestSystemdUserAdapterWritesDeterministicOwnedUnit(t *testing.T) {
 		"StartLimitBurst=3\n" +
 		"\n" +
 		"[Service]\n" +
-		"Type=simple\n" +
+		"Type=exec\n" +
 		"Environment=POWERCONTEXT_SERVICE_OWNED=true\n" +
 		"Environment=POWERCONTEXT_SERVICE_METADATA=" + "PLACEHOLDER" + "\n" +
 		"ExecStart=\"/opt/powercontext/bin/powercontext\" \"server\" \"_service-run\" \"--env-file\" \"/home/alice/.config/powercontext/server.env\" \"--endpoint\" \"http://127.0.0.1:8123\" \"--data-dir\" \"/home/alice/.local/share/powercontext\"\n" +
@@ -118,6 +118,24 @@ func TestSystemdUserAdapterRefusesForeignOrMalformedArtifactsWithoutMutation(t *
 				t.Fatalf("unverified artifact reached the manager: %q", boundary.commandArguments())
 			}
 		})
+	}
+}
+
+func TestSystemdUserAdapterRejectsLegacySimpleUnitArtifact(t *testing.T) {
+	registration := systemdRegistration(t)
+	boundary := newSystemdBoundary()
+	adapter := newSystemdAdapter(t, boundary)
+	if err := adapter.Write(t.Context(), registration); err != nil {
+		t.Fatal(err)
+	}
+	boundary.content = []byte(strings.Replace(string(boundary.content), "Type=exec", "Type=simple", 1))
+
+	artifact, err := adapter.InspectArtifact(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if artifact.State() != personalsvc.RegistrationInvalid {
+		t.Fatalf("artifact state = %s, want invalid", artifact.State())
 	}
 }
 

--- a/internal/personalsvc/systemd_test.go
+++ b/internal/personalsvc/systemd_test.go
@@ -173,14 +173,23 @@ func TestSystemdUserAdapterRejectsEveryManagerOwnershipMismatchWithoutEnablement
 		{
 			name: "marker",
 			mutate: func(value systemdManagerFixture) systemdManagerFixture {
-				value.environment = strings.Replace(value.environment, "POWERCONTEXT_SERVICE_OWNED", "FOREIGN_SERVICE_OWNED", 1)
+				value.environment = slices.Clone(value.environment)
+				value.environment[0] = "FOREIGN_SERVICE_OWNED=true"
 				return value
 			},
 		},
 		{
 			name: "metadata",
 			mutate: func(value systemdManagerFixture) systemdManagerFixture {
-				value.environment = strings.Replace(value.environment, "POWERCONTEXT_SERVICE_METADATA=", "POWERCONTEXT_SERVICE_METADATA=malformed-", 1)
+				value.environment = slices.Clone(value.environment)
+				value.environment[1] = "POWERCONTEXT_SERVICE_METADATA=malformed-"
+				return value
+			},
+		},
+		{
+			name: "combined environment assignment",
+			mutate: func(value systemdManagerFixture) systemdManagerFixture {
+				value.environment = []string{value.environment[0] + " " + value.environment[1]}
 				return value
 			},
 		},
@@ -539,7 +548,7 @@ type systemdManagerFixture struct {
 	fragmentPath       string
 	dropInPathsPresent bool
 	dropInPaths        []string
-	environment        string
+	environment        []string
 	execStart          []personalsvc.SystemdUserExecStart
 }
 
@@ -556,8 +565,11 @@ func systemdOwnedManagerFixture(
 	return systemdManagerFixture{
 		fragmentPath:       systemdUnitPath,
 		dropInPathsPresent: true,
-		environment:        "POWERCONTEXT_SERVICE_OWNED=true POWERCONTEXT_SERVICE_METADATA=" + metadata,
-		execStart:          execStart,
+		environment: []string{
+			"POWERCONTEXT_SERVICE_OWNED=true",
+			"POWERCONTEXT_SERVICE_METADATA=" + metadata,
+		},
+		execStart: execStart,
 	}
 }
 
@@ -629,7 +641,7 @@ func (b *systemdBoundary) InspectUnit(_ context.Context, unit string) (personals
 		return personalsvc.SystemdUserManagerUnit{}, b.managerErr
 	}
 	if b.managerUnit.LoadState() == "" {
-		return personalsvc.NewSystemdUserManagerUnit("not-found", "", false, nil, "", nil), nil
+		return personalsvc.NewSystemdUserManagerUnit("not-found", "", false, nil, nil, nil), nil
 	}
 	return b.managerUnit, nil
 }

--- a/internal/personalsvc/task_scheduler_test.go
+++ b/internal/personalsvc/task_scheduler_test.go
@@ -80,6 +80,7 @@ func TestTaskSchedulerSpecRejectsShellAction(t *testing.T) {
 		Binary:            `C:\Windows\System32\cmd.exe`,
 		Endpoint:          "http://127.0.0.1:8123",
 		DataDir:           `C:\Users\person\AppData\Local\PowerContext`,
+		EnvFile:           `C:\Users\person\AppData\Local\PowerContext\server.env`,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -315,6 +316,7 @@ func taskSchedulerSpec(t *testing.T, startOnLogin bool) personalsvc.TaskSchedule
 		Binary:            `C:\Program Files\PowerContext\powercontext.exe`,
 		Endpoint:          "http://127.0.0.1:8123",
 		DataDir:           `C:\Users\person\AppData\Local\PowerContext`,
+		EnvFile:           `C:\Users\person\AppData\Local\PowerContext\server.env`,
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/test/systemd-user-consumer/Dockerfile
+++ b/test/systemd-user-consumer/Dockerfile
@@ -1,0 +1,28 @@
+# Copyright (c) 2026 OceanBase.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM ubuntu@sha256:33ceb71981b602c1a7443a53469e4dba065f7503eab3078a2d7a57a2ab987517
+
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends \
+        dbus \
+        dbus-user-session \
+        systemd \
+        systemd-sysv \
+    && useradd --create-home --shell /bin/bash --uid 1001 powercontext \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+STOPSIGNAL SIGRTMIN+3
+CMD ["/sbin/init"]

--- a/test/systemd-user-consumer/run.sh
+++ b/test/systemd-user-consumer/run.sh
@@ -133,6 +133,9 @@ else
     )
     if ! docker exec --user powercontext "$container" env -i "${environment[@]}" systemctl --user show-environment >/dev/null 2>&1; then
       result=1
+    elif ! docker exec --user powercontext "$container" env -i "${environment[@]}" \
+      busctl --user --json=short call org.freedesktop.systemd1 /org/freedesktop/systemd1 org.freedesktop.DBus.Peer Ping >/dev/null 2>&1; then
+      result=1
     elif ! docker exec "$container" test ! -e /home/powercontext/.config/systemd/user/powercontext.service; then
       result=1
     else

--- a/test/systemd-user-consumer/run.sh
+++ b/test/systemd-user-consumer/run.sh
@@ -110,6 +110,11 @@ load_state_exit_code=0
 load_state_stdout_bytes=0
 load_state_stdout_sha256="$stage_stdout_sha256"
 load_state_value=not_run
+show_state_stage=not_run
+show_state_exit_code=0
+show_state_stdout_bytes=0
+show_state_stdout_sha256="$stage_stdout_sha256"
+show_state_value=not_run
 
 record_stage() {
   local name="$1"
@@ -186,6 +191,25 @@ record_load_state() {
   rm -f -- "$stage_output"
 }
 
+record_show_state() {
+  local saved_stage="$load_state_stage"
+  local saved_exit_code="$load_state_exit_code"
+  local saved_stdout_bytes="$load_state_stdout_bytes"
+  local saved_stdout_sha256="$load_state_stdout_sha256"
+  local saved_value="$load_state_value"
+  record_load_state "$@"
+  show_state_stage="$load_state_stage"
+  show_state_exit_code="$load_state_exit_code"
+  show_state_stdout_bytes="$load_state_stdout_bytes"
+  show_state_stdout_sha256="$load_state_stdout_sha256"
+  show_state_value="$load_state_value"
+  load_state_stage="$saved_stage"
+  load_state_exit_code="$saved_exit_code"
+  load_state_stdout_bytes="$saved_stdout_bytes"
+  load_state_stdout_sha256="$saved_stdout_sha256"
+  load_state_value="$saved_value"
+}
+
 write_summary() {
   local result="$1"
   local manager_ready=false
@@ -203,7 +227,7 @@ write_summary() {
   local archive_sha
   archive_sha="$(sha256sum "$archive" | awk '{ print $1 }')"
   cat > "$diagnostics/summary.json" <<EOF
-{"archive_name":"$archive_name","archive_sha256":"$archive_sha","manager_ready":$manager_ready,"stage":"$recorded_stage","stage_exit_code":$stage_exit_code,"stage_stdout_bytes":$stage_stdout_bytes,"stage_stdout_sha256":"$stage_stdout_sha256","load_unit":{"stage":"$load_unit_stage","exit_code":$load_unit_exit_code,"stdout_bytes":$load_unit_stdout_bytes,"stdout_sha256":"$load_unit_stdout_sha256"},"unit_properties":{"stage":"$unit_properties_stage","exit_code":$unit_properties_exit_code,"stdout_bytes":$unit_properties_stdout_bytes,"stdout_sha256":"$unit_properties_stdout_sha256"},"service_properties":{"stage":"$service_properties_stage","exit_code":$service_properties_exit_code,"stdout_bytes":$service_properties_stdout_bytes,"stdout_sha256":"$service_properties_stdout_sha256"},"load_state":{"stage":"$load_state_stage","exit_code":$load_state_exit_code,"stdout_bytes":$load_state_stdout_bytes,"stdout_sha256":"$load_state_stdout_sha256","value":"$load_state_value"},"systemd_version":"$systemd_version","test_exit_code":$result}
+{"archive_name":"$archive_name","archive_sha256":"$archive_sha","manager_ready":$manager_ready,"stage":"$recorded_stage","stage_exit_code":$stage_exit_code,"stage_stdout_bytes":$stage_stdout_bytes,"stage_stdout_sha256":"$stage_stdout_sha256","load_unit":{"stage":"$load_unit_stage","exit_code":$load_unit_exit_code,"stdout_bytes":$load_unit_stdout_bytes,"stdout_sha256":"$load_unit_stdout_sha256"},"unit_properties":{"stage":"$unit_properties_stage","exit_code":$unit_properties_exit_code,"stdout_bytes":$unit_properties_stdout_bytes,"stdout_sha256":"$unit_properties_stdout_sha256"},"service_properties":{"stage":"$service_properties_stage","exit_code":$service_properties_exit_code,"stdout_bytes":$service_properties_stdout_bytes,"stdout_sha256":"$service_properties_stdout_sha256"},"load_state":{"stage":"$load_state_stage","exit_code":$load_state_exit_code,"stdout_bytes":$load_state_stdout_bytes,"stdout_sha256":"$load_state_stdout_sha256","value":"$load_state_value"},"show_state":{"stage":"$show_state_stage","exit_code":$show_state_exit_code,"stdout_bytes":$show_state_stdout_bytes,"stdout_sha256":"$show_state_stdout_sha256","value":"$show_state_value"},"systemd_version":"$systemd_version","test_exit_code":$result}
 EOF
 }
 
@@ -253,6 +277,8 @@ else
           busctl --user --json=short call org.freedesktop.systemd1 /org/freedesktop/systemd1/unit/powercontext_2eservice org.freedesktop.DBus.Properties GetAll s org.freedesktop.systemd1.Service
         record_load_state load_state docker exec --user powercontext "$container" env -i "${environment[@]}" \
           systemctl --user show --property=LoadState --value powercontext.service
+        record_show_state show_state docker exec --user powercontext "$container" env -i "${environment[@]}" \
+          systemctl --user show --property=LoadState --property=FragmentPath --property=DropInPaths --property=Environment --property=ExecStart powercontext.service
       fi
     fi
   fi

--- a/test/systemd-user-consumer/run.sh
+++ b/test/systemd-user-consumer/run.sh
@@ -115,6 +115,10 @@ show_state_exit_code=0
 show_state_stdout_bytes=0
 show_state_stdout_sha256="$stage_stdout_sha256"
 show_state_value=not_run
+archive_consumer_stage=not_run
+archive_consumer_exit_code=0
+archive_consumer_stdout_bytes=0
+archive_consumer_stdout_sha256="$stage_stdout_sha256"
 
 record_stage() {
   local name="$1"
@@ -227,7 +231,7 @@ write_summary() {
   local archive_sha
   archive_sha="$(sha256sum "$archive" | awk '{ print $1 }')"
   cat > "$diagnostics/summary.json" <<EOF
-{"archive_name":"$archive_name","archive_sha256":"$archive_sha","manager_ready":$manager_ready,"stage":"$recorded_stage","stage_exit_code":$stage_exit_code,"stage_stdout_bytes":$stage_stdout_bytes,"stage_stdout_sha256":"$stage_stdout_sha256","load_unit":{"stage":"$load_unit_stage","exit_code":$load_unit_exit_code,"stdout_bytes":$load_unit_stdout_bytes,"stdout_sha256":"$load_unit_stdout_sha256"},"unit_properties":{"stage":"$unit_properties_stage","exit_code":$unit_properties_exit_code,"stdout_bytes":$unit_properties_stdout_bytes,"stdout_sha256":"$unit_properties_stdout_sha256"},"service_properties":{"stage":"$service_properties_stage","exit_code":$service_properties_exit_code,"stdout_bytes":$service_properties_stdout_bytes,"stdout_sha256":"$service_properties_stdout_sha256"},"load_state":{"stage":"$load_state_stage","exit_code":$load_state_exit_code,"stdout_bytes":$load_state_stdout_bytes,"stdout_sha256":"$load_state_stdout_sha256","value":"$load_state_value"},"show_state":{"stage":"$show_state_stage","exit_code":$show_state_exit_code,"stdout_bytes":$show_state_stdout_bytes,"stdout_sha256":"$show_state_stdout_sha256","value":"$show_state_value"},"systemd_version":"$systemd_version","test_exit_code":$result}
+{"archive_name":"$archive_name","archive_sha256":"$archive_sha","manager_ready":$manager_ready,"stage":"$recorded_stage","stage_exit_code":$stage_exit_code,"stage_stdout_bytes":$stage_stdout_bytes,"stage_stdout_sha256":"$stage_stdout_sha256","archive_consumer":{"stage":"$archive_consumer_stage","exit_code":$archive_consumer_exit_code,"stdout_bytes":$archive_consumer_stdout_bytes,"stdout_sha256":"$archive_consumer_stdout_sha256"},"load_unit":{"stage":"$load_unit_stage","exit_code":$load_unit_exit_code,"stdout_bytes":$load_unit_stdout_bytes,"stdout_sha256":"$load_unit_stdout_sha256"},"unit_properties":{"stage":"$unit_properties_stage","exit_code":$unit_properties_exit_code,"stdout_bytes":$unit_properties_stdout_bytes,"stdout_sha256":"$unit_properties_stdout_sha256"},"service_properties":{"stage":"$service_properties_stage","exit_code":$service_properties_exit_code,"stdout_bytes":$service_properties_stdout_bytes,"stdout_sha256":"$service_properties_stdout_sha256"},"load_state":{"stage":"$load_state_stage","exit_code":$load_state_exit_code,"stdout_bytes":$load_state_stdout_bytes,"stdout_sha256":"$load_state_stdout_sha256","value":"$load_state_value"},"show_state":{"stage":"$show_state_stage","exit_code":$show_state_exit_code,"stdout_bytes":$show_state_stdout_bytes,"stdout_sha256":"$show_state_stdout_sha256","value":"$show_state_value"},"systemd_version":"$systemd_version","test_exit_code":$result}
 EOF
 }
 
@@ -269,6 +273,10 @@ else
         POWERCONTEXT_PERSONAL_SERVICE_ARCHIVE=/work/"$(basename "$archive")" \
         timeout 90 /work/"$(basename "$test_binary")" -test.v -test.run '^TestReleaseArchiveProvidesConsumablePersonalService$'; then
         result=1
+        archive_consumer_stage="$recorded_stage"
+        archive_consumer_exit_code="$stage_exit_code"
+        archive_consumer_stdout_bytes="$stage_stdout_bytes"
+        archive_consumer_stdout_sha256="$stage_stdout_sha256"
         record_diagnostic_stage load_unit docker exec --user powercontext "$container" env -i "${environment[@]}" \
           busctl --user --json=short call org.freedesktop.systemd1 /org/freedesktop/systemd1 org.freedesktop.systemd1.Manager LoadUnit s powercontext.service
         record_diagnostic_stage unit_properties docker exec --user powercontext "$container" env -i "${environment[@]}" \

--- a/test/systemd-user-consumer/run.sh
+++ b/test/systemd-user-consumer/run.sh
@@ -110,37 +110,6 @@ write_summary() {
 EOF
 }
 
-session="$workspace/session.sh"
-cat > "$session" <<'EOF'
-#!/usr/bin/env bash
-set -euo pipefail
-
-manager_pid=""
-cleanup() {
-  local result=$?
-  if [ -n "$manager_pid" ]; then
-    systemctl --user exit >/dev/null 2>&1 || true
-    wait "$manager_pid" >/dev/null 2>&1 || true
-  fi
-  exit "$result"
-}
-trap cleanup EXIT INT TERM
-
-systemd --user >/dev/null 2>&1 &
-manager_pid=$!
-deadline=$((SECONDS + 30))
-until systemctl --user show-environment >/dev/null 2>&1 && \
-  busctl --user call org.freedesktop.systemd1 /org/freedesktop/systemd1 org.freedesktop.DBus.Peer Ping >/dev/null 2>&1; do
-  if [ "$SECONDS" -ge "$deadline" ]; then
-    exit 1
-  fi
-  sleep 1
-done
-touch "$POWERCONTEXT_SYSTEMD_MANAGER_READY"
-timeout 90 "$POWERCONTEXT_SYSTEMD_TEST_BINARY" -test.v -test.run '^TestReleaseArchiveProvidesConsumablePersonalService$'
-EOF
-chmod 0700 "$session"
-
 result=0
 if ! docker build --quiet --file "$script_dir/Dockerfile" --tag "$image" "$script_dir" >/dev/null; then
   result=1
@@ -150,25 +119,27 @@ elif ! docker run --detach --privileged --tmpfs /run --tmpfs /run/lock \
 else
   if ! docker exec "$container" install -d --owner=powercontext --group=powercontext --mode=0700 /run/user/1001; then
     result=1
-  elif ! docker exec "$container" systemctl show-environment >/dev/null; then
+  elif ! docker exec "$container" systemctl start user@1001.service >/dev/null 2>&1; then
     result=1
   else
     systemd_version="$(docker exec "$container" systemd --version 2>/dev/null | awk 'NR == 1 { print $2 }')"
-    if ! docker exec --user powercontext \
-      --env HOME=/home/powercontext \
-      --env TMPDIR=/work/tmp \
-      --env XDG_RUNTIME_DIR=/run/user/1001 \
-      "$container" env -i \
-      HOME=/home/powercontext \
-      TMPDIR=/work/tmp \
-      XDG_RUNTIME_DIR=/run/user/1001 \
-      PATH=/usr/sbin:/usr/bin:/sbin:/bin \
-      LC_ALL=C \
-      POWERCONTEXT_PERSONAL_SERVICE_ARCHIVE=/work/"$(basename "$archive")" \
-      POWERCONTEXT_SYSTEMD_MANAGER_READY=/work/manager-ready \
-      POWERCONTEXT_SYSTEMD_TEST_BINARY=/work/"$(basename "$test_binary")" \
-      dbus-run-session -- /work/session.sh; then
+    environment=(
+      HOME=/home/powercontext
+      TMPDIR=/work/tmp
+      XDG_RUNTIME_DIR=/run/user/1001
+      DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1001/bus
+      PATH=/usr/sbin:/usr/bin:/sbin:/bin
+      LC_ALL=C
+    )
+    if ! docker exec --user powercontext "$container" env -i "${environment[@]}" systemctl --user show-environment >/dev/null 2>&1; then
       result=1
+    else
+      touch "$workspace/manager-ready"
+      if ! docker exec --user powercontext "$container" env -i "${environment[@]}" \
+        POWERCONTEXT_PERSONAL_SERVICE_ARCHIVE=/work/"$(basename "$archive")" \
+        timeout 90 /work/"$(basename "$test_binary")" -test.v -test.run '^TestReleaseArchiveProvidesConsumablePersonalService$'; then
+        result=1
+      fi
     fi
   fi
 fi

--- a/test/systemd-user-consumer/run.sh
+++ b/test/systemd-user-consumer/run.sh
@@ -78,20 +78,22 @@ runner_temp="$(realpath -- "$runner_temp")"
 workspace="$(mktemp -d "$runner_temp/powercontext-systemd-user.XXXXXX")"
 diagnostics="$(mktemp -d "$runner_temp/powercontext-systemd-user-consumer.XXXXXX")"
 chmod 0700 "$workspace" "$diagnostics"
-home="$workspace/home"
-runtime="$workspace/runtime"
 temporary="$workspace/tmp"
-mkdir -m 0700 "$home" "$runtime" "$temporary"
+mkdir -m 0700 "$temporary"
+cp -- "$archive" "$workspace/$(basename "$archive")"
+cp -- "$test_binary" "$workspace/$(basename "$test_binary")"
+chmod 0400 "$workspace/$(basename "$archive")"
+chmod 0500 "$workspace/$(basename "$test_binary")"
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+container="powercontext-systemd-user-${RANDOM}${RANDOM}"
+image="powercontext-systemd-user-consumer:local"
+systemd_version=unknown
 
 write_summary() {
   local result="$1"
   local manager_ready=false
   if [ -f "$workspace/manager-ready" ]; then
     manager_ready=true
-  fi
-  local systemd_version=unknown
-  if command -v systemd >/dev/null 2>&1; then
-    systemd_version="$(systemd --version 2>/dev/null | awk 'NR == 1 { print $2 }')"
   fi
   case "$systemd_version" in
     ''|*[!0-9.]* ) systemd_version=unknown ;;
@@ -140,19 +142,39 @@ EOF
 chmod 0700 "$session"
 
 result=0
-if ! env -i \
-  HOME="$home" \
-  TMPDIR="$temporary" \
-  XDG_RUNTIME_DIR="$runtime" \
-  PATH=/usr/sbin:/usr/bin:/sbin:/bin \
-  LC_ALL=C \
-  POWERCONTEXT_PERSONAL_SERVICE_ARCHIVE="$archive" \
-  POWERCONTEXT_SYSTEMD_MANAGER_READY="$workspace/manager-ready" \
-  POWERCONTEXT_SYSTEMD_TEST_BINARY="$test_binary" \
-  dbus-run-session -- "$session"; then
+if ! docker build --quiet --file "$script_dir/Dockerfile" --tag "$image" "$script_dir" >/dev/null; then
   result=1
+elif ! docker run --detach --privileged --tmpfs /run --tmpfs /run/lock \
+  --name "$container" --volume "$workspace:/work" "$image" >/dev/null; then
+  result=1
+else
+  if ! docker exec "$container" install -d --owner=powercontext --group=powercontext --mode=0700 /run/user/1001; then
+    result=1
+  elif ! docker exec "$container" systemctl show-environment >/dev/null; then
+    result=1
+  else
+    systemd_version="$(docker exec "$container" systemd --version 2>/dev/null | awk 'NR == 1 { print $2 }')"
+    if ! docker exec --user powercontext \
+      --env HOME=/home/powercontext \
+      --env TMPDIR=/work/tmp \
+      --env XDG_RUNTIME_DIR=/run/user/1001 \
+      "$container" env -i \
+      HOME=/home/powercontext \
+      TMPDIR=/work/tmp \
+      XDG_RUNTIME_DIR=/run/user/1001 \
+      PATH=/usr/sbin:/usr/bin:/sbin:/bin \
+      LC_ALL=C \
+      POWERCONTEXT_PERSONAL_SERVICE_ARCHIVE=/work/"$(basename "$archive")" \
+      POWERCONTEXT_SYSTEMD_MANAGER_READY=/work/manager-ready \
+      POWERCONTEXT_SYSTEMD_TEST_BINARY=/work/"$(basename "$test_binary")" \
+      dbus-run-session -- /work/session.sh; then
+      result=1
+    fi
+  fi
 fi
 write_summary "$result"
+
+docker rm --force "$container" >/dev/null 2>&1 || true
 
 case "$workspace" in
   "$runner_temp"/*) rm -rf -- "$workspace" ;;

--- a/test/systemd-user-consumer/run.sh
+++ b/test/systemd-user-consumer/run.sh
@@ -88,6 +88,29 @@ script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 container="powercontext-systemd-user-${RANDOM}${RANDOM}"
 image="powercontext-systemd-user-consumer:local"
 systemd_version=unknown
+recorded_stage=not_started
+stage_exit_code=0
+stage_stdout_bytes=0
+stage_stdout_sha256="$(printf '' | sha256sum | awk '{ print substr($1, 1, 16) }')"
+stage_output="$workspace/.stage-output"
+
+record_stage() {
+  local name="$1"
+  shift
+  local exit_code
+  : > "$stage_output"
+  if "$@" > "$stage_output" 2>/dev/null; then
+    exit_code=0
+  else
+    exit_code=$?
+  fi
+  recorded_stage="$name"
+  stage_exit_code="$exit_code"
+  stage_stdout_bytes="$(wc -c < "$stage_output" | tr -d '[:space:]')"
+  stage_stdout_sha256="$(sha256sum "$stage_output" | awk '{ print substr($1, 1, 16) }')"
+  rm -f -- "$stage_output"
+  return "$exit_code"
+}
 
 write_summary() {
   local result="$1"
@@ -106,20 +129,20 @@ write_summary() {
   local archive_sha
   archive_sha="$(sha256sum "$archive" | awk '{ print $1 }')"
   cat > "$diagnostics/summary.json" <<EOF
-{"archive_name":"$archive_name","archive_sha256":"$archive_sha","manager_ready":$manager_ready,"systemd_version":"$systemd_version","test_exit_code":$result}
+{"archive_name":"$archive_name","archive_sha256":"$archive_sha","manager_ready":$manager_ready,"stage":"$recorded_stage","stage_exit_code":$stage_exit_code,"stage_stdout_bytes":$stage_stdout_bytes,"stage_stdout_sha256":"$stage_stdout_sha256","systemd_version":"$systemd_version","test_exit_code":$result}
 EOF
 }
 
 result=0
-if ! docker build --quiet --file "$script_dir/Dockerfile" --tag "$image" "$script_dir" >/dev/null; then
+if ! record_stage image_build docker build --quiet --file "$script_dir/Dockerfile" --tag "$image" "$script_dir"; then
   result=1
-elif ! docker run --detach --privileged --tmpfs /run --tmpfs /run/lock \
-  --name "$container" --volume "$workspace:/work" "$image" >/dev/null; then
+elif ! record_stage container_start docker run --detach --privileged --tmpfs /run --tmpfs /run/lock \
+  --name "$container" --volume "$workspace:/work" "$image"; then
   result=1
 else
-  if ! docker exec "$container" install -d --owner=powercontext --group=powercontext --mode=0700 /run/user/1001; then
+  if ! record_stage user_runtime_directory docker exec "$container" install -d --owner=powercontext --group=powercontext --mode=0700 /run/user/1001; then
     result=1
-  elif ! docker exec "$container" systemctl start user@1001.service >/dev/null 2>&1; then
+  elif ! record_stage user_manager_start docker exec "$container" systemctl start user@1001.service; then
     result=1
   else
     systemd_version="$(docker exec "$container" systemd --version 2>/dev/null | awk 'NR == 1 { print $2 }')"
@@ -131,16 +154,20 @@ else
       PATH=/usr/sbin:/usr/bin:/sbin:/bin
       LC_ALL=C
     )
-    if ! docker exec --user powercontext "$container" env -i "${environment[@]}" systemctl --user show-environment >/dev/null 2>&1; then
+    if ! record_stage manager_environment docker exec --user powercontext "$container" env -i "${environment[@]}" systemctl --user show-environment; then
       result=1
-    elif ! docker exec --user powercontext "$container" env -i "${environment[@]}" \
-      busctl --user --json=short call org.freedesktop.systemd1 /org/freedesktop/systemd1 org.freedesktop.DBus.Peer Ping >/dev/null 2>&1; then
+    elif ! record_stage user_dbus_socket_start docker exec --user powercontext "$container" env -i "${environment[@]}" systemctl --user start dbus.socket; then
       result=1
-    elif ! docker exec "$container" test ! -e /home/powercontext/.config/systemd/user/powercontext.service; then
+    elif ! record_stage user_dbus_socket docker exec --user powercontext "$container" env -i "${environment[@]}" test -S /run/user/1001/bus; then
+      result=1
+    elif ! record_stage user_bus_ping docker exec --user powercontext "$container" env -i "${environment[@]}" \
+      busctl --user --json=short call org.freedesktop.systemd1 /org/freedesktop/systemd1 org.freedesktop.DBus.Peer Ping; then
+      result=1
+    elif ! record_stage unowned_unit_path docker exec "$container" test ! -e /home/powercontext/.config/systemd/user/powercontext.service; then
       result=1
     else
       touch "$workspace/manager-ready"
-      if ! docker exec --user powercontext "$container" env -i "${environment[@]}" \
+      if ! record_stage archive_consumer docker exec --user powercontext "$container" env -i "${environment[@]}" \
         POWERCONTEXT_PERSONAL_SERVICE_ARCHIVE=/work/"$(basename "$archive")" \
         timeout 90 /work/"$(basename "$test_binary")" -test.v -test.run '^TestReleaseArchiveProvidesConsumablePersonalService$'; then
         result=1

--- a/test/systemd-user-consumer/run.sh
+++ b/test/systemd-user-consumer/run.sh
@@ -101,6 +101,10 @@ unit_properties_stage=not_run
 unit_properties_exit_code=0
 unit_properties_stdout_bytes=0
 unit_properties_stdout_sha256="$stage_stdout_sha256"
+service_properties_stage=not_run
+service_properties_exit_code=0
+service_properties_stdout_bytes=0
+service_properties_stdout_sha256="$stage_stdout_sha256"
 
 record_stage() {
   local name="$1"
@@ -139,6 +143,12 @@ record_diagnostic_stage() {
       unit_properties_stdout_bytes="$stage_stdout_bytes"
       unit_properties_stdout_sha256="$stage_stdout_sha256"
       ;;
+    service_properties)
+      service_properties_stage="$recorded_stage"
+      service_properties_exit_code="$stage_exit_code"
+      service_properties_stdout_bytes="$stage_stdout_bytes"
+      service_properties_stdout_sha256="$stage_stdout_sha256"
+      ;;
   esac
 }
 
@@ -159,7 +169,7 @@ write_summary() {
   local archive_sha
   archive_sha="$(sha256sum "$archive" | awk '{ print $1 }')"
   cat > "$diagnostics/summary.json" <<EOF
-{"archive_name":"$archive_name","archive_sha256":"$archive_sha","manager_ready":$manager_ready,"stage":"$recorded_stage","stage_exit_code":$stage_exit_code,"stage_stdout_bytes":$stage_stdout_bytes,"stage_stdout_sha256":"$stage_stdout_sha256","load_unit":{"stage":"$load_unit_stage","exit_code":$load_unit_exit_code,"stdout_bytes":$load_unit_stdout_bytes,"stdout_sha256":"$load_unit_stdout_sha256"},"unit_properties":{"stage":"$unit_properties_stage","exit_code":$unit_properties_exit_code,"stdout_bytes":$unit_properties_stdout_bytes,"stdout_sha256":"$unit_properties_stdout_sha256"},"systemd_version":"$systemd_version","test_exit_code":$result}
+{"archive_name":"$archive_name","archive_sha256":"$archive_sha","manager_ready":$manager_ready,"stage":"$recorded_stage","stage_exit_code":$stage_exit_code,"stage_stdout_bytes":$stage_stdout_bytes,"stage_stdout_sha256":"$stage_stdout_sha256","load_unit":{"stage":"$load_unit_stage","exit_code":$load_unit_exit_code,"stdout_bytes":$load_unit_stdout_bytes,"stdout_sha256":"$load_unit_stdout_sha256"},"unit_properties":{"stage":"$unit_properties_stage","exit_code":$unit_properties_exit_code,"stdout_bytes":$unit_properties_stdout_bytes,"stdout_sha256":"$unit_properties_stdout_sha256"},"service_properties":{"stage":"$service_properties_stage","exit_code":$service_properties_exit_code,"stdout_bytes":$service_properties_stdout_bytes,"stdout_sha256":"$service_properties_stdout_sha256"},"systemd_version":"$systemd_version","test_exit_code":$result}
 EOF
 }
 
@@ -205,6 +215,8 @@ else
           busctl --user --json=short call org.freedesktop.systemd1 /org/freedesktop/systemd1 org.freedesktop.systemd1.Manager LoadUnit s powercontext.service
         record_diagnostic_stage unit_properties docker exec --user powercontext "$container" env -i "${environment[@]}" \
           busctl --user --json=short call org.freedesktop.systemd1 /org/freedesktop/systemd1/unit/powercontext_2eservice org.freedesktop.DBus.Properties GetAll s org.freedesktop.systemd1.Unit
+        record_diagnostic_stage service_properties docker exec --user powercontext "$container" env -i "${environment[@]}" \
+          busctl --user --json=short call org.freedesktop.systemd1 /org/freedesktop/systemd1/unit/powercontext_2eservice org.freedesktop.DBus.Properties GetAll s org.freedesktop.systemd1.Service
       fi
     fi
   fi

--- a/test/systemd-user-consumer/run.sh
+++ b/test/systemd-user-consumer/run.sh
@@ -93,6 +93,14 @@ stage_exit_code=0
 stage_stdout_bytes=0
 stage_stdout_sha256="$(printf '' | sha256sum | awk '{ print substr($1, 1, 16) }')"
 stage_output="$workspace/.stage-output"
+load_unit_stage=not_run
+load_unit_exit_code=0
+load_unit_stdout_bytes=0
+load_unit_stdout_sha256="$stage_stdout_sha256"
+unit_properties_stage=not_run
+unit_properties_exit_code=0
+unit_properties_stdout_bytes=0
+unit_properties_stdout_sha256="$stage_stdout_sha256"
 
 record_stage() {
   local name="$1"
@@ -112,6 +120,28 @@ record_stage() {
   return "$exit_code"
 }
 
+record_diagnostic_stage() {
+  local name="$1"
+  shift
+  if record_stage "$name" "$@"; then
+    :
+  fi
+  case "$name" in
+    load_unit)
+      load_unit_stage="$recorded_stage"
+      load_unit_exit_code="$stage_exit_code"
+      load_unit_stdout_bytes="$stage_stdout_bytes"
+      load_unit_stdout_sha256="$stage_stdout_sha256"
+      ;;
+    unit_properties)
+      unit_properties_stage="$recorded_stage"
+      unit_properties_exit_code="$stage_exit_code"
+      unit_properties_stdout_bytes="$stage_stdout_bytes"
+      unit_properties_stdout_sha256="$stage_stdout_sha256"
+      ;;
+  esac
+}
+
 write_summary() {
   local result="$1"
   local manager_ready=false
@@ -129,7 +159,7 @@ write_summary() {
   local archive_sha
   archive_sha="$(sha256sum "$archive" | awk '{ print $1 }')"
   cat > "$diagnostics/summary.json" <<EOF
-{"archive_name":"$archive_name","archive_sha256":"$archive_sha","manager_ready":$manager_ready,"stage":"$recorded_stage","stage_exit_code":$stage_exit_code,"stage_stdout_bytes":$stage_stdout_bytes,"stage_stdout_sha256":"$stage_stdout_sha256","systemd_version":"$systemd_version","test_exit_code":$result}
+{"archive_name":"$archive_name","archive_sha256":"$archive_sha","manager_ready":$manager_ready,"stage":"$recorded_stage","stage_exit_code":$stage_exit_code,"stage_stdout_bytes":$stage_stdout_bytes,"stage_stdout_sha256":"$stage_stdout_sha256","load_unit":{"stage":"$load_unit_stage","exit_code":$load_unit_exit_code,"stdout_bytes":$load_unit_stdout_bytes,"stdout_sha256":"$load_unit_stdout_sha256"},"unit_properties":{"stage":"$unit_properties_stage","exit_code":$unit_properties_exit_code,"stdout_bytes":$unit_properties_stdout_bytes,"stdout_sha256":"$unit_properties_stdout_sha256"},"systemd_version":"$systemd_version","test_exit_code":$result}
 EOF
 }
 
@@ -171,6 +201,10 @@ else
         POWERCONTEXT_PERSONAL_SERVICE_ARCHIVE=/work/"$(basename "$archive")" \
         timeout 90 /work/"$(basename "$test_binary")" -test.v -test.run '^TestReleaseArchiveProvidesConsumablePersonalService$'; then
         result=1
+        record_diagnostic_stage load_unit docker exec --user powercontext "$container" env -i "${environment[@]}" \
+          busctl --user --json=short call org.freedesktop.systemd1 /org/freedesktop/systemd1 org.freedesktop.systemd1.Manager LoadUnit s powercontext.service
+        record_diagnostic_stage unit_properties docker exec --user powercontext "$container" env -i "${environment[@]}" \
+          busctl --user --json=short call org.freedesktop.systemd1 /org/freedesktop/systemd1/unit/powercontext_2eservice org.freedesktop.DBus.Properties GetAll s org.freedesktop.systemd1.Unit
       fi
     fi
   fi

--- a/test/systemd-user-consumer/run.sh
+++ b/test/systemd-user-consumer/run.sh
@@ -105,6 +105,11 @@ service_properties_stage=not_run
 service_properties_exit_code=0
 service_properties_stdout_bytes=0
 service_properties_stdout_sha256="$stage_stdout_sha256"
+load_state_stage=not_run
+load_state_exit_code=0
+load_state_stdout_bytes=0
+load_state_stdout_sha256="$stage_stdout_sha256"
+load_state_value=not_run
 
 record_stage() {
   local name="$1"
@@ -152,6 +157,35 @@ record_diagnostic_stage() {
   esac
 }
 
+record_load_state() {
+  local name="$1"
+  shift
+  local exit_code
+  : > "$stage_output"
+  if "$@" > "$stage_output" 2>/dev/null; then
+    exit_code=0
+  else
+    exit_code=$?
+  fi
+  recorded_stage="$name"
+  stage_exit_code="$exit_code"
+  stage_stdout_bytes="$(wc -c < "$stage_output" | tr -d '[:space:]')"
+  stage_stdout_sha256="$(sha256sum "$stage_output" | awk '{ print substr($1, 1, 16) }')"
+  load_state_stage="$recorded_stage"
+  load_state_exit_code="$stage_exit_code"
+  load_state_stdout_bytes="$stage_stdout_bytes"
+  load_state_stdout_sha256="$stage_stdout_sha256"
+  if [ "$exit_code" -eq 0 ]; then
+    case "$(tr -d '\r\n' < "$stage_output")" in
+      not-found) load_state_value=not_found ;;
+      loaded) load_state_value=loaded ;;
+      '') load_state_value=empty ;;
+      *) load_state_value=other ;;
+    esac
+  fi
+  rm -f -- "$stage_output"
+}
+
 write_summary() {
   local result="$1"
   local manager_ready=false
@@ -169,7 +203,7 @@ write_summary() {
   local archive_sha
   archive_sha="$(sha256sum "$archive" | awk '{ print $1 }')"
   cat > "$diagnostics/summary.json" <<EOF
-{"archive_name":"$archive_name","archive_sha256":"$archive_sha","manager_ready":$manager_ready,"stage":"$recorded_stage","stage_exit_code":$stage_exit_code,"stage_stdout_bytes":$stage_stdout_bytes,"stage_stdout_sha256":"$stage_stdout_sha256","load_unit":{"stage":"$load_unit_stage","exit_code":$load_unit_exit_code,"stdout_bytes":$load_unit_stdout_bytes,"stdout_sha256":"$load_unit_stdout_sha256"},"unit_properties":{"stage":"$unit_properties_stage","exit_code":$unit_properties_exit_code,"stdout_bytes":$unit_properties_stdout_bytes,"stdout_sha256":"$unit_properties_stdout_sha256"},"service_properties":{"stage":"$service_properties_stage","exit_code":$service_properties_exit_code,"stdout_bytes":$service_properties_stdout_bytes,"stdout_sha256":"$service_properties_stdout_sha256"},"systemd_version":"$systemd_version","test_exit_code":$result}
+{"archive_name":"$archive_name","archive_sha256":"$archive_sha","manager_ready":$manager_ready,"stage":"$recorded_stage","stage_exit_code":$stage_exit_code,"stage_stdout_bytes":$stage_stdout_bytes,"stage_stdout_sha256":"$stage_stdout_sha256","load_unit":{"stage":"$load_unit_stage","exit_code":$load_unit_exit_code,"stdout_bytes":$load_unit_stdout_bytes,"stdout_sha256":"$load_unit_stdout_sha256"},"unit_properties":{"stage":"$unit_properties_stage","exit_code":$unit_properties_exit_code,"stdout_bytes":$unit_properties_stdout_bytes,"stdout_sha256":"$unit_properties_stdout_sha256"},"service_properties":{"stage":"$service_properties_stage","exit_code":$service_properties_exit_code,"stdout_bytes":$service_properties_stdout_bytes,"stdout_sha256":"$service_properties_stdout_sha256"},"load_state":{"stage":"$load_state_stage","exit_code":$load_state_exit_code,"stdout_bytes":$load_state_stdout_bytes,"stdout_sha256":"$load_state_stdout_sha256","value":"$load_state_value"},"systemd_version":"$systemd_version","test_exit_code":$result}
 EOF
 }
 
@@ -217,6 +251,8 @@ else
           busctl --user --json=short call org.freedesktop.systemd1 /org/freedesktop/systemd1/unit/powercontext_2eservice org.freedesktop.DBus.Properties GetAll s org.freedesktop.systemd1.Unit
         record_diagnostic_stage service_properties docker exec --user powercontext "$container" env -i "${environment[@]}" \
           busctl --user --json=short call org.freedesktop.systemd1 /org/freedesktop/systemd1/unit/powercontext_2eservice org.freedesktop.DBus.Properties GetAll s org.freedesktop.systemd1.Service
+        record_load_state load_state docker exec --user powercontext "$container" env -i "${environment[@]}" \
+          systemctl --user show --property=LoadState --value powercontext.service
       fi
     fi
   fi

--- a/test/systemd-user-consumer/run.sh
+++ b/test/systemd-user-consumer/run.sh
@@ -133,6 +133,8 @@ else
     )
     if ! docker exec --user powercontext "$container" env -i "${environment[@]}" systemctl --user show-environment >/dev/null 2>&1; then
       result=1
+    elif ! docker exec "$container" test ! -e /home/powercontext/.config/systemd/user/powercontext.service; then
+      result=1
     else
       touch "$workspace/manager-ready"
       if ! docker exec --user powercontext "$container" env -i "${environment[@]}" \

--- a/test/systemd-user-consumer/run.sh
+++ b/test/systemd-user-consumer/run.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2026 OceanBase.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Run the archive consumer under a disposable, non-root systemd --user manager.
+set -euo pipefail
+
+usage() {
+  echo "usage: run.sh --archive ABSOLUTE_PATH --test-binary ABSOLUTE_PATH" >&2
+  exit 2
+}
+
+archive=""
+test_binary=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --archive)
+      [ "$#" -ge 2 ] || usage
+      archive="$2"
+      shift 2
+      ;;
+    --test-binary)
+      [ "$#" -ge 2 ] || usage
+      test_binary="$2"
+      shift 2
+      ;;
+    *)
+      usage
+      ;;
+  esac
+done
+
+if [ "$(id -u)" -eq 0 ]; then
+  echo "systemd user consumer must not run as root" >&2
+  exit 2
+fi
+
+require_absolute_regular_file() {
+  local value="$1"
+  case "$value" in
+    /*) ;;
+    *) echo "systemd user consumer input must be absolute" >&2; exit 2 ;;
+  esac
+  if [ -L "$value" ] || ! [ -f "$value" ]; then
+    echo "systemd user consumer input must be a regular file" >&2
+    exit 2
+  fi
+}
+
+require_absolute_regular_file "$archive"
+require_absolute_regular_file "$test_binary"
+archive="$(realpath -- "$archive")"
+test_binary="$(realpath -- "$test_binary")"
+
+runner_temp="${RUNNER_TEMP:-}"
+case "$runner_temp" in
+  /*) ;;
+  *) echo "RUNNER_TEMP must be an absolute directory" >&2; exit 2 ;;
+esac
+if ! [ -d "$runner_temp" ]; then
+  echo "RUNNER_TEMP must name an existing directory" >&2
+  exit 2
+fi
+runner_temp="$(realpath -- "$runner_temp")"
+
+workspace="$(mktemp -d "$runner_temp/powercontext-systemd-user.XXXXXX")"
+diagnostics="$(mktemp -d "$runner_temp/powercontext-systemd-user-consumer.XXXXXX")"
+chmod 0700 "$workspace" "$diagnostics"
+home="$workspace/home"
+runtime="$workspace/runtime"
+temporary="$workspace/tmp"
+mkdir -m 0700 "$home" "$runtime" "$temporary"
+
+write_summary() {
+  local result="$1"
+  local manager_ready=false
+  if [ -f "$workspace/manager-ready" ]; then
+    manager_ready=true
+  fi
+  local systemd_version=unknown
+  if command -v systemd >/dev/null 2>&1; then
+    systemd_version="$(systemd --version 2>/dev/null | awk 'NR == 1 { print $2 }')"
+  fi
+  case "$systemd_version" in
+    ''|*[!0-9.]* ) systemd_version=unknown ;;
+  esac
+  local archive_name
+  archive_name="$(basename "$archive")"
+  case "$archive_name" in
+    ''|*[!A-Za-z0-9._-]* ) archive_name=invalid ;;
+  esac
+  local archive_sha
+  archive_sha="$(sha256sum "$archive" | awk '{ print $1 }')"
+  cat > "$diagnostics/summary.json" <<EOF
+{"archive_name":"$archive_name","archive_sha256":"$archive_sha","manager_ready":$manager_ready,"systemd_version":"$systemd_version","test_exit_code":$result}
+EOF
+}
+
+session="$workspace/session.sh"
+cat > "$session" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+manager_pid=""
+cleanup() {
+  local result=$?
+  if [ -n "$manager_pid" ]; then
+    systemctl --user exit >/dev/null 2>&1 || true
+    wait "$manager_pid" >/dev/null 2>&1 || true
+  fi
+  exit "$result"
+}
+trap cleanup EXIT INT TERM
+
+systemd --user >/dev/null 2>&1 &
+manager_pid=$!
+deadline=$((SECONDS + 30))
+until systemctl --user show-environment >/dev/null 2>&1 && \
+  busctl --user call org.freedesktop.systemd1 /org/freedesktop/systemd1 org.freedesktop.DBus.Peer Ping >/dev/null 2>&1; do
+  if [ "$SECONDS" -ge "$deadline" ]; then
+    exit 1
+  fi
+  sleep 1
+done
+touch "$POWERCONTEXT_SYSTEMD_MANAGER_READY"
+timeout 90 "$POWERCONTEXT_SYSTEMD_TEST_BINARY" -test.v -test.run '^TestReleaseArchiveProvidesConsumablePersonalService$'
+EOF
+chmod 0700 "$session"
+
+result=0
+if ! env -i \
+  HOME="$home" \
+  TMPDIR="$temporary" \
+  XDG_RUNTIME_DIR="$runtime" \
+  PATH=/usr/sbin:/usr/bin:/sbin:/bin \
+  LC_ALL=C \
+  POWERCONTEXT_PERSONAL_SERVICE_ARCHIVE="$archive" \
+  POWERCONTEXT_SYSTEMD_MANAGER_READY="$workspace/manager-ready" \
+  POWERCONTEXT_SYSTEMD_TEST_BINARY="$test_binary" \
+  dbus-run-session -- "$session"; then
+  result=1
+fi
+write_summary "$result"
+
+case "$workspace" in
+  "$runner_temp"/*) rm -rf -- "$workspace" ;;
+  *) echo "refusing unexpected temporary cleanup target" >&2; exit 2 ;;
+esac
+exit "$result"

--- a/tools/release/archive_personal_service_consumer_test.go
+++ b/tools/release/archive_personal_service_consumer_test.go
@@ -1,0 +1,145 @@
+//go:build linux && systemd_user_consumer
+
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	json "encoding/json/v2"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+const personalServiceConsumerArchive = "POWERCONTEXT_PERSONAL_SERVICE_ARCHIVE"
+
+// TestReleaseArchiveProvidesConsumablePersonalService must run only in a
+// disposable Linux systemd --user manager. It deliberately fails when that
+// manager or the archive input is absent: neither condition is evidence that
+// a release binary can own a native personal service lifecycle.
+func TestReleaseArchiveProvidesConsumablePersonalService(t *testing.T) {
+	archive := strings.TrimSpace(os.Getenv(personalServiceConsumerArchive))
+	if archive == "" {
+		t.Fatalf("%s is required", personalServiceConsumerArchive)
+	}
+	releaseRoot := unpackReleaseArchive(t, archive)
+	binary := filepath.Join(releaseRoot, "bin", "powercontext")
+	info, err := os.Stat(binary)
+	if err != nil || !info.Mode().IsRegular() || info.Mode()&0o111 == 0 {
+		t.Fatalf("release archive has no executable bin/powercontext")
+	}
+
+	before := readReleasePersonalServiceStatus(t, binary)
+	if before.Support != "supported" {
+		t.Fatal("a usable systemd --user manager is required")
+	}
+	if before.Registration != "not_installed" {
+		t.Fatal("disposable user manager already has a personal service registration")
+	}
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal("reserve loopback port")
+	}
+	port := listener.Addr().(*net.TCPAddr).Port
+	if err := listener.Close(); err != nil {
+		t.Fatal("release loopback port")
+	}
+
+	environment := filepath.Join(t.TempDir(), "server.env")
+	if err := os.WriteFile(environment, []byte("POWERCONTEXT_SERVER_HTTP_PORT="+strconv.Itoa(port)+"\n"), 0o600); err != nil {
+		t.Fatal("write private environment file")
+	}
+	dataDir := filepath.Join(t.TempDir(), "data")
+	if _, err := runReleasePersonalService(t, binary, "server", "install", "--env-file", environment, "--data-dir", dataDir); err != nil {
+		// A post-commit liveness observation can race the new Type=exec process.
+		// The persisted registration is checked below through the same archive binary.
+	}
+	t.Cleanup(func() {
+		_, _ = runReleasePersonalService(t, binary, "server", "uninstall")
+	})
+
+	endpoint := "http://127.0.0.1:" + strconv.Itoa(port)
+	awaitReleasePersonalService(t, endpoint)
+	installed := readReleasePersonalServiceStatus(t, binary)
+	if installed.Registration != "installed" || installed.Definition != "current" || installed.ManagerOwnership != "owned" ||
+		installed.Manager != "active" || installed.Liveness != "live" || installed.Recovery != "" {
+		t.Fatalf("release personal service status = %#v", installed)
+	}
+
+	if _, err := runReleasePersonalService(t, binary, "server", "uninstall"); err != nil {
+		t.Fatal("uninstall release personal service")
+	}
+	after := readReleasePersonalServiceStatus(t, binary)
+	if after.Registration != "not_installed" {
+		t.Fatalf("uninstall status = %#v", after)
+	}
+}
+
+type releasePersonalServiceStatus struct {
+	Support          string `json:"support"`
+	Registration     string `json:"registration"`
+	Definition       string `json:"definition"`
+	ManagerOwnership string `json:"manager_ownership"`
+	Manager          string `json:"manager"`
+	Liveness         string `json:"liveness"`
+	Recovery         string `json:"recovery"`
+}
+
+func readReleasePersonalServiceStatus(t *testing.T, binary string) releasePersonalServiceStatus {
+	t.Helper()
+	output, err := runReleasePersonalService(t, binary, "server", "status", "--json")
+	if err != nil {
+		t.Fatal("inspect release personal service")
+	}
+	var status releasePersonalServiceStatus
+	if err := json.Unmarshal(output, &status); err != nil {
+		t.Fatal("decode release personal service status")
+	}
+	return status
+}
+
+func runReleasePersonalService(t *testing.T, binary string, arguments ...string) ([]byte, error) {
+	t.Helper()
+	command := exec.CommandContext(t.Context(), binary, arguments...)
+	command.Env = os.Environ()
+	return command.CombinedOutput()
+}
+
+func awaitReleasePersonalService(t *testing.T, endpoint string) {
+	t.Helper()
+	client := &http.Client{
+		Timeout:   2 * time.Second,
+		Transport: &http.Transport{Proxy: nil},
+	}
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		response, err := client.Get(endpoint + "/health/live")
+		if err == nil {
+			_ = response.Body.Close()
+			if response.StatusCode == http.StatusOK {
+				return
+			}
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatal("release personal service did not become live")
+}

--- a/tools/release/archive_personal_service_consumer_test.go
+++ b/tools/release/archive_personal_service_consumer_test.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	json "encoding/json/v2"
+	"errors"
 	"net"
 	"net/http"
 	"os"
@@ -117,7 +118,7 @@ func readReleasePersonalServiceStatus(t *testing.T, binary string) releasePerson
 	t.Helper()
 	output, err := runReleasePersonalService(t, binary, "server", "status", "--json")
 	if err != nil {
-		t.Fatalf("inspect release personal service: %s", releasePersonalServiceFailureClass(output))
+		t.Fatalf("inspect release personal service: %s", releasePersonalServiceFailureClass(output, err))
 	}
 	var status releasePersonalServiceStatus
 	if err := json.Unmarshal(output, &status); err != nil {
@@ -126,19 +127,28 @@ func readReleasePersonalServiceStatus(t *testing.T, binary string) releasePerson
 	return status
 }
 
-func releasePersonalServiceFailureClass(output []byte) string {
+func releasePersonalServiceFailureClass(output []byte, commandErr error) string {
 	value := string(output)
 	switch {
+	case strings.Contains(value, "personal Server service registration failed"):
+		return "registration"
 	case strings.Contains(value, "systemd user service unit inspect failed"):
 		return "unit_inspect"
+	case strings.Contains(value, "systemd user service inspect manager failed"):
+		return "manager_inspect"
 	case strings.Contains(value, "systemd user service manager command failed"):
 		return "manager_command"
+	case strings.Contains(value, "systemd user service support failed"):
+		return "support"
 	case strings.Contains(value, "personal Server service configuration failed"):
 		return "configuration"
 	case strings.Contains(value, "personal Server service lifecycle is not available"):
 		return "unsupported"
 	}
-	return "redacted"
+	if exitError, found := errors.AsType[*exec.ExitError](commandErr); found {
+		return "redacted_exit_" + strconv.Itoa(exitError.ExitCode()) + "_bytes_" + strconv.Itoa(len(output))
+	}
+	return "redacted_non_exit_bytes_" + strconv.Itoa(len(output))
 }
 
 func runReleasePersonalService(t *testing.T, binary string, arguments ...string) ([]byte, error) {

--- a/tools/release/archive_personal_service_consumer_test.go
+++ b/tools/release/archive_personal_service_consumer_test.go
@@ -17,6 +17,8 @@
 package main
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	json "encoding/json/v2"
 	"errors"
 	"net"
@@ -146,9 +148,14 @@ func releasePersonalServiceFailureClass(output []byte, commandErr error) string 
 		return "unsupported"
 	}
 	if exitError, found := errors.AsType[*exec.ExitError](commandErr); found {
-		return "redacted_exit_" + strconv.Itoa(exitError.ExitCode()) + "_bytes_" + strconv.Itoa(len(output))
+		return "redacted_exit_" + strconv.Itoa(exitError.ExitCode()) + "_bytes_" + strconv.Itoa(len(output)) + "_sha256_" + releasePersonalServiceFailureDigest(output)
 	}
-	return "redacted_non_exit_bytes_" + strconv.Itoa(len(output))
+	return "redacted_non_exit_bytes_" + strconv.Itoa(len(output)) + "_sha256_" + releasePersonalServiceFailureDigest(output)
+}
+
+func releasePersonalServiceFailureDigest(output []byte) string {
+	digest := sha256.Sum256(output)
+	return hex.EncodeToString(digest[:8])
 }
 
 func runReleasePersonalService(t *testing.T, binary string, arguments ...string) ([]byte, error) {

--- a/tools/release/archive_personal_service_consumer_test.go
+++ b/tools/release/archive_personal_service_consumer_test.go
@@ -117,13 +117,28 @@ func readReleasePersonalServiceStatus(t *testing.T, binary string) releasePerson
 	t.Helper()
 	output, err := runReleasePersonalService(t, binary, "server", "status", "--json")
 	if err != nil {
-		t.Fatal("inspect release personal service")
+		t.Fatalf("inspect release personal service: %s", releasePersonalServiceFailureClass(output))
 	}
 	var status releasePersonalServiceStatus
 	if err := json.Unmarshal(output, &status); err != nil {
 		t.Fatal("decode release personal service status")
 	}
 	return status
+}
+
+func releasePersonalServiceFailureClass(output []byte) string {
+	value := string(output)
+	switch {
+	case strings.Contains(value, "systemd user service unit inspect failed"):
+		return "unit_inspect"
+	case strings.Contains(value, "systemd user service manager command failed"):
+		return "manager_command"
+	case strings.Contains(value, "personal Server service configuration failed"):
+		return "configuration"
+	case strings.Contains(value, "personal Server service lifecycle is not available"):
+		return "unsupported"
+	}
+	return "redacted"
 }
 
 func runReleasePersonalService(t *testing.T, binary string, arguments ...string) ([]byte, error) {

--- a/tools/release/archive_personal_service_consumer_test.go
+++ b/tools/release/archive_personal_service_consumer_test.go
@@ -49,6 +49,10 @@ func TestReleaseArchiveProvidesConsumablePersonalService(t *testing.T) {
 	if err != nil || !info.Mode().IsRegular() || info.Mode()&0o111 == 0 {
 		t.Fatalf("release archive has no executable bin/powercontext")
 	}
+	before := readReleasePersonalServiceStatus(t, binary)
+	if before.Support != "supported" || before.Registration != "not_installed" {
+		t.Fatalf("initial release personal service status = %#v", before)
+	}
 
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
@@ -129,6 +133,8 @@ func releasePersonalServiceFailureClass(output []byte, commandErr error) string 
 	case strings.Contains(value, "systemd user service unit inspect failed"):
 		return "unit_inspect"
 	case strings.Contains(value, "systemd user service inspect manager failed"):
+		return "manager_inspect"
+	case strings.Contains(value, "personal service operation failed during inspect_manager"):
 		return "manager_inspect"
 	case strings.Contains(value, "systemd user service manager command failed"):
 		return "manager_command"

--- a/tools/release/archive_personal_service_consumer_test.go
+++ b/tools/release/archive_personal_service_consumer_test.go
@@ -70,8 +70,13 @@ func TestReleaseArchiveProvidesConsumablePersonalService(t *testing.T) {
 	}
 	dataDir := filepath.Join(t.TempDir(), "data")
 	if _, err := runReleasePersonalService(t, binary, "server", "install", "--env-file", environment, "--data-dir", dataDir); err != nil {
-		// A post-commit liveness observation can race the new Type=exec process.
-		// The persisted registration is checked below through the same archive binary.
+		// Type=exec may report the post-commit liveness observation before the
+		// new process is ready. Do not hide an install failure unless the same
+		// archive already observes the only durable state that permits a retry.
+		postCommit := readReleasePersonalServiceStatus(t, binary)
+		if postCommit.Registration != "installed" || postCommit.Definition != "current" || postCommit.ManagerOwnership != "owned" {
+			t.Fatal("release personal service install did not establish an owned current registration")
+		}
 	}
 	t.Cleanup(func() {
 		_, _ = runReleasePersonalService(t, binary, "server", "uninstall")
@@ -79,6 +84,10 @@ func TestReleaseArchiveProvidesConsumablePersonalService(t *testing.T) {
 
 	endpoint := "http://127.0.0.1:" + strconv.Itoa(port)
 	awaitReleasePersonalService(t, endpoint)
+	data, err := os.Stat(filepath.Join(dataDir, "powercontext.db"))
+	if err != nil || !data.Mode().IsRegular() {
+		t.Fatal("release personal service did not create a SQLite database file")
+	}
 	installed := readReleasePersonalServiceStatus(t, binary)
 	if installed.Registration != "installed" || installed.Definition != "current" || installed.ManagerOwnership != "owned" ||
 		installed.Manager != "active" || installed.Liveness != "live" || installed.Recovery != "" {
@@ -132,14 +141,26 @@ func awaitReleasePersonalService(t *testing.T, endpoint string) {
 	}
 	deadline := time.Now().Add(30 * time.Second)
 	for time.Now().Before(deadline) {
-		response, err := client.Get(endpoint + "/health/live")
-		if err == nil {
-			_ = response.Body.Close()
-			if response.StatusCode == http.StatusOK {
-				return
+		ready := true
+		for _, path := range []string{"/health/live", "/health/ready"} {
+			request, err := http.NewRequestWithContext(t.Context(), http.MethodGet, endpoint+path, nil)
+			if err != nil {
+				t.Fatal("construct release health request")
 			}
+			response, requestErr := client.Do(request)
+			if requestErr != nil {
+				ready = false
+				continue
+			}
+			_ = response.Body.Close()
+			if response.StatusCode != http.StatusOK {
+				ready = false
+			}
+		}
+		if ready {
+			return
 		}
 		time.Sleep(100 * time.Millisecond)
 	}
-	t.Fatal("release personal service did not become live")
+	t.Fatal("release personal service did not become live and ready")
 }

--- a/tools/release/archive_personal_service_consumer_test.go
+++ b/tools/release/archive_personal_service_consumer_test.go
@@ -50,14 +50,6 @@ func TestReleaseArchiveProvidesConsumablePersonalService(t *testing.T) {
 		t.Fatalf("release archive has no executable bin/powercontext")
 	}
 
-	before := readReleasePersonalServiceStatus(t, binary)
-	if before.Support != "supported" {
-		t.Fatal("a usable systemd --user manager is required")
-	}
-	if before.Registration != "not_installed" {
-		t.Fatal("disposable user manager already has a personal service registration")
-	}
-
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatal("reserve loopback port")

--- a/tools/release/workflow_test.go
+++ b/tools/release/workflow_test.go
@@ -2165,7 +2165,11 @@ func TestLinuxPersonalServiceConsumerWorkflowContract(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := validateLinuxPersonalServiceConsumerWorkflow(master, release, verification, runner); err != nil {
+	image, err := os.ReadFile(filepath.Join(repository, "test", "systemd-user-consumer", "Dockerfile"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := validateLinuxPersonalServiceConsumerWorkflow(master, release, verification, runner, image); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -2189,6 +2193,10 @@ func TestLinuxPersonalServiceConsumerWorkflowRejectsMutants(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	image, err := os.ReadFile(filepath.Join(repository, "test", "systemd-user-consumer", "Dockerfile"))
+	if err != nil {
+		t.Fatal(err)
+	}
 	for _, mutant := range []struct {
 		name    string
 		payload []byte
@@ -2202,6 +2210,7 @@ func TestLinuxPersonalServiceConsumerWorkflowRejectsMutants(t *testing.T) {
 		{name: "verify provenance order", payload: verification, old: "Verify signed GitHub Release provenance", replace: "Verify signed GitHub Release provenance removed", which: "verification"},
 		{name: "runner isolation", payload: runner, old: "env -i", replace: "env", which: "runner"},
 		{name: "runner manager", payload: runner, old: "systemd --user", replace: "systemd --system", which: "runner"},
+		{name: "runner container privilege", payload: runner, old: "--privileged", replace: "--read-only", which: "runner"},
 	} {
 		t.Run(mutant.name, func(t *testing.T) {
 			changed := strings.Replace(string(mutant.payload), mutant.old, mutant.replace, 1)
@@ -2221,14 +2230,14 @@ func TestLinuxPersonalServiceConsumerWorkflowRejectsMutants(t *testing.T) {
 			default:
 				t.Fatal("unknown consumer workflow mutant")
 			}
-			if err := validateLinuxPersonalServiceConsumerWorkflow(changedMaster, changedRelease, changedVerification, changedRunner); err == nil {
+			if err := validateLinuxPersonalServiceConsumerWorkflow(changedMaster, changedRelease, changedVerification, changedRunner, image); err == nil {
 				t.Fatal("consumer workflow accepted a weakened mutation")
 			}
 		})
 	}
 }
 
-func validateLinuxPersonalServiceConsumerWorkflow(masterPayload, releasePayload, verificationPayload, runnerPayload []byte) error {
+func validateLinuxPersonalServiceConsumerWorkflow(masterPayload, releasePayload, verificationPayload, runnerPayload, imagePayload []byte) error {
 	var master, release, verification releaseIntegrationWorkflow
 	for _, workflow := range []struct {
 		name        string
@@ -2307,14 +2316,24 @@ func validateLinuxPersonalServiceConsumerWorkflow(masterPayload, releasePayload,
 	for _, required := range []string{
 		"env -i", "dbus-run-session", "systemd --user", "systemctl --user exit", "busctl --user", "timeout 90",
 		"POWERCONTEXT_PERSONAL_SERVICE_ARCHIVE", "POWERCONTEXT_SYSTEMD_TEST_BINARY", "mktemp -d", "chmod 0700",
+		"docker run --detach --privileged", "--tmpfs /run", "--tmpfs /run/lock", "--volume \"$workspace:/work\"",
 	} {
 		if !strings.Contains(runner, required) {
 			return fmt.Errorf("systemd user consumer runner is missing %q", required)
 		}
 	}
-	for _, forbidden := range []string{"sudo", "linger", "--system", "--global", "--privileged", "journalctl"} {
+	for _, forbidden := range []string{"sudo", "linger", "--system", "--global", "journalctl"} {
 		if strings.Contains(runner, forbidden) {
 			return fmt.Errorf("systemd user consumer runner contains forbidden %q", forbidden)
+		}
+	}
+	image := string(imagePayload)
+	for _, required := range []string{
+		"FROM ubuntu@sha256:33ceb71981b602c1a7443a53469e4dba065f7503eab3078a2d7a57a2ab987517",
+		"dbus-user-session", "systemd-sysv", "useradd --create-home --shell /bin/bash --uid 1001 powercontext", "CMD [\"/sbin/init\"]",
+	} {
+		if !strings.Contains(image, required) {
+			return fmt.Errorf("systemd user consumer image is missing %q", required)
 		}
 	}
 	return nil
@@ -2465,6 +2484,10 @@ func TestLicenseHeadersHaveOneLocalRepairAndCIContract(t *testing.T) {
 			"header check",
 			"license-fix:",
 			"header fix",
+		},
+		filepath.Join("test", "systemd-user-consumer", "Dockerfile"): {
+			"Copyright (c) 2026 OceanBase.",
+			"FROM ubuntu@sha256:33ceb71981b602c1a7443a53469e4dba065f7503eab3078a2d7a57a2ab987517",
 		},
 		filepath.Join(".github", "workflows", "license-check.yml"): {
 			"pull_request:",

--- a/tools/release/workflow_test.go
+++ b/tools/release/workflow_test.go
@@ -2210,6 +2210,7 @@ func TestLinuxPersonalServiceConsumerWorkflowRejectsMutants(t *testing.T) {
 		{name: "verify provenance order", payload: verification, old: "Verify signed GitHub Release provenance", replace: "Verify signed GitHub Release provenance removed", which: "verification"},
 		{name: "runner isolation", payload: runner, old: "env -i", replace: "env", which: "runner"},
 		{name: "runner manager", payload: runner, old: "systemctl start user@1001.service", replace: "systemctl start user@9999.service", which: "runner"},
+		{name: "runner user-bus ping", payload: runner, old: "busctl --user --json=short call", replace: "busctl --private", which: "runner"},
 		{name: "runner container privilege", payload: runner, old: "--privileged", replace: "--read-only", which: "runner"},
 	} {
 		t.Run(mutant.name, func(t *testing.T) {
@@ -2315,6 +2316,7 @@ func validateLinuxPersonalServiceConsumerWorkflow(masterPayload, releasePayload,
 	runner := string(runnerPayload)
 	for _, required := range []string{
 		"env -i", "systemctl start user@1001.service", "systemctl --user show-environment", "DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1001/bus",
+		"busctl --user --json=short call org.freedesktop.systemd1 /org/freedesktop/systemd1 org.freedesktop.DBus.Peer Ping",
 		"POWERCONTEXT_PERSONAL_SERVICE_ARCHIVE", "mktemp -d", "chmod 0700",
 		"docker run --detach --privileged", "--tmpfs /run", "--tmpfs /run/lock", "--volume \"$workspace:/work\"",
 	} {

--- a/tools/release/workflow_test.go
+++ b/tools/release/workflow_test.go
@@ -2219,6 +2219,7 @@ func TestLinuxPersonalServiceConsumerWorkflowRejectsMutants(t *testing.T) {
 		{name: "runner service-properties diagnosis", payload: runner, old: "record_diagnostic_stage service_properties", replace: "record_diagnostic_stage unrelated_properties", which: "runner"},
 		{name: "runner load-state diagnosis", payload: runner, old: "record_load_state load_state", replace: "record_load_state unrelated_state", which: "runner"},
 		{name: "runner full-show diagnosis", payload: runner, old: "record_show_state show_state", replace: "record_show_state unrelated_show", which: "runner"},
+		{name: "runner consumer diagnostic", payload: runner, old: "archive_consumer_stdout_sha256", replace: "archive_consumer_output_digest", which: "runner"},
 		{name: "runner failure diagnosis recorder", payload: runner, old: "record_diagnostic_stage", replace: "record_external_stage", which: "runner"},
 		{name: "runner container privilege", payload: runner, old: "--privileged", replace: "--read-only", which: "runner"},
 	} {
@@ -2338,6 +2339,7 @@ func validateLinuxPersonalServiceConsumerWorkflow(masterPayload, releasePayload,
 		"load_state_exit_code", "load_state_stdout_bytes", "load_state_stdout_sha256", "load_state_value",
 		"record_show_state show_state", "systemctl --user show --property=LoadState --property=FragmentPath --property=DropInPaths --property=Environment --property=ExecStart powercontext.service",
 		"show_state_exit_code", "show_state_stdout_bytes", "show_state_stdout_sha256", "show_state_value",
+		"archive_consumer_exit_code", "archive_consumer_stdout_bytes", "archive_consumer_stdout_sha256",
 		"POWERCONTEXT_PERSONAL_SERVICE_ARCHIVE", "mktemp -d", "chmod 0700",
 		"docker run --detach --privileged", "--tmpfs /run", "--tmpfs /run/lock", "--volume \"$workspace:/work\"",
 	} {

--- a/tools/release/workflow_test.go
+++ b/tools/release/workflow_test.go
@@ -2216,6 +2216,7 @@ func TestLinuxPersonalServiceConsumerWorkflowRejectsMutants(t *testing.T) {
 		{name: "runner stage diagnostics", payload: runner, old: "record_stage", replace: "record_phase", which: "runner"},
 		{name: "runner load-unit diagnosis", payload: runner, old: "org.freedesktop.systemd1.Manager LoadUnit s powercontext.service", replace: "org.freedesktop.systemd1.Manager LoadUnit s foreign.service", which: "runner"},
 		{name: "runner unit-properties diagnosis", payload: runner, old: "org.freedesktop.DBus.Properties GetAll s org.freedesktop.systemd1.Unit", replace: "org.freedesktop.DBus.Properties GetAll s org.freedesktop.systemd1.Service", which: "runner"},
+		{name: "runner service-properties diagnosis", payload: runner, old: "record_diagnostic_stage service_properties", replace: "record_diagnostic_stage unrelated_properties", which: "runner"},
 		{name: "runner failure diagnosis recorder", payload: runner, old: "record_diagnostic_stage", replace: "record_external_stage", which: "runner"},
 		{name: "runner container privilege", payload: runner, old: "--privileged", replace: "--read-only", which: "runner"},
 	} {
@@ -2329,6 +2330,8 @@ func validateLinuxPersonalServiceConsumerWorkflow(masterPayload, releasePayload,
 		"org.freedesktop.DBus.Properties GetAll s org.freedesktop.systemd1.Unit",
 		"load_unit_exit_code", "load_unit_stdout_bytes", "load_unit_stdout_sha256",
 		"unit_properties_exit_code", "unit_properties_stdout_bytes", "unit_properties_stdout_sha256",
+		"record_diagnostic_stage service_properties", "org.freedesktop.DBus.Properties GetAll s org.freedesktop.systemd1.Service",
+		"service_properties_exit_code", "service_properties_stdout_bytes", "service_properties_stdout_sha256",
 		"POWERCONTEXT_PERSONAL_SERVICE_ARCHIVE", "mktemp -d", "chmod 0700",
 		"docker run --detach --privileged", "--tmpfs /run", "--tmpfs /run/lock", "--volume \"$workspace:/work\"",
 	} {

--- a/tools/release/workflow_test.go
+++ b/tools/release/workflow_test.go
@@ -2218,6 +2218,7 @@ func TestLinuxPersonalServiceConsumerWorkflowRejectsMutants(t *testing.T) {
 		{name: "runner unit-properties diagnosis", payload: runner, old: "org.freedesktop.DBus.Properties GetAll s org.freedesktop.systemd1.Unit", replace: "org.freedesktop.DBus.Properties GetAll s org.freedesktop.systemd1.Service", which: "runner"},
 		{name: "runner service-properties diagnosis", payload: runner, old: "record_diagnostic_stage service_properties", replace: "record_diagnostic_stage unrelated_properties", which: "runner"},
 		{name: "runner load-state diagnosis", payload: runner, old: "record_load_state load_state", replace: "record_load_state unrelated_state", which: "runner"},
+		{name: "runner full-show diagnosis", payload: runner, old: "record_show_state show_state", replace: "record_show_state unrelated_show", which: "runner"},
 		{name: "runner failure diagnosis recorder", payload: runner, old: "record_diagnostic_stage", replace: "record_external_stage", which: "runner"},
 		{name: "runner container privilege", payload: runner, old: "--privileged", replace: "--read-only", which: "runner"},
 	} {
@@ -2335,6 +2336,8 @@ func validateLinuxPersonalServiceConsumerWorkflow(masterPayload, releasePayload,
 		"service_properties_exit_code", "service_properties_stdout_bytes", "service_properties_stdout_sha256",
 		"record_load_state load_state", "systemctl --user show --property=LoadState --value powercontext.service",
 		"load_state_exit_code", "load_state_stdout_bytes", "load_state_stdout_sha256", "load_state_value",
+		"record_show_state show_state", "systemctl --user show --property=LoadState --property=FragmentPath --property=DropInPaths --property=Environment --property=ExecStart powercontext.service",
+		"show_state_exit_code", "show_state_stdout_bytes", "show_state_stdout_sha256", "show_state_value",
 		"POWERCONTEXT_PERSONAL_SERVICE_ARCHIVE", "mktemp -d", "chmod 0700",
 		"docker run --detach --privileged", "--tmpfs /run", "--tmpfs /run/lock", "--volume \"$workspace:/work\"",
 	} {

--- a/tools/release/workflow_test.go
+++ b/tools/release/workflow_test.go
@@ -2209,11 +2209,11 @@ func TestLinuxPersonalServiceConsumerWorkflowRejectsMutants(t *testing.T) {
 		{name: "release consumer platform", payload: release, old: "matrix.target == 'linux-amd64'", replace: "matrix.target == 'linux-arm64'", which: "release"},
 		{name: "verify provenance order", payload: verification, old: "Verify signed GitHub Release provenance", replace: "Verify signed GitHub Release provenance removed", which: "verification"},
 		{name: "runner isolation", payload: runner, old: "env -i", replace: "env", which: "runner"},
-		{name: "runner manager", payload: runner, old: "systemd --user", replace: "systemd --system", which: "runner"},
+		{name: "runner manager", payload: runner, old: "systemctl start user@1001.service", replace: "systemctl start user@9999.service", which: "runner"},
 		{name: "runner container privilege", payload: runner, old: "--privileged", replace: "--read-only", which: "runner"},
 	} {
 		t.Run(mutant.name, func(t *testing.T) {
-			changed := strings.Replace(string(mutant.payload), mutant.old, mutant.replace, 1)
+			changed := strings.ReplaceAll(string(mutant.payload), mutant.old, mutant.replace)
 			if changed == string(mutant.payload) {
 				t.Fatal("mutant did not change the contract")
 			}
@@ -2314,8 +2314,8 @@ func validateLinuxPersonalServiceConsumerWorkflow(masterPayload, releasePayload,
 
 	runner := string(runnerPayload)
 	for _, required := range []string{
-		"env -i", "dbus-run-session", "systemd --user", "systemctl --user exit", "busctl --user", "timeout 90",
-		"POWERCONTEXT_PERSONAL_SERVICE_ARCHIVE", "POWERCONTEXT_SYSTEMD_TEST_BINARY", "mktemp -d", "chmod 0700",
+		"env -i", "systemctl start user@1001.service", "systemctl --user show-environment", "DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1001/bus",
+		"POWERCONTEXT_PERSONAL_SERVICE_ARCHIVE", "mktemp -d", "chmod 0700",
 		"docker run --detach --privileged", "--tmpfs /run", "--tmpfs /run/lock", "--volume \"$workspace:/work\"",
 	} {
 		if !strings.Contains(runner, required) {

--- a/tools/release/workflow_test.go
+++ b/tools/release/workflow_test.go
@@ -2146,6 +2146,198 @@ func TestReleaseWorkflowsExcludeUnsupportedConsumers(t *testing.T) {
 	}
 }
 
+func TestLinuxPersonalServiceConsumerWorkflowContract(t *testing.T) {
+	repository := filepath.Clean(filepath.Join("..", ".."))
+	workflows := filepath.Join(repository, ".github", "workflows")
+	master, err := os.ReadFile(filepath.Join(workflows, "master.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	release, err := os.ReadFile(filepath.Join(workflows, "release.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	verification, err := os.ReadFile(filepath.Join(workflows, "release-verify.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	runner, err := os.ReadFile(filepath.Join(repository, "test", "systemd-user-consumer", "run.sh"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := validateLinuxPersonalServiceConsumerWorkflow(master, release, verification, runner); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestLinuxPersonalServiceConsumerWorkflowRejectsMutants(t *testing.T) {
+	repository := filepath.Clean(filepath.Join("..", ".."))
+	workflows := filepath.Join(repository, ".github", "workflows")
+	master, err := os.ReadFile(filepath.Join(workflows, "master.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	release, err := os.ReadFile(filepath.Join(workflows, "release.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	verification, err := os.ReadFile(filepath.Join(workflows, "release-verify.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	runner, err := os.ReadFile(filepath.Join(repository, "test", "systemd-user-consumer", "run.sh"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, mutant := range []struct {
+		name    string
+		payload []byte
+		old     string
+		replace string
+		which   string
+	}{
+		{name: "master consumer tag", payload: master, old: "-tags systemd_user_consumer", replace: "-tags archive_consumer", which: "master"},
+		{name: "master archive build", payload: master, old: "make package-standard", replace: "make package-full", which: "master"},
+		{name: "release consumer platform", payload: release, old: "matrix.target == 'linux-amd64'", replace: "matrix.target == 'linux-arm64'", which: "release"},
+		{name: "verify provenance order", payload: verification, old: "Verify signed GitHub Release provenance", replace: "Verify signed GitHub Release provenance removed", which: "verification"},
+		{name: "runner isolation", payload: runner, old: "env -i", replace: "env", which: "runner"},
+		{name: "runner manager", payload: runner, old: "systemd --user", replace: "systemd --system", which: "runner"},
+	} {
+		t.Run(mutant.name, func(t *testing.T) {
+			changed := strings.Replace(string(mutant.payload), mutant.old, mutant.replace, 1)
+			if changed == string(mutant.payload) {
+				t.Fatal("mutant did not change the contract")
+			}
+			changedMaster, changedRelease, changedVerification, changedRunner := master, release, verification, runner
+			switch mutant.which {
+			case "master":
+				changedMaster = []byte(changed)
+			case "release":
+				changedRelease = []byte(changed)
+			case "verification":
+				changedVerification = []byte(changed)
+			case "runner":
+				changedRunner = []byte(changed)
+			default:
+				t.Fatal("unknown consumer workflow mutant")
+			}
+			if err := validateLinuxPersonalServiceConsumerWorkflow(changedMaster, changedRelease, changedVerification, changedRunner); err == nil {
+				t.Fatal("consumer workflow accepted a weakened mutation")
+			}
+		})
+	}
+}
+
+func validateLinuxPersonalServiceConsumerWorkflow(masterPayload, releasePayload, verificationPayload, runnerPayload []byte) error {
+	var master, release, verification releaseIntegrationWorkflow
+	for _, workflow := range []struct {
+		name        string
+		payload     []byte
+		destination *releaseIntegrationWorkflow
+	}{
+		{name: "master.yml", payload: masterPayload, destination: &master},
+		{name: "release.yml", payload: releasePayload, destination: &release},
+		{name: "release-verify.yml", payload: verificationPayload, destination: &verification},
+	} {
+		if err := yaml.Unmarshal(workflow.payload, workflow.destination); err != nil {
+			return fmt.Errorf("%s: %w", workflow.name, err)
+		}
+	}
+	consumer, ok := master.Jobs["linux-personal-service-consumer"]
+	if !ok {
+		return errors.New("master.yml has no Linux personal-service consumer job")
+	}
+	if consumer.RunsOn != "ubuntu-24.04" || consumer.TimeoutMinutes != 45 {
+		return fmt.Errorf("master consumer runner = (%q, %d)", consumer.RunsOn, consumer.TimeoutMinutes)
+	}
+	if err := requireWorkflowPermissions("master consumer", consumer.Permissions, map[string]string{"contents": "read"}); err != nil {
+		return err
+	}
+	if continueOnErrorEnabled(consumer.ContinueOnError) {
+		return errors.New("master consumer job tolerates failure")
+	}
+	masterArchiveIndex, archiveStep := findReleaseIntegrationWorkflowStep(consumer.Steps, "Build Standard Linux archive for personal-service consumer")
+	consumerBuildIndex, _ := findReleaseIntegrationWorkflowStep(consumer.Steps, "Build Linux personal-service consumer")
+	consumerExerciseIndex, _ := findReleaseIntegrationWorkflowStep(consumer.Steps, "Exercise Standard Linux personal-service archive")
+	if archiveStep == nil || !strings.Contains(archiveStep.Run, "make package-standard") ||
+		consumerBuildIndex <= masterArchiveIndex || consumerExerciseIndex <= consumerBuildIndex {
+		return errors.New("master consumer does not build and consume the Standard archive in order")
+	}
+	if err := requirePersonalServiceConsumerBuild(consumer.Steps, ""); err != nil {
+		return fmt.Errorf("master.yml: %w", err)
+	}
+	if err := requirePersonalServiceConsumerStep(consumer.Steps, "", "Exercise Standard Linux personal-service archive"); err != nil {
+		return fmt.Errorf("master.yml: %w", err)
+	}
+
+	binaries, ok := release.Jobs["binaries"]
+	if !ok {
+		return errors.New("release.yml has no binaries job")
+	}
+	packagingIndex, packaging := findReleaseIntegrationWorkflowStep(binaries.Steps, "Build and package both editions")
+	buildIndex, _ := findReleaseIntegrationWorkflowStep(binaries.Steps, "Build Linux personal-service consumer")
+	exerciseIndex, _ := findReleaseIntegrationWorkflowStep(binaries.Steps, "Exercise Standard Linux personal-service archive")
+	if packaging == nil || buildIndex <= packagingIndex || exerciseIndex <= buildIndex {
+		return errors.New("release.yml does not run the consumer after packaging")
+	}
+	if err := requirePersonalServiceConsumerBuild(binaries.Steps, "matrix.target == 'linux-amd64'"); err != nil {
+		return fmt.Errorf("release.yml: %w", err)
+	}
+	if err := requirePersonalServiceConsumerStep(binaries.Steps, "matrix.target == 'linux-amd64'", "Exercise Standard Linux personal-service archive"); err != nil {
+		return fmt.Errorf("release.yml: %w", err)
+	}
+
+	verify, ok := verification.Jobs["verify"]
+	if !ok {
+		return errors.New("release-verify.yml has no verify job")
+	}
+	provenanceIndex, _ := findReleaseIntegrationWorkflowStep(verify.Steps, "Verify signed GitHub Release provenance")
+	archiveIndex, _ := findReleaseIntegrationWorkflowStep(verify.Steps, "Verify extracted Linux release contracts")
+	consumerIndex, consumerStep := findReleaseIntegrationWorkflowStep(verify.Steps, "Exercise published Linux personal-service archive")
+	if provenanceIndex < 0 || archiveIndex <= provenanceIndex || consumerIndex <= archiveIndex || consumerStep == nil {
+		return errors.New("release-verify.yml does not run the consumer after provenance and archive checks")
+	}
+	if !strings.Contains(consumerStep.Run, "systemd-user-consumer/run.sh") ||
+		!strings.Contains(consumerStep.Run, "--archive") || !strings.Contains(consumerStep.Run, "--test-binary") ||
+		!strings.Contains(consumerStep.Run, "-tags systemd_user_consumer") {
+		return fmt.Errorf("release-verify consumer step = %#v", consumerStep)
+	}
+
+	runner := string(runnerPayload)
+	for _, required := range []string{
+		"env -i", "dbus-run-session", "systemd --user", "systemctl --user exit", "busctl --user", "timeout 90",
+		"POWERCONTEXT_PERSONAL_SERVICE_ARCHIVE", "POWERCONTEXT_SYSTEMD_TEST_BINARY", "mktemp -d", "chmod 0700",
+	} {
+		if !strings.Contains(runner, required) {
+			return fmt.Errorf("systemd user consumer runner is missing %q", required)
+		}
+	}
+	for _, forbidden := range []string{"sudo", "linger", "--system", "--global", "--privileged", "journalctl"} {
+		if strings.Contains(runner, forbidden) {
+			return fmt.Errorf("systemd user consumer runner contains forbidden %q", forbidden)
+		}
+	}
+	return nil
+}
+
+func requirePersonalServiceConsumerStep(steps []releaseIntegrationWorkflowStep, condition, name string) error {
+	_, step := findReleaseIntegrationWorkflowStep(steps, name)
+	if step == nil || step.If != condition || !strings.Contains(step.Run, "systemd-user-consumer/run.sh") ||
+		!strings.Contains(step.Run, "--archive") || !strings.Contains(step.Run, "--test-binary") {
+		return fmt.Errorf("missing personal-service consumer step %q", name)
+	}
+	return nil
+}
+
+func requirePersonalServiceConsumerBuild(steps []releaseIntegrationWorkflowStep, condition string) error {
+	_, step := findReleaseIntegrationWorkflowStep(steps, "Build Linux personal-service consumer")
+	if step == nil || step.If != condition || !strings.Contains(step.Run, "go test -c -tags systemd_user_consumer") ||
+		!strings.Contains(step.Run, "powercontext-systemd-user-consumer.test") {
+		return errors.New("missing personal-service consumer build step")
+	}
+	return nil
+}
+
 func validateReleaseIntegrationWorkflows(releasePayload, verificationPayload []byte) error {
 	var releaseWorkflow, verificationWorkflow releaseIntegrationWorkflow
 	if err := yaml.Unmarshal(releasePayload, &releaseWorkflow); err != nil {
@@ -2209,6 +2401,8 @@ type releaseIntegrationWorkflow struct {
 }
 
 type releaseIntegrationWorkflowJob struct {
+	RunsOn          string                           `yaml:"runs-on"`
+	TimeoutMinutes  int                              `yaml:"timeout-minutes"`
 	Permissions     map[string]string                `yaml:"permissions"`
 	ContinueOnError any                              `yaml:"continue-on-error"`
 	Steps           []releaseIntegrationWorkflowStep `yaml:"steps"`

--- a/tools/release/workflow_test.go
+++ b/tools/release/workflow_test.go
@@ -2210,7 +2210,10 @@ func TestLinuxPersonalServiceConsumerWorkflowRejectsMutants(t *testing.T) {
 		{name: "verify provenance order", payload: verification, old: "Verify signed GitHub Release provenance", replace: "Verify signed GitHub Release provenance removed", which: "verification"},
 		{name: "runner isolation", payload: runner, old: "env -i", replace: "env", which: "runner"},
 		{name: "runner manager", payload: runner, old: "systemctl start user@1001.service", replace: "systemctl start user@9999.service", which: "runner"},
+		{name: "runner dbus socket", payload: runner, old: "systemctl --user start dbus.socket", replace: "systemctl --user start user@1001.service", which: "runner"},
+		{name: "runner dbus socket verification", payload: runner, old: "test -S /run/user/1001/bus", replace: "test -e /run/user/1001/bus", which: "runner"},
 		{name: "runner user-bus ping", payload: runner, old: "busctl --user --json=short call", replace: "busctl --private", which: "runner"},
+		{name: "runner stage diagnostics", payload: runner, old: "record_stage", replace: "record_phase", which: "runner"},
 		{name: "runner container privilege", payload: runner, old: "--privileged", replace: "--read-only", which: "runner"},
 	} {
 		t.Run(mutant.name, func(t *testing.T) {
@@ -2316,7 +2319,9 @@ func validateLinuxPersonalServiceConsumerWorkflow(masterPayload, releasePayload,
 	runner := string(runnerPayload)
 	for _, required := range []string{
 		"env -i", "systemctl start user@1001.service", "systemctl --user show-environment", "DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1001/bus",
+		"systemctl --user start dbus.socket", "test -S /run/user/1001/bus",
 		"busctl --user --json=short call org.freedesktop.systemd1 /org/freedesktop/systemd1 org.freedesktop.DBus.Peer Ping",
+		"record_stage", "stage_exit_code", "stage_stdout_bytes", "stage_stdout_sha256",
 		"POWERCONTEXT_PERSONAL_SERVICE_ARCHIVE", "mktemp -d", "chmod 0700",
 		"docker run --detach --privileged", "--tmpfs /run", "--tmpfs /run/lock", "--volume \"$workspace:/work\"",
 	} {

--- a/tools/release/workflow_test.go
+++ b/tools/release/workflow_test.go
@@ -2214,6 +2214,9 @@ func TestLinuxPersonalServiceConsumerWorkflowRejectsMutants(t *testing.T) {
 		{name: "runner dbus socket verification", payload: runner, old: "test -S /run/user/1001/bus", replace: "test -e /run/user/1001/bus", which: "runner"},
 		{name: "runner user-bus ping", payload: runner, old: "busctl --user --json=short call", replace: "busctl --private", which: "runner"},
 		{name: "runner stage diagnostics", payload: runner, old: "record_stage", replace: "record_phase", which: "runner"},
+		{name: "runner load-unit diagnosis", payload: runner, old: "org.freedesktop.systemd1.Manager LoadUnit s powercontext.service", replace: "org.freedesktop.systemd1.Manager LoadUnit s foreign.service", which: "runner"},
+		{name: "runner unit-properties diagnosis", payload: runner, old: "org.freedesktop.DBus.Properties GetAll s org.freedesktop.systemd1.Unit", replace: "org.freedesktop.DBus.Properties GetAll s org.freedesktop.systemd1.Service", which: "runner"},
+		{name: "runner failure diagnosis recorder", payload: runner, old: "record_diagnostic_stage", replace: "record_external_stage", which: "runner"},
 		{name: "runner container privilege", payload: runner, old: "--privileged", replace: "--read-only", which: "runner"},
 	} {
 		t.Run(mutant.name, func(t *testing.T) {
@@ -2322,6 +2325,10 @@ func validateLinuxPersonalServiceConsumerWorkflow(masterPayload, releasePayload,
 		"systemctl --user start dbus.socket", "test -S /run/user/1001/bus",
 		"busctl --user --json=short call org.freedesktop.systemd1 /org/freedesktop/systemd1 org.freedesktop.DBus.Peer Ping",
 		"record_stage", "stage_exit_code", "stage_stdout_bytes", "stage_stdout_sha256",
+		"record_diagnostic_stage", "org.freedesktop.systemd1.Manager LoadUnit s powercontext.service",
+		"org.freedesktop.DBus.Properties GetAll s org.freedesktop.systemd1.Unit",
+		"load_unit_exit_code", "load_unit_stdout_bytes", "load_unit_stdout_sha256",
+		"unit_properties_exit_code", "unit_properties_stdout_bytes", "unit_properties_stdout_sha256",
 		"POWERCONTEXT_PERSONAL_SERVICE_ARCHIVE", "mktemp -d", "chmod 0700",
 		"docker run --detach --privileged", "--tmpfs /run", "--tmpfs /run/lock", "--volume \"$workspace:/work\"",
 	} {

--- a/tools/release/workflow_test.go
+++ b/tools/release/workflow_test.go
@@ -2217,6 +2217,7 @@ func TestLinuxPersonalServiceConsumerWorkflowRejectsMutants(t *testing.T) {
 		{name: "runner load-unit diagnosis", payload: runner, old: "org.freedesktop.systemd1.Manager LoadUnit s powercontext.service", replace: "org.freedesktop.systemd1.Manager LoadUnit s foreign.service", which: "runner"},
 		{name: "runner unit-properties diagnosis", payload: runner, old: "org.freedesktop.DBus.Properties GetAll s org.freedesktop.systemd1.Unit", replace: "org.freedesktop.DBus.Properties GetAll s org.freedesktop.systemd1.Service", which: "runner"},
 		{name: "runner service-properties diagnosis", payload: runner, old: "record_diagnostic_stage service_properties", replace: "record_diagnostic_stage unrelated_properties", which: "runner"},
+		{name: "runner load-state diagnosis", payload: runner, old: "record_load_state load_state", replace: "record_load_state unrelated_state", which: "runner"},
 		{name: "runner failure diagnosis recorder", payload: runner, old: "record_diagnostic_stage", replace: "record_external_stage", which: "runner"},
 		{name: "runner container privilege", payload: runner, old: "--privileged", replace: "--read-only", which: "runner"},
 	} {
@@ -2332,6 +2333,8 @@ func validateLinuxPersonalServiceConsumerWorkflow(masterPayload, releasePayload,
 		"unit_properties_exit_code", "unit_properties_stdout_bytes", "unit_properties_stdout_sha256",
 		"record_diagnostic_stage service_properties", "org.freedesktop.DBus.Properties GetAll s org.freedesktop.systemd1.Service",
 		"service_properties_exit_code", "service_properties_stdout_bytes", "service_properties_stdout_sha256",
+		"record_load_state load_state", "systemctl --user show --property=LoadState --value powercontext.service",
+		"load_state_exit_code", "load_state_stdout_bytes", "load_state_stdout_sha256", "load_state_value",
 		"POWERCONTEXT_PERSONAL_SERVICE_ARCHIVE", "mktemp -d", "chmod 0700",
 		"docker run --detach --privileged", "--tmpfs /run", "--tmpfs /run/lock", "--volume \"$workspace:/work\"",
 	} {


### PR DESCRIPTION
## Scope

Implements the Linux-only personal-server lifecycle boundary and makes its release-consumer proof executable in CI.

- `server install`, `status`, `uninstall`, and hidden `_service-run` use the user-scoped systemd adapter only on Linux; other platforms remain typed unsupported.
- Installation freezes and later revalidates the executable, loopback endpoint, SQLite data root, and private environment-file identity. The launcher clears inherited environment state and forces the SQLite data root before reusing the foreground server runner.
- A disposable non-root `systemd --user` runner consumes the Standard Linux archive under `env -i`, verifies D-Bus manager readiness, then proves archive install/status/uninstall plus proxy-free `/health/live` and `/health/ready` and a regular SQLite data file.
- The PR, release build, and published-release verification workflows compile and run the tagged consumer; workflow contract mutants reject a removed archive build, wrong tag/platform, missing provenance order, lost environment isolation, or system manager substitution.

## Boundaries

SQLite only. No seekDB/OceanBase, no third-party agent surface, no `sudo`/linger/`--system`/`--global` service behavior, and no macOS/Windows native-service claim. A native Linux support claim remains contingent on the exact-Head CI consumer job passing.

## Local Evidence

Focused release workflow contracts and mutants, tagged Linux consumer cross-compilation, explicit actionlint, Bash syntax, license checks, `go vet`, generated checks, focused CLI/personalsvc tests, and incremental lint all passed. The local Windows/WSL environment does not provide an active user manager, so it intentionally does not stand in for the new CI proof.