### PR TITLE
feat(cli): operate Windows personal server lifecycle

### DIFF
--- a/internal/cli/server_command.go
+++ b/internal/cli/server_command.go
@@ -44,7 +44,13 @@ type serverEnvironmentValue struct {
 
 func newServerCommand(state *commandState) *cobra.Command {
 	command := &cobra.Command{Use: "server", Short: "Run a configured PowerContext service."}
-	command.AddCommand(newServerRunCommand(state))
+	command.AddCommand(
+		newServerRunCommand(state),
+		newPersonalServiceInstallCommand(state),
+		newPersonalServiceStatusCommand(state),
+		newPersonalServiceUninstallCommand(state),
+		newPersonalServiceRunCommand(state),
+	)
 	return command
 }
 

--- a/internal/cli/server_personal_service.go
+++ b/internal/cli/server_personal_service.go
@@ -1,0 +1,128 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"errors"
+	"runtime"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// UnsupportedPersonalServiceError reports that this build cannot operate a
+// native personal-server lifecycle. Its text contains no caller values.
+type UnsupportedPersonalServiceError struct{}
+
+func (*UnsupportedPersonalServiceError) Error() string {
+	if runtime.GOOS == "windows" {
+		return "personal Server service lifecycle is not available in this build"
+	}
+	return "personal Server service is supported only on Windows"
+}
+
+func newPersonalServiceInstallCommand(state *commandState) *cobra.Command {
+	var envFile, dataDir string
+	var startOnLogin bool
+	command := &cobra.Command{
+		Use: "install", Short: "Install the current user's PowerContext Server service.", Args: cobra.NoArgs,
+		RunE: func(command *cobra.Command, _ []string) error {
+			if err := personalServiceRequiredPath("env-file", envFile); err != nil {
+				return usageError(err)
+			}
+			if command.Flags().Changed("data-dir") {
+				if err := personalServiceOptionalPath("data-dir", dataDir); err != nil {
+					return usageError(err)
+				}
+			}
+			return runPersonalServiceInstall(command.Context(), state, envFile, dataDir, startOnLogin)
+		},
+	}
+	command.Flags().StringVar(&envFile, "env-file", "", "Credential-free Server environment file identity.")
+	command.Flags().StringVar(&dataDir, "data-dir", "", "Private PowerContext data directory.")
+	command.Flags().BoolVar(&startOnLogin, "start-on-login", true, "Start the owned service when the current user signs in.")
+	_ = command.MarkFlagRequired("env-file")
+	return command
+}
+
+func newPersonalServiceStatusCommand(state *commandState) *cobra.Command {
+	var dataDir string
+	command := &cobra.Command{
+		Use: "status", Short: "Inspect the current user's PowerContext Server service.", Args: cobra.NoArgs,
+		RunE: func(command *cobra.Command, _ []string) error {
+			if command.Flags().Changed("data-dir") {
+				if err := personalServiceOptionalPath("data-dir", dataDir); err != nil {
+					return usageError(err)
+				}
+			}
+			return runPersonalServiceStatus(command.Context(), state, dataDir)
+		},
+	}
+	command.Flags().StringVar(&dataDir, "data-dir", "", "Private PowerContext data directory.")
+	return command
+}
+
+func newPersonalServiceUninstallCommand(state *commandState) *cobra.Command {
+	var dataDir string
+	command := &cobra.Command{
+		Use: "uninstall", Short: "Remove the owned PowerContext Server service.", Args: cobra.NoArgs,
+		RunE: func(command *cobra.Command, _ []string) error {
+			if command.Flags().Changed("data-dir") {
+				if err := personalServiceOptionalPath("data-dir", dataDir); err != nil {
+					return usageError(err)
+				}
+			}
+			return runPersonalServiceUninstall(command.Context(), state, dataDir)
+		},
+	}
+	command.Flags().StringVar(&dataDir, "data-dir", "", "Private PowerContext data directory.")
+	return command
+}
+
+func newPersonalServiceRunCommand(state *commandState) *cobra.Command {
+	var envFile, endpoint, dataDir string
+	command := &cobra.Command{
+		Use: "_service-run", Hidden: true, Args: cobra.NoArgs,
+		RunE: func(command *cobra.Command, _ []string) error {
+			for _, value := range []struct{ name, value string }{{"env-file", envFile}, {"endpoint", endpoint}, {"data-dir", dataDir}} {
+				if err := personalServiceRequiredPath(value.name, value.value); err != nil {
+					return usageError(err)
+				}
+			}
+			return runPersonalServiceChild(command.Context(), state, envFile, endpoint, dataDir)
+		},
+	}
+	command.Flags().StringVar(&envFile, "env-file", "", "Credential-free Server environment file identity.")
+	command.Flags().StringVar(&endpoint, "endpoint", "", "Owned loopback Server endpoint.")
+	command.Flags().StringVar(&dataDir, "data-dir", "", "Private PowerContext data directory.")
+	for _, name := range []string{"env-file", "endpoint", "data-dir"} {
+		_ = command.MarkFlagRequired(name)
+	}
+	return command
+}
+
+func personalServiceRequiredPath(name, value string) error {
+	if value == "" || strings.TrimSpace(value) != value {
+		return errors.New("server: --" + name + " must be a non-empty trimmed value")
+	}
+	return nil
+}
+
+func personalServiceOptionalPath(name, value string) error {
+	if value == "" || strings.TrimSpace(value) != value {
+		return errors.New("server: --" + name + " must be a non-empty trimmed value")
+	}
+	return nil
+}

--- a/internal/cli/server_personal_service_other.go
+++ b/internal/cli/server_personal_service_other.go
@@ -1,0 +1,35 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !windows
+
+package cli
+
+import "context"
+
+func runPersonalServiceInstall(context.Context, *commandState, string, string, bool) error {
+	return &UnsupportedPersonalServiceError{}
+}
+
+func runPersonalServiceStatus(context.Context, *commandState, string) error {
+	return &UnsupportedPersonalServiceError{}
+}
+
+func runPersonalServiceUninstall(context.Context, *commandState, string) error {
+	return &UnsupportedPersonalServiceError{}
+}
+
+func runPersonalServiceChild(context.Context, *commandState, string, string, string) error {
+	return &UnsupportedPersonalServiceError{}
+}

--- a/internal/cli/server_personal_service_test.go
+++ b/internal/cli/server_personal_service_test.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import "testing"
+
+func TestServerPersonalServiceCommandsExposeLifecycleContract(t *testing.T) {
+	command := newCommand(VersionInfo{}, nil, nil)
+	server, _, err := command.Find([]string{"server"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, test := range []struct {
+		name     string
+		hidden   bool
+		required []string
+		optional []string
+	}{
+		{name: "install", required: []string{"env-file"}, optional: []string{"data-dir", "start-on-login"}},
+		{name: "status", optional: []string{"data-dir", "json"}},
+		{name: "uninstall", optional: []string{"data-dir", "json"}},
+		{name: "_service-run", hidden: true, required: []string{"env-file", "endpoint", "data-dir"}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			child, _, findErr := server.Find([]string{test.name})
+			if findErr != nil || child.Name() != test.name {
+				t.Fatalf("server %s command = %v, %v", test.name, child, findErr)
+			}
+			if child.Hidden != test.hidden {
+				t.Fatalf("server %s Hidden = %t, want %t", test.name, child.Hidden, test.hidden)
+			}
+			for _, name := range test.required {
+				flag := child.Flags().Lookup(name)
+				if flag == nil || flag.Annotations["cobra_annotation_bash_completion_one_required_flag"] == nil {
+					t.Fatalf("server %s --%s is not required", test.name, name)
+				}
+			}
+			for _, name := range test.optional {
+				if child.Flags().Lookup(name) == nil && child.InheritedFlags().Lookup(name) == nil {
+					t.Fatalf("server %s --%s is missing", test.name, name)
+				}
+			}
+		})
+	}
+}

--- a/internal/cli/server_personal_service_windows.go
+++ b/internal/cli/server_personal_service_windows.go
@@ -1,0 +1,353 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build windows
+
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"maps"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/ob-labs/powercontext-go/internal/personalsvc"
+	personalsvcwindows "github.com/ob-labs/powercontext-go/internal/personalsvchost/windows"
+	"github.com/ob-labs/powercontext-go/server"
+)
+
+func runPersonalServiceInstall(ctx context.Context, state *commandState, envFile, dataDir string, startOnLogin bool) error {
+	registration, plan, root, err := newWindowsPersonalServiceRegistration(ctx, state, envFile, dataDir, startOnLogin)
+	if err != nil {
+		return err
+	}
+	runtime, err := newWindowsPersonalServiceRuntime(root, plan)
+	if err != nil {
+		return err
+	}
+	status, err := runtime.controller.Install(ctx, registration)
+	if err != nil {
+		return err
+	}
+	return writeWindowsPersonalServiceStatus(state, status)
+}
+
+func runPersonalServiceStatus(ctx context.Context, state *commandState, dataDir string) error {
+	runtime, err := newWindowsPersonalServiceInspectionRuntime(dataDir)
+	if err != nil {
+		return err
+	}
+	registration, found, err := installedWindowsPersonalServiceRegistration(ctx, runtime.composition.Adapter())
+	if err != nil {
+		return err
+	}
+	if !found {
+		status, statusErr := runtime.controller.Status(ctx, personalsvc.Registration{})
+		if statusErr != nil {
+			return statusErr
+		}
+		return writeWindowsPersonalServiceStatus(state, status)
+	}
+	status, err := runtime.controller.Status(ctx, registration)
+	if err != nil {
+		return err
+	}
+	return writeWindowsPersonalServiceStatus(state, status)
+}
+
+func runPersonalServiceUninstall(ctx context.Context, state *commandState, dataDir string) error {
+	runtime, err := newWindowsPersonalServiceInspectionRuntime(dataDir)
+	if err != nil {
+		return err
+	}
+	registration, found, err := installedWindowsPersonalServiceRegistration(ctx, runtime.composition.Adapter())
+	if err != nil {
+		return err
+	}
+	if !found {
+		status, statusErr := runtime.controller.Status(ctx, personalsvc.Registration{})
+		if statusErr != nil {
+			return statusErr
+		}
+		return writeWindowsPersonalServiceStatus(state, status)
+	}
+	status, err := runtime.controller.Uninstall(ctx, registration)
+	if err != nil {
+		return err
+	}
+	return writeWindowsPersonalServiceStatus(state, status)
+}
+
+func runPersonalServiceChild(ctx context.Context, state *commandState, envFile, endpoint, dataDir string) error {
+	envFile, err := windowsPersonalServiceEnvFile(envFile)
+	if err != nil {
+		return err
+	}
+	dataDir, err = windowsPersonalServiceDataDir(dataDir)
+	if err != nil {
+		return err
+	}
+	override, err := windowsPersonalServiceHTTPOverride(endpoint)
+	if err != nil {
+		return errors.New("server: invalid personal service endpoint")
+	}
+	expected, plan, err := newWindowsPersonalServiceRegistrationFromIdentity(state, envFile, endpoint, dataDir, true)
+	if err != nil {
+		return errors.New("server: personal service identity is invalid")
+	}
+	runtime, err := newWindowsPersonalServiceRuntime(dataDir, plan)
+	if err != nil {
+		return err
+	}
+	registered, found, err := installedWindowsPersonalServiceRegistration(ctx, runtime.composition.Adapter())
+	if err != nil || !found || registered != expected {
+		return errors.New("server: personal service identity is unavailable")
+	}
+	values, err := loadServerEnvironmentFile(envFile)
+	if err != nil {
+		return err
+	}
+	var config server.ProcessConfig
+	err = withServerEnvironment(windowsPersonalServiceEnvironment(values, dataDir), func() error {
+		var configErr error
+		config, configErr = server.LoadConfigWithHTTPOverride(override)
+		return configErr
+	})
+	if err != nil || config.Database.Kind != "sqlite" {
+		return errors.New("server: personal service configuration is invalid")
+	}
+	runner := state.serverRun
+	if runner == nil {
+		runner = runServer
+	}
+	return runner(ctx, state, config)
+}
+
+type windowsPersonalServiceRuntime struct {
+	composition *personalsvcwindows.Composition
+	controller  *personalsvc.Controller
+}
+
+func newWindowsPersonalServiceRuntime(root string, plan personalsvc.TaskSchedulerSpec) (windowsPersonalServiceRuntime, error) {
+	composition, err := personalsvcwindows.New(personalsvcwindows.Config{UserDataRoot: root, Plan: plan})
+	if err != nil || composition.Adapter() == nil || composition.OperationBoundary() == nil {
+		return windowsPersonalServiceRuntime{}, errors.New("server: Windows personal service configuration is unavailable")
+	}
+	controller, err := personalsvc.NewController(composition.Adapter(), composition.OperationBoundary())
+	if err != nil {
+		return windowsPersonalServiceRuntime{}, errors.New("server: Windows personal service controller is unavailable")
+	}
+	return windowsPersonalServiceRuntime{composition: composition, controller: controller}, nil
+}
+
+func newWindowsPersonalServiceInspectionRuntime(dataDir string) (windowsPersonalServiceRuntime, error) {
+	dataDir, err := windowsPersonalServiceDataDir(dataDir)
+	if err != nil {
+		return windowsPersonalServiceRuntime{}, err
+	}
+	plan, err := newWindowsPersonalServiceInspectionPlan(dataDir)
+	if err != nil {
+		return windowsPersonalServiceRuntime{}, errors.New("server: Windows personal service configuration is unavailable")
+	}
+	return newWindowsPersonalServiceRuntime(dataDir, plan)
+}
+
+func newWindowsPersonalServiceInspectionPlan(dataDir string) (personalsvc.TaskSchedulerSpec, error) {
+	binary, err := windowsPersonalServiceExecutable()
+	if err != nil {
+		return personalsvc.TaskSchedulerSpec{}, err
+	}
+	definition, err := personalsvc.NewDefinition(personalsvc.DefinitionInput{
+		Ownership: personalsvc.OwnershipMarker, DefinitionVersion: personalsvc.DefinitionVersion,
+		PackageVersion: "inspection", Binary: binary, Endpoint: "http://127.0.0.1:1",
+		DataDir: dataDir, EnvFile: filepath.Join(dataDir, "server.env"),
+	})
+	if err != nil {
+		return personalsvc.TaskSchedulerSpec{}, err
+	}
+	registration, err := personalsvc.NewRegistration(definition)
+	if err != nil {
+		return personalsvc.TaskSchedulerSpec{}, err
+	}
+	return personalsvc.NewTaskSchedulerSpec(registration, []string{"server", "_service-run"}, dataDir, true)
+}
+
+func newWindowsPersonalServiceRegistration(ctx context.Context, state *commandState, envFile, dataDir string, startOnLogin bool) (personalsvc.Registration, personalsvc.TaskSchedulerSpec, string, error) {
+	envFile, err := windowsPersonalServiceEnvFile(envFile)
+	if err != nil {
+		return personalsvc.Registration{}, personalsvc.TaskSchedulerSpec{}, "", err
+	}
+	dataDir, err = windowsPersonalServiceDataDir(dataDir)
+	if err != nil {
+		return personalsvc.Registration{}, personalsvc.TaskSchedulerSpec{}, "", err
+	}
+	if mkdirErr := os.MkdirAll(dataDir, 0o700); mkdirErr != nil {
+		return personalsvc.Registration{}, personalsvc.TaskSchedulerSpec{}, "", errors.New("server: personal service data directory is unavailable")
+	}
+	values, err := loadServerEnvironmentFile(envFile)
+	if err != nil {
+		return personalsvc.Registration{}, personalsvc.TaskSchedulerSpec{}, "", err
+	}
+	var config server.ProcessConfig
+	err = withServerEnvironment(windowsPersonalServiceEnvironment(values, dataDir), func() error {
+		var configErr error
+		config, configErr = server.LoadConfig()
+		return configErr
+	})
+	if err != nil || config.Database.Kind != "sqlite" {
+		return personalsvc.Registration{}, personalsvc.TaskSchedulerSpec{}, "", errors.New("server: personal service configuration is invalid")
+	}
+	registration, plan, err := newWindowsPersonalServiceRegistrationFromIdentity(state, envFile, "http://"+config.HTTP.Address(), dataDir, startOnLogin)
+	if err != nil {
+		return personalsvc.Registration{}, personalsvc.TaskSchedulerSpec{}, "", err
+	}
+	return registration, plan, dataDir, ctx.Err()
+}
+
+func newWindowsPersonalServiceRegistrationFromIdentity(state *commandState, envFile, endpoint, dataDir string, startOnLogin bool) (personalsvc.Registration, personalsvc.TaskSchedulerSpec, error) {
+	binary, err := windowsPersonalServiceExecutable()
+	if err != nil {
+		return personalsvc.Registration{}, personalsvc.TaskSchedulerSpec{}, err
+	}
+	definition, err := personalsvc.NewDefinition(personalsvc.DefinitionInput{
+		Ownership: personalsvc.OwnershipMarker, DefinitionVersion: personalsvc.DefinitionVersion,
+		PackageVersion: windowsPersonalServiceVersion(state), Binary: binary,
+		Endpoint: endpoint, DataDir: dataDir, EnvFile: envFile,
+	})
+	if err != nil {
+		return personalsvc.Registration{}, personalsvc.TaskSchedulerSpec{}, err
+	}
+	registration, err := personalsvc.NewRegistration(definition)
+	if err != nil {
+		return personalsvc.Registration{}, personalsvc.TaskSchedulerSpec{}, err
+	}
+	arguments := []string{"server", "_service-run", "--env-file", envFile, "--endpoint", definition.Endpoint(), "--data-dir", dataDir}
+	plan, err := personalsvc.NewTaskSchedulerSpec(registration, arguments, dataDir, startOnLogin)
+	if err != nil {
+		return personalsvc.Registration{}, personalsvc.TaskSchedulerSpec{}, err
+	}
+	return registration, plan, nil
+}
+
+func installedWindowsPersonalServiceRegistration(ctx context.Context, adapter *personalsvcwindows.Adapter) (personalsvc.Registration, bool, error) {
+	if adapter == nil {
+		return personalsvc.Registration{}, false, errors.New("server: Windows personal service adapter is unavailable")
+	}
+	artifact, err := adapter.InspectArtifact(ctx)
+	if err != nil {
+		return personalsvc.Registration{}, false, err
+	}
+	if artifact.State() == personalsvc.RegistrationNotInstalled {
+		return personalsvc.Registration{}, false, nil
+	}
+	registration, found := artifact.Registration()
+	if artifact.State() != personalsvc.RegistrationInstalled || !found || registration.Definition().Validate() != nil {
+		return personalsvc.Registration{}, false, errors.New("server: Windows personal service registration is invalid")
+	}
+	return registration, true, nil
+}
+
+func windowsPersonalServiceEnvironment(values map[string]string, dataDir string) map[string]string {
+	result := maps.Clone(values)
+	result[server.PowerContextHomeEnv] = dataDir
+	result["POWERCONTEXT_SERVER_DATABASE_KIND"] = "sqlite"
+	result["POWERCONTEXT_SERVER_DATABASE_URL"] = "sqlite+aiosqlite:///" + filepath.ToSlash(filepath.Join(dataDir, "powercontext.db"))
+	return result
+}
+
+func windowsPersonalServiceEnvFile(value string) (string, error) {
+	if !filepath.IsAbs(value) || strings.TrimSpace(value) != value {
+		return "", errors.New("server: personal service environment file is invalid")
+	}
+	resolved, err := filepath.EvalSymlinks(value)
+	if err != nil {
+		return "", errors.New("server: personal service environment file is unavailable")
+	}
+	info, err := os.Stat(resolved)
+	if err != nil || !info.Mode().IsRegular() || strings.TrimSpace(resolved) != resolved {
+		return "", errors.New("server: personal service environment file is invalid")
+	}
+	return filepath.Clean(resolved), nil
+}
+
+func windowsPersonalServiceDataDir(value string) (string, error) {
+	if value == "" {
+		var err error
+		value, err = server.PowerContextDataDir()
+		if err != nil {
+			return "", err
+		}
+	}
+	if !filepath.IsAbs(value) || strings.TrimSpace(value) != value {
+		return "", errors.New("server: personal service data directory is invalid")
+	}
+	return resolvePath(value)
+}
+
+func windowsPersonalServiceHTTPOverride(endpoint string) (server.HTTPConfigOverride, error) {
+	parsed, err := url.Parse(endpoint)
+	if err != nil || parsed.Scheme != "http" || parsed.User != nil || parsed.Path != "" || parsed.RawQuery != "" || parsed.Fragment != "" {
+		return server.HTTPConfigOverride{}, errors.New("invalid endpoint")
+	}
+	port, err := strconv.Atoi(parsed.Port())
+	if err != nil || port < 1 || port > 65535 || parsed.Hostname() == "" {
+		return server.HTTPConfigOverride{}, errors.New("invalid endpoint")
+	}
+	host := parsed.Hostname()
+	return server.HTTPConfigOverride{Host: &host, Port: &port}, nil
+}
+
+func windowsPersonalServiceExecutable() (string, error) {
+	executable, err := os.Executable()
+	if err != nil {
+		return "", errors.New("server: personal service executable is unavailable")
+	}
+	resolved, err := filepath.EvalSymlinks(executable)
+	if err != nil {
+		return "", errors.New("server: personal service executable is unavailable")
+	}
+	info, err := os.Stat(resolved)
+	if err != nil || !info.Mode().IsRegular() {
+		return "", errors.New("server: personal service executable is invalid")
+	}
+	return filepath.Clean(resolved), nil
+}
+
+func windowsPersonalServiceVersion(state *commandState) string {
+	if state == nil || strings.TrimSpace(state.version.Version) == "" {
+		return "devel"
+	}
+	return state.version.Version
+}
+
+func writeWindowsPersonalServiceStatus(state *commandState, status personalsvc.Status) error {
+	if state == nil {
+		return errors.New("server: personal service command state is unavailable")
+	}
+	view := map[string]string{
+		"support": string(status.Support()), "registration": string(status.Registration()), "definition": string(status.Definition()),
+		"manager_ownership": string(status.ManagerOwnership()), "manager": string(status.Manager()),
+		"liveness": string(status.Liveness()), "recovery": string(status.Recovery()),
+	}
+	if state.json {
+		return writeJSON(state.stdout, view)
+	}
+	_, err := fmt.Fprintf(state.stdout, "Support: %s\nRegistration: %s\nDefinition: %s\nManager ownership: %s\nManager: %s\nLiveness: %s\nRecovery: %s\n", status.Support(), status.Registration(), status.Definition(), status.ManagerOwnership(), status.Manager(), status.Liveness(), status.Recovery())
+	return err
+}

--- a/internal/cli/server_personal_service_windows_test.go
+++ b/internal/cli/server_personal_service_windows_test.go
@@ -1,0 +1,86 @@
+// Copyright (c) 2026 OceanBase.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build windows
+
+package cli
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/ob-labs/powercontext-go/internal/personalsvc"
+)
+
+func TestWindowsPersonalServiceRegistrationUsesCredentialFreeEnvironmentIdentity(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "service-root")
+	envFile := filepath.Join(t.TempDir(), "server.env")
+	if err := os.WriteFile(envFile, []byte("POWERCONTEXT_SERVER_DATABASE_KIND=seekdb\nPOWERCONTEXT_SERVER_HTTP_HOST=127.0.0.1\nPOWERCONTEXT_SERVER_HTTP_PORT=7614\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	registration, plan, resolvedRoot, err := newWindowsPersonalServiceRegistration(t.Context(), &commandState{version: VersionInfo{Version: "test"}}, envFile, root, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolvedEnv, err := filepath.EvalSymlinks(envFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	definition := registration.Definition()
+	if definition.Ownership() != personalsvc.OwnershipMarker || definition.Version() != personalsvc.DefinitionVersion ||
+		definition.PackageVersion() != "test" || definition.DataDir() != resolvedRoot || definition.EnvFile() != filepath.Clean(resolvedEnv) ||
+		definition.Endpoint() != "http://127.0.0.1:7614" || !plan.StartOnLogin() || plan.Registration() != registration {
+		t.Fatalf("registration/plan = %#v %#v", definition, plan)
+	}
+	wantArgs := []string{"server", "_service-run", "--env-file", definition.EnvFile(), "--endpoint", definition.Endpoint(), "--data-dir", definition.DataDir()}
+	if !slices.Equal(plan.Arguments(), wantArgs) {
+		t.Fatalf("Task Scheduler arguments = %#v, want %#v", plan.Arguments(), wantArgs)
+	}
+	if _, statErr := os.Stat(resolvedRoot); statErr != nil {
+		t.Fatalf("private root was not created: %v", statErr)
+	}
+}
+
+func TestWindowsPersonalServiceEnvironmentFileRejectsMissingOrRelativePaths(t *testing.T) {
+	for _, value := range []string{"", "relative.env", filepath.Join(t.TempDir(), "missing.env")} {
+		if _, err := windowsPersonalServiceEnvFile(value); err == nil {
+			t.Fatalf("windowsPersonalServiceEnvFile(%q) unexpectedly succeeded", value)
+		}
+	}
+	if _, _, _, err := newWindowsPersonalServiceRegistration(context.Background(), nil, "relative.env", t.TempDir(), false); err == nil {
+		t.Fatal("relative environment identity reached configuration loading")
+	}
+}
+
+func TestWindowsPersonalServiceStatusInspectsWithoutCreatingARegistration(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "status-root")
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	var output bytes.Buffer
+	state := &commandState{stdout: &output}
+	if err := runPersonalServiceStatus(t.Context(), state, root); err != nil {
+		t.Fatal(err)
+	}
+	if output.Len() == 0 {
+		t.Fatal("status did not render a result")
+	}
+	if _, err := os.Stat(filepath.Join(root, "PowerContext", "Services", "personal-server.xml")); !os.IsNotExist(err) {
+		t.Fatalf("status created a personal-service artifact: %v", err)
+	}
+}


### PR DESCRIPTION
Part of #202 Phase 5-W2 only.

Adds Windows-only public personal-server lifecycle commands:

- `server install --env-file [--data-dir] [--start-on-login]`
- `server status [--data-dir]`
- `server uninstall [--data-dir]`
- hidden Task Scheduler child `server _service-run --env-file --endpoint --data-dir`

Install loads a real environment file but persists only its canonical path in registration v3. It forces SQLite home/database configuration and creates an owned Task Scheduler registration. The scheduled child rebuilds its expected registration from its argv, verifies the persisted owned Task Scheduler artifact matches exactly, then loads the environment file and starts the SQLite-only Server.

`status` is proven through the real Windows native read path and never creates an artifact. `uninstall` acts only on a verified owned registration. Non-Windows builds return the typed unsupported error without native side effects.

Out of scope: release archive consumer proof, fixed product task install/health/uninstall, long-running logon proof, Linux systemd, macOS LaunchAgent, non-SQLite backends, and non-Codex/WorkBuddy agent behavior.

Validation: CLI contract/build tests, pure registration builder tests, read-only Windows native status, ordinary/race tests across CLI/personalsvc/Windows host, vet, and target lint.