### PR TITLE
feat(personalsvc): bind registration to environment identity

### DIFF
--- a/internal/personalsvc/controller_test.go
+++ b/internal/personalsvc/controller_test.go
@@ -397,6 +397,7 @@ func testRegistration(t *testing.T, packageVersion string) personalsvc.Registrat
 		Binary:            `C:\\Program Files\\PowerContext\\powercontext.exe`,
 		Endpoint:          "http://127.0.0.1:8123",
 		DataDir:           `C:\\Users\\person\\AppData\\Local\\PowerContext`,
+		EnvFile:           `C:\Users\person\AppData\Local\PowerContext\server.env`,
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/internal/personalsvc/definition.go
+++ b/internal/personalsvc/definition.go
@@ -36,13 +36,14 @@ const (
 	// DefinitionVersion is the currently supported registration metadata
 	// format. A newer value must be deliberately introduced with a parser and
 	// migration decision rather than silently accepted.
-	DefinitionVersion uint = 2
+	DefinitionVersion uint = 3
 
 	MaxOwnershipLength      = 128
 	MaxPackageVersionLength = 128
 	MaxBinaryLength         = 4096
 	MaxEndpointLength       = 2048
 	MaxDataDirLength        = 4096
+	MaxEnvFileLength        = 4096
 
 	maxDecodedRegistrationLength = 12 * 1024
 	maxEncodedRegistrationLength = 16 * 1024
@@ -69,6 +70,7 @@ type DefinitionInput struct {
 	Binary            string
 	Endpoint          string
 	DataDir           string
+	EnvFile           string
 }
 
 // Definition is an immutable, side-effect-free declaration that a native
@@ -80,6 +82,7 @@ type Definition struct {
 	binary            string
 	endpoint          string
 	dataDir           string
+	envFile           string
 }
 
 // NewDefinition validates an owned personal-service declaration.
@@ -91,6 +94,7 @@ func NewDefinition(input DefinitionInput) (Definition, error) {
 		binary:            input.Binary,
 		endpoint:          input.Endpoint,
 		dataDir:           input.DataDir,
+		envFile:           input.EnvFile,
 	}
 	if err := definition.Validate(); err != nil {
 		return Definition{}, err
@@ -104,6 +108,7 @@ func (d Definition) PackageVersion() string { return d.packageVersion }
 func (d Definition) Binary() string         { return d.binary }
 func (d Definition) Endpoint() string       { return d.endpoint }
 func (d Definition) DataDir() string        { return d.dataDir }
+func (d Definition) EnvFile() string        { return d.envFile }
 
 // Validate rejects zero-value, unsupported, and unsafe definitions.
 func (d Definition) Validate() error {
@@ -125,7 +130,10 @@ func (d Definition) Validate() error {
 	if err := validateEndpoint(d.endpoint); err != nil {
 		return err
 	}
-	return validateAbsolutePath("data_dir", d.dataDir, MaxDataDirLength)
+	if err := validateAbsolutePath("data_dir", d.dataDir, MaxDataDirLength); err != nil {
+		return err
+	}
+	return validateNormalizedAbsolutePath("env_file", d.envFile, MaxEnvFileLength)
 }
 
 // CanonicalJSON returns the RFC 8785 canonical registration definition.
@@ -140,6 +148,7 @@ func (d Definition) CanonicalJSON() ([]byte, error) {
 		Binary:            d.binary,
 		Endpoint:          d.endpoint,
 		DataDir:           d.dataDir,
+		EnvFile:           d.envFile,
 	})
 	if err != nil {
 		return nil, invalidMetadata("payload", "cannot be encoded")
@@ -219,6 +228,7 @@ type definitionWire struct {
 	Binary            string `json:"binary"`
 	Endpoint          string `json:"endpoint"`
 	DataDir           string `json:"data_dir"`
+	EnvFile           string `json:"env_file"`
 }
 
 func decodeDefinition(payload []byte) (Definition, error) {
@@ -229,7 +239,7 @@ func decodeDefinition(payload []byte) (Definition, error) {
 	if err := json.Unmarshal(payload, &object); err != nil {
 		return Definition{}, invalidMetadata("payload", "must be valid JSON without duplicate members or trailing data")
 	}
-	if len(object) != 6 {
+	if len(object) != 7 {
 		for name := range object {
 			if !definitionField(name) && sensitiveMetadataName(name) {
 				return Definition{}, invalidMetadata("metadata", "must not contain sensitive members")
@@ -270,6 +280,10 @@ func decodeDefinition(payload []byte) (Definition, error) {
 	if err != nil {
 		return Definition{}, err
 	}
+	envFile, err := requiredString(object["env_file"], "env_file")
+	if err != nil {
+		return Definition{}, err
+	}
 	return NewDefinition(DefinitionInput{
 		Ownership:         ownership,
 		DefinitionVersion: version,
@@ -277,6 +291,7 @@ func decodeDefinition(payload []byte) (Definition, error) {
 		Binary:            binary,
 		Endpoint:          endpoint,
 		DataDir:           dataDir,
+		EnvFile:           envFile,
 	})
 }
 
@@ -353,6 +368,16 @@ func validateAbsolutePath(field, value string, maximum int) error {
 	return nil
 }
 
+func validateNormalizedAbsolutePath(field, value string, maximum int) error {
+	if err := validateAbsolutePath(field, value, maximum); err != nil {
+		return err
+	}
+	if !normalizedAbsolutePath(value) {
+		return invalidMetadata(field, "must be normalized")
+	}
+	return nil
+}
+
 // absolutePath accepts a portable POSIX absolute path and the stable Windows
 // drive and UNC forms. It deliberately does not inspect the host filesystem.
 func absolutePath(value string) bool {
@@ -362,13 +387,45 @@ func absolutePath(value string) bool {
 	return len(value) >= 3 && asciiLetter(value[0]) && value[1] == ':' && (value[2] == '/' || value[2] == '\\')
 }
 
+func normalizedAbsolutePath(value string) bool {
+	separator := "/"
+	var remainder string
+	switch {
+	case strings.HasPrefix(value, "/"):
+		if strings.HasPrefix(value, "//") {
+			return false
+		}
+		remainder = value[1:]
+	case strings.HasPrefix(value, `\\`):
+		separator = `\`
+		remainder = value[2:]
+	case len(value) >= 3 && asciiLetter(value[0]) && value[1] == ':' && (value[2] == '/' || value[2] == '\\'):
+		separator = value[2:3]
+		remainder = value[3:]
+	default:
+		return false
+	}
+	if remainder == "" || strings.Contains(remainder, separator+separator) {
+		return false
+	}
+	if separator == "/" && strings.ContainsRune(remainder, '\\') || separator == `\` && strings.ContainsRune(remainder, '/') {
+		return false
+	}
+	for segment := range strings.SplitSeq(remainder, separator) {
+		if segment == "" || segment == "." || segment == ".." {
+			return false
+		}
+	}
+	return true
+}
+
 func asciiLetter(value byte) bool {
 	return value >= 'a' && value <= 'z' || value >= 'A' && value <= 'Z'
 }
 
 func definitionField(name string) bool {
 	switch name {
-	case "ownership", "definition_version", "package_version", "binary", "endpoint", "data_dir":
+	case "ownership", "definition_version", "package_version", "binary", "endpoint", "data_dir", "env_file":
 		return true
 	default:
 		return false

--- a/internal/personalsvc/definition_test.go
+++ b/internal/personalsvc/definition_test.go
@@ -42,7 +42,7 @@ func TestRegistrationEncodesAnImmutableCanonicalDefinition(t *testing.T) {
 	if decodeErr != nil {
 		t.Fatalf("DecodeString() error = %v", decodeErr)
 	}
-	const want = `{"binary":"/opt/powercontext/bin/powercontext","data_dir":"/var/lib/powercontext","definition_version":2,"endpoint":"http://127.0.0.1:7614","ownership":"powercontext.personal-server","package_version":"0.2.0"}`
+	const want = `{"binary":"/opt/powercontext/bin/powercontext","data_dir":"/var/lib/powercontext","definition_version":3,"endpoint":"http://127.0.0.1:7614","env_file":"/etc/powercontext/server.env","ownership":"powercontext.personal-server","package_version":"0.2.0"}`
 	if string(payload) != want {
 		t.Fatalf("canonical payload = %q, want %q", payload, want)
 	}
@@ -164,6 +164,49 @@ func TestDefinitionAcceptsTransportPolicyLoopbackEndpoints(t *testing.T) {
 	}
 }
 
+func TestDefinitionRequiresANormalizedAbsoluteEnvironmentFileIdentity(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		envFile string
+		wantErr bool
+	}{
+		{name: "POSIX", envFile: "/etc/powercontext/server.env"},
+		{name: "Windows drive", envFile: `C:\ProgramData\PowerContext\server.env`},
+		{name: "UNC", envFile: `\\server\share\server.env`},
+		{name: "relative", envFile: "config/server.env", wantErr: true},
+		{name: "empty", envFile: "", wantErr: true},
+		{name: "POSIX dot", envFile: "/etc/./powercontext/server.env", wantErr: true},
+		{name: "POSIX parent", envFile: "/etc/powercontext/../server.env", wantErr: true},
+		{name: "POSIX repeated separator", envFile: "/etc//powercontext/server.env", wantErr: true},
+		{name: "Windows dot", envFile: `C:\ProgramData\.\server.env`, wantErr: true},
+		{name: "Windows repeated separator", envFile: `C:\ProgramData\\server.env`, wantErr: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			input := testDefinitionInput()
+			input.EnvFile = test.envFile
+			definition, err := personalsvc.NewDefinition(input)
+			if test.wantErr {
+				if err == nil {
+					t.Fatal("NewDefinition() accepted an invalid environment file identity")
+				}
+				if _, ok := errors.AsType[*personalsvc.InvalidMetadataError](err); !ok {
+					t.Fatalf("NewDefinition() error type = %T, want *InvalidMetadataError", err)
+				}
+				if test.envFile != "" && strings.Contains(err.Error(), test.envFile) {
+					t.Fatalf("NewDefinition() error exposed environment file: %q", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("NewDefinition() error = %v", err)
+			}
+			if definition.EnvFile() != test.envFile {
+				t.Fatalf("EnvFile() = %q, want %q", definition.EnvFile(), test.envFile)
+			}
+		})
+	}
+}
+
 func TestDecodeRegistrationRejectsNonCanonicalUnknownDuplicateAndSensitiveMetadata(t *testing.T) {
 	cases := []struct {
 		name    string
@@ -203,6 +246,17 @@ func TestDecodeRegistrationRejectsNonCanonicalUnknownDuplicateAndSensitiveMetada
 				t.Fatalf("DecodeRegistration() error exposed sensitive value: %q", err)
 			}
 		})
+	}
+}
+
+func TestDecodeRegistrationRejectsLegacyV2WithoutEnvironmentFile(t *testing.T) {
+	payload := `{"binary":"/opt/powercontext/bin/powercontext","data_dir":"/var/lib/powercontext","definition_version":2,"endpoint":"http://127.0.0.1:7614","ownership":"powercontext.personal-server","package_version":"0.2.0"}`
+	_, err := personalsvc.DecodeRegistration(base64.RawURLEncoding.EncodeToString([]byte(payload)))
+	if err == nil {
+		t.Fatal("DecodeRegistration() accepted a legacy v2 registration")
+	}
+	if _, ok := errors.AsType[*personalsvc.InvalidMetadataError](err); !ok {
+		t.Fatalf("DecodeRegistration() error type = %T, want *InvalidMetadataError", err)
 	}
 }
 
@@ -255,5 +309,6 @@ func testDefinitionInput() personalsvc.DefinitionInput {
 		Binary:            "/opt/powercontext/bin/powercontext",
 		Endpoint:          "http://127.0.0.1:7614",
 		DataDir:           "/var/lib/powercontext",
+		EnvFile:           "/etc/powercontext/server.env",
 	}
 }

--- a/internal/personalsvc/launchd_test.go
+++ b/internal/personalsvc/launchd_test.go
@@ -246,6 +246,7 @@ func launchdRegistration(t *testing.T) personalsvc.Registration {
 		Binary:            "/opt/powercontext/bin/powercontext",
 		Endpoint:          "http://127.0.0.1:7614",
 		DataDir:           "/var/lib/powercontext",
+		EnvFile:           "/etc/powercontext/server.env",
 	})
 	if err != nil {
 		t.Fatalf("NewDefinition() error = %v", err)

--- a/internal/personalsvc/systemd_test.go
+++ b/internal/personalsvc/systemd_test.go
@@ -522,6 +522,7 @@ func systemdRegistration(t *testing.T) personalsvc.Registration {
 		Binary:            "/opt/powercontext/bin/powercontext",
 		Endpoint:          "http://127.0.0.1:8123",
 		DataDir:           "/home/alice/.local/share/powercontext",
+		EnvFile:           "/home/alice/.config/powercontext/server.env",
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/internal/personalsvc/task_scheduler_test.go
+++ b/internal/personalsvc/task_scheduler_test.go
@@ -80,6 +80,7 @@ func TestTaskSchedulerSpecRejectsShellAction(t *testing.T) {
 		Binary:            `C:\Windows\System32\cmd.exe`,
 		Endpoint:          "http://127.0.0.1:8123",
 		DataDir:           `C:\Users\person\AppData\Local\PowerContext`,
+		EnvFile:           `C:\Users\person\AppData\Local\PowerContext\server.env`,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -501,6 +502,7 @@ func taskSchedulerSpec(t *testing.T, startOnLogin bool) personalsvc.TaskSchedule
 		Binary:            `C:\Program Files\PowerContext\powercontext.exe`,
 		Endpoint:          "http://127.0.0.1:8123",
 		DataDir:           `C:\Users\person\AppData\Local\PowerContext`,
+		EnvFile:           `C:\Users\person\AppData\Local\PowerContext\server.env`,
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/internal/personalsvchost/windows/adapter_windows_test.go
+++ b/internal/personalsvchost/windows/adapter_windows_test.go
@@ -879,6 +879,7 @@ func adapterPlanForPackage(t *testing.T, root, packageVersion string) personalsv
 		Binary:            binary,
 		Endpoint:          "http://127.0.0.1:1",
 		DataDir:           root,
+		EnvFile:           filepath.Join(root, "server.env"),
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/internal/personalsvchost/windows/lifecycle_windows_test.go
+++ b/internal/personalsvchost/windows/lifecycle_windows_test.go
@@ -255,6 +255,7 @@ func nativeLifecyclePlan(t *testing.T, root, sentinel string, startOnLogin bool)
 		Binary:            binary,
 		Endpoint:          "http://127.0.0.1:1",
 		DataDir:           root,
+		EnvFile:           filepath.Join(root, "server.env"),
 	})
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Part of #202 Phase 5 W2 prerequisite only.

Upgrades personal-service registration metadata to v3 by adding a required normalized absolute `env_file` identity. The registration stores the path only: no environment values, credentials, headers, tokens, or other secret-bearing configuration are persisted.

- legacy v2 registration payloads fail closed;
- unknown, duplicate, noncanonical, sensitive, relative, dot/parent, and non-normalized environment-file forms are rejected;
- Windows Task Scheduler, systemd, and LaunchAgent contract fixtures now carry the same credential-free identity;
- Windows W1 native host fixtures use a private-root `server.env` identity.

This PR does not add CLI commands, read environment values, install a service, launch a child process, add a backend, or expand the agent matrix. It is the durable configuration-identity prerequisite for Windows W2 public lifecycle wiring.

Validation: focused portable/Windows ordinary and race tests, vet, target lint, and contract checks.