### PR TITLE
feat(personalsvc): add Windows native task host

### DIFF
--- a/.github/workflows/windows-contract.yml
+++ b/.github/workflows/windows-contract.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Verify API baseline replacement on Windows
         run: go test -count=1 ./tools/api-baseline -run '^TestWriteBaselineReplacesExistingOutput$'
 
+      - name: Verify Windows Task Scheduler executor boundary
+        run: go test -count=1 ./internal/personalsvchost/windows
+
       - name: Verify LF attributes and frozen fixture hashes
         shell: pwsh
         run: |

--- a/internal/personalsvc/adapter.go
+++ b/internal/personalsvc/adapter.go
@@ -138,6 +138,12 @@ type Adapter interface {
 	ManagerState(context.Context) (ManagerState, error)
 }
 
+// snapshotRestorer is an optional exact rollback boundary for adapters whose
+// native manager object and stored artifact can exist independently.
+type snapshotRestorer interface {
+	Restore(context.Context, Artifact, ManagerRegistration) error
+}
+
 // OperationBoundary serializes one complete lifecycle mutation. It is injected
 // so Controller remains pure Go and cannot select a host lock implementation.
 type OperationBoundary interface {

--- a/internal/personalsvc/adapter.go
+++ b/internal/personalsvc/adapter.go
@@ -36,7 +36,10 @@ type Artifact struct {
 	definition      DefinitionState
 	registration    Registration
 	hasRegistration bool
+	restoreSnapshot *restoreSnapshot
 }
+
+type restoreSnapshot struct{ value any }
 
 // InstalledArtifact returns a verified owned artifact with its executable
 // available. Adapters may use InstalledArtifactWithDefinition when they can
@@ -80,12 +83,29 @@ func (a Artifact) DefinitionState() DefinitionState { return a.definition }
 // Registration returns the verified immutable registration when one exists.
 func (a Artifact) Registration() (Registration, bool) { return a.registration, a.hasRegistration }
 
+// WithRestoreSnapshot returns a copy carrying immutable adapter-owned rollback
+// state. The snapshot is not part of status or ownership decisions.
+func (a Artifact) WithRestoreSnapshot(snapshot any) Artifact {
+	a.restoreSnapshot = &restoreSnapshot{value: snapshot}
+	return a
+}
+
+// RestoreSnapshot returns opaque adapter-owned rollback state to the adapter
+// that produced this observation.
+func (a Artifact) RestoreSnapshot() (any, bool) {
+	if a.restoreSnapshot == nil {
+		return nil, false
+	}
+	return a.restoreSnapshot.value, true
+}
+
 // ManagerRegistration is an immutable inspection result for the object loaded
 // by the native manager. It is separate from Artifact by design.
 type ManagerRegistration struct {
 	ownership       ManagerOwnership
 	registration    Registration
 	hasRegistration bool
+	restoreSnapshot *restoreSnapshot
 }
 
 // OwnedManager returns a loaded native object verified as PowerContext-owned.
@@ -118,6 +138,22 @@ func (r ManagerRegistration) Ownership() ManagerOwnership { return r.ownership }
 // Registration returns the verified registration for an owned manager object.
 func (r ManagerRegistration) Registration() (Registration, bool) {
 	return r.registration, r.hasRegistration
+}
+
+// WithRestoreSnapshot returns a copy carrying immutable adapter-owned rollback
+// state independently from the artifact observation.
+func (r ManagerRegistration) WithRestoreSnapshot(snapshot any) ManagerRegistration {
+	r.restoreSnapshot = &restoreSnapshot{value: snapshot}
+	return r
+}
+
+// RestoreSnapshot returns opaque adapter-owned rollback state to the adapter
+// that produced this observation.
+func (r ManagerRegistration) RestoreSnapshot() (any, bool) {
+	if r.restoreSnapshot == nil {
+		return nil, false
+	}
+	return r.restoreSnapshot.value, true
 }
 
 // Adapter isolates every native, filesystem, process, and network operation.

--- a/internal/personalsvc/controller.go
+++ b/internal/personalsvc/controller.go
@@ -17,7 +17,10 @@ package personalsvc
 import (
 	"context"
 	"errors"
+	"time"
 )
+
+const restoreTimeout = 30 * time.Second
 
 // Controller orchestrates one immutable personal-service registration through
 // a supplied native Adapter. It does not read the environment, access storage,
@@ -253,32 +256,50 @@ func (c *Controller) installLocked(ctx context.Context, desired Registration, in
 func (c *Controller) commit(ctx context.Context, desired Registration, previous Artifact) error {
 	if err := c.adapter.Write(ctx, desired); err != nil {
 		c.restore(ctx, previous)
-		return newOperationError(ErrorOperation, StageWrite, statusForSupportedUnknown())
+		return newContextOperationError(ErrorOperation, StageWrite, statusForSupportedUnknown(), ctx)
 	}
 	if err := c.adapter.Reload(ctx); err != nil {
 		c.restore(ctx, previous)
-		return newOperationError(ErrorOperation, StageReload, statusForSupportedUnknown())
+		return newContextOperationError(ErrorOperation, StageReload, statusForSupportedUnknown(), ctx)
 	}
 	if err := c.adapter.Enable(ctx); err != nil {
 		c.restore(ctx, previous)
-		return newOperationError(ErrorOperation, StageEnable, statusForSupportedUnknown())
+		return newContextOperationError(ErrorOperation, StageEnable, statusForSupportedUnknown(), ctx)
 	}
 	return nil
 }
 
 func (c *Controller) restore(ctx context.Context, previous Artifact) {
-	_ = c.adapter.Disable(ctx)
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	restoreCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), restoreTimeout)
+	defer cancel()
+
+	_ = c.adapter.Disable(restoreCtx)
 	if previous.State() == RegistrationInstalled {
 		registration, found := previous.Registration()
 		if found {
-			_ = c.adapter.Write(ctx, registration)
-			_ = c.adapter.Reload(ctx)
-			_ = c.adapter.Enable(ctx)
+			_ = c.adapter.Write(restoreCtx, registration)
+			_ = c.adapter.Reload(restoreCtx)
+			_ = c.adapter.Enable(restoreCtx)
 			return
 		}
 	}
-	_ = c.adapter.Remove(ctx)
-	_ = c.adapter.Reload(ctx)
+	_ = c.adapter.Remove(restoreCtx)
+	_ = c.adapter.Reload(restoreCtx)
+}
+
+func newContextOperationError(
+	kind ErrorKind,
+	stage OperationStage,
+	status Status,
+	ctx context.Context,
+) *OperationError {
+	if ctx == nil {
+		return newOperationError(kind, stage, status)
+	}
+	return newOperationErrorWithCause(kind, stage, status, ctx.Err())
 }
 
 func (c *Controller) uninstallLocked(ctx context.Context) error {

--- a/internal/personalsvc/controller.go
+++ b/internal/personalsvc/controller.go
@@ -261,15 +261,15 @@ func (c *Controller) commit(
 ) error {
 	if err := c.adapter.Write(ctx, desired); err != nil {
 		c.restore(ctx, previousArtifact, previousManager)
-		return newContextOperationError(ErrorOperation, StageWrite, statusForSupportedUnknown(), ctx)
+		return newContextOperationError(ctx, ErrorOperation, StageWrite, statusForSupportedUnknown())
 	}
 	if err := c.adapter.Reload(ctx); err != nil {
 		c.restore(ctx, previousArtifact, previousManager)
-		return newContextOperationError(ErrorOperation, StageReload, statusForSupportedUnknown(), ctx)
+		return newContextOperationError(ctx, ErrorOperation, StageReload, statusForSupportedUnknown())
 	}
 	if err := c.adapter.Enable(ctx); err != nil {
 		c.restore(ctx, previousArtifact, previousManager)
-		return newContextOperationError(ErrorOperation, StageEnable, statusForSupportedUnknown(), ctx)
+		return newContextOperationError(ctx, ErrorOperation, StageEnable, statusForSupportedUnknown())
 	}
 	return nil
 }
@@ -300,10 +300,10 @@ func (c *Controller) restore(ctx context.Context, previousArtifact Artifact, pre
 }
 
 func newContextOperationError(
+	ctx context.Context,
 	kind ErrorKind,
 	stage OperationStage,
 	status Status,
-	ctx context.Context,
 ) *OperationError {
 	if ctx == nil {
 		return newOperationError(kind, stage, status)

--- a/internal/personalsvc/controller.go
+++ b/internal/personalsvc/controller.go
@@ -238,7 +238,7 @@ func (c *Controller) installLocked(ctx context.Context, desired Registration, in
 		changed = stored != desired
 	}
 	if changed {
-		if err := c.commit(ctx, desired, artifact); err != nil {
+		if err := c.commit(ctx, desired, artifact, managerRegistration); err != nil {
 			return false, err
 		}
 	} else if err := c.adapter.Enable(ctx); err != nil {
@@ -253,32 +253,41 @@ func (c *Controller) installLocked(ctx context.Context, desired Registration, in
 	return true, nil
 }
 
-func (c *Controller) commit(ctx context.Context, desired Registration, previous Artifact) error {
+func (c *Controller) commit(
+	ctx context.Context,
+	desired Registration,
+	previousArtifact Artifact,
+	previousManager ManagerRegistration,
+) error {
 	if err := c.adapter.Write(ctx, desired); err != nil {
-		c.restore(ctx, previous)
+		c.restore(ctx, previousArtifact, previousManager)
 		return newContextOperationError(ErrorOperation, StageWrite, statusForSupportedUnknown(), ctx)
 	}
 	if err := c.adapter.Reload(ctx); err != nil {
-		c.restore(ctx, previous)
+		c.restore(ctx, previousArtifact, previousManager)
 		return newContextOperationError(ErrorOperation, StageReload, statusForSupportedUnknown(), ctx)
 	}
 	if err := c.adapter.Enable(ctx); err != nil {
-		c.restore(ctx, previous)
+		c.restore(ctx, previousArtifact, previousManager)
 		return newContextOperationError(ErrorOperation, StageEnable, statusForSupportedUnknown(), ctx)
 	}
 	return nil
 }
 
-func (c *Controller) restore(ctx context.Context, previous Artifact) {
+func (c *Controller) restore(ctx context.Context, previousArtifact Artifact, previousManager ManagerRegistration) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
 	restoreCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), restoreTimeout)
 	defer cancel()
+	if restorer, found := c.adapter.(snapshotRestorer); found {
+		_ = restorer.Restore(restoreCtx, previousArtifact, previousManager)
+		return
+	}
 
 	_ = c.adapter.Disable(restoreCtx)
-	if previous.State() == RegistrationInstalled {
-		registration, found := previous.Registration()
+	if previousArtifact.State() == RegistrationInstalled {
+		registration, found := previousArtifact.Registration()
 		if found {
 			_ = c.adapter.Write(restoreCtx, registration)
 			_ = c.adapter.Reload(restoreCtx)

--- a/internal/personalsvc/status.go
+++ b/internal/personalsvc/status.go
@@ -237,10 +237,15 @@ type OperationError struct {
 	kind   ErrorKind
 	stage  OperationStage
 	status Status
+	cause  error
 }
 
 func newOperationError(kind ErrorKind, stage OperationStage, status Status) *OperationError {
 	return &OperationError{kind: kind, stage: stage, status: status}
+}
+
+func newOperationErrorWithCause(kind ErrorKind, stage OperationStage, status Status, cause error) *OperationError {
+	return &OperationError{kind: kind, stage: stage, status: status, cause: cause}
 }
 
 // Error returns a stable, redacted failure description.
@@ -263,6 +268,15 @@ func (e *OperationError) Error() string {
 	default:
 		return "personal service operation failed during " + string(e.stage)
 	}
+}
+
+// Unwrap retains only a caller-context cancellation classification. Adapter
+// and native errors are never attached to an OperationError.
+func (e *OperationError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.cause
 }
 
 // Kind returns the typed failure class.

--- a/internal/personalsvc/task_scheduler.go
+++ b/internal/personalsvc/task_scheduler.go
@@ -524,20 +524,25 @@ func decodeTaskSchedulerXMLNode(decoder *xml.Decoder, start xml.StartElement) (t
 }
 
 func parseTaskSchedulerRoot(root taskSchedulerXMLNode) (TaskSchedulerSpec, error) {
-	children, valid := taskSchedulerContainer(root, "Task", map[string]string{"xmlns": taskSchedulerNamespace, "version": taskSchedulerVersion},
-		"RegistrationInfo", "Triggers", "Principals", "Settings", "Actions")
+	children, valid := taskSchedulerChildMap(
+		root,
+		"Task",
+		map[string]string{"xmlns": taskSchedulerNamespace, "version": taskSchedulerVersion},
+		[]string{"RegistrationInfo", "Triggers", "Principals", "Settings", "Actions"},
+		[]string{"RegistrationInfo", "Triggers", "Principals", "Settings", "Actions"},
+	)
 	if !valid {
 		return TaskSchedulerSpec{}, taskSchedulerError(TaskSchedulerInvalid)
 	}
-	registration, err := parseTaskSchedulerRegistration(children[0])
+	registration, err := parseTaskSchedulerRegistration(children["RegistrationInfo"])
 	if err != nil {
 		return TaskSchedulerSpec{}, err
 	}
-	startOnLogin, valid := parseTaskSchedulerTriggers(children[1])
-	if !valid || !parseTaskSchedulerPrincipals(children[2]) || !parseTaskSchedulerSettings(children[3]) {
+	startOnLogin, valid := parseTaskSchedulerTriggers(children["Triggers"])
+	if !valid || !parseTaskSchedulerPrincipals(children["Principals"]) || !parseTaskSchedulerSettings(children["Settings"]) {
 		return TaskSchedulerSpec{}, taskSchedulerError(TaskSchedulerInvalid)
 	}
-	arguments, workingDirectory, valid := parseTaskSchedulerActions(children[4], registration)
+	arguments, workingDirectory, valid := parseTaskSchedulerActions(children["Actions"], registration)
 	if !valid {
 		return TaskSchedulerSpec{}, taskSchedulerError(TaskSchedulerInvalid)
 	}
@@ -549,11 +554,17 @@ func parseTaskSchedulerRoot(root taskSchedulerXMLNode) (TaskSchedulerSpec, error
 }
 
 func parseTaskSchedulerRegistration(node taskSchedulerXMLNode) (Registration, error) {
-	children, valid := taskSchedulerContainer(node, "RegistrationInfo", nil, "URI", "Description")
-	if !valid || !taskSchedulerLeaf(children[0], "URI", TaskSchedulerTaskName) {
+	children, valid := taskSchedulerChildMap(
+		node,
+		"RegistrationInfo",
+		nil,
+		[]string{"URI", "Description"},
+		[]string{"URI", "Description"},
+	)
+	if !valid || !taskSchedulerLeaf(children["URI"], "URI", TaskSchedulerTaskName) {
 		return Registration{}, taskSchedulerError(TaskSchedulerInvalid)
 	}
-	description, valid := taskSchedulerLeafText(children[1], "Description")
+	description, valid := taskSchedulerLeafText(children["Description"], "Description")
 	if !valid {
 		return Registration{}, taskSchedulerError(TaskSchedulerInvalid)
 	}
@@ -589,27 +600,78 @@ func parseTaskSchedulerPrincipals(node taskSchedulerXMLNode) bool {
 	if !valid {
 		return false
 	}
-	principal, valid := taskSchedulerContainer(children[0], "Principal", map[string]string{"id": taskSchedulerPrincipalID},
-		"UserId", "LogonType", "RunLevel")
-	return valid &&
-		taskSchedulerLeaf(principal[0], "UserId", TaskSchedulerInteractiveUser) &&
-		taskSchedulerLeaf(principal[1], "LogonType", "InteractiveToken") &&
-		taskSchedulerLeaf(principal[2], "RunLevel", "LeastPrivilege")
+	principal, valid := taskSchedulerChildMap(
+		children[0],
+		"Principal",
+		map[string]string{"id": taskSchedulerPrincipalID},
+		[]string{"UserId", "LogonType", "RunLevel"},
+		[]string{"UserId", "LogonType"},
+	)
+	if !valid ||
+		!taskSchedulerLeaf(principal["UserId"], "UserId", TaskSchedulerInteractiveUser) ||
+		!taskSchedulerLeaf(principal["LogonType"], "LogonType", "InteractiveToken") {
+		return false
+	}
+	runLevel, found := principal["RunLevel"]
+	return !found || taskSchedulerLeaf(runLevel, "RunLevel", "LeastPrivilege")
 }
 
 func parseTaskSchedulerSettings(node taskSchedulerXMLNode) bool {
-	children, valid := taskSchedulerContainer(node, "Settings", nil,
-		"MultipleInstancesPolicy", "DisallowStartIfOnBatteries", "StopIfGoingOnBatteries", "StartWhenAvailable", "RestartOnFailure", "ExecutionTimeLimit")
+	children, valid := taskSchedulerChildMap(
+		node,
+		"Settings",
+		nil,
+		[]string{
+			"MultipleInstancesPolicy", "DisallowStartIfOnBatteries", "StopIfGoingOnBatteries",
+			"StartWhenAvailable", "RestartOnFailure", "ExecutionTimeLimit", "IdleSettings",
+			"UseUnifiedSchedulingEngine", "Enabled",
+		},
+		[]string{
+			"MultipleInstancesPolicy", "DisallowStartIfOnBatteries", "StopIfGoingOnBatteries",
+			"StartWhenAvailable", "RestartOnFailure", "ExecutionTimeLimit",
+		},
+	)
 	if !valid ||
-		!taskSchedulerLeaf(children[0], "MultipleInstancesPolicy", "IgnoreNew") ||
-		!taskSchedulerLeaf(children[1], "DisallowStartIfOnBatteries", "false") ||
-		!taskSchedulerLeaf(children[2], "StopIfGoingOnBatteries", "false") ||
-		!taskSchedulerLeaf(children[3], "StartWhenAvailable", "true") ||
-		!taskSchedulerLeaf(children[5], "ExecutionTimeLimit", "PT0S") {
+		!taskSchedulerLeaf(children["MultipleInstancesPolicy"], "MultipleInstancesPolicy", "IgnoreNew") ||
+		!taskSchedulerLeaf(children["DisallowStartIfOnBatteries"], "DisallowStartIfOnBatteries", "false") ||
+		!taskSchedulerLeaf(children["StopIfGoingOnBatteries"], "StopIfGoingOnBatteries", "false") ||
+		!taskSchedulerLeaf(children["StartWhenAvailable"], "StartWhenAvailable", "true") ||
+		!taskSchedulerLeaf(children["ExecutionTimeLimit"], "ExecutionTimeLimit", "PT0S") {
 		return false
 	}
-	restart, valid := taskSchedulerContainer(children[4], "RestartOnFailure", nil, "Interval", "Count")
-	return valid && taskSchedulerLeaf(restart[0], "Interval", "PT1M") && taskSchedulerLeaf(restart[1], "Count", "3")
+	restart, valid := taskSchedulerChildMap(
+		children["RestartOnFailure"],
+		"RestartOnFailure",
+		nil,
+		[]string{"Interval", "Count"},
+		[]string{"Interval", "Count"},
+	)
+	if !valid || !taskSchedulerLeaf(restart["Interval"], "Interval", "PT1M") ||
+		!taskSchedulerLeaf(restart["Count"], "Count", "3") {
+		return false
+	}
+	if idle, found := children["IdleSettings"]; found {
+		settings, valid := taskSchedulerChildMap(
+			idle,
+			"IdleSettings",
+			nil,
+			[]string{"StopOnIdleEnd", "RestartOnIdle"},
+			[]string{"StopOnIdleEnd", "RestartOnIdle"},
+		)
+		if !valid || !taskSchedulerLeaf(settings["StopOnIdleEnd"], "StopOnIdleEnd", "true") ||
+			!taskSchedulerLeaf(settings["RestartOnIdle"], "RestartOnIdle", "false") {
+			return false
+		}
+	}
+	if unified, found := children["UseUnifiedSchedulingEngine"]; found &&
+		!taskSchedulerLeaf(unified, "UseUnifiedSchedulingEngine", "true") {
+		return false
+	}
+	if enabled, found := children["Enabled"]; found &&
+		!taskSchedulerLeaf(enabled, "Enabled", "true") && !taskSchedulerLeaf(enabled, "Enabled", "false") {
+		return false
+	}
+	return true
 }
 
 func parseTaskSchedulerActions(node taskSchedulerXMLNode, registration Registration) ([]string, string, bool) {
@@ -654,6 +716,42 @@ func taskSchedulerContainer(
 	return node.children, true
 }
 
+func taskSchedulerChildMap(
+	node taskSchedulerXMLNode,
+	name string,
+	attributes map[string]string,
+	allowed []string,
+	required []string,
+) (map[string]taskSchedulerXMLNode, bool) {
+	if node.name.Space != taskSchedulerNamespace || node.name.Local != name ||
+		!taskSchedulerAttributes(node.attrs, attributes) || strings.TrimSpace(node.text) != "" {
+		return nil, false
+	}
+	allowedNames := make(map[string]struct{}, len(allowed))
+	for _, child := range allowed {
+		allowedNames[child] = struct{}{}
+	}
+	children := make(map[string]taskSchedulerXMLNode, len(node.children))
+	for _, child := range node.children {
+		if child.name.Space != taskSchedulerNamespace {
+			return nil, false
+		}
+		if _, found := allowedNames[child.name.Local]; !found {
+			return nil, false
+		}
+		if _, duplicate := children[child.name.Local]; duplicate {
+			return nil, false
+		}
+		children[child.name.Local] = child
+	}
+	for _, child := range required {
+		if _, found := children[child]; !found {
+			return nil, false
+		}
+	}
+	return children, true
+}
+
 func taskSchedulerAttributes(attributes []xml.Attr, expected map[string]string) bool {
 	if len(attributes) != len(expected) {
 		return false
@@ -680,8 +778,9 @@ func taskSchedulerLeafText(node taskSchedulerXMLNode, name string) (string, bool
 }
 
 // TaskSchedulerResult is the process result used by the portable task
-// contract. Output is deliberately never parsed because schtasks.exe emits
-// localized text that is not a stable status API.
+// contract. Output is retained only for command forms whose structured XML or
+// CSV payload is consumed by the Windows host adapter; native diagnostics must
+// not be returned in this field.
 type TaskSchedulerResult struct {
 	ExitCode uint32
 	Output   []byte
@@ -734,17 +833,24 @@ func (s TaskScheduler) Create(ctx context.Context, xmlPath string) error {
 // Query maps only schtasks.exe exit codes. It deliberately ignores output so
 // locale changes cannot alter ownership or lifecycle decisions.
 func (s TaskScheduler) Query(ctx context.Context) (TaskSchedulerState, error) {
+	state, _, err := s.QueryXML(ctx)
+	return state, err
+}
+
+// QueryXML maps the fixed query exit code and returns an independent copy of
+// the task XML for host-owned identity normalization and ownership parsing.
+func (s TaskScheduler) QueryXML(ctx context.Context) (TaskSchedulerState, []byte, error) {
 	result, err := s.executeRaw(ctx, []string{"/Query", "/TN", TaskSchedulerTaskName, "/XML", "/HRESULT"})
 	if err != nil {
-		return TaskSchedulerUnknown, taskSchedulerError(TaskSchedulerExecution)
+		return TaskSchedulerUnknown, nil, taskSchedulerError(TaskSchedulerExecution)
 	}
 	switch result.ExitCode {
 	case 0:
-		return TaskSchedulerPresent, nil
+		return TaskSchedulerPresent, slices.Clone(result.Output), nil
 	case taskSchedulerNotFound:
-		return TaskSchedulerAbsent, nil
+		return TaskSchedulerAbsent, nil, nil
 	default:
-		return TaskSchedulerUnknown, taskSchedulerError(TaskSchedulerExecution)
+		return TaskSchedulerUnknown, nil, taskSchedulerError(TaskSchedulerExecution)
 	}
 }
 
@@ -760,6 +866,36 @@ func (s TaskScheduler) Delete(ctx context.Context) error {
 func (s TaskScheduler) Run(ctx context.Context) error {
 	_, err := s.execute(ctx, []string{"/Run", "/TN", TaskSchedulerTaskName, "/HRESULT"})
 	return err
+}
+
+// End asks the executor to stop only the fixed owned Task Scheduler identity.
+func (s TaskScheduler) End(ctx context.Context) error {
+	_, err := s.execute(ctx, []string{"/End", "/TN", TaskSchedulerTaskName, "/HRESULT"})
+	return err
+}
+
+// Enable asks the executor to enable only the fixed owned Task Scheduler identity.
+func (s TaskScheduler) Enable(ctx context.Context) error {
+	_, err := s.execute(ctx, []string{"/Change", "/TN", TaskSchedulerTaskName, "/ENABLE", "/HRESULT"})
+	return err
+}
+
+// Disable asks the executor to disable only the fixed owned Task Scheduler identity.
+func (s TaskScheduler) Disable(ctx context.Context) error {
+	_, err := s.execute(ctx, []string{"/Change", "/TN", TaskSchedulerTaskName, "/DISABLE", "/HRESULT"})
+	return err
+}
+
+// QueryStatus returns the fixed verbose CSV query for locale-independent
+// numeric Task Scheduler result classification in the Windows host adapter.
+func (s TaskScheduler) QueryStatus(ctx context.Context) ([]byte, error) {
+	result, err := s.execute(ctx, []string{
+		"/Query", "/TN", TaskSchedulerTaskName, "/FO", "CSV", "/NH", "/V", "/HRESULT",
+	})
+	if err != nil {
+		return nil, err
+	}
+	return slices.Clone(result.Output), nil
 }
 
 func (s TaskScheduler) execute(ctx context.Context, arguments []string) (TaskSchedulerResult, error) {

--- a/internal/personalsvc/task_scheduler.go
+++ b/internal/personalsvc/task_scheduler.go
@@ -183,8 +183,10 @@ func (s TaskSchedulerSpec) XML() ([]byte, error) {
 		},
 	}
 	if s.startOnLogin {
-		document.Triggers.LogonTrigger = new(taskSchedulerLogonTrigger)
-		document.Triggers.LogonTrigger.Enabled = "true"
+		document.Triggers.LogonTrigger = &taskSchedulerLogonTrigger{
+			UserID:  TaskSchedulerInteractiveUser,
+			Enabled: "true",
+		}
 	}
 
 	payload, err := xml.MarshalIndent(document, "", "  ")
@@ -393,6 +395,7 @@ type taskSchedulerTriggers struct {
 
 type taskSchedulerLogonTrigger struct {
 	Enabled string `xml:"Enabled"`
+	UserID  string `xml:"UserId"`
 }
 
 type taskSchedulerPrincipals struct {
@@ -590,8 +593,18 @@ func parseTaskSchedulerTriggers(node taskSchedulerXMLNode) (bool, bool) {
 	if len(node.children) != 1 {
 		return false, false
 	}
-	trigger, valid := taskSchedulerContainer(node.children[0], "LogonTrigger", nil, "Enabled")
-	enabled := valid && taskSchedulerLeaf(trigger[0], "Enabled", "true")
+	trigger, valid := taskSchedulerChildMap(
+		node.children[0],
+		"LogonTrigger",
+		nil,
+		[]string{"UserId", "Enabled"},
+		[]string{"UserId"},
+	)
+	if !valid || !taskSchedulerLeaf(trigger["UserId"], "UserId", TaskSchedulerInteractiveUser) {
+		return false, false
+	}
+	enabledNode, found := trigger["Enabled"]
+	enabled := !found || taskSchedulerLeaf(enabledNode, "Enabled", "true")
 	return enabled, enabled
 }
 

--- a/internal/personalsvc/task_scheduler_test.go
+++ b/internal/personalsvc/task_scheduler_test.go
@@ -345,14 +345,14 @@ func TestTaskSchedulerBuildsCompleteAdapterCommandSet(t *testing.T) {
 	if err != nil || state != personalsvc.TaskSchedulerPresent || !bytes.Equal(queried, document) {
 		t.Fatalf("QueryXML() = %s, %x, %v", state, queried, err)
 	}
-	if err := scheduler.End(t.Context()); err != nil {
-		t.Fatal(err)
+	if endErr := scheduler.End(t.Context()); endErr != nil {
+		t.Fatal(endErr)
 	}
-	if err := scheduler.Enable(t.Context()); err != nil {
-		t.Fatal(err)
+	if enableErr := scheduler.Enable(t.Context()); enableErr != nil {
+		t.Fatal(enableErr)
 	}
-	if err := scheduler.Disable(t.Context()); err != nil {
-		t.Fatal(err)
+	if disableErr := scheduler.Disable(t.Context()); disableErr != nil {
+		t.Fatal(disableErr)
 	}
 	status, err := scheduler.QueryStatus(t.Context())
 	if err != nil || !bytes.Equal(status, []byte("status")) {

--- a/internal/personalsvc/task_scheduler_test.go
+++ b/internal/personalsvc/task_scheduler_test.go
@@ -102,9 +102,17 @@ func TestTaskSchedulerSpecControlsLoginTrigger(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			gotTrigger := strings.Contains(decodeUTF16LE(t, document), "<LogonTrigger>")
+			decoded := decodeUTF16LE(t, document)
+			gotTrigger := strings.Contains(decoded, "<LogonTrigger>")
 			if gotTrigger != startOnLogin {
 				t.Fatalf("LogonTrigger present = %t, want %t", gotTrigger, startOnLogin)
+			}
+			wantUserIDs := 1
+			if startOnLogin {
+				wantUserIDs = 2
+			}
+			if got := strings.Count(decoded, "<UserId>"+personalsvc.TaskSchedulerInteractiveUser+"</UserId>"); got != wantUserIDs {
+				t.Fatalf("interactive UserId count = %d, want %d", got, wantUserIDs)
 			}
 			parsed, err := personalsvc.ParseTaskSchedulerXML(document)
 			if err != nil {
@@ -115,6 +123,67 @@ func TestTaskSchedulerSpecControlsLoginTrigger(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestTaskSchedulerParserRejectsUnboundLoginTrigger(t *testing.T) {
+	document, err := taskSchedulerSpec(t, true).XML()
+	if err != nil {
+		t.Fatal(err)
+	}
+	canonical := decodeUTF16LE(t, document)
+	for _, test := range []struct {
+		name   string
+		mutate func(string) string
+	}{
+		{
+			name: "missing user",
+			mutate: func(document string) string {
+				start := strings.Index(document, "<LogonTrigger>")
+				end := strings.Index(document, "</LogonTrigger>")
+				if start < 0 || end < start {
+					return document
+				}
+				trigger := document[start:end]
+				trigger = strings.Replace(trigger, "<UserId>"+personalsvc.TaskSchedulerInteractiveUser+"</UserId>", "", 1)
+				return document[:start] + trigger + document[end:]
+			},
+		},
+		{
+			name: "different user",
+			mutate: func(document string) string {
+				start := strings.Index(document, "<LogonTrigger>")
+				end := strings.Index(document, "</LogonTrigger>")
+				if start < 0 || end < start {
+					return document
+				}
+				trigger := document[start:end]
+				trigger = strings.Replace(trigger, personalsvc.TaskSchedulerInteractiveUser, "S-1-5-21-foreign", 1)
+				return document[:start] + trigger + document[end:]
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			_, parseErr := personalsvc.ParseTaskSchedulerXML(encodeUTF16LE(test.mutate(canonical)))
+			assertTaskSchedulerError(t, parseErr, personalsvc.TaskSchedulerInvalid)
+		})
+	}
+}
+
+func TestTaskSchedulerParserAcceptsOnlyEnabledLoginDefaultOmission(t *testing.T) {
+	spec := taskSchedulerSpec(t, true)
+	document, err := spec.XML()
+	if err != nil {
+		t.Fatal(err)
+	}
+	canonical := decodeUTF16LE(t, document)
+	withoutDefault := strings.Replace(canonical, "      <Enabled>true</Enabled>\n", "", 1)
+	parsed, err := personalsvc.ParseTaskSchedulerXML(encodeUTF16LE(withoutDefault))
+	if err != nil || !parsed.Matches(spec) {
+		t.Fatalf("default-normalized trigger = %#v, %v; want original plan", parsed, err)
+	}
+	withFalse := strings.Replace(canonical, "<Enabled>true</Enabled>", "<Enabled>false</Enabled>", 1)
+	_, err = personalsvc.ParseTaskSchedulerXML(encodeUTF16LE(withFalse))
+	assertTaskSchedulerError(t, err, personalsvc.TaskSchedulerInvalid)
 }
 
 func TestTaskSchedulerParserAcceptsOnlyKnownSchedulerNormalization(t *testing.T) {

--- a/internal/personalsvc/task_scheduler_test.go
+++ b/internal/personalsvc/task_scheduler_test.go
@@ -117,6 +117,45 @@ func TestTaskSchedulerSpecControlsLoginTrigger(t *testing.T) {
 	}
 }
 
+func TestTaskSchedulerParserAcceptsOnlyKnownSchedulerNormalization(t *testing.T) {
+	spec := taskSchedulerSpec(t, false)
+	document, err := spec.XML()
+	if err != nil {
+		t.Fatal(err)
+	}
+	normalized := decodeUTF16LE(t, document)
+	normalized = strings.Replace(normalized, "      <RunLevel>LeastPrivilege</RunLevel>\n", "", 1)
+	normalized = strings.Replace(
+		normalized,
+		"    <ExecutionTimeLimit>PT0S</ExecutionTimeLimit>\n",
+		"    <ExecutionTimeLimit>PT0S</ExecutionTimeLimit>\n"+
+			"    <IdleSettings><StopOnIdleEnd>true</StopOnIdleEnd><RestartOnIdle>false</RestartOnIdle></IdleSettings>\n"+
+			"    <UseUnifiedSchedulingEngine>true</UseUnifiedSchedulingEngine>\n"+
+			"    <Enabled>false</Enabled>\n",
+		1,
+	)
+	parsed, err := personalsvc.ParseTaskSchedulerXML(encodeUTF16LE(normalized))
+	if err != nil || !parsed.Matches(spec) {
+		t.Fatalf("scheduler-normalized task = %#v, %v; want original plan", parsed, err)
+	}
+
+	for _, test := range []struct {
+		name string
+		old  string
+		new  string
+	}{
+		{name: "idle policy", old: "<StopOnIdleEnd>true</StopOnIdleEnd>", new: "<StopOnIdleEnd>false</StopOnIdleEnd>"},
+		{name: "unified engine", old: "<UseUnifiedSchedulingEngine>true</UseUnifiedSchedulingEngine>", new: "<UseUnifiedSchedulingEngine>false</UseUnifiedSchedulingEngine>"},
+		{name: "enabled value", old: "<Enabled>false</Enabled>", new: "<Enabled>maybe</Enabled>"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			mutant := strings.Replace(normalized, test.old, test.new, 1)
+			_, parseErr := personalsvc.ParseTaskSchedulerXML(encodeUTF16LE(mutant))
+			assertTaskSchedulerError(t, parseErr, personalsvc.TaskSchedulerInvalid)
+		})
+	}
+}
+
 func TestTaskSchedulerParserFailsClosedForForeignOrMutatedTask(t *testing.T) {
 	spec := taskSchedulerSpec(t, true)
 	document, err := spec.XML()
@@ -219,6 +258,52 @@ func TestTaskSchedulerUsesFixedSchtasksCommands(t *testing.T) {
 	}
 }
 
+func TestTaskSchedulerBuildsCompleteAdapterCommandSet(t *testing.T) {
+	document := []byte{0xff, 0xfe, '<', 0}
+	executor := &recordingTaskSchedulerExecutor{results: []personalsvc.TaskSchedulerResult{
+		{Output: document},
+		{},
+		{},
+		{},
+		{Output: []byte("status")},
+	}}
+	scheduler, err := personalsvc.NewTaskScheduler(executor)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	state, queried, err := scheduler.QueryXML(t.Context())
+	if err != nil || state != personalsvc.TaskSchedulerPresent || !bytes.Equal(queried, document) {
+		t.Fatalf("QueryXML() = %s, %x, %v", state, queried, err)
+	}
+	if err := scheduler.End(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	if err := scheduler.Enable(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	if err := scheduler.Disable(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	status, err := scheduler.QueryStatus(t.Context())
+	if err != nil || !bytes.Equal(status, []byte("status")) {
+		t.Fatalf("QueryStatus() = %q, %v", status, err)
+	}
+
+	want := []taskSchedulerCall{
+		{program: "schtasks.exe", arguments: []string{"/Query", "/TN", `\PowerContext Personal Server`, "/XML", "/HRESULT"}},
+		{program: "schtasks.exe", arguments: []string{"/End", "/TN", `\PowerContext Personal Server`, "/HRESULT"}},
+		{program: "schtasks.exe", arguments: []string{"/Change", "/TN", `\PowerContext Personal Server`, "/ENABLE", "/HRESULT"}},
+		{program: "schtasks.exe", arguments: []string{"/Change", "/TN", `\PowerContext Personal Server`, "/DISABLE", "/HRESULT"}},
+		{program: "schtasks.exe", arguments: []string{"/Query", "/TN", `\PowerContext Personal Server`, "/FO", "CSV", "/NH", "/V", "/HRESULT"}},
+	}
+	if !slices.EqualFunc(executor.calls, want, func(got, want taskSchedulerCall) bool {
+		return got.program == want.program && slices.Equal(got.arguments, want.arguments)
+	}) {
+		t.Fatalf("schtasks calls = %#v, want %#v", executor.calls, want)
+	}
+}
+
 func TestTaskSchedulerQueryUsesExitCodesNotLocalizedOutput(t *testing.T) {
 	for _, test := range []struct {
 		name      string
@@ -295,6 +380,38 @@ func TestTaskSchedulerZeroValueFailsClosed(t *testing.T) {
 			name: "run",
 			invoke: func(scheduler personalsvc.TaskScheduler) error {
 				return scheduler.Run(t.Context())
+			},
+		},
+		{
+			name: "query XML",
+			invoke: func(scheduler personalsvc.TaskScheduler) error {
+				_, _, err := scheduler.QueryXML(t.Context())
+				return err
+			},
+		},
+		{
+			name: "query status",
+			invoke: func(scheduler personalsvc.TaskScheduler) error {
+				_, err := scheduler.QueryStatus(t.Context())
+				return err
+			},
+		},
+		{
+			name: "end",
+			invoke: func(scheduler personalsvc.TaskScheduler) error {
+				return scheduler.End(t.Context())
+			},
+		},
+		{
+			name: "enable",
+			invoke: func(scheduler personalsvc.TaskScheduler) error {
+				return scheduler.Enable(t.Context())
+			},
+		},
+		{
+			name: "disable",
+			invoke: func(scheduler personalsvc.TaskScheduler) error {
+				return scheduler.Disable(t.Context())
 			},
 		},
 	} {

--- a/internal/personalsvchost/windows/adapter_windows.go
+++ b/internal/personalsvchost/windows/adapter_windows.go
@@ -1,0 +1,607 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package windows
+
+import (
+	"bytes"
+	"context"
+	"encoding/csv"
+	json "encoding/json/v2"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"net/url"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+	"unicode/utf16"
+	"unicode/utf8"
+
+	"github.com/ob-labs/powercontext-go/internal/personalsvc"
+	"github.com/ob-labs/powercontext-go/internal/transportpolicy"
+)
+
+const (
+	testTaskNamePrefix = `\PowerContext\Tests\`
+	maxProbeBytes      = 4 << 10
+)
+
+var requestIDPattern = regexp.MustCompile(`^[0-9a-f]{16}$`)
+
+// Error is a typed, redacted Windows personal-service failure.
+type Error struct {
+	operation string
+	cause     error
+}
+
+func (e *Error) Error() string {
+	return fmt.Sprintf("Windows personal service %s failed", e.operation)
+}
+
+func (e *Error) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.cause
+}
+
+type taskScheduler interface {
+	Query(context.Context) (personalsvc.TaskSchedulerState, []byte, error)
+	Create(context.Context, string) error
+	Run(context.Context) error
+	End(context.Context) error
+	Enable(context.Context) error
+	Disable(context.Context) error
+	Delete(context.Context) error
+	State(context.Context) (personalsvc.ManagerState, error)
+}
+
+type artifactStore interface {
+	Read(context.Context, string) ([]byte, bool, error)
+	Write(context.Context, string, []byte) error
+	Remove(context.Context, string) error
+	RegularFile(context.Context, string) (bool, error)
+}
+
+// Adapter composes the portable Task Scheduler document with Windows-owned
+// process, filesystem, identity, and probe boundaries.
+type Adapter struct {
+	plan         personalsvc.TaskSchedulerSpec
+	artifactPath string
+	taskName     string
+	userSID      string
+	scheduler    taskScheduler
+	artifacts    artifactStore
+	httpClient   *http.Client
+	plansMu      sync.Mutex
+	knownPlans   map[personalsvc.Registration]personalsvc.TaskSchedulerSpec
+}
+
+var _ personalsvc.Adapter = (*Adapter)(nil)
+
+func newAdapter(
+	plan personalsvc.TaskSchedulerSpec,
+	userDataRoot string,
+	taskName string,
+	userSID string,
+	scheduler taskScheduler,
+	artifacts artifactStore,
+	httpClient *http.Client,
+) (*Adapter, error) {
+	if scheduler == nil || artifacts == nil || httpClient == nil ||
+		!validUserDataRoot(userDataRoot) || !validTaskName(taskName) || !validInteractiveSID(userSID) {
+		return nil, newError("configuration", nil)
+	}
+	if _, err := plan.XML(); err != nil {
+		return nil, newError("configuration", nil)
+	}
+	return &Adapter{
+		plan:         plan,
+		artifactPath: filepath.Join(userDataRoot, filepath.FromSlash("PowerContext/Services/personal-server.xml")),
+		taskName:     taskName,
+		userSID:      userSID,
+		scheduler:    scheduler,
+		artifacts:    artifacts,
+		httpClient:   httpClient,
+		knownPlans:   map[personalsvc.Registration]personalsvc.TaskSchedulerSpec{plan.Registration(): plan},
+	}, nil
+}
+
+// Support reports whether the current user's Task Scheduler can resolve the
+// exact configured task identity.
+func (a *Adapter) Support(ctx context.Context) (personalsvc.Support, error) {
+	if err := a.available(ctx); err != nil {
+		return personalsvc.SupportUnsupported, err
+	}
+	_, _, err := a.scheduler.Query(ctx)
+	if err != nil {
+		if ctx.Err() != nil {
+			return personalsvc.SupportUnsupported, newError("support", ctx.Err())
+		}
+		return personalsvc.SupportUnsupported, nil
+	}
+	return personalsvc.SupportSupported, nil
+}
+
+// InspectArtifact verifies the exact stored XML through the portable parser.
+func (a *Adapter) InspectArtifact(ctx context.Context) (personalsvc.Artifact, error) {
+	if err := a.available(ctx); err != nil {
+		return personalsvc.UnknownArtifact(), err
+	}
+	document, exists, err := a.artifacts.Read(ctx, a.artifactPath)
+	if err != nil {
+		return personalsvc.UnknownArtifact(), newError("inspect artifact", contextCause(ctx, err))
+	}
+	if !exists {
+		return personalsvc.NoArtifact(), nil
+	}
+	plan, ok := a.parse(document)
+	if !ok {
+		return personalsvc.InvalidArtifact(), nil
+	}
+	a.remember(plan)
+	registration := plan.Registration()
+	regular, err := a.artifacts.RegularFile(ctx, registration.Definition().Binary())
+	if err != nil {
+		return personalsvc.UnknownArtifact(), newError("inspect artifact", contextCause(ctx, err))
+	}
+	if !regular {
+		return personalsvc.InstalledArtifactWithDefinition(registration, personalsvc.DefinitionMissingExecutable), nil
+	}
+	return personalsvc.InstalledArtifact(registration), nil
+}
+
+// InspectManager verifies independently queried Task Scheduler XML before
+// treating the loaded object as PowerContext-owned.
+func (a *Adapter) InspectManager(ctx context.Context) (personalsvc.ManagerRegistration, error) {
+	if err := a.available(ctx); err != nil {
+		return personalsvc.UnknownManager(), err
+	}
+	state, document, err := a.scheduler.Query(ctx)
+	if err != nil {
+		return personalsvc.UnknownManager(), newError("inspect manager", contextCause(ctx, err))
+	}
+	if state == personalsvc.TaskSchedulerAbsent {
+		return personalsvc.NotLoadedManager(), nil
+	}
+	if state != personalsvc.TaskSchedulerPresent {
+		return personalsvc.UnknownManager(), nil
+	}
+	plan, ok := a.parse(document)
+	if !ok {
+		return personalsvc.ForeignManager(), nil
+	}
+	a.remember(plan)
+	return personalsvc.OwnedManager(plan.Registration()), nil
+}
+
+// Probe accepts only the exact unauthenticated loopback liveness contract.
+func (a *Adapter) Probe(ctx context.Context, endpoint string) (personalsvc.ProbeState, error) {
+	if err := a.available(ctx); err != nil {
+		return personalsvc.ProbeUnreachable, err
+	}
+	parsed, err := url.Parse(endpoint)
+	if err != nil || parsed.Host == "" || parsed.Hostname() == "" ||
+		(parsed.Scheme != "http" && parsed.Scheme != "https") ||
+		parsed.Path != "" || parsed.RawPath != "" || parsed.RawQuery != "" || parsed.Fragment != "" ||
+		parsed.User != nil || !transportpolicy.IsLoopbackHost(parsed.Hostname()) {
+		return personalsvc.ProbeUnreachable, newError("probe", nil)
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint+"/health/live", nil)
+	if err != nil {
+		return personalsvc.ProbeUnreachable, newError("probe", nil)
+	}
+	request.Header.Set("Accept", "application/json")
+	request.Header.Set("User-Agent", "powercontext-personal-service")
+	response, err := a.httpClient.Do(request)
+	if err != nil {
+		if ctx.Err() != nil {
+			return personalsvc.ProbeUnreachable, newError("probe", ctx.Err())
+		}
+		return personalsvc.ProbeUnreachable, nil
+	}
+	defer response.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(response.Body, maxProbeBytes+1))
+	if err != nil {
+		if ctx.Err() != nil {
+			return personalsvc.ProbeUnreachable, newError("probe", ctx.Err())
+		}
+		return personalsvc.ProbeConflict, nil
+	}
+	mediaType, _, mediaErr := mime.ParseMediaType(response.Header.Get("Content-Type"))
+	if len(body) > maxProbeBytes || response.StatusCode != http.StatusOK || mediaErr != nil ||
+		mediaType != "application/json" || !requestIDPattern.MatchString(response.Header.Get("X-PowerContext-Request-ID")) {
+		return personalsvc.ProbeConflict, nil
+	}
+	var health map[string]string
+	if err := json.Unmarshal(body, &health); err != nil || len(health) != 1 || health["status"] != "ok" {
+		return personalsvc.ProbeConflict, nil
+	}
+	return personalsvc.ProbeLive, nil
+}
+
+// Write atomically delegates the exact resolved XML artifact after fresh
+// artifact and manager ownership checks.
+func (a *Adapter) Write(ctx context.Context, registration personalsvc.Registration) error {
+	plan, found := a.knownPlan(registration)
+	if !found {
+		return newError("write", nil)
+	}
+	artifact, manager, err := a.mutableState(ctx)
+	if err != nil {
+		return err
+	}
+	if artifact.State() != personalsvc.RegistrationInstalled && artifact.State() != personalsvc.RegistrationNotInstalled {
+		return newError("write", nil)
+	}
+	if manager.Ownership() != personalsvc.ManagerOwnershipOwned && manager.Ownership() != personalsvc.ManagerOwnershipNotLoaded {
+		return newError("write", nil)
+	}
+	document, err := a.renderPlan(plan)
+	if err != nil {
+		return err
+	}
+	if err := a.artifacts.Write(ctx, a.artifactPath, document); err != nil {
+		return newError("write", contextCause(ctx, err))
+	}
+	return nil
+}
+
+// Reload is a no-op because schtasks /Create consumes the complete artifact.
+func (a *Adapter) Reload(ctx context.Context) error { return a.available(ctx) }
+
+// Enable creates or replaces only an absent or already-owned configured task.
+func (a *Adapter) Enable(ctx context.Context) error {
+	artifact, manager, err := a.mutableState(ctx)
+	if err != nil {
+		return err
+	}
+	if artifact.State() != personalsvc.RegistrationInstalled ||
+		(manager.Ownership() != personalsvc.ManagerOwnershipOwned && manager.Ownership() != personalsvc.ManagerOwnershipNotLoaded) {
+		return newError("enable", nil)
+	}
+	if err := a.scheduler.Create(ctx, a.artifactPath); err != nil {
+		return newError("enable", contextCause(ctx, err))
+	}
+	if err := a.scheduler.Enable(ctx); err != nil {
+		return newError("enable", contextCause(ctx, err))
+	}
+	return nil
+}
+
+// Start runs only a freshly verified owned task.
+func (a *Adapter) Start(ctx context.Context) error {
+	manager, err := a.InspectManager(ctx)
+	if err != nil || manager.Ownership() != personalsvc.ManagerOwnershipOwned {
+		return newError("start", contextCause(ctx, err))
+	}
+	if err := a.scheduler.Run(ctx); err != nil {
+		return newError("start", contextCause(ctx, err))
+	}
+	return nil
+}
+
+// Stop ends only a freshly verified owned task. An absent task is stopped.
+func (a *Adapter) Stop(ctx context.Context) error {
+	manager, err := a.InspectManager(ctx)
+	if err != nil {
+		return err
+	}
+	if manager.Ownership() == personalsvc.ManagerOwnershipNotLoaded {
+		return nil
+	}
+	if manager.Ownership() != personalsvc.ManagerOwnershipOwned {
+		return newError("stop", nil)
+	}
+	state, err := a.scheduler.State(ctx)
+	if err != nil {
+		return newError("stop", contextCause(ctx, err))
+	}
+	if state == personalsvc.ManagerInactive || state == personalsvc.ManagerFailed {
+		return nil
+	}
+	if state != personalsvc.ManagerActive {
+		return newError("stop", nil)
+	}
+	if err := a.scheduler.End(ctx); err != nil {
+		return newError("stop", contextCause(ctx, err))
+	}
+	return nil
+}
+
+// Disable disables only a freshly verified owned task. An absent task is
+// already disabled.
+func (a *Adapter) Disable(ctx context.Context) error {
+	manager, err := a.InspectManager(ctx)
+	if err != nil {
+		return err
+	}
+	if manager.Ownership() == personalsvc.ManagerOwnershipNotLoaded {
+		return nil
+	}
+	if manager.Ownership() != personalsvc.ManagerOwnershipOwned {
+		return newError("disable", nil)
+	}
+	if err := a.scheduler.Disable(ctx); err != nil {
+		return newError("disable", contextCause(ctx, err))
+	}
+	return nil
+}
+
+// Remove deletes only an owned loaded task and its separately verified owned
+// artifact.
+func (a *Adapter) Remove(ctx context.Context) error {
+	artifact, manager, err := a.mutableState(ctx)
+	if err != nil {
+		return err
+	}
+	if artifact.State() == personalsvc.RegistrationNotInstalled && manager.Ownership() == personalsvc.ManagerOwnershipNotLoaded {
+		return nil
+	}
+	if artifact.State() != personalsvc.RegistrationInstalled ||
+		(manager.Ownership() != personalsvc.ManagerOwnershipOwned && manager.Ownership() != personalsvc.ManagerOwnershipNotLoaded) {
+		return newError("remove", nil)
+	}
+	if manager.Ownership() == personalsvc.ManagerOwnershipOwned {
+		if err := a.scheduler.Delete(ctx); err != nil {
+			return newError("remove", contextCause(ctx, err))
+		}
+	}
+	if err := a.artifacts.Remove(ctx, a.artifactPath); err != nil {
+		return newError("remove", contextCause(ctx, err))
+	}
+	return nil
+}
+
+// ManagerState reads state only after ownership has been freshly verified.
+func (a *Adapter) ManagerState(ctx context.Context) (personalsvc.ManagerState, error) {
+	manager, err := a.InspectManager(ctx)
+	if err != nil {
+		return personalsvc.ManagerUnknown, err
+	}
+	if manager.Ownership() != personalsvc.ManagerOwnershipOwned {
+		return personalsvc.ManagerUnknown, nil
+	}
+	state, err := a.scheduler.State(ctx)
+	if err != nil {
+		return personalsvc.ManagerUnknown, newError("manager state", contextCause(ctx, err))
+	}
+	return state, nil
+}
+
+func (a *Adapter) mutableState(ctx context.Context) (personalsvc.Artifact, personalsvc.ManagerRegistration, error) {
+	artifact, err := a.InspectArtifact(ctx)
+	if err != nil {
+		return personalsvc.UnknownArtifact(), personalsvc.UnknownManager(), err
+	}
+	manager, err := a.InspectManager(ctx)
+	if err != nil {
+		return personalsvc.UnknownArtifact(), personalsvc.UnknownManager(), err
+	}
+	return artifact, manager, nil
+}
+
+func (a *Adapter) render() ([]byte, error) {
+	return a.renderPlan(a.plan)
+}
+
+func (a *Adapter) renderPlan(plan personalsvc.TaskSchedulerSpec) ([]byte, error) {
+	document, err := plan.XML()
+	if err != nil {
+		return nil, newError("render", nil)
+	}
+	resolved, ok := rewriteTaskDocument(
+		document,
+		personalsvc.TaskSchedulerTaskName,
+		a.taskName,
+		personalsvc.TaskSchedulerInteractiveUser,
+		a.userSID,
+	)
+	if !ok {
+		return nil, newError("render", nil)
+	}
+	return resolved, nil
+}
+
+func (a *Adapter) parse(document []byte) (personalsvc.TaskSchedulerSpec, bool) {
+	normalized, ok := rewriteTaskDocument(
+		document,
+		a.taskName,
+		personalsvc.TaskSchedulerTaskName,
+		a.userSID,
+		personalsvc.TaskSchedulerInteractiveUser,
+	)
+	if !ok {
+		return personalsvc.TaskSchedulerSpec{}, false
+	}
+	plan, err := personalsvc.ParseTaskSchedulerXML(normalized)
+	if err != nil {
+		return personalsvc.TaskSchedulerSpec{}, false
+	}
+	return plan, true
+}
+
+func (a *Adapter) remember(plan personalsvc.TaskSchedulerSpec) {
+	a.plansMu.Lock()
+	defer a.plansMu.Unlock()
+	a.knownPlans[plan.Registration()] = plan
+}
+
+func (a *Adapter) knownPlan(registration personalsvc.Registration) (personalsvc.TaskSchedulerSpec, bool) {
+	a.plansMu.Lock()
+	defer a.plansMu.Unlock()
+	plan, found := a.knownPlans[registration]
+	return plan, found
+}
+
+func (a *Adapter) available(ctx context.Context) error {
+	if a == nil || a.scheduler == nil || a.artifacts == nil || a.httpClient == nil || ctx == nil {
+		return newError("configuration", nil)
+	}
+	if err := ctx.Err(); err != nil {
+		return newError("operation", err)
+	}
+	return nil
+}
+
+func rewriteTaskDocument(document []byte, oldTask, newTask, oldUser, newUser string) ([]byte, bool) {
+	text, ok := decodeTaskDocument(document)
+	if !ok {
+		return nil, false
+	}
+	oldURI := "<URI>" + oldTask + "</URI>"
+	oldUserID := "<UserId>" + oldUser + "</UserId>"
+	if strings.Count(text, oldURI) != 1 || strings.Count(text, oldUserID) != 1 {
+		return nil, false
+	}
+	text = strings.Replace(text, oldURI, "<URI>"+newTask+"</URI>", 1)
+	text = strings.Replace(text, oldUserID, "<UserId>"+newUser+"</UserId>", 1)
+	return encodeTaskDocument(text), true
+}
+
+func decodeTaskDocument(document []byte) (string, bool) {
+	if len(document) >= 2 && document[0] == 0xff && document[1] == 0xfe {
+		return decodeUTF16(document[2:])
+	}
+	if len(document) >= 2 && document[0] == '<' && document[1] == 0 {
+		return decodeUTF16(document)
+	}
+	if bytes.HasPrefix(document, []byte{0xef, 0xbb, 0xbf}) {
+		document = document[3:]
+	}
+	if !utf8.Valid(document) {
+		return "", false
+	}
+	return string(document), true
+}
+
+func decodeUTF16(document []byte) (string, bool) {
+	if len(document)%2 != 0 {
+		return "", false
+	}
+	units := make([]uint16, 0, len(document)/2)
+	for index := 0; index < len(document); index += 2 {
+		units = append(units, uint16(document[index])|uint16(document[index+1])<<8)
+	}
+	return string(utf16.Decode(units)), true
+}
+
+func encodeTaskDocument(document string) []byte {
+	units := utf16.Encode([]rune(document))
+	encoded := make([]byte, 2, 2+len(units)*2)
+	encoded[0], encoded[1] = 0xff, 0xfe
+	for _, unit := range units {
+		encoded = append(encoded, byte(unit), byte(unit>>8))
+	}
+	return encoded
+}
+
+func parseTaskState(output []byte) (personalsvc.ManagerState, error) {
+	text, ok := decodeTaskDocument(output)
+	if !ok {
+		return personalsvc.ManagerUnknown, newError("manager state", nil)
+	}
+	reader := csv.NewReader(strings.NewReader(text))
+	reader.FieldsPerRecord = -1
+	record, err := reader.Read()
+	if err != nil || len(record) < 7 {
+		return personalsvc.ManagerUnknown, newError("manager state", nil)
+	}
+	if _, err := reader.Read(); err != io.EOF {
+		return personalsvc.ManagerUnknown, newError("manager state", nil)
+	}
+	result, ok := parseTaskResult(strings.TrimSpace(record[6]))
+	if !ok {
+		return personalsvc.ManagerUnknown, newError("manager state", nil)
+	}
+	switch result {
+	case 0x41301, 0x41325:
+		return personalsvc.ManagerActive, nil
+	case 0:
+		return personalsvc.ManagerInactive, nil
+	default:
+		if result >= 0x41300 && result < 0x41400 {
+			return personalsvc.ManagerInactive, nil
+		}
+		return personalsvc.ManagerFailed, nil
+	}
+}
+
+func parseTaskResult(value string) (uint32, bool) {
+	if value == "" {
+		return 0, false
+	}
+	if strings.HasPrefix(value, "-") {
+		parsed, err := strconv.ParseInt(value, 10, 32)
+		return uint32(parsed), err == nil
+	}
+	parsed, err := strconv.ParseUint(value, 0, 32)
+	return uint32(parsed), err == nil
+}
+
+func validUserDataRoot(root string) bool {
+	if root == "" || filepath.Clean(root) != root || !filepath.IsAbs(root) {
+		return false
+	}
+	volume := filepath.VolumeName(root)
+	if strings.EqualFold(root, volume+string(filepath.Separator)) {
+		return false
+	}
+	lower := strings.ToLower(filepath.Clean(root))
+	for _, global := range []string{
+		strings.ToLower(filepath.Join(volume+string(filepath.Separator), "ProgramData")),
+		strings.ToLower(filepath.Join(volume+string(filepath.Separator), "Windows")),
+	} {
+		if lower == global || strings.HasPrefix(lower, global+string(filepath.Separator)) {
+			return false
+		}
+	}
+	return true
+}
+
+func validTaskName(name string) bool {
+	return name == personalsvc.TaskSchedulerTaskName ||
+		(strings.HasPrefix(name, testTaskNamePrefix) && len(name) > len(testTaskNamePrefix) && len(name) <= 238)
+}
+
+func validInteractiveSID(sid string) bool {
+	if !strings.HasPrefix(sid, "S-1-") || strings.TrimSpace(sid) != sid {
+		return false
+	}
+	switch strings.ToUpper(sid) {
+	case "S-1-5-18", "S-1-5-19", "S-1-5-20":
+		return false
+	default:
+		return true
+	}
+}
+
+func contextCause(ctx context.Context, err error) error {
+	if ctx != nil && ctx.Err() != nil {
+		return ctx.Err()
+	}
+	return err
+}
+
+func newError(operation string, cause error) *Error {
+	if !errors.Is(cause, context.Canceled) && !errors.Is(cause, context.DeadlineExceeded) {
+		cause = nil
+	}
+	return &Error{operation: operation, cause: cause}
+}

--- a/internal/personalsvchost/windows/adapter_windows.go
+++ b/internal/personalsvchost/windows/adapter_windows.go
@@ -393,6 +393,129 @@ func (a *Adapter) ManagerState(ctx context.Context) (personalsvc.ManagerState, e
 	return state, nil
 }
 
+// Restore reconstructs the independently captured artifact and manager
+// snapshots after a failed mutation. It never infers one snapshot from the
+// other, so either side may have been absent before the operation.
+func (a *Adapter) Restore(
+	ctx context.Context,
+	previousArtifact personalsvc.Artifact,
+	previousManager personalsvc.ManagerRegistration,
+) error {
+	if err := a.available(ctx); err != nil {
+		return err
+	}
+	artifactPlan, artifactExists, err := a.planForArtifact(previousArtifact)
+	if err != nil {
+		return err
+	}
+	managerPlan, managerExists, err := a.planForManager(previousManager)
+	if err != nil {
+		return err
+	}
+	currentArtifact, currentManager, err := a.mutableState(ctx)
+	if err != nil {
+		return err
+	}
+	if currentArtifact.State() != personalsvc.RegistrationInstalled &&
+		currentArtifact.State() != personalsvc.RegistrationNotInstalled {
+		return newError("restore", nil)
+	}
+	if currentManager.Ownership() != personalsvc.ManagerOwnershipOwned &&
+		currentManager.Ownership() != personalsvc.ManagerOwnershipNotLoaded {
+		return newError("restore", nil)
+	}
+	if currentManager.Ownership() == personalsvc.ManagerOwnershipOwned {
+		state, stateErr := a.scheduler.State(ctx)
+		if stateErr != nil || state == personalsvc.ManagerUnknown {
+			return newError("restore", contextCause(ctx, stateErr))
+		}
+		if state == personalsvc.ManagerActive {
+			if err := a.scheduler.End(ctx); err != nil {
+				return newError("restore", contextCause(ctx, err))
+			}
+		}
+		if err := a.scheduler.Disable(ctx); err != nil {
+			return newError("restore", contextCause(ctx, err))
+		}
+		if err := a.scheduler.Delete(ctx); err != nil {
+			return newError("restore", contextCause(ctx, err))
+		}
+	}
+	if currentArtifact.State() == personalsvc.RegistrationInstalled {
+		if err := a.artifacts.Remove(ctx, a.artifactPath); err != nil {
+			return newError("restore", contextCause(ctx, err))
+		}
+	}
+
+	if managerExists {
+		if err := a.writePlan(ctx, managerPlan); err != nil {
+			return err
+		}
+		if err := a.scheduler.Create(ctx, a.artifactPath); err != nil {
+			return newError("restore", contextCause(ctx, err))
+		}
+		if err := a.scheduler.Enable(ctx); err != nil {
+			return newError("restore", contextCause(ctx, err))
+		}
+	}
+	if artifactExists {
+		return a.writePlan(ctx, artifactPlan)
+	}
+	if managerExists {
+		if err := a.artifacts.Remove(ctx, a.artifactPath); err != nil {
+			return newError("restore", contextCause(ctx, err))
+		}
+	}
+	return nil
+}
+
+func (a *Adapter) planForArtifact(artifact personalsvc.Artifact) (personalsvc.TaskSchedulerSpec, bool, error) {
+	if artifact.State() == personalsvc.RegistrationNotInstalled {
+		return personalsvc.TaskSchedulerSpec{}, false, nil
+	}
+	if artifact.State() != personalsvc.RegistrationInstalled {
+		return personalsvc.TaskSchedulerSpec{}, false, newError("restore", nil)
+	}
+	registration, found := artifact.Registration()
+	if !found {
+		return personalsvc.TaskSchedulerSpec{}, false, newError("restore", nil)
+	}
+	plan, found := a.knownPlan(registration)
+	if !found {
+		return personalsvc.TaskSchedulerSpec{}, false, newError("restore", nil)
+	}
+	return plan, true, nil
+}
+
+func (a *Adapter) planForManager(manager personalsvc.ManagerRegistration) (personalsvc.TaskSchedulerSpec, bool, error) {
+	if manager.Ownership() == personalsvc.ManagerOwnershipNotLoaded {
+		return personalsvc.TaskSchedulerSpec{}, false, nil
+	}
+	if manager.Ownership() != personalsvc.ManagerOwnershipOwned {
+		return personalsvc.TaskSchedulerSpec{}, false, newError("restore", nil)
+	}
+	registration, found := manager.Registration()
+	if !found {
+		return personalsvc.TaskSchedulerSpec{}, false, newError("restore", nil)
+	}
+	plan, found := a.knownPlan(registration)
+	if !found {
+		return personalsvc.TaskSchedulerSpec{}, false, newError("restore", nil)
+	}
+	return plan, true, nil
+}
+
+func (a *Adapter) writePlan(ctx context.Context, plan personalsvc.TaskSchedulerSpec) error {
+	document, err := a.renderPlan(plan)
+	if err != nil {
+		return err
+	}
+	if err := a.artifacts.Write(ctx, a.artifactPath, document); err != nil {
+		return newError("restore", contextCause(ctx, err))
+	}
+	return nil
+}
+
 func (a *Adapter) mutableState(ctx context.Context) (personalsvc.Artifact, personalsvc.ManagerRegistration, error) {
 	artifact, err := a.InspectArtifact(ctx)
 	if err != nil {

--- a/internal/personalsvchost/windows/adapter_windows.go
+++ b/internal/personalsvchost/windows/adapter_windows.go
@@ -221,7 +221,7 @@ func (a *Adapter) Probe(ctx context.Context, endpoint string) (personalsvc.Probe
 		}
 		return personalsvc.ProbeUnreachable, nil
 	}
-	defer response.Body.Close()
+	defer func() { _ = response.Body.Close() }()
 	body, err := io.ReadAll(io.LimitReader(response.Body, maxProbeBytes+1))
 	if err != nil {
 		if ctx.Err() != nil {

--- a/internal/personalsvchost/windows/adapter_windows.go
+++ b/internal/personalsvchost/windows/adapter_windows.go
@@ -106,8 +106,9 @@ func newAdapter(
 	artifacts artifactStore,
 	httpClient *http.Client,
 ) (*Adapter, error) {
+	resolvedRoot, rootErr := resolveUserDataRoot(userDataRoot)
 	if scheduler == nil || artifacts == nil || httpClient == nil ||
-		!validUserDataRoot(userDataRoot) || !validTaskName(taskName) || !validUserIdentity(identity) {
+		rootErr != nil || !validTaskName(taskName) || !validUserIdentity(identity) {
 		return nil, newError("configuration", nil)
 	}
 	if _, err := plan.XML(); err != nil {
@@ -115,7 +116,7 @@ func newAdapter(
 	}
 	return &Adapter{
 		plan:         plan,
-		artifactPath: filepath.Join(userDataRoot, filepath.FromSlash("PowerContext/Services/personal-server.xml")),
+		artifactPath: filepath.Join(resolvedRoot, filepath.FromSlash("PowerContext/Services/personal-server.xml")),
 		taskName:     taskName,
 		userSID:      identity.sid,
 		userAccount:  identity.account,

--- a/internal/personalsvchost/windows/adapter_windows.go
+++ b/internal/personalsvchost/windows/adapter_windows.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"encoding/csv"
 	json "encoding/json/v2"
+	"encoding/xml"
 	"errors"
 	"fmt"
 	"io"
@@ -40,6 +41,7 @@ import (
 const (
 	testTaskNamePrefix = `\PowerContext\Tests\`
 	maxProbeBytes      = 4 << 10
+	taskXMLNamespace   = "http://schemas.microsoft.com/windows/2004/02/mit/task"
 )
 
 var requestIDPattern = regexp.MustCompile(`^[0-9a-f]{16}$`)
@@ -86,6 +88,9 @@ type Adapter struct {
 	artifactPath string
 	taskName     string
 	userSID      string
+	userAccount  string
+	userName     string
+	userLookup   func(string) bool
 	scheduler    taskScheduler
 	artifacts    artifactStore
 	httpClient   *http.Client
@@ -99,13 +104,13 @@ func newAdapter(
 	plan personalsvc.TaskSchedulerSpec,
 	userDataRoot string,
 	taskName string,
-	userSID string,
+	identity userIdentity,
 	scheduler taskScheduler,
 	artifacts artifactStore,
 	httpClient *http.Client,
 ) (*Adapter, error) {
 	if scheduler == nil || artifacts == nil || httpClient == nil ||
-		!validUserDataRoot(userDataRoot) || !validTaskName(taskName) || !validInteractiveSID(userSID) {
+		!validUserDataRoot(userDataRoot) || !validTaskName(taskName) || !validUserIdentity(identity) {
 		return nil, newError("configuration", nil)
 	}
 	if _, err := plan.XML(); err != nil {
@@ -115,7 +120,10 @@ func newAdapter(
 		plan:         plan,
 		artifactPath: filepath.Join(userDataRoot, filepath.FromSlash("PowerContext/Services/personal-server.xml")),
 		taskName:     taskName,
-		userSID:      userSID,
+		userSID:      identity.sid,
+		userAccount:  identity.account,
+		userName:     identity.name,
+		userLookup:   identity.lookup,
 		scheduler:    scheduler,
 		artifacts:    artifacts,
 		httpClient:   httpClient,
@@ -406,25 +414,43 @@ func (a *Adapter) renderPlan(plan personalsvc.TaskSchedulerSpec) ([]byte, error)
 	if err != nil {
 		return nil, newError("render", nil)
 	}
-	resolved, ok := rewriteTaskDocument(
-		document,
-		personalsvc.TaskSchedulerTaskName,
-		a.taskName,
-		personalsvc.TaskSchedulerInteractiveUser,
-		a.userSID,
-	)
+	resolved, ok := resolveTaskDocument(document, a.taskName, userIdentity{
+		sid: a.userSID, account: a.userAccount, name: a.userName, lookup: a.userLookup,
+	}, plan.StartOnLogin())
 	if !ok {
 		return nil, newError("render", nil)
 	}
 	return resolved, nil
 }
 
+func resolveTaskDocument(document []byte, taskName string, identity userIdentity, startOnLogin bool) ([]byte, bool) {
+	text, ok := decodeTaskDocument(document)
+	if !ok {
+		return nil, false
+	}
+	oldURI := taskXMLLeaf("URI", personalsvc.TaskSchedulerTaskName)
+	oldUser := taskXMLLeaf("UserId", personalsvc.TaskSchedulerInteractiveUser)
+	wantUsers := 1
+	if startOnLogin {
+		wantUsers = 2
+	}
+	if strings.Count(text, oldURI) != 1 || strings.Count(text, oldUser) != wantUsers {
+		return nil, false
+	}
+	text = strings.Replace(text, oldURI, taskXMLLeaf("URI", taskName), 1)
+	if startOnLogin {
+		text = strings.Replace(text, oldUser, taskXMLLeaf("UserId", identity.account), 1)
+	}
+	text = strings.Replace(text, oldUser, taskXMLLeaf("UserId", identity.sid), 1)
+	return encodeTaskDocument(text), true
+}
+
 func (a *Adapter) parse(document []byte) (personalsvc.TaskSchedulerSpec, bool) {
-	normalized, ok := rewriteTaskDocument(
+	normalized, ok := rewriteTaskDocumentIdentity(
 		document,
 		a.taskName,
 		personalsvc.TaskSchedulerTaskName,
-		a.userSID,
+		userIdentity{sid: a.userSID, account: a.userAccount, name: a.userName, lookup: a.userLookup},
 		personalsvc.TaskSchedulerInteractiveUser,
 	)
 	if !ok {
@@ -461,18 +487,119 @@ func (a *Adapter) available(ctx context.Context) error {
 }
 
 func rewriteTaskDocument(document []byte, oldTask, newTask, oldUser, newUser string) ([]byte, bool) {
+	return rewriteTaskDocumentUsers(document, oldTask, newTask, []string{oldUser}, newUser)
+}
+
+func rewriteTaskDocumentUsers(
+	document []byte,
+	oldTask string,
+	newTask string,
+	oldUsers []string,
+	newUser string,
+) ([]byte, bool) {
 	text, ok := decodeTaskDocument(document)
 	if !ok {
 		return nil, false
 	}
-	oldURI := "<URI>" + oldTask + "</URI>"
-	oldUserID := "<UserId>" + oldUser + "</UserId>"
-	if strings.Count(text, oldURI) != 1 || strings.Count(text, oldUserID) != 1 {
+	oldURI := taskXMLLeaf("URI", oldTask)
+	if strings.Count(text, oldURI) != 1 {
 		return nil, false
 	}
-	text = strings.Replace(text, oldURI, "<URI>"+newTask+"</URI>", 1)
-	text = strings.Replace(text, oldUserID, "<UserId>"+newUser+"</UserId>", 1)
+	totalUsers := strings.Count(text, "<UserId>")
+	if totalUsers < 1 || totalUsers > 2 {
+		return nil, false
+	}
+	matchedUsers := 0
+	seen := make(map[string]struct{}, len(oldUsers))
+	for _, oldUser := range oldUsers {
+		if _, duplicate := seen[oldUser]; duplicate {
+			continue
+		}
+		seen[oldUser] = struct{}{}
+		oldUserID := taskXMLLeaf("UserId", oldUser)
+		matches := strings.Count(text, oldUserID)
+		matchedUsers += matches
+		text = strings.ReplaceAll(text, oldUserID, taskXMLLeaf("UserId", newUser))
+	}
+	if matchedUsers != totalUsers {
+		return nil, false
+	}
+	text = strings.Replace(text, oldURI, taskXMLLeaf("URI", newTask), 1)
 	return encodeTaskDocument(text), true
+}
+
+func rewriteTaskDocumentIdentity(
+	document []byte,
+	oldTask string,
+	newTask string,
+	identity userIdentity,
+	newUser string,
+) ([]byte, bool) {
+	text, ok := decodeTaskDocument(document)
+	if !ok {
+		return nil, false
+	}
+	oldURI := taskXMLLeaf("URI", oldTask)
+	if strings.Count(text, oldURI) != 1 {
+		return nil, false
+	}
+	userIDs, ok := taskDocumentUserIDs(text)
+	if !ok || len(userIDs) < 1 || len(userIDs) > 2 {
+		return nil, false
+	}
+	seen := make(map[string]struct{}, len(userIDs))
+	for _, userID := range userIDs {
+		if !identity.matches(userID) {
+			return nil, false
+		}
+		if _, duplicate := seen[userID]; duplicate {
+			continue
+		}
+		seen[userID] = struct{}{}
+		leaf := taskXMLLeaf("UserId", userID)
+		if strings.Count(text, leaf) == 0 {
+			return nil, false
+		}
+		text = strings.ReplaceAll(text, leaf, taskXMLLeaf("UserId", newUser))
+	}
+	text = strings.Replace(text, oldURI, taskXMLLeaf("URI", newTask), 1)
+	return encodeTaskDocument(text), true
+}
+
+func taskDocumentUserIDs(document string) ([]string, bool) {
+	decoder := xml.NewDecoder(strings.NewReader(document))
+	decoder.Strict = true
+	decoder.CharsetReader = func(label string, input io.Reader) (io.Reader, error) {
+		if strings.EqualFold(label, "UTF-16") {
+			return input, nil
+		}
+		return nil, errors.New("unsupported task document encoding")
+	}
+	userIDs := make([]string, 0, 2)
+	for {
+		token, err := decoder.Token()
+		if err == io.EOF {
+			return userIDs, true
+		}
+		if err != nil {
+			return nil, false
+		}
+		start, found := token.(xml.StartElement)
+		if !found || start.Name.Space != taskXMLNamespace || start.Name.Local != "UserId" {
+			continue
+		}
+		var userID string
+		if err := decoder.DecodeElement(&userID, &start); err != nil || userID == "" || len(userIDs) == 2 {
+			return nil, false
+		}
+		userIDs = append(userIDs, userID)
+	}
+}
+
+func taskXMLLeaf(name, value string) string {
+	var escaped bytes.Buffer
+	_ = xml.EscapeText(&escaped, []byte(value))
+	return "<" + name + ">" + escaped.String() + "</" + name + ">"
 }
 
 func decodeTaskDocument(document []byte) (string, bool) {
@@ -586,6 +713,35 @@ func validInteractiveSID(sid string) bool {
 	}
 	switch strings.ToUpper(sid) {
 	case "S-1-5-18", "S-1-5-19", "S-1-5-20":
+		return false
+	default:
+		return true
+	}
+}
+
+type userIdentity struct {
+	sid     string
+	account string
+	name    string
+	lookup  func(string) bool
+}
+
+func (i userIdentity) matches(value string) bool {
+	if value == i.sid || strings.EqualFold(value, i.account) || strings.EqualFold(value, i.name) {
+		return true
+	}
+	return i.lookup != nil && i.lookup(value)
+}
+
+func validUserIdentity(identity userIdentity) bool {
+	if !validInteractiveSID(identity.sid) || identity.account == "" || identity.name == "" ||
+		strings.TrimSpace(identity.account) != identity.account || strings.TrimSpace(identity.name) != identity.name ||
+		strings.ContainsAny(identity.account, "\r\n\x00") || strings.ContainsAny(identity.name, "\r\n\x00") {
+		return false
+	}
+	switch strings.ToLower(identity.account) {
+	case "system", `nt authority\system`, "local service", `nt authority\local service`,
+		"network service", `nt authority\network service`:
 		return false
 	default:
 		return true

--- a/internal/personalsvchost/windows/adapter_windows.go
+++ b/internal/personalsvchost/windows/adapter_windows.go
@@ -30,7 +30,6 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
-	"sync"
 	"unicode/utf16"
 	"unicode/utf8"
 
@@ -94,8 +93,6 @@ type Adapter struct {
 	scheduler    taskScheduler
 	artifacts    artifactStore
 	httpClient   *http.Client
-	plansMu      sync.Mutex
-	knownPlans   map[personalsvc.Registration]personalsvc.TaskSchedulerSpec
 }
 
 var _ personalsvc.Adapter = (*Adapter)(nil)
@@ -127,7 +124,6 @@ func newAdapter(
 		scheduler:    scheduler,
 		artifacts:    artifacts,
 		httpClient:   httpClient,
-		knownPlans:   map[personalsvc.Registration]personalsvc.TaskSchedulerSpec{plan.Registration(): plan},
 	}, nil
 }
 
@@ -163,16 +159,18 @@ func (a *Adapter) InspectArtifact(ctx context.Context) (personalsvc.Artifact, er
 	if !ok {
 		return personalsvc.InvalidArtifact(), nil
 	}
-	a.remember(plan)
 	registration := plan.Registration()
 	regular, err := a.artifacts.RegularFile(ctx, registration.Definition().Binary())
 	if err != nil {
 		return personalsvc.UnknownArtifact(), newError("inspect artifact", contextCause(ctx, err))
 	}
 	if !regular {
-		return personalsvc.InstalledArtifactWithDefinition(registration, personalsvc.DefinitionMissingExecutable), nil
+		return personalsvc.InstalledArtifactWithDefinition(
+			registration,
+			personalsvc.DefinitionMissingExecutable,
+		).WithRestoreSnapshot(plan), nil
 	}
-	return personalsvc.InstalledArtifact(registration), nil
+	return personalsvc.InstalledArtifact(registration).WithRestoreSnapshot(plan), nil
 }
 
 // InspectManager verifies independently queried Task Scheduler XML before
@@ -195,8 +193,7 @@ func (a *Adapter) InspectManager(ctx context.Context) (personalsvc.ManagerRegist
 	if !ok {
 		return personalsvc.ForeignManager(), nil
 	}
-	a.remember(plan)
-	return personalsvc.OwnedManager(plan.Registration()), nil
+	return personalsvc.OwnedManager(plan.Registration()).WithRestoreSnapshot(plan), nil
 }
 
 // Probe accepts only the exact unauthenticated loopback liveness contract.
@@ -247,8 +244,7 @@ func (a *Adapter) Probe(ctx context.Context, endpoint string) (personalsvc.Probe
 // Write atomically delegates the exact resolved XML artifact after fresh
 // artifact and manager ownership checks.
 func (a *Adapter) Write(ctx context.Context, registration personalsvc.Registration) error {
-	plan, found := a.knownPlan(registration)
-	if !found {
+	if registration != a.plan.Registration() {
 		return newError("write", nil)
 	}
 	artifact, manager, err := a.mutableState(ctx)
@@ -261,7 +257,7 @@ func (a *Adapter) Write(ctx context.Context, registration personalsvc.Registrati
 	if manager.Ownership() != personalsvc.ManagerOwnershipOwned && manager.Ownership() != personalsvc.ManagerOwnershipNotLoaded {
 		return newError("write", nil)
 	}
-	document, err := a.renderPlan(plan)
+	document, err := a.renderPlan(a.plan)
 	if err != nil {
 		return err
 	}
@@ -480,8 +476,9 @@ func (a *Adapter) planForArtifact(artifact personalsvc.Artifact) (personalsvc.Ta
 	if !found {
 		return personalsvc.TaskSchedulerSpec{}, false, newError("restore", nil)
 	}
-	plan, found := a.knownPlan(registration)
-	if !found {
+	snapshot, found := artifact.RestoreSnapshot()
+	plan, valid := snapshot.(personalsvc.TaskSchedulerSpec)
+	if !found || !valid || plan.Registration() != registration {
 		return personalsvc.TaskSchedulerSpec{}, false, newError("restore", nil)
 	}
 	return plan, true, nil
@@ -498,8 +495,9 @@ func (a *Adapter) planForManager(manager personalsvc.ManagerRegistration) (perso
 	if !found {
 		return personalsvc.TaskSchedulerSpec{}, false, newError("restore", nil)
 	}
-	plan, found := a.knownPlan(registration)
-	if !found {
+	snapshot, found := manager.RestoreSnapshot()
+	plan, valid := snapshot.(personalsvc.TaskSchedulerSpec)
+	if !found || !valid || plan.Registration() != registration {
 		return personalsvc.TaskSchedulerSpec{}, false, newError("restore", nil)
 	}
 	return plan, true, nil
@@ -584,19 +582,6 @@ func (a *Adapter) parse(document []byte) (personalsvc.TaskSchedulerSpec, bool) {
 		return personalsvc.TaskSchedulerSpec{}, false
 	}
 	return plan, true
-}
-
-func (a *Adapter) remember(plan personalsvc.TaskSchedulerSpec) {
-	a.plansMu.Lock()
-	defer a.plansMu.Unlock()
-	a.knownPlans[plan.Registration()] = plan
-}
-
-func (a *Adapter) knownPlan(registration personalsvc.Registration) (personalsvc.TaskSchedulerSpec, bool) {
-	a.plansMu.Lock()
-	defer a.plansMu.Unlock()
-	plan, found := a.knownPlans[registration]
-	return plan, found
 }
 
 func (a *Adapter) available(ctx context.Context) error {

--- a/internal/personalsvchost/windows/adapter_windows_test.go
+++ b/internal/personalsvchost/windows/adapter_windows_test.go
@@ -31,7 +31,11 @@ import (
 	"github.com/ob-labs/powercontext-go/internal/personalsvc"
 )
 
-const testTaskSID = "S-1-5-21-100-200-300-1001"
+var testIdentity = userIdentity{
+	sid:     "S-1-5-21-100-200-300-1001",
+	account: `CONTOSO\alice`,
+	name:    "alice",
+}
 
 func TestAdapterCompletesOwnedTaskLifecycleThroughExplicitBoundaries(t *testing.T) {
 	root := t.TempDir()
@@ -42,7 +46,7 @@ func TestAdapterCompletesOwnedTaskLifecycleThroughExplicitBoundaries(t *testing.
 		plan,
 		root,
 		`\PowerContext\Tests\unit-lifecycle`,
-		testTaskSID,
+		testIdentity,
 		scheduler,
 		files,
 		http.DefaultClient,
@@ -117,7 +121,7 @@ func TestAdapterRejectsForeignLoadedTaskBeforeMutation(t *testing.T) {
 		plan,
 		root,
 		`\PowerContext\Tests\unit-foreign`,
-		testTaskSID,
+		testIdentity,
 		scheduler,
 		files,
 		http.DefaultClient,
@@ -167,6 +171,58 @@ func TestAdapterRejectsForeignLoadedTaskBeforeMutation(t *testing.T) {
 	}
 }
 
+func TestAdapterLoginTriggerAcceptsOnlyCurrentUserIdentity(t *testing.T) {
+	root := t.TempDir()
+	base := adapterPlan(t, root)
+	plan, err := personalsvc.NewTaskSchedulerSpec(
+		base.Registration(), base.Arguments(), base.WorkingDirectory(), true,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	files := newMemoryArtifacts()
+	scheduler := &memoryScheduler{files: files}
+	adapter, err := newAdapter(
+		plan,
+		root,
+		`\PowerContext\Tests\unit-login-user`,
+		testIdentity,
+		scheduler,
+		files,
+		http.DefaultClient,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	document, err := adapter.render()
+	if err != nil {
+		t.Fatal(err)
+	}
+	scheduler.present, scheduler.document = true, document
+	manager, err := adapter.InspectManager(t.Context())
+	if err != nil || manager.Ownership() != personalsvc.ManagerOwnershipOwned {
+		t.Fatalf("current-user trigger = %s, %v; want owned", manager.Ownership(), err)
+	}
+	text, ok := decodeTaskDocument(document)
+	if !ok {
+		t.Fatal("cannot decode login trigger fixture")
+	}
+	foreign := encodeTaskDocument(strings.Replace(
+		text,
+		taskXMLLeaf("UserId", testIdentity.account),
+		taskXMLLeaf("UserId", `CONTOSO\foreign`),
+		1,
+	))
+	if bytes.Equal(foreign, document) {
+		t.Fatal("foreign trigger fixture did not change")
+	}
+	scheduler.document = foreign
+	manager, err = adapter.InspectManager(t.Context())
+	if err != nil || manager.Ownership() != personalsvc.ManagerOwnershipForeign {
+		t.Fatalf("foreign-user trigger = %s, %v; want foreign", manager.Ownership(), err)
+	}
+}
+
 func TestTaskSchedulerStateUsesNumericResultInsteadOfLocalizedText(t *testing.T) {
 	for _, test := range []struct {
 		name string
@@ -210,7 +266,7 @@ func TestAdapterRejectsGlobalRoot(t *testing.T) {
 		plan,
 		root,
 		personalsvc.TaskSchedulerTaskName,
-		testTaskSID,
+		testIdentity,
 		&memoryScheduler{files: newMemoryArtifacts()},
 		newMemoryArtifacts(),
 		http.DefaultClient,
@@ -236,7 +292,7 @@ func TestNewComposesProductionAdapterAndOperationBoundary(t *testing.T) {
 	if (&Composition{}).Adapter() != nil || (&Composition{}).OperationBoundary() != nil {
 		t.Fatal("zero-value composition exposed a typed-nil boundary")
 	}
-	if _, err := currentUserSID(); err != nil {
+	if _, err := currentUserIdentity(); err != nil {
 		t.Skip("current process does not have an interactive user identity")
 	}
 	root := t.TempDir()
@@ -314,7 +370,7 @@ func TestProbeRequiresExactLoopbackLivenessContract(t *testing.T) {
 		plan,
 		root,
 		`\PowerContext\Tests\unit-probe`,
-		testTaskSID,
+		testIdentity,
 		&memoryScheduler{files: newMemoryArtifacts()},
 		newMemoryArtifacts(),
 		client,
@@ -345,7 +401,7 @@ func TestStopDoesNotEndOwnedInactiveTask(t *testing.T) {
 		plan,
 		root,
 		`\PowerContext\Tests\unit-inactive`,
-		testTaskSID,
+		testIdentity,
 		scheduler,
 		files,
 		http.DefaultClient,
@@ -379,7 +435,7 @@ func TestControllerRestoresPreviouslyInspectedTaskAfterEnableFailure(t *testing.
 		desired,
 		root,
 		`\PowerContext\Tests\unit-rollback`,
-		testTaskSID,
+		testIdentity,
 		scheduler,
 		files,
 		http.DefaultClient,
@@ -396,7 +452,7 @@ func TestControllerRestoresPreviouslyInspectedTaskAfterEnableFailure(t *testing.
 		personalsvc.TaskSchedulerTaskName,
 		adapter.taskName,
 		personalsvc.TaskSchedulerInteractiveUser,
-		testTaskSID,
+		testIdentity.sid,
 	)
 	if !ok {
 		t.Fatal("cannot resolve previous task fixture")
@@ -418,6 +474,61 @@ func TestControllerRestoresPreviouslyInspectedTaskAfterEnableFailure(t *testing.
 	registration, found := artifact.Registration()
 	if !found || registration != previous.Registration() {
 		t.Fatal("enable failure did not restore the previously inspected registration")
+	}
+}
+
+func TestControllerCancellationAfterCreateRemovesNewTask(t *testing.T) {
+	root := t.TempDir()
+	plan := adapterPlan(t, root)
+	files := newMemoryArtifacts()
+	type cleanupContextKey struct{}
+	parent := context.WithValue(t.Context(), cleanupContextKey{}, "preserved")
+	ctx, cancel := context.WithCancel(parent)
+	cleanupObserved := false
+	scheduler := &memoryScheduler{
+		files: files, cancelAfterCreate: cancel, rejectCanceled: true,
+		observeCleanup: func(cleanupCtx context.Context) error {
+			if cleanupCtx.Err() != nil || cleanupCtx.Value(cleanupContextKey{}) != "preserved" {
+				return errors.New("cleanup context did not preserve values independently")
+			}
+			if _, bounded := cleanupCtx.Deadline(); !bounded {
+				return errors.New("cleanup context is not bounded")
+			}
+			cleanupObserved = true
+			return nil
+		},
+	}
+	adapter, err := newAdapter(
+		plan,
+		root,
+		`\PowerContext\Tests\unit-cancel-create`,
+		testIdentity,
+		scheduler,
+		files,
+		http.DefaultClient,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	controller, err := personalsvc.NewController(adapter, directOperationBoundary{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, installErr := controller.Install(ctx, plan.Registration())
+	if !errors.Is(installErr, context.Canceled) {
+		t.Fatalf("Install() error = %v; want context cancellation", installErr)
+	}
+	artifact, err := adapter.InspectArtifact(t.Context())
+	if err != nil || artifact.State() != personalsvc.RegistrationNotInstalled {
+		t.Fatalf("artifact after cancellation = %s, %v; want removed", artifact.State(), err)
+	}
+	manager, err := adapter.InspectManager(t.Context())
+	if err != nil || manager.Ownership() != personalsvc.ManagerOwnershipNotLoaded {
+		t.Fatalf("manager after cancellation = %s, %v; want not loaded", manager.Ownership(), err)
+	}
+	if !cleanupObserved {
+		t.Fatal("cancellation recovery did not use the bounded cleanup context")
 	}
 }
 
@@ -551,15 +662,21 @@ func (f *memoryArtifacts) Remove(_ context.Context, path string) error {
 func (*memoryArtifacts) RegularFile(context.Context, string) (bool, error) { return true, nil }
 
 type memoryScheduler struct {
-	files     *memoryArtifacts
-	document  []byte
-	present   bool
-	state     personalsvc.ManagerState
-	mutations []string
-	enableErr error
+	files             *memoryArtifacts
+	document          []byte
+	present           bool
+	state             personalsvc.ManagerState
+	mutations         []string
+	enableErr         error
+	cancelAfterCreate context.CancelFunc
+	rejectCanceled    bool
+	observeCleanup    func(context.Context) error
 }
 
-func (s *memoryScheduler) Query(context.Context) (personalsvc.TaskSchedulerState, []byte, error) {
+func (s *memoryScheduler) Query(ctx context.Context) (personalsvc.TaskSchedulerState, []byte, error) {
+	if err := s.contextError(ctx); err != nil {
+		return personalsvc.TaskSchedulerUnknown, nil, err
+	}
 	if !s.present {
 		return personalsvc.TaskSchedulerAbsent, nil, nil
 	}
@@ -567,6 +684,9 @@ func (s *memoryScheduler) Query(context.Context) (personalsvc.TaskSchedulerState
 }
 
 func (s *memoryScheduler) Create(ctx context.Context, path string) error {
+	if err := s.contextError(ctx); err != nil {
+		return err
+	}
 	content, exists, err := s.files.Read(ctx, path)
 	if err != nil || !exists {
 		return os.ErrNotExist
@@ -575,6 +695,11 @@ func (s *memoryScheduler) Create(ctx context.Context, path string) error {
 	s.present = true
 	s.state = personalsvc.ManagerInactive
 	s.mutations = append(s.mutations, "create")
+	if s.cancelAfterCreate != nil {
+		cancel := s.cancelAfterCreate
+		s.cancelAfterCreate = nil
+		cancel()
+	}
 	return nil
 }
 
@@ -590,8 +715,11 @@ func (s *memoryScheduler) End(context.Context) error {
 	return nil
 }
 
-func (s *memoryScheduler) Enable(context.Context) error {
+func (s *memoryScheduler) Enable(ctx context.Context) error {
 	s.mutations = append(s.mutations, "enable")
+	if err := s.contextError(ctx); err != nil {
+		return err
+	}
 	if s.enableErr != nil {
 		err := s.enableErr
 		s.enableErr = nil
@@ -600,13 +728,26 @@ func (s *memoryScheduler) Enable(context.Context) error {
 	return nil
 }
 
-func (s *memoryScheduler) Disable(context.Context) error {
+func (s *memoryScheduler) Disable(ctx context.Context) error {
+	if err := s.contextError(ctx); err != nil {
+		return err
+	}
+	if s.observeCleanup != nil {
+		observe := s.observeCleanup
+		s.observeCleanup = nil
+		if err := observe(ctx); err != nil {
+			return err
+		}
+	}
 	s.state = personalsvc.ManagerInactive
 	s.mutations = append(s.mutations, "disable")
 	return nil
 }
 
-func (s *memoryScheduler) Delete(context.Context) error {
+func (s *memoryScheduler) Delete(ctx context.Context) error {
+	if err := s.contextError(ctx); err != nil {
+		return err
+	}
 	s.document = nil
 	s.present = false
 	s.state = personalsvc.ManagerInactive
@@ -616,6 +757,13 @@ func (s *memoryScheduler) Delete(context.Context) error {
 
 func (s *memoryScheduler) State(context.Context) (personalsvc.ManagerState, error) {
 	return s.state, nil
+}
+
+func (s *memoryScheduler) contextError(ctx context.Context) error {
+	if s.rejectCanceled {
+		return ctx.Err()
+	}
+	return nil
 }
 
 type directOperationBoundary struct{}

--- a/internal/personalsvchost/windows/adapter_windows_test.go
+++ b/internal/personalsvchost/windows/adapter_windows_test.go
@@ -584,6 +584,105 @@ func TestControllerCancellationAfterReplaceRestoresPreviousTask(t *testing.T) {
 	}
 }
 
+func TestControllerCancellationRestoresManagerWithoutArtifact(t *testing.T) {
+	root := t.TempDir()
+	desired := adapterPlanForPackage(t, root, "2.0.0")
+	previous := adapterPlanForPackage(t, root, "1.0.0")
+	files := newMemoryArtifacts()
+	ctx, cancel := context.WithCancel(t.Context())
+	scheduler := &memoryScheduler{files: files, cancelAfterCreate: cancel, rejectCanceled: true}
+	adapter, err := newAdapter(
+		desired,
+		root,
+		`\PowerContext\Tests\unit-mixed-manager`,
+		testIdentity,
+		scheduler,
+		files,
+		http.DefaultClient,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	previousDocument, err := adapter.renderPlan(previous)
+	if err != nil {
+		t.Fatal(err)
+	}
+	scheduler.document, scheduler.present = previousDocument, true
+	controller, err := personalsvc.NewController(adapter, directOperationBoundary{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, installErr := controller.Install(ctx, desired.Registration())
+	if !errors.Is(installErr, context.Canceled) {
+		t.Fatalf("Install() error = %v; want context cancellation", installErr)
+	}
+	artifact, err := adapter.InspectArtifact(t.Context())
+	if err != nil || artifact.State() != personalsvc.RegistrationNotInstalled {
+		t.Fatalf("mixed artifact after cancellation = %s, %v; want absent", artifact.State(), err)
+	}
+	assertOwnedManagerRegistration(t, adapter, previous.Registration())
+}
+
+func TestControllerCancellationRestoresArtifactWithoutManager(t *testing.T) {
+	root := t.TempDir()
+	desired := adapterPlanForPackage(t, root, "2.0.0")
+	previous := adapterPlanForPackage(t, root, "1.0.0")
+	files := newMemoryArtifacts()
+	ctx, cancel := context.WithCancel(t.Context())
+	scheduler := &memoryScheduler{files: files, cancelAfterCreate: cancel, rejectCanceled: true}
+	adapter, err := newAdapter(
+		desired,
+		root,
+		`\PowerContext\Tests\unit-mixed-artifact`,
+		testIdentity,
+		scheduler,
+		files,
+		http.DefaultClient,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	previousDocument, err := adapter.renderPlan(previous)
+	if err != nil {
+		t.Fatal(err)
+	}
+	files.content, files.exists = previousDocument, true
+	controller, err := personalsvc.NewController(adapter, directOperationBoundary{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, installErr := controller.Install(ctx, desired.Registration())
+	if !errors.Is(installErr, context.Canceled) {
+		t.Fatalf("Install() error = %v; want context cancellation", installErr)
+	}
+	artifact, err := adapter.InspectArtifact(t.Context())
+	if err != nil || artifact.State() != personalsvc.RegistrationInstalled {
+		t.Fatalf("mixed artifact after cancellation = %s, %v; want installed", artifact.State(), err)
+	}
+	stored, found := artifact.Registration()
+	if !found || stored != previous.Registration() {
+		t.Fatal("mixed cancellation did not restore the prior artifact")
+	}
+	manager, err := adapter.InspectManager(t.Context())
+	if err != nil || manager.Ownership() != personalsvc.ManagerOwnershipNotLoaded {
+		t.Fatalf("mixed manager after cancellation = %s, %v; want not loaded", manager.Ownership(), err)
+	}
+}
+
+func assertOwnedManagerRegistration(t *testing.T, adapter *Adapter, want personalsvc.Registration) {
+	t.Helper()
+	manager, err := adapter.InspectManager(t.Context())
+	if err != nil || manager.Ownership() != personalsvc.ManagerOwnershipOwned {
+		t.Fatalf("manager after cancellation = %s, %v; want owned", manager.Ownership(), err)
+	}
+	loaded, found := manager.Registration()
+	if !found || loaded != want {
+		t.Fatal("manager after cancellation has the wrong registration")
+	}
+}
+
 func TestNativeArtifactStoreReplacesExactArtifact(t *testing.T) {
 	root := t.TempDir()
 	store, err := newNativeArtifactStore(root)

--- a/internal/personalsvchost/windows/adapter_windows_test.go
+++ b/internal/personalsvchost/windows/adapter_windows_test.go
@@ -532,6 +532,58 @@ func TestControllerCancellationAfterCreateRemovesNewTask(t *testing.T) {
 	}
 }
 
+func TestControllerCancellationAfterReplaceRestoresPreviousTask(t *testing.T) {
+	root := t.TempDir()
+	desired := adapterPlanForPackage(t, root, "2.0.0")
+	previous := adapterPlanForPackage(t, root, "1.0.0")
+	files := newMemoryArtifacts()
+	ctx, cancel := context.WithCancel(t.Context())
+	scheduler := &memoryScheduler{files: files, cancelAfterCreate: cancel, rejectCanceled: true}
+	adapter, err := newAdapter(
+		desired,
+		root,
+		`\PowerContext\Tests\unit-cancel-replace`,
+		testIdentity,
+		scheduler,
+		files,
+		http.DefaultClient,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	previousDocument, err := adapter.renderPlan(previous)
+	if err != nil {
+		t.Fatal(err)
+	}
+	files.content, files.exists = previousDocument, true
+	scheduler.document, scheduler.present = bytes.Clone(previousDocument), true
+	controller, err := personalsvc.NewController(adapter, directOperationBoundary{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, installErr := controller.Install(ctx, desired.Registration())
+	if !errors.Is(installErr, context.Canceled) {
+		t.Fatalf("Install() error = %v; want context cancellation", installErr)
+	}
+	artifact, err := adapter.InspectArtifact(t.Context())
+	if err != nil || artifact.State() != personalsvc.RegistrationInstalled {
+		t.Fatalf("artifact after canceled replace = %s, %v", artifact.State(), err)
+	}
+	stored, found := artifact.Registration()
+	if !found || stored != previous.Registration() {
+		t.Fatal("canceled replace did not restore the previous artifact")
+	}
+	manager, err := adapter.InspectManager(t.Context())
+	if err != nil || manager.Ownership() != personalsvc.ManagerOwnershipOwned {
+		t.Fatalf("manager after canceled replace = %s, %v", manager.Ownership(), err)
+	}
+	loaded, found := manager.Registration()
+	if !found || loaded != previous.Registration() {
+		t.Fatal("canceled replace did not restore the previous loaded task")
+	}
+}
+
 func TestNativeArtifactStoreReplacesExactArtifact(t *testing.T) {
 	root := t.TempDir()
 	store, err := newNativeArtifactStore(root)

--- a/internal/personalsvchost/windows/adapter_windows_test.go
+++ b/internal/personalsvchost/windows/adapter_windows_test.go
@@ -25,6 +25,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -669,6 +670,110 @@ func TestControllerCancellationRestoresArtifactWithoutManager(t *testing.T) {
 	if err != nil || manager.Ownership() != personalsvc.ManagerOwnershipNotLoaded {
 		t.Fatalf("mixed manager after cancellation = %s, %v; want not loaded", manager.Ownership(), err)
 	}
+}
+
+func TestRestoreKeepsRoleSpecificSpecsAfterLaterStatusInspection(t *testing.T) {
+	root := t.TempDir()
+	base := adapterPlan(t, root)
+	registration := base.Registration()
+	desired := taskPlanVariant(t, registration, []string{"desired", "value"}, filepath.Join(root, "desired"), false)
+	artifactPlan := taskPlanVariant(t, registration, []string{"artifact", "value"}, filepath.Join(root, "artifact"), false)
+	managerPlan := taskPlanVariant(t, registration, []string{"manager", "value"}, filepath.Join(root, "manager"), true)
+	statusPlan := taskPlanVariant(t, registration, []string{"status", "value"}, filepath.Join(root, "status"), false)
+	files := newMemoryArtifacts()
+	scheduler := &memoryScheduler{files: files, state: personalsvc.ManagerInactive}
+	adapter, err := newAdapter(
+		desired,
+		root,
+		`\PowerContext\Tests\unit-role-snapshots`,
+		testIdentity,
+		scheduler,
+		files,
+		&http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return nil, errors.New("test endpoint is unreachable")
+		})},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	files.content, files.exists = mustRenderPlan(t, adapter, artifactPlan), true
+	scheduler.document, scheduler.present = mustRenderPlan(t, adapter, managerPlan), true
+	artifactSnapshot, err := adapter.InspectArtifact(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	managerSnapshot, err := adapter.InspectManager(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	statusDocument := mustRenderPlan(t, adapter, statusPlan)
+	files.content = statusDocument
+	scheduler.document = statusDocument
+	controller, err := personalsvc.NewController(adapter, directOperationBoundary{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	const statusChecks = 32
+	statusErrors := make(chan error, statusChecks)
+	var wait sync.WaitGroup
+	for range statusChecks {
+		wait.Go(func() {
+			_, statusErr := controller.Status(t.Context(), registration)
+			statusErrors <- statusErr
+		})
+	}
+	wait.Wait()
+	close(statusErrors)
+	for statusErr := range statusErrors {
+		if statusErr != nil {
+			t.Fatal(statusErr)
+		}
+	}
+	if err := adapter.Restore(t.Context(), artifactSnapshot, managerSnapshot); err != nil {
+		t.Fatal(err)
+	}
+
+	artifactDocument, exists, err := files.Read(t.Context(), adapter.artifactPath)
+	if err != nil || !exists {
+		t.Fatalf("restored artifact exists = %t, error = %v", exists, err)
+	}
+	restoredArtifact, ok := adapter.parse(artifactDocument)
+	if !ok || !restoredArtifact.Matches(artifactPlan) {
+		t.Fatal("later Status inspection overwrote the artifact restore snapshot")
+	}
+	state, managerDocument, err := scheduler.Query(t.Context())
+	if err != nil || state != personalsvc.TaskSchedulerPresent {
+		t.Fatalf("restored manager = %s, %v", state, err)
+	}
+	restoredManager, ok := adapter.parse(managerDocument)
+	if !ok || !restoredManager.Matches(managerPlan) {
+		t.Fatal("later Status inspection overwrote the manager restore snapshot")
+	}
+}
+
+func taskPlanVariant(
+	t *testing.T,
+	registration personalsvc.Registration,
+	arguments []string,
+	workingDirectory string,
+	startOnLogin bool,
+) personalsvc.TaskSchedulerSpec {
+	t.Helper()
+	plan, err := personalsvc.NewTaskSchedulerSpec(registration, arguments, workingDirectory, startOnLogin)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return plan
+}
+
+func mustRenderPlan(t *testing.T, adapter *Adapter, plan personalsvc.TaskSchedulerSpec) []byte {
+	t.Helper()
+	document, err := adapter.renderPlan(plan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return document
 }
 
 func assertOwnedManagerRegistration(t *testing.T, adapter *Adapter, want personalsvc.Registration) {

--- a/internal/personalsvchost/windows/adapter_windows_test.go
+++ b/internal/personalsvchost/windows/adapter_windows_test.go
@@ -1,0 +1,625 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package windows
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ob-labs/powercontext-go/internal/personalsvc"
+)
+
+const testTaskSID = "S-1-5-21-100-200-300-1001"
+
+func TestAdapterCompletesOwnedTaskLifecycleThroughExplicitBoundaries(t *testing.T) {
+	root := t.TempDir()
+	plan := adapterPlan(t, root)
+	files := newMemoryArtifacts()
+	scheduler := &memoryScheduler{files: files}
+	adapter, err := newAdapter(
+		plan,
+		root,
+		`\PowerContext\Tests\unit-lifecycle`,
+		testTaskSID,
+		scheduler,
+		files,
+		http.DefaultClient,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	support, err := adapter.Support(t.Context())
+	if err != nil || support != personalsvc.SupportSupported {
+		t.Fatalf("support = %s, %v; want supported", support, err)
+	}
+	artifact, err := adapter.InspectArtifact(t.Context())
+	if err != nil || artifact.State() != personalsvc.RegistrationNotInstalled {
+		t.Fatalf("initial artifact = %s, %v; want not installed", artifact.State(), err)
+	}
+	if err := adapter.Write(t.Context(), plan.Registration()); err != nil {
+		t.Fatal(err)
+	}
+	if err := adapter.Reload(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	if err := adapter.Enable(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	manager, err := adapter.InspectManager(t.Context())
+	if err != nil || manager.Ownership() != personalsvc.ManagerOwnershipOwned {
+		t.Fatalf("manager = %s, %v; want owned", manager.Ownership(), err)
+	}
+	if err := adapter.Start(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	if state, stateErr := adapter.ManagerState(t.Context()); stateErr != nil || state != personalsvc.ManagerActive {
+		t.Fatalf("manager state = %s, %v; want active", state, stateErr)
+	}
+	if err := adapter.Stop(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	if err := adapter.Disable(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	if err := adapter.Remove(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+
+	wantPath := filepath.Join(root, "PowerContext", "Services", "personal-server.xml")
+	if files.writePath != wantPath || files.removePath != wantPath {
+		t.Fatalf("artifact paths = write %q, remove %q; want %q", files.writePath, files.removePath, wantPath)
+	}
+	if bytes.Contains(files.lastWrite, []byte(personalsvc.TaskSchedulerInteractiveUser)) {
+		t.Fatal("written task retained the unresolved interactive-user placeholder")
+	}
+	if !slices.Equal(scheduler.mutations, []string{"create", "enable", "run", "end", "disable", "delete"}) {
+		t.Fatalf("scheduler mutations = %#v", scheduler.mutations)
+	}
+	artifact, err = adapter.InspectArtifact(t.Context())
+	if err != nil || artifact.State() != personalsvc.RegistrationNotInstalled {
+		t.Fatalf("final artifact = %s, %v; want not installed", artifact.State(), err)
+	}
+	manager, err = adapter.InspectManager(t.Context())
+	if err != nil || manager.Ownership() != personalsvc.ManagerOwnershipNotLoaded {
+		t.Fatalf("final manager = %s, %v; want not loaded", manager.Ownership(), err)
+	}
+}
+
+func TestAdapterRejectsForeignLoadedTaskBeforeMutation(t *testing.T) {
+	root := t.TempDir()
+	plan := adapterPlan(t, root)
+	files := newMemoryArtifacts()
+	scheduler := &memoryScheduler{files: files}
+	adapter, err := newAdapter(
+		plan,
+		root,
+		`\PowerContext\Tests\unit-foreign`,
+		testTaskSID,
+		scheduler,
+		files,
+		http.DefaultClient,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	owned, err := adapter.render()
+	if err != nil {
+		t.Fatal(err)
+	}
+	text, ok := decodeTaskDocument(owned)
+	if !ok {
+		t.Fatal("cannot decode owned fixture")
+	}
+	foreign := encodeTaskDocument(strings.Replace(text, personalsvc.OwnershipMarker, "foreign.owner", 1))
+	if bytes.Equal(foreign, owned) {
+		t.Fatal("foreign fixture did not change the ownership marker")
+	}
+	scheduler.present = true
+	scheduler.document = foreign
+	before := bytes.Clone(scheduler.document)
+
+	manager, err := adapter.InspectManager(t.Context())
+	if err != nil || manager.Ownership() != personalsvc.ManagerOwnershipForeign {
+		t.Fatalf("manager = %s, %v; want foreign", manager.Ownership(), err)
+	}
+	for _, operation := range []struct {
+		name string
+		run  func() error
+	}{
+		{name: "write", run: func() error { return adapter.Write(t.Context(), plan.Registration()) }},
+		{name: "enable", run: func() error { return adapter.Enable(t.Context()) }},
+		{name: "start", run: func() error { return adapter.Start(t.Context()) }},
+		{name: "stop", run: func() error { return adapter.Stop(t.Context()) }},
+		{name: "disable", run: func() error { return adapter.Disable(t.Context()) }},
+		{name: "remove", run: func() error { return adapter.Remove(t.Context()) }},
+	} {
+		t.Run(operation.name, func(t *testing.T) {
+			if err := operation.run(); err == nil {
+				t.Fatal("operation accepted a foreign loaded task")
+			}
+		})
+	}
+	if len(scheduler.mutations) != 0 || !bytes.Equal(scheduler.document, before) {
+		t.Fatalf("foreign task changed: mutations = %#v", scheduler.mutations)
+	}
+}
+
+func TestTaskSchedulerStateUsesNumericResultInsteadOfLocalizedText(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		code uint32
+		want personalsvc.ManagerState
+	}{
+		{name: "running", code: 0x41301, want: personalsvc.ManagerActive},
+		{name: "queued", code: 0x41325, want: personalsvc.ManagerActive},
+		{name: "successful", code: 0, want: personalsvc.ManagerInactive},
+		{name: "not yet run", code: 0x41303, want: personalsvc.ManagerInactive},
+		{name: "failed", code: 5, want: personalsvc.ManagerFailed},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			line := `"主机","任务","下次运行","任意本地化状态","登录","上次运行","` +
+				fmt.Sprint(test.code) + `","作者","操作","目录","注释","任意状态"` + "\r\n"
+			state, err := parseTaskState([]byte(line))
+			if err != nil || state != test.want {
+				t.Fatalf("parseTaskState() = %s, %v; want %s", state, err, test.want)
+			}
+		})
+	}
+	if _, err := parseTaskState([]byte(`"too","short"`)); err == nil {
+		t.Fatal("parseTaskState() accepted a truncated row")
+	}
+}
+
+func TestAdapterZeroValueFailsClosed(t *testing.T) {
+	zero := &Adapter{}
+	if _, err := zero.InspectManager(t.Context()); err == nil {
+		t.Fatal("zero-value adapter inspected the scheduler")
+	}
+	if err := zero.Start(t.Context()); err == nil {
+		t.Fatal("zero-value adapter started a task")
+	}
+}
+
+func TestAdapterRejectsGlobalRoot(t *testing.T) {
+	root := filepath.Join(filepath.VolumeName(t.TempDir())+string(filepath.Separator), "Windows")
+	plan := adapterPlan(t, t.TempDir())
+	adapter, err := newAdapter(
+		plan,
+		root,
+		personalsvc.TaskSchedulerTaskName,
+		testTaskSID,
+		&memoryScheduler{files: newMemoryArtifacts()},
+		newMemoryArtifacts(),
+		http.DefaultClient,
+	)
+	if adapter != nil || err == nil {
+		t.Fatalf("newAdapter(global root) = %v, %v; want rejection", adapter, err)
+	}
+	if _, found := errors.AsType[*Error](err); !found {
+		t.Fatalf("configuration error type = %T; want *Error", err)
+	}
+}
+
+func TestInteractiveSessionRejectsServiceSession(t *testing.T) {
+	if validInteractiveSession(0) {
+		t.Fatal("session 0 was accepted as an interactive user session")
+	}
+	if !validInteractiveSession(1) {
+		t.Fatal("nonzero user session was rejected")
+	}
+}
+
+func TestNewComposesProductionAdapterAndOperationBoundary(t *testing.T) {
+	if (&Composition{}).Adapter() != nil || (&Composition{}).OperationBoundary() != nil {
+		t.Fatal("zero-value composition exposed a typed-nil boundary")
+	}
+	if _, err := currentUserSID(); err != nil {
+		t.Skip("current process does not have an interactive user identity")
+	}
+	root := t.TempDir()
+	composition, err := New(Config{UserDataRoot: root, Plan: adapterPlan(t, root)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if composition.Adapter() == nil || composition.OperationBoundary() == nil {
+		t.Fatal("New() returned an incomplete composition")
+	}
+	if got := composition.Adapter().artifactPath; got != filepath.Join(root, "PowerContext", "Services", "personal-server.xml") {
+		t.Fatalf("artifact path = %q", got)
+	}
+	if composition.Adapter().taskName != personalsvc.TaskSchedulerTaskName {
+		t.Fatalf("production task = %q", composition.Adapter().taskName)
+	}
+}
+
+func TestOperationBoundarySerializesAndHonorsCancellation(t *testing.T) {
+	boundary, err := newOperationBoundary(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	first := make(chan error, 1)
+	go func() {
+		first <- boundary.Run(t.Context(), func(context.Context) error {
+			close(entered)
+			<-release
+			return nil
+		})
+	}()
+	select {
+	case <-entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("first operation did not enter the boundary")
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 50*time.Millisecond)
+	defer cancel()
+	secondEntered := false
+	err = boundary.Run(ctx, func(context.Context) error {
+		secondEntered = true
+		return nil
+	})
+	if !errors.Is(err, context.DeadlineExceeded) || secondEntered {
+		t.Fatalf("contended Run() = %v, entered = %t", err, secondEntered)
+	}
+	close(release)
+	if err := <-first; err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestProbeRequiresExactLoopbackLivenessContract(t *testing.T) {
+	contacts := 0
+	client := &http.Client{Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		contacts++
+		if request.URL.String() != "http://127.0.0.1:8123/health/live" {
+			t.Errorf("probe URL = %q", request.URL)
+		}
+		header := make(http.Header)
+		header.Set("Content-Type", "application/json")
+		header.Set("X-PowerContext-Request-ID", "0123456789abcdef")
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     header,
+			Body:       io.NopCloser(strings.NewReader(`{"status":"ok"}`)),
+		}, nil
+	})}
+	root := t.TempDir()
+	plan := adapterPlan(t, root)
+	adapter, err := newAdapter(
+		plan,
+		root,
+		`\PowerContext\Tests\unit-probe`,
+		testTaskSID,
+		&memoryScheduler{files: newMemoryArtifacts()},
+		newMemoryArtifacts(),
+		client,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	state, err := adapter.Probe(t.Context(), "http://127.0.0.1:8123")
+	if err != nil || state != personalsvc.ProbeLive {
+		t.Fatalf("Probe() = %s, %v; want live", state, err)
+	}
+	state, err = adapter.Probe(t.Context(), "http://example.test:8123")
+	if err == nil || state != personalsvc.ProbeUnreachable {
+		t.Fatalf("remote Probe() = %s, %v; want rejected", state, err)
+	}
+	if contacts != 1 {
+		t.Fatalf("probe contacts = %d; want one loopback request", contacts)
+	}
+}
+
+func TestStopDoesNotEndOwnedInactiveTask(t *testing.T) {
+	root := t.TempDir()
+	plan := adapterPlan(t, root)
+	files := newMemoryArtifacts()
+	scheduler := &memoryScheduler{files: files}
+	adapter, err := newAdapter(
+		plan,
+		root,
+		`\PowerContext\Tests\unit-inactive`,
+		testTaskSID,
+		scheduler,
+		files,
+		http.DefaultClient,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	document, err := adapter.render()
+	if err != nil {
+		t.Fatal(err)
+	}
+	scheduler.present = true
+	scheduler.document = document
+	scheduler.state = personalsvc.ManagerInactive
+
+	if err := adapter.Stop(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	if len(scheduler.mutations) != 0 {
+		t.Fatalf("inactive Stop() mutations = %#v; want none", scheduler.mutations)
+	}
+}
+
+func TestControllerRestoresPreviouslyInspectedTaskAfterEnableFailure(t *testing.T) {
+	root := t.TempDir()
+	desired := adapterPlanForPackage(t, root, "2.0.0")
+	previous := adapterPlanForPackage(t, root, "1.0.0")
+	files := newMemoryArtifacts()
+	scheduler := &memoryScheduler{files: files, enableErr: errors.New("native enable detail")}
+	adapter, err := newAdapter(
+		desired,
+		root,
+		`\PowerContext\Tests\unit-rollback`,
+		testTaskSID,
+		scheduler,
+		files,
+		http.DefaultClient,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	previousDocument, err := previous.XML()
+	if err != nil {
+		t.Fatal(err)
+	}
+	previousDocument, ok := rewriteTaskDocument(
+		previousDocument,
+		personalsvc.TaskSchedulerTaskName,
+		adapter.taskName,
+		personalsvc.TaskSchedulerInteractiveUser,
+		testTaskSID,
+	)
+	if !ok {
+		t.Fatal("cannot resolve previous task fixture")
+	}
+	files.content, files.exists = previousDocument, true
+	scheduler.document, scheduler.present = bytes.Clone(previousDocument), true
+	controller, err := personalsvc.NewController(adapter, directOperationBoundary{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := controller.Install(t.Context(), desired.Registration()); err == nil {
+		t.Fatal("Install() unexpectedly survived the injected enable failure")
+	}
+	artifact, err := adapter.InspectArtifact(t.Context())
+	if err != nil || artifact.State() != personalsvc.RegistrationInstalled {
+		t.Fatalf("restored artifact = %s, %v", artifact.State(), err)
+	}
+	registration, found := artifact.Registration()
+	if !found || registration != previous.Registration() {
+		t.Fatal("enable failure did not restore the previously inspected registration")
+	}
+}
+
+func TestNativeArtifactStoreReplacesExactArtifact(t *testing.T) {
+	root := t.TempDir()
+	store, err := newNativeArtifactStore(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(root, "PowerContext", "Services", "personal-server.xml")
+	if err := store.Write(t.Context(), path, []byte("first")); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Write(t.Context(), path, []byte("second")); err != nil {
+		t.Fatal(err)
+	}
+	content, exists, err := store.Read(t.Context(), path)
+	if err != nil || !exists || string(content) != "second" {
+		t.Fatalf("replaced artifact = %q, exists %t, error %v", content, exists, err)
+	}
+	if _, _, err := store.Read(t.Context(), filepath.Join(root, "foreign.xml")); err == nil {
+		t.Fatal("artifact store accepted a foreign path")
+	}
+}
+
+func TestOperationBoundaryUsesCrossInstanceFileLock(t *testing.T) {
+	root := t.TempDir()
+	firstBoundary, err := newOperationBoundary(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondBoundary, err := newOperationBoundary(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	first := make(chan error, 1)
+	go func() {
+		first <- firstBoundary.Run(t.Context(), func(context.Context) error {
+			close(entered)
+			<-release
+			return nil
+		})
+	}()
+	select {
+	case <-entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("first operation did not acquire its file lock")
+	}
+	ctx, cancel := context.WithTimeout(t.Context(), 50*time.Millisecond)
+	defer cancel()
+	err = secondBoundary.Run(ctx, func(context.Context) error {
+		t.Fatal("contended cross-instance operation entered")
+		return nil
+	})
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("contended cross-instance Run() = %v", err)
+	}
+	close(release)
+	if err := <-first; err != nil {
+		t.Fatal(err)
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) { return f(request) }
+
+func adapterPlan(t *testing.T, root string) personalsvc.TaskSchedulerSpec {
+	return adapterPlanForPackage(t, root, "1.2.3")
+}
+
+func adapterPlanForPackage(t *testing.T, root, packageVersion string) personalsvc.TaskSchedulerSpec {
+	t.Helper()
+	binary, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	definition, err := personalsvc.NewDefinition(personalsvc.DefinitionInput{
+		Ownership:         personalsvc.OwnershipMarker,
+		DefinitionVersion: personalsvc.DefinitionVersion,
+		PackageVersion:    packageVersion,
+		Binary:            binary,
+		Endpoint:          "http://127.0.0.1:1",
+		DataDir:           root,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	registration, err := personalsvc.NewRegistration(definition)
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan, err := personalsvc.NewTaskSchedulerSpec(registration, []string{"server", "run"}, root, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return plan
+}
+
+type memoryArtifacts struct {
+	content    []byte
+	exists     bool
+	writePath  string
+	removePath string
+	lastWrite  []byte
+}
+
+func newMemoryArtifacts() *memoryArtifacts { return &memoryArtifacts{} }
+
+func (f *memoryArtifacts) Read(_ context.Context, path string) ([]byte, bool, error) {
+	return bytes.Clone(f.content), f.exists, nil
+}
+
+func (f *memoryArtifacts) Write(_ context.Context, path string, content []byte) error {
+	f.content = bytes.Clone(content)
+	f.exists = true
+	f.writePath = path
+	f.lastWrite = bytes.Clone(content)
+	return nil
+}
+
+func (f *memoryArtifacts) Remove(_ context.Context, path string) error {
+	f.content = nil
+	f.exists = false
+	f.removePath = path
+	return nil
+}
+
+func (*memoryArtifacts) RegularFile(context.Context, string) (bool, error) { return true, nil }
+
+type memoryScheduler struct {
+	files     *memoryArtifacts
+	document  []byte
+	present   bool
+	state     personalsvc.ManagerState
+	mutations []string
+	enableErr error
+}
+
+func (s *memoryScheduler) Query(context.Context) (personalsvc.TaskSchedulerState, []byte, error) {
+	if !s.present {
+		return personalsvc.TaskSchedulerAbsent, nil, nil
+	}
+	return personalsvc.TaskSchedulerPresent, bytes.Clone(s.document), nil
+}
+
+func (s *memoryScheduler) Create(ctx context.Context, path string) error {
+	content, exists, err := s.files.Read(ctx, path)
+	if err != nil || !exists {
+		return os.ErrNotExist
+	}
+	s.document = content
+	s.present = true
+	s.state = personalsvc.ManagerInactive
+	s.mutations = append(s.mutations, "create")
+	return nil
+}
+
+func (s *memoryScheduler) Run(context.Context) error {
+	s.state = personalsvc.ManagerActive
+	s.mutations = append(s.mutations, "run")
+	return nil
+}
+
+func (s *memoryScheduler) End(context.Context) error {
+	s.state = personalsvc.ManagerInactive
+	s.mutations = append(s.mutations, "end")
+	return nil
+}
+
+func (s *memoryScheduler) Enable(context.Context) error {
+	s.mutations = append(s.mutations, "enable")
+	if s.enableErr != nil {
+		err := s.enableErr
+		s.enableErr = nil
+		return err
+	}
+	return nil
+}
+
+func (s *memoryScheduler) Disable(context.Context) error {
+	s.state = personalsvc.ManagerInactive
+	s.mutations = append(s.mutations, "disable")
+	return nil
+}
+
+func (s *memoryScheduler) Delete(context.Context) error {
+	s.document = nil
+	s.present = false
+	s.state = personalsvc.ManagerInactive
+	s.mutations = append(s.mutations, "delete")
+	return nil
+}
+
+func (s *memoryScheduler) State(context.Context) (personalsvc.ManagerState, error) {
+	return s.state, nil
+}
+
+type directOperationBoundary struct{}
+
+func (directOperationBoundary) Run(ctx context.Context, operation func(context.Context) error) error {
+	return operation(ctx)
+}

--- a/internal/personalsvchost/windows/adapter_windows_test.go
+++ b/internal/personalsvchost/windows/adapter_windows_test.go
@@ -304,7 +304,11 @@ func TestNewComposesProductionAdapterAndOperationBoundary(t *testing.T) {
 	if composition.Adapter() == nil || composition.OperationBoundary() == nil {
 		t.Fatal("New() returned an incomplete composition")
 	}
-	if got := composition.Adapter().artifactPath; got != filepath.Join(root, "PowerContext", "Services", "personal-server.xml") {
+	canonicalRoot, rootErr := resolveUserDataRoot(root)
+	if rootErr != nil {
+		t.Fatal(rootErr)
+	}
+	if got := composition.Adapter().artifactPath; got != filepath.Join(canonicalRoot, "PowerContext", "Services", "personal-server.xml") {
 		t.Fatalf("artifact path = %q", got)
 	}
 	if composition.Adapter().taskName != personalsvc.TaskSchedulerTaskName {
@@ -794,7 +798,7 @@ func TestNativeArtifactStoreReplacesExactArtifact(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	path := filepath.Join(root, "PowerContext", "Services", "personal-server.xml")
+	path := store.artifactPath
 	if firstWriteErr := store.Write(t.Context(), path, []byte("first")); firstWriteErr != nil {
 		t.Fatal(firstWriteErr)
 	}

--- a/internal/personalsvchost/windows/adapter_windows_test.go
+++ b/internal/personalsvchost/windows/adapter_windows_test.go
@@ -64,33 +64,33 @@ func TestAdapterCompletesOwnedTaskLifecycleThroughExplicitBoundaries(t *testing.
 	if err != nil || artifact.State() != personalsvc.RegistrationNotInstalled {
 		t.Fatalf("initial artifact = %s, %v; want not installed", artifact.State(), err)
 	}
-	if err := adapter.Write(t.Context(), plan.Registration()); err != nil {
-		t.Fatal(err)
+	if writeErr := adapter.Write(t.Context(), plan.Registration()); writeErr != nil {
+		t.Fatal(writeErr)
 	}
-	if err := adapter.Reload(t.Context()); err != nil {
-		t.Fatal(err)
+	if reloadErr := adapter.Reload(t.Context()); reloadErr != nil {
+		t.Fatal(reloadErr)
 	}
-	if err := adapter.Enable(t.Context()); err != nil {
-		t.Fatal(err)
+	if enableErr := adapter.Enable(t.Context()); enableErr != nil {
+		t.Fatal(enableErr)
 	}
 	manager, err := adapter.InspectManager(t.Context())
 	if err != nil || manager.Ownership() != personalsvc.ManagerOwnershipOwned {
 		t.Fatalf("manager = %s, %v; want owned", manager.Ownership(), err)
 	}
-	if err := adapter.Start(t.Context()); err != nil {
-		t.Fatal(err)
+	if startErr := adapter.Start(t.Context()); startErr != nil {
+		t.Fatal(startErr)
 	}
 	if state, stateErr := adapter.ManagerState(t.Context()); stateErr != nil || state != personalsvc.ManagerActive {
 		t.Fatalf("manager state = %s, %v; want active", state, stateErr)
 	}
-	if err := adapter.Stop(t.Context()); err != nil {
-		t.Fatal(err)
+	if stopErr := adapter.Stop(t.Context()); stopErr != nil {
+		t.Fatal(stopErr)
 	}
-	if err := adapter.Disable(t.Context()); err != nil {
-		t.Fatal(err)
+	if disableErr := adapter.Disable(t.Context()); disableErr != nil {
+		t.Fatal(disableErr)
 	}
-	if err := adapter.Remove(t.Context()); err != nil {
-		t.Fatal(err)
+	if removeErr := adapter.Remove(t.Context()); removeErr != nil {
+		t.Fatal(removeErr)
 	}
 
 	wantPath := filepath.Join(root, "PowerContext", "Services", "personal-server.xml")
@@ -465,7 +465,7 @@ func TestControllerRestoresPreviouslyInspectedTaskAfterEnableFailure(t *testing.
 		t.Fatal(err)
 	}
 
-	if _, err := controller.Install(t.Context(), desired.Registration()); err == nil {
+	if _, installErr := controller.Install(t.Context(), desired.Registration()); installErr == nil {
 		t.Fatal("Install() unexpectedly survived the injected enable failure")
 	}
 	artifact, err := adapter.InspectArtifact(t.Context())
@@ -730,8 +730,8 @@ func TestRestoreKeepsRoleSpecificSpecsAfterLaterStatusInspection(t *testing.T) {
 			t.Fatal(statusErr)
 		}
 	}
-	if err := adapter.Restore(t.Context(), artifactSnapshot, managerSnapshot); err != nil {
-		t.Fatal(err)
+	if restoreErr := adapter.Restore(t.Context(), artifactSnapshot, managerSnapshot); restoreErr != nil {
+		t.Fatal(restoreErr)
 	}
 
 	artifactDocument, exists, err := files.Read(t.Context(), adapter.artifactPath)
@@ -795,11 +795,11 @@ func TestNativeArtifactStoreReplacesExactArtifact(t *testing.T) {
 		t.Fatal(err)
 	}
 	path := filepath.Join(root, "PowerContext", "Services", "personal-server.xml")
-	if err := store.Write(t.Context(), path, []byte("first")); err != nil {
-		t.Fatal(err)
+	if firstWriteErr := store.Write(t.Context(), path, []byte("first")); firstWriteErr != nil {
+		t.Fatal(firstWriteErr)
 	}
-	if err := store.Write(t.Context(), path, []byte("second")); err != nil {
-		t.Fatal(err)
+	if secondWriteErr := store.Write(t.Context(), path, []byte("second")); secondWriteErr != nil {
+		t.Fatal(secondWriteErr)
 	}
 	content, exists, err := store.Read(t.Context(), path)
 	if err != nil || !exists || string(content) != "second" {

--- a/internal/personalsvchost/windows/adapter_windows_test.go
+++ b/internal/personalsvchost/windows/adapter_windows_test.go
@@ -93,7 +93,11 @@ func TestAdapterCompletesOwnedTaskLifecycleThroughExplicitBoundaries(t *testing.
 		t.Fatal(removeErr)
 	}
 
-	wantPath := filepath.Join(root, "PowerContext", "Services", "personal-server.xml")
+	canonicalRoot, rootErr := resolveUserDataRoot(root)
+	if rootErr != nil {
+		t.Fatal(rootErr)
+	}
+	wantPath := filepath.Join(canonicalRoot, "PowerContext", "Services", "personal-server.xml")
 	if files.writePath != wantPath || files.removePath != wantPath {
 		t.Fatalf("artifact paths = write %q, remove %q; want %q", files.writePath, files.removePath, wantPath)
 	}

--- a/internal/personalsvchost/windows/doc.go
+++ b/internal/personalsvchost/windows/doc.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package windows provides the Windows-native process boundary for the
-// portable personal-service Task Scheduler contract.
+// Package windows composes the portable personal-service Task Scheduler
+// contract with current-user Windows process, filesystem, identity, liveness,
+// and operation-lock boundaries.
 package windows

--- a/internal/personalsvchost/windows/doc.go
+++ b/internal/personalsvchost/windows/doc.go
@@ -1,0 +1,17 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package windows provides the Windows-native process boundary for the
+// portable personal-service Task Scheduler contract.
+package windows

--- a/internal/personalsvchost/windows/executor_windows.go
+++ b/internal/personalsvchost/windows/executor_windows.go
@@ -1,0 +1,134 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package windows
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+
+	"github.com/ob-labs/powercontext-go/internal/personalsvc"
+	golangwindows "golang.org/x/sys/windows"
+)
+
+const (
+	taskSchedulerProgram  = "schtasks.exe"
+	maxCommandOutputBytes = 1 << 20
+)
+
+var (
+	errExecutorInvalid     = errors.New("Windows Task Scheduler executor is invalid")
+	errExecutorUnavailable = errors.New("Windows Task Scheduler executable is unavailable")
+	errExecutorOutputLimit = errors.New("Windows Task Scheduler command output exceeded the limit")
+)
+
+// Executor runs the fixed Task Scheduler program without a command shell.
+// It must be constructed with NewExecutor.
+type Executor struct {
+	executable string
+}
+
+var _ personalsvc.TaskSchedulerExecutor = Executor{}
+
+// String returns a content-free description of the executor.
+func (Executor) String() string { return "Windows Task Scheduler executor" }
+
+// GoString returns a content-free Go-syntax description of the executor.
+func (Executor) GoString() string { return "windows.Executor{}" }
+
+// NewExecutor resolves the Windows system copy of schtasks.exe to an absolute
+// path before any command is run.
+func NewExecutor() (Executor, error) {
+	systemDirectory, err := golangwindows.GetSystemDirectory()
+	if err != nil || !filepath.IsAbs(systemDirectory) {
+		return Executor{}, errExecutorUnavailable
+	}
+	executable := filepath.Join(systemDirectory, taskSchedulerProgram)
+	info, err := os.Stat(executable)
+	if err != nil || !info.Mode().IsRegular() {
+		return Executor{}, errExecutorUnavailable
+	}
+	return newExecutor(executable), nil
+}
+
+func newExecutor(executable string) Executor {
+	return Executor{executable: filepath.Clean(executable)}
+}
+
+// Execute runs one argv vector from the portable Task Scheduler contract.
+// Command output is drained under a fixed combined limit but never returned.
+func (e Executor) Execute(
+	ctx context.Context,
+	program string,
+	arguments []string,
+) (personalsvc.TaskSchedulerResult, error) {
+	if ctx == nil || program != taskSchedulerProgram || !filepath.IsAbs(e.executable) {
+		return personalsvc.TaskSchedulerResult{}, errExecutorInvalid
+	}
+
+	commandContext, cancel := context.WithCancel(ctx)
+	defer cancel()
+	output := &boundedOutput{limit: maxCommandOutputBytes, cancel: cancel}
+	command := exec.CommandContext(commandContext, e.executable, arguments...)
+	command.Stdout = output
+	command.Stderr = output
+	runErr := command.Run()
+	if contextErr := ctx.Err(); contextErr != nil {
+		return personalsvc.TaskSchedulerResult{}, contextErr
+	}
+	if output.Exceeded() {
+		return personalsvc.TaskSchedulerResult{}, errExecutorOutputLimit
+	}
+	if runErr == nil {
+		return personalsvc.TaskSchedulerResult{}, nil
+	}
+	if exitError, matched := errors.AsType[*exec.ExitError](runErr); matched {
+		return personalsvc.TaskSchedulerResult{ExitCode: uint32(exitError.ExitCode())}, nil
+	}
+	return personalsvc.TaskSchedulerResult{}, errExecutorUnavailable
+}
+
+type boundedOutput struct {
+	mu       sync.Mutex
+	limit    int
+	written  int
+	exceeded bool
+	cancel   context.CancelFunc
+}
+
+func (w *boundedOutput) Write(data []byte) (int, error) {
+	w.mu.Lock()
+	remaining := max(0, w.limit-w.written)
+	accepted := min(remaining, len(data))
+	w.written += accepted
+	exceeded := accepted != len(data)
+	if exceeded {
+		w.exceeded = true
+	}
+	w.mu.Unlock()
+	if exceeded && w.cancel != nil {
+		w.cancel()
+	}
+	return len(data), nil
+}
+
+func (w *boundedOutput) Exceeded() bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.exceeded
+}

--- a/internal/personalsvchost/windows/executor_windows.go
+++ b/internal/personalsvchost/windows/executor_windows.go
@@ -23,8 +23,9 @@ import (
 	"path/filepath"
 	"sync"
 
-	"github.com/ob-labs/powercontext-go/internal/personalsvc"
 	golangwindows "golang.org/x/sys/windows"
+
+	"github.com/ob-labs/powercontext-go/internal/personalsvc"
 )
 
 const (

--- a/internal/personalsvchost/windows/executor_windows.go
+++ b/internal/personalsvchost/windows/executor_windows.go
@@ -15,6 +15,7 @@
 package windows
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"os"
@@ -83,27 +84,35 @@ func (e Executor) Execute(
 
 	commandContext, cancel := context.WithCancel(ctx)
 	defer cancel()
-	output := &boundedOutput{limit: maxCommandOutputBytes, cancel: cancel}
+	budget := &outputBudget{limit: maxCommandOutputBytes, cancel: cancel}
+	stdout := &boundedOutput{budget: budget, capture: structuredQuery(arguments)}
+	stderr := &boundedOutput{budget: budget}
 	command := exec.CommandContext(commandContext, e.executable, arguments...)
-	command.Stdout = output
-	command.Stderr = output
+	command.Stdout = stdout
+	command.Stderr = stderr
 	runErr := command.Run()
 	if contextErr := ctx.Err(); contextErr != nil {
 		return personalsvc.TaskSchedulerResult{}, contextErr
 	}
-	if output.Exceeded() {
+	if budget.Exceeded() {
 		return personalsvc.TaskSchedulerResult{}, errExecutorOutputLimit
 	}
 	if runErr == nil {
-		return personalsvc.TaskSchedulerResult{}, nil
+		return personalsvc.TaskSchedulerResult{Output: stdout.Bytes()}, nil
 	}
 	if exitError, matched := errors.AsType[*exec.ExitError](runErr); matched {
-		return personalsvc.TaskSchedulerResult{ExitCode: uint32(exitError.ExitCode())}, nil
+		return personalsvc.TaskSchedulerResult{ExitCode: uint32(exitError.ExitCode()), Output: stdout.Bytes()}, nil
 	}
 	return personalsvc.TaskSchedulerResult{}, errExecutorUnavailable
 }
 
 type boundedOutput struct {
+	budget  *outputBudget
+	capture bool
+	buffer  bytes.Buffer
+}
+
+type outputBudget struct {
 	mu       sync.Mutex
 	limit    int
 	written  int
@@ -112,23 +121,42 @@ type boundedOutput struct {
 }
 
 func (w *boundedOutput) Write(data []byte) (int, error) {
-	w.mu.Lock()
-	remaining := max(0, w.limit-w.written)
+	w.budget.mu.Lock()
+	remaining := max(0, w.budget.limit-w.budget.written)
 	accepted := min(remaining, len(data))
-	w.written += accepted
+	w.budget.written += accepted
 	exceeded := accepted != len(data)
 	if exceeded {
-		w.exceeded = true
+		w.budget.exceeded = true
 	}
-	w.mu.Unlock()
-	if exceeded && w.cancel != nil {
-		w.cancel()
+	if w.capture && accepted != 0 {
+		_, _ = w.buffer.Write(data[:accepted])
+	}
+	w.budget.mu.Unlock()
+	if exceeded && w.budget.cancel != nil {
+		w.budget.cancel()
 	}
 	return len(data), nil
 }
 
-func (w *boundedOutput) Exceeded() bool {
-	w.mu.Lock()
-	defer w.mu.Unlock()
-	return w.exceeded
+func (w *boundedOutput) Bytes() []byte {
+	w.budget.mu.Lock()
+	defer w.budget.mu.Unlock()
+	return bytes.Clone(w.buffer.Bytes())
+}
+
+func (b *outputBudget) Exceeded() bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.exceeded
+}
+
+func structuredQuery(arguments []string) bool {
+	if len(arguments) == 5 {
+		return arguments[0] == "/Query" && arguments[1] == "/TN" && arguments[2] != "" &&
+			arguments[3] == "/XML" && arguments[4] == "/HRESULT"
+	}
+	return len(arguments) == 8 && arguments[0] == "/Query" && arguments[1] == "/TN" && arguments[2] != "" &&
+		arguments[3] == "/FO" && arguments[4] == "CSV" && arguments[5] == "/NH" &&
+		arguments[6] == "/V" && arguments[7] == "/HRESULT"
 }

--- a/internal/personalsvchost/windows/executor_windows_test.go
+++ b/internal/personalsvchost/windows/executor_windows_test.go
@@ -164,6 +164,36 @@ func TestExecutorOutputLimitTerminatesCommand(t *testing.T) {
 	assertExecutorResultRedacted(t, result, err)
 }
 
+func TestExecutorCombinedOutputLimitFailsClosed(t *testing.T) {
+	t.Setenv(helperProcessEnvironment, "split-overflow")
+	executor := executorForTest(t)
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+
+	result, err := executor.Execute(ctx, "schtasks.exe", []string{"/Query", "/XML"})
+	if !errors.Is(err, errExecutorOutputLimit) {
+		t.Fatalf("Execute() error = %v, want output-limit error", err)
+	}
+	if ctx.Err() != nil {
+		t.Fatalf("Execute() waited for caller cancellation: %v", ctx.Err())
+	}
+	assertExecutorResultRedacted(t, result, err)
+}
+
+func TestExecutorAllowsExactCombinedOutputLimit(t *testing.T) {
+	t.Setenv(helperProcessEnvironment, "split-at-limit")
+	executor := executorForTest(t)
+
+	result, err := executor.Execute(t.Context(), "schtasks.exe", []string{"/Query", "/XML"})
+	if err != nil {
+		t.Fatalf("Execute() error = %v, want nil at the combined output limit", err)
+	}
+	if result.ExitCode != 0 {
+		t.Fatalf("Execute() exit code = %#x, want 0", result.ExitCode)
+	}
+	assertExecutorResultRedacted(t, result, err)
+}
+
 func TestExecutorInvalidBoundaryFailsClosed(t *testing.T) {
 	for _, test := range []struct {
 		name     string
@@ -286,6 +316,12 @@ func runExecutorHelperProcess() {
 	case "overflow-block":
 		_, _ = os.Stdout.Write(bytesOf('x', maxCommandOutputBytes+1))
 		time.Sleep(24 * time.Hour)
+	case "split-overflow":
+		_, _ = os.Stdout.Write(bytesOf('x', maxCommandOutputBytes/2+1))
+		_, _ = os.Stderr.Write(bytesOf('y', maxCommandOutputBytes/2+1))
+	case "split-at-limit":
+		_, _ = os.Stdout.Write(bytesOf('x', maxCommandOutputBytes/2))
+		_, _ = os.Stderr.Write(bytesOf('y', maxCommandOutputBytes/2))
 	default:
 		os.Exit(123)
 	}

--- a/internal/personalsvchost/windows/executor_windows_test.go
+++ b/internal/personalsvchost/windows/executor_windows_test.go
@@ -1,0 +1,300 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package windows
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ob-labs/powercontext-go/internal/personalsvc"
+)
+
+const helperProcessEnvironment = "POWERCONTEXT_WINDOWS_EXECUTOR_HELPER"
+
+func TestMain(m *testing.M) {
+	if os.Getenv(helperProcessEnvironment) != "" {
+		runExecutorHelperProcess()
+		os.Exit(0)
+	}
+	os.Exit(m.Run())
+}
+
+func TestExecutorPassesArgumentsWithoutShell(t *testing.T) {
+	argumentsPath := filepath.Join(t.TempDir(), "arguments.txt")
+	t.Setenv(helperProcessEnvironment, "record-arguments")
+	t.Setenv("POWERCONTEXT_WINDOWS_EXECUTOR_ARGUMENTS", argumentsPath)
+	executor := executorForTest(t)
+
+	result, err := executor.Execute(t.Context(), "schtasks.exe", []string{
+		"/Query",
+		"/TN",
+		`\PowerContext Personal Server`,
+		"argument with spaces",
+		"&whoami",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.ExitCode != 0 {
+		t.Fatalf("Execute() exit code = %#x, want 0", result.ExitCode)
+	}
+	if result.Output != nil {
+		t.Fatalf("Execute() output = %q, want nil", result.Output)
+	}
+
+	recorded, err := os.ReadFile(argumentsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"/Query", "/TN", `\PowerContext Personal Server`, "argument with spaces", "&whoami"}
+	if got := strings.Split(string(recorded), "\n"); !slices.Equal(got, want) {
+		t.Fatalf("helper arguments = %#v, want %#v", got, want)
+	}
+}
+
+func TestExecutorPreservesExitCodeBitPattern(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		code uint32
+	}{
+		{name: "ordinary nonzero", code: 5},
+		{name: "HRESULT with signed process representation", code: 0x80070002},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv(helperProcessEnvironment, "exit")
+			t.Setenv("POWERCONTEXT_WINDOWS_EXECUTOR_EXIT_CODE", strconv.FormatUint(uint64(test.code), 10))
+			executor := executorForTest(t)
+
+			result, err := executor.Execute(t.Context(), "schtasks.exe", []string{"/Query"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if result.ExitCode != test.code {
+				t.Fatalf("Execute() exit code = %#x, want %#x", result.ExitCode, test.code)
+			}
+			if result.Output != nil {
+				t.Fatalf("Execute() output = %q, want nil", result.Output)
+			}
+		})
+	}
+}
+
+func TestExecutorCancellationTerminatesCommand(t *testing.T) {
+	startedPath := filepath.Join(t.TempDir(), "started")
+	t.Setenv(helperProcessEnvironment, "block")
+	t.Setenv("POWERCONTEXT_WINDOWS_EXECUTOR_STARTED", startedPath)
+	executor := executorForTest(t)
+	ctx, cancel := context.WithCancel(t.Context())
+	resultChannel := make(chan executeResult, 1)
+	go func() {
+		result, err := executor.Execute(ctx, "schtasks.exe", []string{"/Query"})
+		resultChannel <- executeResult{result: result, err: err}
+	}()
+
+	waitForHelperStart(t, startedPath)
+	cancel()
+
+	select {
+	case got := <-resultChannel:
+		if !errors.Is(got.err, context.Canceled) {
+			t.Fatalf("Execute() error = %v, want context cancellation", got.err)
+		}
+		assertExecutorResultRedacted(t, got.result, got.err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Execute() did not return after cancellation")
+	}
+}
+
+func TestExecutorMissingExecutableReturnsRedactedFailure(t *testing.T) {
+	executor := newExecutor(filepath.Join(t.TempDir(), "missing-schtasks.exe"))
+
+	result, err := executor.Execute(t.Context(), "schtasks.exe", []string{
+		"/Create", "/XML", `C:\Users\person\secret-task.xml`,
+	})
+	if !errors.Is(err, errExecutorUnavailable) {
+		t.Fatalf("Execute() error = %v, want unavailable error", err)
+	}
+	assertExecutorResultRedacted(t, result, err)
+}
+
+func TestExecutorOutputLimitFailsClosed(t *testing.T) {
+	t.Setenv(helperProcessEnvironment, "overflow")
+	executor := executorForTest(t)
+
+	result, err := executor.Execute(t.Context(), "schtasks.exe", []string{"/Query", "/XML"})
+	if !errors.Is(err, errExecutorOutputLimit) {
+		t.Fatalf("Execute() error = %v, want output-limit error", err)
+	}
+	assertExecutorResultRedacted(t, result, err)
+}
+
+func TestExecutorOutputLimitTerminatesCommand(t *testing.T) {
+	t.Setenv(helperProcessEnvironment, "overflow-block")
+	executor := executorForTest(t)
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+
+	result, err := executor.Execute(ctx, "schtasks.exe", []string{"/Query", "/XML"})
+	if !errors.Is(err, errExecutorOutputLimit) {
+		t.Fatalf("Execute() error = %v, want output-limit error", err)
+	}
+	if ctx.Err() != nil {
+		t.Fatalf("Execute() waited for caller cancellation: %v", ctx.Err())
+	}
+	assertExecutorResultRedacted(t, result, err)
+}
+
+func TestExecutorInvalidBoundaryFailsClosed(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		executor Executor
+		ctx      context.Context
+		program  string
+	}{
+		{name: "zero value", ctx: t.Context(), program: "schtasks.exe"},
+		{name: "nil context", executor: executorForTest(t), program: "schtasks.exe"},
+		{name: "unexpected program", executor: executorForTest(t), ctx: t.Context(), program: "cmd.exe"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := test.executor.Execute(test.ctx, test.program, []string{"/Query"})
+			if !errors.Is(err, errExecutorInvalid) {
+				t.Fatalf("Execute() error = %v, want invalid-boundary error", err)
+			}
+			assertExecutorResultRedacted(t, result, err)
+		})
+	}
+}
+
+func TestNewExecutorIgnoresEnvironmentExecutableOverride(t *testing.T) {
+	overrideRoot := t.TempDir()
+	overrideDirectory := filepath.Join(overrideRoot, "System32")
+	if err := os.Mkdir(overrideDirectory, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	overrideExecutable := filepath.Join(overrideDirectory, "schtasks.exe")
+	if err := os.WriteFile(overrideExecutable, nil, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("SystemRoot", overrideRoot)
+
+	executor, err := NewExecutor()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !filepath.IsAbs(executor.executable) {
+		t.Fatal("NewExecutor() executable is not absolute")
+	}
+	if strings.EqualFold(executor.executable, overrideExecutable) {
+		t.Fatal("NewExecutor() trusted the environment executable override")
+	}
+	if !strings.EqualFold(filepath.Base(executor.executable), "schtasks.exe") {
+		t.Fatal("NewExecutor() executable has an unexpected basename")
+	}
+	rendered := fmt.Sprintf("%v\n%+v\n%#v", executor, executor, executor)
+	if strings.Contains(rendered, executor.executable) {
+		t.Fatal("formatted Executor disclosed its executable path")
+	}
+}
+
+type executeResult struct {
+	result personalsvc.TaskSchedulerResult
+	err    error
+}
+
+func executorForTest(t *testing.T) Executor {
+	t.Helper()
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return newExecutor(executable)
+}
+
+func waitForHelperStart(t *testing.T, path string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(path); err == nil {
+			return
+		} else if !errors.Is(err, os.ErrNotExist) {
+			t.Fatal(err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("helper process did not report startup")
+}
+
+func assertExecutorResultRedacted(t *testing.T, result personalsvc.TaskSchedulerResult, err error) {
+	t.Helper()
+	rendered := fmt.Sprintf("%v\n%+v\n%#v\n%#v", err, err, err, result)
+	for _, protected := range []string{
+		`C:\Users\person`,
+		"secret-task.xml",
+		"http://127.0.0.1:8123",
+		"<Task",
+		"PowerContext Personal Server",
+	} {
+		if strings.Contains(rendered, protected) {
+			t.Fatalf("executor result contains protected value %q", protected)
+		}
+	}
+	if result.Output != nil {
+		t.Fatalf("Execute() output = %q, want nil", result.Output)
+	}
+}
+
+func runExecutorHelperProcess() {
+	switch os.Getenv(helperProcessEnvironment) {
+	case "record-arguments":
+		if err := os.WriteFile(os.Getenv("POWERCONTEXT_WINDOWS_EXECUTOR_ARGUMENTS"), []byte(strings.Join(os.Args[1:], "\n")), 0o600); err != nil {
+			os.Exit(120)
+		}
+	case "exit":
+		code, err := strconv.ParseUint(os.Getenv("POWERCONTEXT_WINDOWS_EXECUTOR_EXIT_CODE"), 10, 32)
+		if err != nil {
+			os.Exit(121)
+		}
+		os.Exit(int(uint32(code)))
+	case "block":
+		if err := os.WriteFile(os.Getenv("POWERCONTEXT_WINDOWS_EXECUTOR_STARTED"), nil, 0o600); err != nil {
+			os.Exit(122)
+		}
+		time.Sleep(24 * time.Hour)
+	case "overflow":
+		_, _ = os.Stdout.Write(bytesOf('x', maxCommandOutputBytes+1))
+		_, _ = os.Stderr.WriteString(`C:\Users\person\secret-task.xml http://127.0.0.1:8123 <Task>`)
+	case "overflow-block":
+		_, _ = os.Stdout.Write(bytesOf('x', maxCommandOutputBytes+1))
+		time.Sleep(24 * time.Hour)
+	default:
+		os.Exit(123)
+	}
+}
+
+func bytesOf(value byte, count int) []byte {
+	result := make([]byte, count)
+	for index := range result {
+		result[index] = value
+	}
+	return result
+}

--- a/internal/personalsvchost/windows/executor_windows_test.go
+++ b/internal/personalsvchost/windows/executor_windows_test.go
@@ -34,9 +34,9 @@ const helperProcessEnvironment = "POWERCONTEXT_WINDOWS_EXECUTOR_HELPER"
 func TestMain(m *testing.M) {
 	if os.Getenv(helperProcessEnvironment) != "" {
 		runExecutorHelperProcess()
-		os.Exit(0)
+		return
 	}
-	os.Exit(m.Run())
+	m.Run()
 }
 
 func TestExecutorPassesArgumentsWithoutShell(t *testing.T) {

--- a/internal/personalsvchost/windows/executor_windows_test.go
+++ b/internal/personalsvchost/windows/executor_windows_test.go
@@ -72,6 +72,41 @@ func TestExecutorPassesArgumentsWithoutShell(t *testing.T) {
 	}
 }
 
+func TestExecutorReturnsOnlyBoundedStructuredQueryOutput(t *testing.T) {
+	t.Setenv(helperProcessEnvironment, "structured-output")
+	executor := executorForTest(t)
+
+	for _, test := range []struct {
+		name      string
+		arguments []string
+		want      string
+	}{
+		{
+			name:      "XML",
+			arguments: []string{"/Query", "/TN", `\PowerContext Personal Server`, "/XML", "/HRESULT"},
+			want:      "<Task />",
+		},
+		{
+			name:      "CSV status",
+			arguments: []string{"/Query", "/TN", `\PowerContext Personal Server`, "/FO", "CSV", "/NH", "/V", "/HRESULT"},
+			want:      "structured,status",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := executor.Execute(t.Context(), "schtasks.exe", test.arguments)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := string(result.Output); got != test.want {
+				t.Fatalf("Execute() output = %q, want %q", got, test.want)
+			}
+			if strings.Contains(string(result.Output), "secret stderr") {
+				t.Fatal("Execute() returned native stderr")
+			}
+		})
+	}
+}
+
 func TestExecutorPreservesExitCodeBitPattern(t *testing.T) {
 	for _, test := range []struct {
 		name string
@@ -322,6 +357,13 @@ func runExecutorHelperProcess() {
 	case "split-at-limit":
 		_, _ = os.Stdout.Write(bytesOf('x', maxCommandOutputBytes/2))
 		_, _ = os.Stderr.Write(bytesOf('y', maxCommandOutputBytes/2))
+	case "structured-output":
+		if slices.Contains(os.Args, "/XML") {
+			_, _ = os.Stdout.WriteString("<Task />")
+		} else {
+			_, _ = os.Stdout.WriteString("structured,status")
+		}
+		_, _ = os.Stderr.WriteString("secret stderr")
 	default:
 		os.Exit(123)
 	}

--- a/internal/personalsvchost/windows/host_windows.go
+++ b/internal/personalsvchost/windows/host_windows.go
@@ -129,22 +129,30 @@ type nativeArtifactStore struct {
 }
 
 func newNativeArtifactStore(root string) (*nativeArtifactStore, error) {
-	root = filepath.Clean(root)
-	if !validUserDataRoot(root) {
-		return nil, newError("configuration", nil)
-	}
-	info, err := os.Lstat(root)
-	if err != nil || !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
-		return nil, newError("configuration", nil)
-	}
-	resolved, err := filepath.EvalSymlinks(root)
-	if err != nil || !validUserDataRoot(resolved) {
+	resolved, err := resolveUserDataRoot(root)
+	if err != nil {
 		return nil, newError("configuration", nil)
 	}
 	return &nativeArtifactStore{
 		root:         resolved,
 		artifactPath: filepath.Join(resolved, filepath.FromSlash("PowerContext/Services/personal-server.xml")),
 	}, nil
+}
+
+func resolveUserDataRoot(root string) (string, error) {
+	root = filepath.Clean(root)
+	if !validUserDataRoot(root) {
+		return "", errors.New("invalid personal service root")
+	}
+	info, err := os.Lstat(root)
+	if err != nil || !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		return "", errors.New("invalid personal service root")
+	}
+	resolved, err := filepath.EvalSymlinks(root)
+	if err != nil || !validUserDataRoot(resolved) {
+		return "", errors.New("invalid personal service root")
+	}
+	return resolved, nil
 }
 
 func (s *nativeArtifactStore) Read(ctx context.Context, path string) ([]byte, bool, error) {

--- a/internal/personalsvchost/windows/host_windows.go
+++ b/internal/personalsvchost/windows/host_windows.go
@@ -24,8 +24,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/ob-labs/powercontext-go/internal/personalsvc"
 	golangwindows "golang.org/x/sys/windows"
+
+	"github.com/ob-labs/powercontext-go/internal/personalsvc"
 )
 
 const maxArtifactBytes = 1 << 20
@@ -160,7 +161,7 @@ func (s *nativeArtifactStore) Read(ctx context.Context, path string) ([]byte, bo
 	if err != nil {
 		return nil, false, err
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 	info, err := file.Stat()
 	if err != nil || !info.Mode().IsRegular() || info.Size() > maxArtifactBytes {
 		return nil, false, errors.New("unsafe personal service artifact")
@@ -192,7 +193,7 @@ func (s *nativeArtifactStore) Write(ctx context.Context, path string, content []
 		return err
 	}
 	temporaryPath := temporary.Name()
-	defer os.Remove(temporaryPath)
+	defer func() { _ = os.Remove(temporaryPath) }()
 	if err := temporary.Chmod(0o600); err != nil {
 		_ = temporary.Close()
 		return err

--- a/internal/personalsvchost/windows/host_windows.go
+++ b/internal/personalsvchost/windows/host_windows.go
@@ -59,15 +59,15 @@ func New(config Config) (*Composition, error) {
 	if err != nil {
 		return nil, newError("configuration", nil)
 	}
-	userSID, err := currentUserSID()
-	if err != nil || !validInteractiveSID(userSID) {
+	identity, err := currentUserIdentity()
+	if err != nil || !validUserIdentity(identity) {
 		return nil, newError("configuration", nil)
 	}
 	adapter, err := newAdapter(
 		config.Plan,
 		config.UserDataRoot,
 		personalsvc.TaskSchedulerTaskName,
-		userSID,
+		identity,
 		portableScheduler{scheduler: portable},
 		artifacts,
 		loopbackHTTPClient(),
@@ -264,16 +264,31 @@ func (s *nativeArtifactStore) check(ctx context.Context, path string) error {
 	return ctx.Err()
 }
 
-func currentUserSID() (string, error) {
+func currentUserIdentity() (userIdentity, error) {
 	var sessionID uint32
 	if err := golangwindows.ProcessIdToSessionId(uint32(os.Getpid()), &sessionID); err != nil || !validInteractiveSession(sessionID) {
-		return "", errors.New("current Windows session is not interactive")
+		return userIdentity{}, errors.New("current Windows session is not interactive")
 	}
 	user, err := golangwindows.GetCurrentProcessToken().GetTokenUser()
 	if err != nil || user == nil || user.User.Sid == nil {
-		return "", errors.New("current Windows user is unavailable")
+		return userIdentity{}, errors.New("current Windows user is unavailable")
 	}
-	return user.User.Sid.String(), nil
+	name, domain, _, err := user.User.Sid.LookupAccount("")
+	if err != nil || name == "" {
+		return userIdentity{}, errors.New("current Windows account is unavailable")
+	}
+	account := name
+	if domain != "" {
+		account = domain + `\` + name
+	}
+	expectedSID := user.User.Sid.String()
+	return userIdentity{
+		sid: expectedSID, account: account, name: name,
+		lookup: func(value string) bool {
+			resolved, _, _, lookupErr := golangwindows.LookupSID("", value)
+			return lookupErr == nil && resolved != nil && resolved.String() == expectedSID
+		},
+	}, nil
 }
 
 func validInteractiveSession(sessionID uint32) bool { return sessionID != 0 }

--- a/internal/personalsvchost/windows/host_windows.go
+++ b/internal/personalsvchost/windows/host_windows.go
@@ -1,0 +1,290 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package windows
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/ob-labs/powercontext-go/internal/personalsvc"
+	golangwindows "golang.org/x/sys/windows"
+)
+
+const maxArtifactBytes = 1 << 20
+
+// Config supplies the pure Task Scheduler plan and the current user's
+// composition-owned data root. New never reads an environment variable.
+type Config struct {
+	UserDataRoot string
+	Plan         personalsvc.TaskSchedulerSpec
+}
+
+// Composition binds one Adapter and its cross-operation lock to the same
+// current-user root and Task Scheduler identity.
+type Composition struct {
+	adapter  *Adapter
+	boundary *OperationBoundary
+}
+
+// New constructs the production-only fixed PowerContext Task Scheduler
+// composition for the current process token's interactive user.
+func New(config Config) (*Composition, error) {
+	artifacts, err := newNativeArtifactStore(config.UserDataRoot)
+	if err != nil {
+		return nil, newError("configuration", nil)
+	}
+	executor, err := NewExecutor()
+	if err != nil {
+		return nil, newError("configuration", nil)
+	}
+	portable, err := personalsvc.NewTaskScheduler(executor)
+	if err != nil {
+		return nil, newError("configuration", nil)
+	}
+	userSID, err := currentUserSID()
+	if err != nil || !validInteractiveSID(userSID) {
+		return nil, newError("configuration", nil)
+	}
+	adapter, err := newAdapter(
+		config.Plan,
+		config.UserDataRoot,
+		personalsvc.TaskSchedulerTaskName,
+		userSID,
+		portableScheduler{scheduler: portable},
+		artifacts,
+		loopbackHTTPClient(),
+	)
+	if err != nil {
+		return nil, err
+	}
+	boundary, err := newOperationBoundary(config.UserDataRoot)
+	if err != nil {
+		return nil, err
+	}
+	return &Composition{adapter: adapter, boundary: boundary}, nil
+}
+
+// Adapter returns the Windows native adapter owned by the composition.
+func (c *Composition) Adapter() *Adapter {
+	if c == nil || c.adapter == nil {
+		return nil
+	}
+	return c.adapter
+}
+
+// OperationBoundary returns the lock paired with the adapter's exact root.
+func (c *Composition) OperationBoundary() personalsvc.OperationBoundary {
+	if c == nil || c.boundary == nil {
+		return nil
+	}
+	return c.boundary
+}
+
+type portableScheduler struct{ scheduler personalsvc.TaskScheduler }
+
+func (s portableScheduler) Query(ctx context.Context) (personalsvc.TaskSchedulerState, []byte, error) {
+	return s.scheduler.QueryXML(ctx)
+}
+
+func (s portableScheduler) Create(ctx context.Context, path string) error {
+	return s.scheduler.Create(ctx, path)
+}
+
+func (s portableScheduler) Run(ctx context.Context) error     { return s.scheduler.Run(ctx) }
+func (s portableScheduler) End(ctx context.Context) error     { return s.scheduler.End(ctx) }
+func (s portableScheduler) Enable(ctx context.Context) error  { return s.scheduler.Enable(ctx) }
+func (s portableScheduler) Disable(ctx context.Context) error { return s.scheduler.Disable(ctx) }
+func (s portableScheduler) Delete(ctx context.Context) error  { return s.scheduler.Delete(ctx) }
+
+func (s portableScheduler) State(ctx context.Context) (personalsvc.ManagerState, error) {
+	output, err := s.scheduler.QueryStatus(ctx)
+	if err != nil {
+		return personalsvc.ManagerUnknown, err
+	}
+	return parseTaskState(output)
+}
+
+type nativeArtifactStore struct {
+	root         string
+	artifactPath string
+}
+
+func newNativeArtifactStore(root string) (*nativeArtifactStore, error) {
+	if !validUserDataRoot(root) {
+		return nil, newError("configuration", nil)
+	}
+	info, err := os.Lstat(root)
+	if err != nil || !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		return nil, newError("configuration", nil)
+	}
+	resolved, err := filepath.EvalSymlinks(root)
+	if err != nil || !strings.EqualFold(filepath.Clean(resolved), root) {
+		return nil, newError("configuration", nil)
+	}
+	return &nativeArtifactStore{
+		root:         root,
+		artifactPath: filepath.Join(root, filepath.FromSlash("PowerContext/Services/personal-server.xml")),
+	}, nil
+}
+
+func (s *nativeArtifactStore) Read(ctx context.Context, path string) ([]byte, bool, error) {
+	if err := s.check(ctx, path); err != nil {
+		return nil, false, err
+	}
+	entry, err := os.Lstat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, false, nil
+	}
+	if err != nil || !entry.Mode().IsRegular() || entry.Mode()&os.ModeSymlink != 0 {
+		return nil, false, errors.New("unsafe personal service artifact")
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, false, err
+	}
+	defer file.Close()
+	info, err := file.Stat()
+	if err != nil || !info.Mode().IsRegular() || info.Size() > maxArtifactBytes {
+		return nil, false, errors.New("unsafe personal service artifact")
+	}
+	content, err := io.ReadAll(io.LimitReader(file, maxArtifactBytes+1))
+	if err != nil || len(content) > maxArtifactBytes {
+		return nil, false, errors.New("invalid personal service artifact")
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, false, err
+	}
+	return bytes.Clone(content), true, nil
+}
+
+func (s *nativeArtifactStore) Write(ctx context.Context, path string, content []byte) error {
+	if err := s.check(ctx, path); err != nil || len(content) == 0 || len(content) > maxArtifactBytes {
+		return errors.New("invalid personal service artifact write")
+	}
+	if err := s.ensureDirectory(); err != nil {
+		return err
+	}
+	if info, err := os.Lstat(path); err == nil && (!info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0) {
+		return errors.New("unsafe personal service artifact")
+	} else if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	temporary, err := os.CreateTemp(filepath.Dir(path), ".personal-server-*.tmp")
+	if err != nil {
+		return err
+	}
+	temporaryPath := temporary.Name()
+	defer os.Remove(temporaryPath)
+	if err := temporary.Chmod(0o600); err != nil {
+		_ = temporary.Close()
+		return err
+	}
+	if _, err := temporary.Write(content); err != nil {
+		_ = temporary.Close()
+		return err
+	}
+	if err := temporary.Sync(); err != nil {
+		_ = temporary.Close()
+		return err
+	}
+	if err := temporary.Close(); err != nil {
+		return err
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	return os.Rename(temporaryPath, path)
+}
+
+func (s *nativeArtifactStore) Remove(ctx context.Context, path string) error {
+	if err := s.check(ctx, path); err != nil {
+		return err
+	}
+	info, err := os.Lstat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil || !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 {
+		return errors.New("unsafe personal service artifact")
+	}
+	return os.Remove(path)
+}
+
+func (*nativeArtifactStore) RegularFile(ctx context.Context, path string) (bool, error) {
+	if ctx == nil || !filepath.IsAbs(path) {
+		return false, errors.New("invalid executable path")
+	}
+	if err := ctx.Err(); err != nil {
+		return false, err
+	}
+	info, err := os.Lstat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return info.Mode().IsRegular() && info.Mode()&os.ModeSymlink == 0, nil
+}
+
+func (s *nativeArtifactStore) ensureDirectory() error {
+	directory := filepath.Dir(s.artifactPath)
+	if err := os.MkdirAll(directory, 0o700); err != nil {
+		return err
+	}
+	resolved, err := filepath.EvalSymlinks(directory)
+	if err != nil || !strings.EqualFold(filepath.Clean(resolved), directory) {
+		return errors.New("unsafe personal service artifact directory")
+	}
+	return nil
+}
+
+func (s *nativeArtifactStore) check(ctx context.Context, path string) error {
+	if s == nil || ctx == nil || path != s.artifactPath {
+		return errors.New("invalid personal service artifact path")
+	}
+	return ctx.Err()
+}
+
+func currentUserSID() (string, error) {
+	var sessionID uint32
+	if err := golangwindows.ProcessIdToSessionId(uint32(os.Getpid()), &sessionID); err != nil || !validInteractiveSession(sessionID) {
+		return "", errors.New("current Windows session is not interactive")
+	}
+	user, err := golangwindows.GetCurrentProcessToken().GetTokenUser()
+	if err != nil || user == nil || user.User.Sid == nil {
+		return "", errors.New("current Windows user is unavailable")
+	}
+	return user.User.Sid.String(), nil
+}
+
+func validInteractiveSession(sessionID uint32) bool { return sessionID != 0 }
+
+func loopbackHTTPClient() *http.Client {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.Proxy = nil
+	return &http.Client{
+		Transport: transport,
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+}

--- a/internal/personalsvchost/windows/host_windows.go
+++ b/internal/personalsvchost/windows/host_windows.go
@@ -66,7 +66,7 @@ func New(config Config) (*Composition, error) {
 	}
 	adapter, err := newAdapter(
 		config.Plan,
-		config.UserDataRoot,
+		artifacts.root,
 		personalsvc.TaskSchedulerTaskName,
 		identity,
 		portableScheduler{scheduler: portable},
@@ -76,7 +76,7 @@ func New(config Config) (*Composition, error) {
 	if err != nil {
 		return nil, err
 	}
-	boundary, err := newOperationBoundary(config.UserDataRoot)
+	boundary, err := newOperationBoundary(artifacts.root)
 	if err != nil {
 		return nil, err
 	}
@@ -129,6 +129,7 @@ type nativeArtifactStore struct {
 }
 
 func newNativeArtifactStore(root string) (*nativeArtifactStore, error) {
+	root = filepath.Clean(root)
 	if !validUserDataRoot(root) {
 		return nil, newError("configuration", nil)
 	}
@@ -137,12 +138,12 @@ func newNativeArtifactStore(root string) (*nativeArtifactStore, error) {
 		return nil, newError("configuration", nil)
 	}
 	resolved, err := filepath.EvalSymlinks(root)
-	if err != nil || !strings.EqualFold(filepath.Clean(resolved), root) {
+	if err != nil || !validUserDataRoot(resolved) {
 		return nil, newError("configuration", nil)
 	}
 	return &nativeArtifactStore{
-		root:         root,
-		artifactPath: filepath.Join(root, filepath.FromSlash("PowerContext/Services/personal-server.xml")),
+		root:         resolved,
+		artifactPath: filepath.Join(resolved, filepath.FromSlash("PowerContext/Services/personal-server.xml")),
 	}, nil
 }
 

--- a/internal/personalsvchost/windows/lifecycle_windows_test.go
+++ b/internal/personalsvchost/windows/lifecycle_windows_test.go
@@ -44,34 +44,34 @@ func TestNativeTaskSchedulerLifecycleUsesOnlyUniqueTestTask(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := adapter.Write(t.Context(), plan.Registration()); err != nil {
-		t.Fatal(err)
+	if writeErr := adapter.Write(t.Context(), plan.Registration()); writeErr != nil {
+		t.Fatal(writeErr)
 	}
-	if err := adapter.Enable(t.Context()); err != nil {
-		t.Fatal(err)
+	if enableErr := adapter.Enable(t.Context()); enableErr != nil {
+		t.Fatal(enableErr)
 	}
 	fixture.created = true
 	manager, err := adapter.InspectManager(t.Context())
 	if err != nil || manager.Ownership() != personalsvc.ManagerOwnershipOwned {
 		t.Fatalf("registered manager = %s, %v; want owned", manager.Ownership(), err)
 	}
-	if err := adapter.Start(t.Context()); err != nil {
-		t.Fatal(err)
+	if startErr := adapter.Start(t.Context()); startErr != nil {
+		t.Fatal(startErr)
 	}
 	waitForFile(t, sentinel, 15*time.Second)
 	waitForManagerState(t, adapter, personalsvc.ManagerActive, 10*time.Second)
 	if probe, probeErr := adapter.Probe(t.Context(), plan.Registration().Definition().Endpoint()); probeErr != nil || probe != personalsvc.ProbeUnreachable {
 		t.Fatalf("harmless child liveness = %s, %v; want unreachable", probe, probeErr)
 	}
-	if err := adapter.Stop(t.Context()); err != nil {
-		t.Fatal(err)
+	if stopErr := adapter.Stop(t.Context()); stopErr != nil {
+		t.Fatal(stopErr)
 	}
 	waitForManagerState(t, adapter, personalsvc.ManagerInactive, 10*time.Second)
-	if err := adapter.Disable(t.Context()); err != nil {
-		t.Fatal(err)
+	if disableErr := adapter.Disable(t.Context()); disableErr != nil {
+		t.Fatal(disableErr)
 	}
-	if err := adapter.Remove(t.Context()); err != nil {
-		t.Fatal(err)
+	if removeErr := adapter.Remove(t.Context()); removeErr != nil {
+		t.Fatal(removeErr)
 	}
 	state, _, err := scheduler.Query(t.Context())
 	if err != nil || state != personalsvc.TaskSchedulerAbsent {
@@ -90,11 +90,11 @@ func TestNativeTaskSchedulerLifecycleUsesOnlyUniqueTestTask(t *testing.T) {
 		t.Fatal("cannot decode owned task fixture")
 	}
 	foreignDocument := encodeTaskDocument(strings.Replace(text, personalsvc.OwnershipMarker, "foreign.owner", 1))
-	if err := os.WriteFile(foreignPath, foreignDocument, 0o600); err != nil {
-		t.Fatal(err)
+	if writeErr := os.WriteFile(foreignPath, foreignDocument, 0o600); writeErr != nil {
+		t.Fatal(writeErr)
 	}
-	if err := scheduler.Create(t.Context(), foreignPath); err != nil {
-		t.Fatal(err)
+	if createErr := scheduler.Create(t.Context(), foreignPath); createErr != nil {
+		t.Fatal(createErr)
 	}
 	fixture.created = true
 	state, before, err := scheduler.Query(t.Context())
@@ -105,15 +105,15 @@ func TestNativeTaskSchedulerLifecycleUsesOnlyUniqueTestTask(t *testing.T) {
 	if err != nil || manager.Ownership() != personalsvc.ManagerOwnershipForeign {
 		t.Fatalf("foreign manager = %s, %v; want foreign", manager.Ownership(), err)
 	}
-	if err := adapter.Remove(t.Context()); err == nil {
+	if removeErr := adapter.Remove(t.Context()); removeErr == nil {
 		t.Fatal("Remove() accepted the intentional foreign task")
 	}
 	state, after, err := scheduler.Query(t.Context())
 	if err != nil || state != personalsvc.TaskSchedulerPresent || !bytes.Equal(before, after) {
 		t.Fatalf("foreign task changed after refusal: state = %s, error = %v", state, err)
 	}
-	if err := scheduler.Delete(t.Context()); err != nil {
-		t.Fatal(err)
+	if deleteErr := scheduler.Delete(t.Context()); deleteErr != nil {
+		t.Fatal(deleteErr)
 	}
 	state, _, err = scheduler.Query(t.Context())
 	if err != nil || state != personalsvc.TaskSchedulerAbsent {
@@ -142,11 +142,11 @@ func TestNativeTaskSchedulerLoginTriggerUsesCurrentUser(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := adapter.Write(t.Context(), plan.Registration()); err != nil {
-		t.Fatal(err)
+	if writeErr := adapter.Write(t.Context(), plan.Registration()); writeErr != nil {
+		t.Fatal(writeErr)
 	}
-	if err := adapter.Enable(t.Context()); err != nil {
-		t.Fatal(err)
+	if enableErr := adapter.Enable(t.Context()); enableErr != nil {
+		t.Fatal(enableErr)
 	}
 	fixture.created = true
 	manager, err := adapter.InspectManager(t.Context())

--- a/internal/personalsvchost/windows/lifecycle_windows_test.go
+++ b/internal/personalsvchost/windows/lifecycle_windows_test.go
@@ -1,0 +1,364 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package windows
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+	"uuid"
+
+	"github.com/ob-labs/powercontext-go/internal/personalsvc"
+)
+
+func TestNativeTaskSchedulerLifecycleUsesOnlyUniqueTestTask(t *testing.T) {
+	executor, err := NewExecutor()
+	if errors.Is(err, errExecutorUnavailable) {
+		t.Skip("Windows Task Scheduler executable is unavailable")
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	userSID, err := currentUserSID()
+	if err != nil || !validInteractiveSID(userSID) {
+		t.Skip("current process does not have an interactive user identity")
+	}
+
+	root := t.TempDir()
+	taskName := testTaskNamePrefix + "WP5-" + uuid.New().String()
+	scheduler := &namedTaskScheduler{executor: executor, taskName: taskName}
+	createdByTest := false
+	t.Cleanup(func() {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer cancel()
+		state, _, queryErr := scheduler.Query(cleanupCtx)
+		if queryErr != nil {
+			t.Errorf("cleanup query failed: %v", queryErr)
+			return
+		}
+		if state == personalsvc.TaskSchedulerPresent {
+			if !createdByTest {
+				t.Errorf("random task identity unexpectedly existed; it was not changed")
+				return
+			}
+			_ = scheduler.End(cleanupCtx)
+			if deleteErr := scheduler.Delete(cleanupCtx); deleteErr != nil {
+				t.Errorf("cleanup delete failed: %v", deleteErr)
+				return
+			}
+		}
+		state, _, queryErr = scheduler.Query(cleanupCtx)
+		if queryErr != nil || state != personalsvc.TaskSchedulerAbsent {
+			t.Errorf("cleanup final state = %s, %v; want absent", state, queryErr)
+		}
+	})
+
+	state, _, err := scheduler.Query(t.Context())
+	if errors.Is(err, errExecutorUnavailable) {
+		t.Skip("Windows Task Scheduler service is unavailable")
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state != personalsvc.TaskSchedulerAbsent {
+		t.Fatal("random Task Scheduler test identity already exists; refusing to alter it")
+	}
+
+	sentinel := filepath.Join(root, "scheduled-child.started")
+	plan := nativeLifecyclePlan(t, root, sentinel)
+	artifacts, err := newNativeArtifactStore(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	adapter, err := newAdapter(plan, root, taskName, userSID, scheduler, artifacts, loopbackHTTPClient())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := adapter.Write(t.Context(), plan.Registration()); err != nil {
+		t.Fatal(err)
+	}
+	if err := adapter.Enable(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	createdByTest = true
+	manager, err := adapter.InspectManager(t.Context())
+	if err != nil || manager.Ownership() != personalsvc.ManagerOwnershipOwned {
+		t.Fatalf("registered manager = %s, %v; want owned", manager.Ownership(), err)
+	}
+	if err := adapter.Start(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	waitForFile(t, sentinel, 15*time.Second)
+	waitForManagerState(t, adapter, personalsvc.ManagerActive, 10*time.Second)
+	if probe, probeErr := adapter.Probe(t.Context(), plan.Registration().Definition().Endpoint()); probeErr != nil || probe != personalsvc.ProbeUnreachable {
+		t.Fatalf("harmless child liveness = %s, %v; want unreachable", probe, probeErr)
+	}
+	if err := adapter.Stop(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	waitForManagerState(t, adapter, personalsvc.ManagerInactive, 10*time.Second)
+	if err := adapter.Disable(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	if err := adapter.Remove(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	state, _, err = scheduler.Query(t.Context())
+	if err != nil || state != personalsvc.TaskSchedulerAbsent {
+		t.Fatalf("removed task state = %s, %v; want absent", state, err)
+	}
+	t.Logf("native scheduler lifecycle: %s; sentinel=observed; manager=active-to-inactive; final=absent", scheduler.summary())
+	scheduler.events = nil
+
+	foreignPath := filepath.Join(root, "foreign-task.xml")
+	ownedDocument, err := adapter.render()
+	if err != nil {
+		t.Fatal(err)
+	}
+	text, ok := decodeTaskDocument(ownedDocument)
+	if !ok {
+		t.Fatal("cannot decode owned task fixture")
+	}
+	foreignDocument := encodeTaskDocument(strings.Replace(text, personalsvc.OwnershipMarker, "foreign.owner", 1))
+	if err := os.WriteFile(foreignPath, foreignDocument, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := scheduler.Create(t.Context(), foreignPath); err != nil {
+		t.Fatal(err)
+	}
+	createdByTest = true
+	state, before, err := scheduler.Query(t.Context())
+	if err != nil || state != personalsvc.TaskSchedulerPresent {
+		t.Fatalf("foreign fixture state = %s, %v", state, err)
+	}
+	manager, err = adapter.InspectManager(t.Context())
+	if err != nil || manager.Ownership() != personalsvc.ManagerOwnershipForeign {
+		t.Fatalf("foreign manager = %s, %v; want foreign", manager.Ownership(), err)
+	}
+	if err := adapter.Remove(t.Context()); err == nil {
+		t.Fatal("Remove() accepted the intentional foreign task")
+	}
+	state, after, err := scheduler.Query(t.Context())
+	if err != nil || state != personalsvc.TaskSchedulerPresent || !bytes.Equal(before, after) {
+		t.Fatalf("foreign task changed after refusal: state = %s, error = %v", state, err)
+	}
+	if err := scheduler.Delete(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	state, _, err = scheduler.Query(t.Context())
+	if err != nil || state != personalsvc.TaskSchedulerAbsent {
+		t.Fatalf("foreign fixture cleanup state = %s, %v; want absent", state, err)
+	}
+	t.Logf("foreign ownership refusal: %s; manager=foreign; adapter-mutation=refused; xml=unchanged; fixture-cleanup=absent", scheduler.summary())
+}
+
+func TestTaskSchedulerSentinelChild(t *testing.T) {
+	separator := -1
+	for index, argument := range os.Args {
+		if argument == "--" {
+			separator = index
+			break
+		}
+	}
+	if separator < 0 || separator+1 >= len(os.Args) {
+		return
+	}
+	if err := os.WriteFile(os.Args[separator+1], []byte("started\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(30 * time.Second)
+}
+
+func nativeLifecyclePlan(t *testing.T, root, sentinel string) personalsvc.TaskSchedulerSpec {
+	t.Helper()
+	binary, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	definition, err := personalsvc.NewDefinition(personalsvc.DefinitionInput{
+		Ownership:         personalsvc.OwnershipMarker,
+		DefinitionVersion: personalsvc.DefinitionVersion,
+		PackageVersion:    "e2e",
+		Binary:            binary,
+		Endpoint:          "http://127.0.0.1:1",
+		DataDir:           root,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	registration, err := personalsvc.NewRegistration(definition)
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan, err := personalsvc.NewTaskSchedulerSpec(
+		registration,
+		[]string{"-test.run=^TestTaskSchedulerSentinelChild$", "-test.count=1", "--", sentinel},
+		root,
+		false,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return plan
+}
+
+type namedTaskScheduler struct {
+	executor Executor
+	taskName string
+	events   []schedulerEvent
+}
+
+type schedulerEvent struct {
+	operation string
+	exitCode  uint32
+}
+
+func (s *namedTaskScheduler) Query(ctx context.Context) (personalsvc.TaskSchedulerState, []byte, error) {
+	result, err := s.execute(ctx, "/Query", "/TN", s.taskName, "/XML", "/HRESULT")
+	if err != nil {
+		return personalsvc.TaskSchedulerUnknown, nil, err
+	}
+	switch result.ExitCode {
+	case 0:
+		return personalsvc.TaskSchedulerPresent, result.Output, nil
+	case 0x80070002, 0x80070003:
+		return personalsvc.TaskSchedulerAbsent, nil, nil
+	default:
+		return personalsvc.TaskSchedulerUnknown, nil, &taskCommandError{code: result.ExitCode}
+	}
+}
+
+func (s *namedTaskScheduler) Create(ctx context.Context, path string) error {
+	return s.required(ctx, "/Create", "/TN", s.taskName, "/XML", path, "/F", "/HRESULT")
+}
+
+func (s *namedTaskScheduler) Run(ctx context.Context) error {
+	return s.required(ctx, "/Run", "/TN", s.taskName, "/HRESULT")
+}
+
+func (s *namedTaskScheduler) End(ctx context.Context) error {
+	return s.required(ctx, "/End", "/TN", s.taskName, "/HRESULT")
+}
+
+func (s *namedTaskScheduler) Enable(ctx context.Context) error {
+	return s.required(ctx, "/Change", "/TN", s.taskName, "/ENABLE", "/HRESULT")
+}
+
+func (s *namedTaskScheduler) Disable(ctx context.Context) error {
+	return s.required(ctx, "/Change", "/TN", s.taskName, "/DISABLE", "/HRESULT")
+}
+
+func (s *namedTaskScheduler) Delete(ctx context.Context) error {
+	return s.required(ctx, "/Delete", "/TN", s.taskName, "/F", "/HRESULT")
+}
+
+func (s *namedTaskScheduler) State(ctx context.Context) (personalsvc.ManagerState, error) {
+	result, err := s.execute(ctx, "/Query", "/TN", s.taskName, "/FO", "CSV", "/NH", "/V", "/HRESULT")
+	if err != nil || result.ExitCode != 0 {
+		if err != nil {
+			return personalsvc.ManagerUnknown, err
+		}
+		return personalsvc.ManagerUnknown, &taskCommandError{code: result.ExitCode}
+	}
+	return parseTaskState(result.Output)
+}
+
+func (s *namedTaskScheduler) required(ctx context.Context, arguments ...string) error {
+	result, err := s.execute(ctx, arguments...)
+	if err != nil {
+		return err
+	}
+	if result.ExitCode != 0 {
+		return &taskCommandError{code: result.ExitCode}
+	}
+	return nil
+}
+
+func (s *namedTaskScheduler) execute(ctx context.Context, arguments ...string) (personalsvc.TaskSchedulerResult, error) {
+	result, err := s.executor.Execute(ctx, taskSchedulerProgram, arguments)
+	if len(s.events) < 64 {
+		s.events = append(s.events, schedulerEvent{operation: schedulerOperation(arguments), exitCode: result.ExitCode})
+	}
+	return result, err
+}
+
+func (s *namedTaskScheduler) summary() string {
+	parts := make([]string, 0, len(s.events))
+	for _, event := range s.events {
+		parts = append(parts, fmt.Sprintf("%s=%#x", event.operation, event.exitCode))
+	}
+	return strings.Join(parts, ",")
+}
+
+func schedulerOperation(arguments []string) string {
+	if len(arguments) == 0 {
+		return "invalid"
+	}
+	operation := strings.ToLower(strings.TrimPrefix(arguments[0], "/"))
+	if operation == "query" && slices.Contains(arguments, "/XML") {
+		return "query-xml"
+	}
+	if operation == "query" && slices.Contains(arguments, "CSV") {
+		return "query-state"
+	}
+	if operation == "change" && slices.Contains(arguments, "/ENABLE") {
+		return "enable"
+	}
+	if operation == "change" && slices.Contains(arguments, "/DISABLE") {
+		return "disable"
+	}
+	return operation
+}
+
+type taskCommandError struct{ code uint32 }
+
+func (e *taskCommandError) Error() string {
+	return fmt.Sprintf("Task Scheduler command failed with code %#x", e.code)
+}
+
+func waitForFile(t *testing.T, path string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(path); err == nil {
+			return
+		} else if !errors.Is(err, os.ErrNotExist) {
+			t.Fatal(err)
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	t.Fatal("scheduled child did not create its sentinel")
+}
+
+func waitForManagerState(t *testing.T, adapter *Adapter, want personalsvc.ManagerState, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		state, err := adapter.ManagerState(t.Context())
+		if err == nil && state == want {
+			return
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	state, err := adapter.ManagerState(t.Context())
+	t.Fatalf("manager state = %s, %v; want %s", state, err, want)
+}

--- a/internal/personalsvchost/windows/lifecycle_windows_test.go
+++ b/internal/personalsvchost/windows/lifecycle_windows_test.go
@@ -31,65 +31,16 @@ import (
 )
 
 func TestNativeTaskSchedulerLifecycleUsesOnlyUniqueTestTask(t *testing.T) {
-	executor, err := NewExecutor()
-	if errors.Is(err, errExecutorUnavailable) {
-		t.Skip("Windows Task Scheduler executable is unavailable")
-	}
-	if err != nil {
-		t.Fatal(err)
-	}
-	userSID, err := currentUserSID()
-	if err != nil || !validInteractiveSID(userSID) {
-		t.Skip("current process does not have an interactive user identity")
-	}
-
-	root := t.TempDir()
-	taskName := testTaskNamePrefix + "WP5-" + uuid.New().String()
-	scheduler := &namedTaskScheduler{executor: executor, taskName: taskName}
-	createdByTest := false
-	t.Cleanup(func() {
-		cleanupCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-		defer cancel()
-		state, _, queryErr := scheduler.Query(cleanupCtx)
-		if queryErr != nil {
-			t.Errorf("cleanup query failed: %v", queryErr)
-			return
-		}
-		if state == personalsvc.TaskSchedulerPresent {
-			if !createdByTest {
-				t.Errorf("random task identity unexpectedly existed; it was not changed")
-				return
-			}
-			_ = scheduler.End(cleanupCtx)
-			if deleteErr := scheduler.Delete(cleanupCtx); deleteErr != nil {
-				t.Errorf("cleanup delete failed: %v", deleteErr)
-				return
-			}
-		}
-		state, _, queryErr = scheduler.Query(cleanupCtx)
-		if queryErr != nil || state != personalsvc.TaskSchedulerAbsent {
-			t.Errorf("cleanup final state = %s, %v; want absent", state, queryErr)
-		}
-	})
-
-	state, _, err := scheduler.Query(t.Context())
-	if errors.Is(err, errExecutorUnavailable) {
-		t.Skip("Windows Task Scheduler service is unavailable")
-	}
-	if err != nil {
-		t.Fatal(err)
-	}
-	if state != personalsvc.TaskSchedulerAbsent {
-		t.Fatal("random Task Scheduler test identity already exists; refusing to alter it")
-	}
+	fixture := newNativeTaskFixture(t)
+	root, identity, scheduler := fixture.root, fixture.identity, fixture.scheduler
 
 	sentinel := filepath.Join(root, "scheduled-child.started")
-	plan := nativeLifecyclePlan(t, root, sentinel)
+	plan := nativeLifecyclePlan(t, root, sentinel, false)
 	artifacts, err := newNativeArtifactStore(root)
 	if err != nil {
 		t.Fatal(err)
 	}
-	adapter, err := newAdapter(plan, root, taskName, userSID, scheduler, artifacts, loopbackHTTPClient())
+	adapter, err := newAdapter(plan, root, scheduler.taskName, identity, scheduler, artifacts, loopbackHTTPClient())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -99,7 +50,7 @@ func TestNativeTaskSchedulerLifecycleUsesOnlyUniqueTestTask(t *testing.T) {
 	if err := adapter.Enable(t.Context()); err != nil {
 		t.Fatal(err)
 	}
-	createdByTest = true
+	fixture.created = true
 	manager, err := adapter.InspectManager(t.Context())
 	if err != nil || manager.Ownership() != personalsvc.ManagerOwnershipOwned {
 		t.Fatalf("registered manager = %s, %v; want owned", manager.Ownership(), err)
@@ -122,7 +73,7 @@ func TestNativeTaskSchedulerLifecycleUsesOnlyUniqueTestTask(t *testing.T) {
 	if err := adapter.Remove(t.Context()); err != nil {
 		t.Fatal(err)
 	}
-	state, _, err = scheduler.Query(t.Context())
+	state, _, err := scheduler.Query(t.Context())
 	if err != nil || state != personalsvc.TaskSchedulerAbsent {
 		t.Fatalf("removed task state = %s, %v; want absent", state, err)
 	}
@@ -145,7 +96,7 @@ func TestNativeTaskSchedulerLifecycleUsesOnlyUniqueTestTask(t *testing.T) {
 	if err := scheduler.Create(t.Context(), foreignPath); err != nil {
 		t.Fatal(err)
 	}
-	createdByTest = true
+	fixture.created = true
 	state, before, err := scheduler.Query(t.Context())
 	if err != nil || state != personalsvc.TaskSchedulerPresent {
 		t.Fatalf("foreign fixture state = %s, %v", state, err)
@@ -171,6 +122,109 @@ func TestNativeTaskSchedulerLifecycleUsesOnlyUniqueTestTask(t *testing.T) {
 	t.Logf("foreign ownership refusal: %s; manager=foreign; adapter-mutation=refused; xml=unchanged; fixture-cleanup=absent", scheduler.summary())
 }
 
+func TestNativeTaskSchedulerLoginTriggerUsesCurrentUser(t *testing.T) {
+	fixture := newNativeTaskFixture(t)
+	sentinel := filepath.Join(fixture.root, "login-trigger-unused")
+	plan := nativeLifecyclePlan(t, fixture.root, sentinel, true)
+	artifacts, err := newNativeArtifactStore(fixture.root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	adapter, err := newAdapter(
+		plan,
+		fixture.root,
+		fixture.scheduler.taskName,
+		fixture.identity,
+		fixture.scheduler,
+		artifacts,
+		loopbackHTTPClient(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := adapter.Write(t.Context(), plan.Registration()); err != nil {
+		t.Fatal(err)
+	}
+	if err := adapter.Enable(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	fixture.created = true
+	manager, err := adapter.InspectManager(t.Context())
+	if err != nil || manager.Ownership() != personalsvc.ManagerOwnershipOwned {
+		t.Fatalf("login-trigger manager = %s, %v; want owned", manager.Ownership(), err)
+	}
+	state, document, err := fixture.scheduler.Query(t.Context())
+	if err != nil || state != personalsvc.TaskSchedulerPresent {
+		t.Fatalf("login-trigger query = %s, %v", state, err)
+	}
+	text, ok := decodeTaskDocument(document)
+	currentUserIDs := strings.Count(text, taskXMLLeaf("UserId", fixture.identity.sid)) +
+		strings.Count(text, taskXMLLeaf("UserId", fixture.identity.account)) +
+		strings.Count(text, taskXMLLeaf("UserId", fixture.identity.name))
+	if !ok || currentUserIDs != 2 {
+		t.Fatal("registered login trigger is not bound to the current user")
+	}
+	if err := adapter.Disable(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	if err := adapter.Remove(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("login trigger: %s; principal=current-user; trigger=current-user; final=absent", fixture.scheduler.summary())
+}
+
+func TestNativeTaskSchedulerCancellationAfterCreateRemovesTask(t *testing.T) {
+	fixture := newNativeTaskFixture(t)
+	sentinel := filepath.Join(fixture.root, "cancel-create-unused")
+	plan := nativeLifecyclePlan(t, fixture.root, sentinel, false)
+	artifacts, err := newNativeArtifactStore(fixture.root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	canceling := &cancelAfterCreateScheduler{
+		taskScheduler: fixture.scheduler,
+		afterCreate: func() {
+			fixture.created = true
+			cancel()
+		},
+	}
+	adapter, err := newAdapter(
+		plan,
+		fixture.root,
+		fixture.scheduler.taskName,
+		fixture.identity,
+		canceling,
+		artifacts,
+		loopbackHTTPClient(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	boundary, err := newOperationBoundary(fixture.root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	controller, err := personalsvc.NewController(adapter, boundary)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, installErr := controller.Install(ctx, plan.Registration())
+	if !errors.Is(installErr, context.Canceled) {
+		t.Fatalf("Install() error = %v; want context cancellation", installErr)
+	}
+	state, _, err := fixture.scheduler.Query(t.Context())
+	if err != nil || state != personalsvc.TaskSchedulerAbsent {
+		t.Fatalf("task after canceled create = %s, %v; want absent", state, err)
+	}
+	artifact, err := adapter.InspectArtifact(t.Context())
+	if err != nil || artifact.State() != personalsvc.RegistrationNotInstalled {
+		t.Fatalf("artifact after canceled create = %s, %v; want absent", artifact.State(), err)
+	}
+	t.Logf("canceled create cleanup: %s; caller=canceled; task=absent; artifact=absent", fixture.scheduler.summary())
+}
+
 func TestTaskSchedulerSentinelChild(t *testing.T) {
 	separator := -1
 	for index, argument := range os.Args {
@@ -188,7 +242,7 @@ func TestTaskSchedulerSentinelChild(t *testing.T) {
 	time.Sleep(30 * time.Second)
 }
 
-func nativeLifecyclePlan(t *testing.T, root, sentinel string) personalsvc.TaskSchedulerSpec {
+func nativeLifecyclePlan(t *testing.T, root, sentinel string, startOnLogin bool) personalsvc.TaskSchedulerSpec {
 	t.Helper()
 	binary, err := os.Executable()
 	if err != nil {
@@ -213,12 +267,94 @@ func nativeLifecyclePlan(t *testing.T, root, sentinel string) personalsvc.TaskSc
 		registration,
 		[]string{"-test.run=^TestTaskSchedulerSentinelChild$", "-test.count=1", "--", sentinel},
 		root,
-		false,
+		startOnLogin,
 	)
 	if err != nil {
 		t.Fatal(err)
 	}
 	return plan
+}
+
+type nativeTaskFixture struct {
+	root      string
+	identity  userIdentity
+	scheduler *namedTaskScheduler
+	created   bool
+}
+
+func newNativeTaskFixture(t *testing.T) *nativeTaskFixture {
+	t.Helper()
+	executor, err := NewExecutor()
+	if errors.Is(err, errExecutorUnavailable) {
+		t.Skip("Windows Task Scheduler executable is unavailable")
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	identity, err := currentUserIdentity()
+	if err != nil || !validUserIdentity(identity) {
+		t.Skip("current process does not have an interactive user identity")
+	}
+	fixture := &nativeTaskFixture{
+		root:     t.TempDir(),
+		identity: identity,
+		scheduler: &namedTaskScheduler{
+			executor: executor,
+			taskName: testTaskNamePrefix + "WP5-" + uuid.New().String(),
+		},
+	}
+	state, _, err := fixture.scheduler.Query(t.Context())
+	if errors.Is(err, errExecutorUnavailable) {
+		t.Skip("Windows Task Scheduler service is unavailable")
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state != personalsvc.TaskSchedulerAbsent {
+		t.Fatal("random Task Scheduler test identity already exists; refusing to alter it")
+	}
+	t.Cleanup(func() {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer cancel()
+		state, _, queryErr := fixture.scheduler.Query(cleanupCtx)
+		if queryErr != nil {
+			t.Errorf("cleanup query failed: %v", queryErr)
+			return
+		}
+		if state == personalsvc.TaskSchedulerPresent {
+			if !fixture.created {
+				t.Errorf("random task identity unexpectedly existed; it was not changed")
+				return
+			}
+			_ = fixture.scheduler.End(cleanupCtx)
+			if deleteErr := fixture.scheduler.Delete(cleanupCtx); deleteErr != nil {
+				t.Errorf("cleanup delete failed: %v", deleteErr)
+				return
+			}
+		}
+		state, _, queryErr = fixture.scheduler.Query(cleanupCtx)
+		if queryErr != nil || state != personalsvc.TaskSchedulerAbsent {
+			t.Errorf("cleanup final state = %s, %v; want absent", state, queryErr)
+		}
+	})
+	return fixture
+}
+
+type cancelAfterCreateScheduler struct {
+	taskScheduler
+	afterCreate func()
+}
+
+func (s *cancelAfterCreateScheduler) Create(ctx context.Context, path string) error {
+	if err := s.taskScheduler.Create(ctx, path); err != nil {
+		return err
+	}
+	if s.afterCreate != nil {
+		afterCreate := s.afterCreate
+		s.afterCreate = nil
+		afterCreate()
+	}
+	return nil
 }
 
 type namedTaskScheduler struct {
@@ -229,7 +365,7 @@ type namedTaskScheduler struct {
 
 type schedulerEvent struct {
 	operation string
-	exitCode  uint32
+	outcome   string
 }
 
 func (s *namedTaskScheduler) Query(ctx context.Context) (personalsvc.TaskSchedulerState, []byte, error) {
@@ -296,7 +432,15 @@ func (s *namedTaskScheduler) required(ctx context.Context, arguments ...string) 
 func (s *namedTaskScheduler) execute(ctx context.Context, arguments ...string) (personalsvc.TaskSchedulerResult, error) {
 	result, err := s.executor.Execute(ctx, taskSchedulerProgram, arguments)
 	if len(s.events) < 64 {
-		s.events = append(s.events, schedulerEvent{operation: schedulerOperation(arguments), exitCode: result.ExitCode})
+		outcome := fmt.Sprintf("%#x", result.ExitCode)
+		if errors.Is(err, context.Canceled) {
+			outcome = "canceled"
+		} else if errors.Is(err, context.DeadlineExceeded) {
+			outcome = "deadline"
+		} else if err != nil {
+			outcome = "error"
+		}
+		s.events = append(s.events, schedulerEvent{operation: schedulerOperation(arguments), outcome: outcome})
 	}
 	return result, err
 }
@@ -304,7 +448,7 @@ func (s *namedTaskScheduler) execute(ctx context.Context, arguments ...string) (
 func (s *namedTaskScheduler) summary() string {
 	parts := make([]string, 0, len(s.events))
 	for _, event := range s.events {
-		parts = append(parts, fmt.Sprintf("%s=%#x", event.operation, event.exitCode))
+		parts = append(parts, event.operation+"="+event.outcome)
 	}
 	return strings.Join(parts, ",")
 }

--- a/internal/personalsvchost/windows/operation_boundary_windows.go
+++ b/internal/personalsvchost/windows/operation_boundary_windows.go
@@ -21,8 +21,9 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/ob-labs/powercontext-go/internal/personalsvc"
 	golangwindows "golang.org/x/sys/windows"
+
+	"github.com/ob-labs/powercontext-go/internal/personalsvc"
 )
 
 const operationLockPollInterval = 10 * time.Millisecond
@@ -73,8 +74,8 @@ func (b *OperationBoundary) Run(ctx context.Context, operation func(context.Cont
 	if err != nil {
 		return newError("operation lock", nil)
 	}
-	defer lock.Close()
-	if info, err := lock.Stat(); err != nil || !info.Mode().IsRegular() {
+	defer func() { _ = lock.Close() }()
+	if info, statErr := lock.Stat(); statErr != nil || !info.Mode().IsRegular() {
 		return newError("operation lock", nil)
 	}
 

--- a/internal/personalsvchost/windows/operation_boundary_windows.go
+++ b/internal/personalsvchost/windows/operation_boundary_windows.go
@@ -1,0 +1,115 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package windows
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/ob-labs/powercontext-go/internal/personalsvc"
+	golangwindows "golang.org/x/sys/windows"
+)
+
+const operationLockPollInterval = 10 * time.Millisecond
+
+// OperationBoundary serializes one complete controller lifecycle operation
+// with both an in-process gate and a current-user-rooted Windows file lock.
+type OperationBoundary struct {
+	lockPath string
+	gate     chan struct{}
+}
+
+var _ personalsvc.OperationBoundary = (*OperationBoundary)(nil)
+
+func newOperationBoundary(userDataRoot string) (*OperationBoundary, error) {
+	if !validUserDataRoot(userDataRoot) {
+		return nil, newError("operation lock", nil)
+	}
+	return &OperationBoundary{
+		lockPath: filepath.Join(userDataRoot, "PowerContext", "Services", ".personal-server.lock"),
+		gate:     make(chan struct{}, 1),
+	}, nil
+}
+
+// Run holds the exact lifecycle lock until operation returns. Contention is
+// cancelable and never broadens the lock to a global task or filesystem root.
+func (b *OperationBoundary) Run(ctx context.Context, operation func(context.Context) error) error {
+	if b == nil || ctx == nil || operation == nil || b.lockPath == "" || b.gate == nil {
+		return newError("operation lock", nil)
+	}
+	select {
+	case b.gate <- struct{}{}:
+		defer func() { <-b.gate }()
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(b.lockPath), 0o700); err != nil {
+		return newError("operation lock", nil)
+	}
+	if info, err := os.Lstat(b.lockPath); err == nil && (!info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0) {
+		return newError("operation lock", nil)
+	} else if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return newError("operation lock", nil)
+	}
+	lock, err := os.OpenFile(b.lockPath, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return newError("operation lock", nil)
+	}
+	defer lock.Close()
+	if info, err := lock.Stat(); err != nil || !info.Mode().IsRegular() {
+		return newError("operation lock", nil)
+	}
+
+	overlapped := &golangwindows.Overlapped{}
+	for {
+		err = golangwindows.LockFileEx(
+			golangwindows.Handle(lock.Fd()),
+			golangwindows.LOCKFILE_EXCLUSIVE_LOCK|golangwindows.LOCKFILE_FAIL_IMMEDIATELY,
+			0,
+			1,
+			0,
+			overlapped,
+		)
+		if err == nil {
+			break
+		}
+		if !errors.Is(err, golangwindows.ERROR_LOCK_VIOLATION) {
+			return newError("operation lock", nil)
+		}
+		timer := time.NewTimer(operationLockPollInterval)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return ctx.Err()
+		case <-timer.C:
+		}
+	}
+
+	operationErr := operation(ctx)
+	unlockErr := golangwindows.UnlockFileEx(golangwindows.Handle(lock.Fd()), 0, 1, 0, overlapped)
+	if operationErr != nil {
+		return operationErr
+	}
+	if unlockErr != nil {
+		return newError("operation lock", nil)
+	}
+	return nil
+}

--- a/tools/release/workflow_test.go
+++ b/tools/release/workflow_test.go
@@ -1476,7 +1476,7 @@ func TestWindowsContractExercisesTargetedGoRegressions(t *testing.T) {
 	if !ok {
 		t.Fatal("windows-contract.yml has no windows-contract job")
 	}
-	setupIndex, apiTestIndex := -1, -1
+	setupIndex, apiTestIndex, executorTestIndex := -1, -1, -1
 	for index, step := range job.Steps {
 		switch step.Name {
 		case "Set up the Go environment":
@@ -1487,13 +1487,18 @@ func TestWindowsContractExercisesTargetedGoRegressions(t *testing.T) {
 			if strings.TrimSpace(step.Run) == "go test -count=1 ./tools/api-baseline -run '^TestWriteBaselineReplacesExistingOutput$'" {
 				apiTestIndex = index
 			}
+		case "Verify Windows Task Scheduler executor boundary":
+			if strings.TrimSpace(step.Run) == "go test -count=1 ./internal/personalsvchost/windows" {
+				executorTestIndex = index
+			}
 		}
 	}
-	if setupIndex < 0 || apiTestIndex <= setupIndex {
+	if setupIndex < 0 || apiTestIndex <= setupIndex || executorTestIndex <= apiTestIndex {
 		t.Fatalf(
-			"Windows targeted Go steps = setup %d, API %d, want ordered setup and regression tests",
+			"Windows targeted Go steps = setup %d, API %d, executor %d, want ordered setup and regression tests",
 			setupIndex,
 			apiTestIndex,
+			executorTestIndex,
 		)
 	}
 }


### PR DESCRIPTION
Part of #202 Phase 5-W1 only.

Adds the Windows-only native host boundary for the existing Task Scheduler personal-service contract:

- fixed System32 `schtasks.exe` executor with shell-free argv, bounded output, redacted failures, cancellation, and HRESULT preservation;
- current interactive-user identity substituted into principal and LogonTrigger; global roots and service sessions refused;
- owned artifact and manager inspection, foreign-task refusal, atomic private artifact storage, loopback liveness probe, and cross-instance operation lock;
- cancellation/failure rollback preserves independent artifact and native-manager snapshots;
- real `windows-2025` host tests use only a random test task, validate start/stop and login trigger behavior, and prove a foreign task remains unchanged.

Out of scope for this PR: public CLI install/status/uninstall wiring, release archive consumer lifecycle, long-lived fixed product task proof, Linux systemd, macOS LaunchAgent, any non-SQLite backend, and any non-Codex/WorkBuddy agent behavior.

Validation:

- `go test` and `go test -race` for `internal/personalsvc` plus `internal/personalsvchost/windows`;
- real Windows Task Scheduler lifecycle/cancellation/foreign-ownership tests;
- target `go vet`, pinned target lint, and Windows workflow contract test.

The full `tools/release` suite currently has an unrelated Windows archive mode baseline failure (`TestReleaseArchiveKeepsStableExecutablePathAndMode`: packaged binary `0644`); this PR does not change release packaging. The targeted workflow contract test passes.