### PR TITLE
feat(release): verify Windows personal server archive

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -14,6 +14,7 @@
 *.mjs text eol=lf
 *.mod text eol=lf
 *.py text eol=lf
+*.ps1 text eol=lf
 *.sh text eol=lf
 *.sum text eol=lf
 *.toml text eol=lf

--- a/.github/workflows/windows-contract.yml
+++ b/.github/workflows/windows-contract.yml
@@ -18,7 +18,7 @@ jobs:
   windows-contract:
     name: windows-contract
     runs-on: windows-2025
-    timeout-minutes: 10
+    timeout-minutes: 20
     steps:
       - name: Check out with repository attributes
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -33,6 +33,41 @@ jobs:
 
       - name: Verify Windows Task Scheduler executor boundary
         run: go test -count=1 ./internal/personalsvchost/windows
+
+      - name: Stage locked SQLite headers for Windows archive consumption
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $moduleCache = (& go env GOMODCACHE).Trim()
+          $source = Join-Path $moduleCache 'github.com\mattn\go-sqlite3@v1.14.33\sqlite3-binding.h'
+          if (!(Test-Path -LiteralPath $source -PathType Leaf)) {
+            throw 'locked go-sqlite3 header is unavailable'
+          }
+          $headers = Join-Path $env:RUNNER_TEMP 'powercontext-sqlite-header-v1.14.33'
+          New-Item -ItemType Directory -Force -Path $headers | Out-Null
+          Copy-Item -LiteralPath $source -Destination (Join-Path $headers 'sqlite3.h') -Force
+
+      - name: Install the pinned SBOM generator for Windows archive consumption
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $version = (& go run ./tools/release asset -component syft -field version).Trim()
+          $tools = Join-Path $env:RUNNER_TEMP 'tools'
+          New-Item -ItemType Directory -Force -Path $tools | Out-Null
+          $env:GOBIN = $tools
+          & go install "github.com/anchore/syft/cmd/syft@v$version"
+          if ($LASTEXITCODE -ne 0) {
+            throw "install pinned Syft $version failed"
+          }
+
+      - name: Verify Windows release archive personal server lifecycle
+        shell: pwsh
+        env:
+          CGO_CPPFLAGS: -I${{ runner.temp }}\powercontext-sqlite-header-v1.14.33
+          POWERCONTEXT_WINDOWS_RELEASE_CONSUMER_SYFT: ${{ runner.temp }}\tools\syft.exe
+        run: |
+          $ErrorActionPreference = 'Stop'
+          .\test\release\windows-archive-consumer.ps1 -Syft $env:POWERCONTEXT_WINDOWS_RELEASE_CONSUMER_SYFT
 
       - name: Verify LF attributes and frozen fixture hashes
         shell: pwsh
@@ -54,6 +89,7 @@ jobs:
             'test/conformance/testdata/python-v0.0.2/manifest.json',
             'test/conformance/testdata/python-v0.1.0/manifest.json',
             'artifact/memory/prompts/conversation.txt',
+            'test/release/windows-archive-consumer.ps1',
             'evaluation/tests/contract/fixtures/swebench_pro_public_v2.jsonl'
           )
           foreach ($path in $textPaths) {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -216,6 +216,12 @@ source / artifact / trigger / inference
   Keep every runtime stage beneath that root, make cancellation dominate
   failure/success/noop, and verify both trace-parent isolation and that scope
   IDs or protected inputs never become exported attributes.
+- When a native personal service starts asynchronously, do not treat an
+  accepted scheduler start as service readiness. The public install command
+  must observe its owned loopback liveness contract within a bounded,
+  cancellable window before reporting success; verify the release archive
+  lifecycle through the real native manager and preserve the original
+  redacted recovery result when the service never becomes live.
 - When a test invokes a freshly built external binary, disable result caching
   or key it to the binary content. Verify the gate reruns after the binary
   changes without changing the test package.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -219,9 +219,11 @@ source / artifact / trigger / inference
 - When a native personal service starts asynchronously, do not treat an
   accepted scheduler start as service readiness. The public install command
   must observe its owned loopback liveness contract within a bounded,
-  cancellable window before reporting success; verify the release archive
-  lifecycle through the real native manager and preserve the original
-  redacted recovery result when the service never becomes live.
+  cancellable window before reporting success. Likewise, uninstall must wait
+  for the owned native manager to become inactive before removing its
+  artifacts; verify the release archive lifecycle through the real native
+  manager and preserve the original redacted recovery result when the service
+  never becomes live or never stops.
 - When a test invokes a freshly built external binary, disable result caching
   or key it to the binary content. Verify the gate reruns after the binary
   changes without changing the test package.

--- a/internal/cli/server_personal_service_windows.go
+++ b/internal/cli/server_personal_service_windows.go
@@ -26,10 +26,16 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/ob-labs/powercontext-go/internal/personalsvc"
 	personalsvcwindows "github.com/ob-labs/powercontext-go/internal/personalsvchost/windows"
 	"github.com/ob-labs/powercontext-go/server"
+)
+
+const (
+	windowsPersonalServiceStartupTimeout  = 15 * time.Second
+	windowsPersonalServiceStartupInterval = 100 * time.Millisecond
 )
 
 func runPersonalServiceInstall(ctx context.Context, state *commandState, envFile, dataDir string, startOnLogin bool) error {
@@ -42,10 +48,55 @@ func runPersonalServiceInstall(ctx context.Context, state *commandState, envFile
 		return err
 	}
 	status, err := runtime.controller.Install(ctx, registration)
+	if err != nil && windowsPersonalServiceStartupPending(status, err) {
+		ready, waitErr := waitForWindowsPersonalServiceStartup(ctx, runtime.controller, registration)
+		if waitErr != nil {
+			return waitErr
+		}
+		if ready {
+			status, err = runtime.controller.Status(ctx, registration)
+		}
+	}
 	if err != nil {
 		return err
 	}
 	return writeWindowsPersonalServiceStatus(state, status)
+}
+
+func windowsPersonalServiceStartupPending(status personalsvc.Status, err error) bool {
+	var operation *personalsvc.OperationError
+	return errors.As(err, &operation) &&
+		operation.Kind() == personalsvc.ErrorPostCommit &&
+		operation.Stage() == personalsvc.StageProbe &&
+		status.Registration() == personalsvc.RegistrationInstalled &&
+		status.Definition() == personalsvc.DefinitionCurrent &&
+		status.ManagerOwnership() == personalsvc.ManagerOwnershipOwned &&
+		status.Manager() == personalsvc.ManagerActive &&
+		status.Liveness() == personalsvc.LivenessUnreachable
+}
+
+func waitForWindowsPersonalServiceStartup(
+	ctx context.Context,
+	controller *personalsvc.Controller,
+	registration personalsvc.Registration,
+) (bool, error) {
+	startupCtx, cancel := context.WithTimeout(ctx, windowsPersonalServiceStartupTimeout)
+	defer cancel()
+	ticker := time.NewTicker(windowsPersonalServiceStartupInterval)
+	defer ticker.Stop()
+	for {
+		status, err := controller.Status(startupCtx, registration)
+		if err == nil && status.Healthy() {
+			return true, nil
+		}
+		select {
+		case <-ctx.Done():
+			return false, context.Cause(ctx)
+		case <-startupCtx.Done():
+			return false, nil
+		case <-ticker.C:
+		}
+	}
 }
 
 func runPersonalServiceStatus(ctx context.Context, state *commandState, dataDir string) error {

--- a/internal/personalsvchost/windows/adapter_windows.go
+++ b/internal/personalsvchost/windows/adapter_windows.go
@@ -30,6 +30,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 	"unicode/utf16"
 	"unicode/utf8"
 
@@ -41,6 +42,8 @@ const (
 	testTaskNamePrefix = `\PowerContext\Tests\`
 	maxProbeBytes      = 4 << 10
 	taskXMLNamespace   = "http://schemas.microsoft.com/windows/2004/02/mit/task"
+	stopTimeout        = 15 * time.Second
+	stopPollInterval   = 50 * time.Millisecond
 )
 
 var requestIDPattern = regexp.MustCompile(`^[0-9a-f]{16}$`)
@@ -327,7 +330,32 @@ func (a *Adapter) Stop(ctx context.Context) error {
 	if err := a.scheduler.End(ctx); err != nil {
 		return newError("stop", contextCause(ctx, err))
 	}
-	return nil
+	return a.waitForStopped(ctx)
+}
+
+func (a *Adapter) waitForStopped(ctx context.Context) error {
+	stopCtx, cancel := context.WithTimeout(ctx, stopTimeout)
+	defer cancel()
+	ticker := time.NewTicker(stopPollInterval)
+	defer ticker.Stop()
+	for {
+		state, err := a.scheduler.State(stopCtx)
+		if err != nil {
+			return newError("stop", contextCause(stopCtx, err))
+		}
+		switch state {
+		case personalsvc.ManagerInactive, personalsvc.ManagerFailed:
+			return nil
+		case personalsvc.ManagerActive:
+		default:
+			return newError("stop", nil)
+		}
+		select {
+		case <-stopCtx.Done():
+			return newError("stop", context.Cause(stopCtx))
+		case <-ticker.C:
+		}
+	}
 }
 
 // Disable disables only a freshly verified owned task. An absent task is

--- a/internal/personalsvchost/windows/adapter_windows_test.go
+++ b/internal/personalsvchost/windows/adapter_windows_test.go
@@ -434,6 +434,46 @@ func TestStopDoesNotEndOwnedInactiveTask(t *testing.T) {
 	}
 }
 
+func TestStopWaitsForOwnedTaskToBecomeInactive(t *testing.T) {
+	root := t.TempDir()
+	plan := adapterPlan(t, root)
+	files := newMemoryArtifacts()
+	scheduler := &memoryScheduler{files: files}
+	adapter, err := newAdapter(
+		plan,
+		root,
+		`\PowerContext\Tests\unit-stop-wait`,
+		testIdentity,
+		scheduler,
+		files,
+		http.DefaultClient,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	document, err := adapter.render()
+	if err != nil {
+		t.Fatal(err)
+	}
+	scheduler.present = true
+	scheduler.document = document
+	scheduler.state = personalsvc.ManagerActive
+	scheduler.statesAfterEnd = []personalsvc.ManagerState{
+		personalsvc.ManagerActive,
+		personalsvc.ManagerInactive,
+	}
+
+	if err := adapter.Stop(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Equal(scheduler.mutations, []string{"end"}) {
+		t.Fatalf("Stop() mutations = %#v, want end before release", scheduler.mutations)
+	}
+	if len(scheduler.statesAfterEnd) != 0 || scheduler.state != personalsvc.ManagerInactive {
+		t.Fatalf("Stop() did not observe an inactive task: states = %#v, state = %s", scheduler.statesAfterEnd, scheduler.state)
+	}
+}
+
 func TestControllerRestoresPreviouslyInspectedTaskAfterEnableFailure(t *testing.T) {
 	root := t.TempDir()
 	desired := adapterPlanForPackage(t, root, "2.0.0")
@@ -931,6 +971,8 @@ type memoryScheduler struct {
 	document          []byte
 	present           bool
 	state             personalsvc.ManagerState
+	statesAfterEnd    []personalsvc.ManagerState
+	endRequested      bool
 	mutations         []string
 	enableErr         error
 	cancelAfterCreate context.CancelFunc
@@ -975,7 +1017,10 @@ func (s *memoryScheduler) Run(context.Context) error {
 }
 
 func (s *memoryScheduler) End(context.Context) error {
-	s.state = personalsvc.ManagerInactive
+	s.endRequested = true
+	if len(s.statesAfterEnd) == 0 {
+		s.state = personalsvc.ManagerInactive
+	}
 	s.mutations = append(s.mutations, "end")
 	return nil
 }
@@ -1021,6 +1066,10 @@ func (s *memoryScheduler) Delete(ctx context.Context) error {
 }
 
 func (s *memoryScheduler) State(context.Context) (personalsvc.ManagerState, error) {
+	if s.endRequested && len(s.statesAfterEnd) != 0 {
+		s.state = s.statesAfterEnd[0]
+		s.statesAfterEnd = s.statesAfterEnd[1:]
+	}
 	return s.state, nil
 }
 

--- a/test/release/windows-archive-consumer.ps1
+++ b/test/release/windows-archive-consumer.ps1
@@ -236,12 +236,12 @@ try {
   if (!(Test-Path -LiteralPath $database -PathType Leaf)) {
     throw 'personal service did not create its SQLite database'
   }
-  $header = [Text.Encoding]::ASCII.GetString([IO.File]::ReadAllBytes($database), 0, 16)
-  Assert-Equal -Name 'personal service SQLite header' -Actual $header -Expected "SQLite format 3$([char]0)"
 
   $uninstall = Invoke-Server -Binary $archiveBinary -Arguments @('server', 'uninstall', '--data-dir', $dataDirectory)
   Assert-Equal -Name 'uninstall registration' -Actual $uninstall.registration -Expected 'not_installed'
   Wait-ArchiveProcessExit -Binary $archiveBinary
+  $header = [Text.Encoding]::ASCII.GetString([IO.File]::ReadAllBytes($database), 0, 16)
+  Assert-Equal -Name 'personal service SQLite header' -Actual $header -Expected "SQLite format 3$([char]0)"
   Wait-Unreachable -Endpoint $endpoint
   $postUninstall = Invoke-Server -Binary $archiveBinary -Arguments @('server', 'status', '--data-dir', $dataDirectory)
   Assert-Equal -Name 'post-uninstall registration' -Actual $postUninstall.registration -Expected 'not_installed'

--- a/test/release/windows-archive-consumer.ps1
+++ b/test/release/windows-archive-consumer.ps1
@@ -1,0 +1,236 @@
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory)]
+  [string]$Syft
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Invoke-Native {
+  param(
+    [Parameter(Mandatory)]
+    [string]$Name,
+    [Parameter(Mandatory)]
+    [scriptblock]$Command
+  )
+
+  $output = & $Command 2>&1
+  if ($LASTEXITCODE -ne 0) {
+    throw "$Name failed with exit code ${LASTEXITCODE}:`n$($output | Out-String)"
+  }
+  return ($output | Out-String)
+}
+
+function Invoke-Server {
+  param(
+    [Parameter(Mandatory)]
+    [string]$Binary,
+    [Parameter(Mandatory)]
+    [string[]]$Arguments
+  )
+
+  $output = Invoke-Native -Name "powercontext $($Arguments -join ' ')" -Command {
+    & $Binary --json @Arguments
+  }
+  return $output | ConvertFrom-Json
+}
+
+function Assert-Equal {
+  param(
+    [Parameter(Mandatory)]
+    [string]$Name,
+    [Parameter(Mandatory)]
+    [string]$Actual,
+    [Parameter(Mandatory)]
+    [string]$Expected
+  )
+
+  if ($Actual -cne $Expected) {
+    throw "$Name = $Actual, want $Expected"
+  }
+}
+
+function Wait-Live {
+  param([Parameter(Mandatory)][string]$Endpoint)
+
+  $deadline = [DateTime]::UtcNow.AddSeconds(45)
+  do {
+    try {
+      $response = Invoke-WebRequest -NoProxy -UseBasicParsing -TimeoutSec 2 -Uri "$Endpoint/health/live"
+      if ($response.StatusCode -eq 200 -and $response.Content.Trim() -eq '{"status":"ok"}') {
+        return
+      }
+    } catch {
+    }
+    Start-Sleep -Milliseconds 250
+  } while ([DateTime]::UtcNow -lt $deadline)
+  throw "PowerContext did not become live at $Endpoint"
+}
+
+function Wait-Unreachable {
+  param([Parameter(Mandatory)][string]$Endpoint)
+
+  $deadline = [DateTime]::UtcNow.AddSeconds(30)
+  do {
+    try {
+      $response = Invoke-WebRequest -NoProxy -UseBasicParsing -TimeoutSec 2 -Uri "$Endpoint/health/live"
+      if ($response.StatusCode -ne 200) {
+        return
+      }
+    } catch {
+      return
+    }
+    Start-Sleep -Milliseconds 250
+  } while ([DateTime]::UtcNow -lt $deadline)
+  throw "PowerContext remained live at $Endpoint after uninstall"
+}
+
+function Get-FreeLoopbackPort {
+  $listener = [Net.Sockets.TcpListener]::new([Net.IPAddress]::Loopback, 0)
+  try {
+    $listener.Start()
+    return $listener.LocalEndpoint.Port
+  } finally {
+    $listener.Stop()
+  }
+}
+
+$repository = [IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\..'))
+$syftPath = [IO.Path]::GetFullPath($Syft)
+if (!(Test-Path -LiteralPath $syftPath -PathType Leaf)) {
+  throw 'pinned Syft executable is unavailable'
+}
+
+$commit = (Invoke-Native -Name 'read source commit' -Command { git -C $repository rev-parse HEAD }).Trim()
+if ($commit -notmatch '^[0-9a-f]{40}$') {
+  throw 'source commit is invalid'
+}
+$epoch = [Int64]((Invoke-Native -Name 'read source timestamp' -Command { git -C $repository show -s --format=%ct $commit }).Trim())
+$buildDate = [DateTimeOffset]::FromUnixTimeSeconds($epoch).UtcDateTime.ToString('yyyy-MM-ddTHH:mm:ssZ')
+$runIdentity = if ($env:GITHUB_RUN_ID) { $env:GITHUB_RUN_ID } else { [DateTime]::UtcNow.Ticks }
+$version = "0.0.0-windows.consumer.$runIdentity"
+$workRoot = Join-Path ([IO.Path]::GetTempPath()) ("powercontext-windows-release-consumer-" + [Guid]::NewGuid().ToString('N'))
+$taskName = '\PowerContext Personal Server'
+$archiveBinary = ''
+$dataDirectory = ''
+
+try {
+  New-Item -ItemType Directory -Path $workRoot | Out-Null
+  $buildDirectory = Join-Path $workRoot 'build'
+  $distribution = Join-Path $workRoot 'dist'
+  $extractDirectory = Join-Path $workRoot 'extract'
+  $builtBinary = Join-Path $buildDirectory 'powercontext.exe'
+  $dataDirectory = Join-Path $workRoot 'data'
+  $environmentFile = Join-Path $workRoot 'server.env'
+  $port = Get-FreeLoopbackPort
+  $endpoint = "http://127.0.0.1:$port"
+  New-Item -ItemType Directory -Path $buildDirectory, $distribution, $extractDirectory | Out-Null
+  @(
+    'POWERCONTEXT_SERVER_HTTP_HOST=127.0.0.1',
+    "POWERCONTEXT_SERVER_HTTP_PORT=$port",
+    'POWERCONTEXT_SERVER_AUTH_ENABLED=false',
+    'POWERCONTEXT_SERVER_MCP_ENABLED=false',
+    'POWERCONTEXT_SERVER_RUNTIME_SOURCE_WINDOW_LIMIT=1'
+  ) | Set-Content -LiteralPath $environmentFile -Encoding ascii
+
+  Push-Location $repository
+  try {
+    Invoke-Native -Name 'build Windows standard release binary' -Command {
+      $env:CGO_ENABLED = '1'
+      & go build -tags sqlite_fts5 -trimpath `
+        -ldflags "-s -w -X main.version=$version -X main.commit=$commit -X main.date=$buildDate" `
+        -o $builtBinary ./cmd/powercontext
+    } | Out-Null
+    Invoke-Native -Name 'package Windows standard release archive' -Command {
+      & go run ./tools/release package `
+        -binary $builtBinary -edition standard -version $version -commit $commit -build-date $buildDate `
+        -output $distribution -syft $syftPath
+    } | Out-Null
+  } finally {
+    Pop-Location
+  }
+
+  $archives = @(Get-ChildItem -LiteralPath $distribution -Filter '*.tar.gz' -File)
+  if ($archives.Count -ne 1) {
+    throw "standard release archive count = $($archives.Count), want 1"
+  }
+  Invoke-Native -Name 'extract Windows standard release archive' -Command {
+    & tar.exe -xzf $archives[0].FullName -C $extractDirectory
+  } | Out-Null
+  $releaseRoots = @(Get-ChildItem -LiteralPath $extractDirectory -Directory)
+  if ($releaseRoots.Count -ne 1) {
+    throw "release archive root count = $($releaseRoots.Count), want 1"
+  }
+  $releaseRoot = $releaseRoots[0].FullName
+  $archiveBinary = Join-Path $releaseRoot 'bin\powercontext.exe'
+  if (!(Test-Path -LiteralPath $archiveBinary -PathType Leaf)) {
+    throw 'release archive does not contain bin/powercontext.exe'
+  }
+  if (Test-Path -LiteralPath (Join-Path $releaseRoot 'bin\powercontext')) {
+    throw 'Windows release archive retained an extensionless binary'
+  }
+  $buildInfo = Get-Content -Raw -LiteralPath (Join-Path $releaseRoot 'BUILD-INFO.json') | ConvertFrom-Json
+  Assert-Equal -Name 'build manifest binary path' -Actual $buildInfo.binary.path -Expected 'bin/powercontext.exe'
+  Assert-Equal -Name 'archive binary hash' -Actual (Get-FileHash -Algorithm SHA256 -LiteralPath $archiveBinary).Hash.ToLowerInvariant() -Expected $buildInfo.binary.sha256
+
+  $install = Invoke-Server -Binary $archiveBinary -Arguments @('server', 'install', '--env-file', $environmentFile, '--data-dir', $dataDirectory)
+  Assert-Equal -Name 'install support' -Actual $install.support -Expected 'supported'
+  Wait-Live -Endpoint $endpoint
+
+  $status = Invoke-Server -Binary $archiveBinary -Arguments @('server', 'status', '--data-dir', $dataDirectory)
+  foreach ($assertion in @(
+    @{ Name = 'status support'; Actual = $status.support; Expected = 'supported' },
+    @{ Name = 'status registration'; Actual = $status.registration; Expected = 'installed' },
+    @{ Name = 'status definition'; Actual = $status.definition; Expected = 'current' },
+    @{ Name = 'status manager ownership'; Actual = $status.manager_ownership; Expected = 'owned' },
+    @{ Name = 'status manager'; Actual = $status.manager; Expected = 'active' },
+    @{ Name = 'status liveness'; Actual = $status.liveness; Expected = 'live' }
+  )) {
+    Assert-Equal -Name $assertion.Name -Actual $assertion.Actual -Expected $assertion.Expected
+  }
+
+  [xml]$taskDocument = Invoke-Native -Name 'inspect fixed PowerContext task' -Command {
+    & schtasks.exe /Query /TN $taskName /XML
+  }
+  $namespace = [Xml.XmlNamespaceManager]::new($taskDocument.NameTable)
+  $namespace.AddNamespace('task', 'http://schemas.microsoft.com/windows/2004/02/mit/task')
+  $command = $taskDocument.SelectSingleNode('/task:Task/task:Actions/task:Exec/task:Command', $namespace)
+  if ($null -eq $command) {
+    throw 'fixed PowerContext task has no executable command'
+  }
+  $actualBinary = [IO.Path]::GetFullPath($command.InnerText)
+  $expectedBinary = [IO.Path]::GetFullPath($archiveBinary)
+  if (![string]::Equals($actualBinary, $expectedBinary, [StringComparison]::OrdinalIgnoreCase)) {
+    throw 'fixed PowerContext task does not execute the archived binary'
+  }
+  $taskXML = $taskDocument.OuterXml
+  if ($taskXML.Contains($repository, [StringComparison]::OrdinalIgnoreCase)) {
+    throw 'fixed PowerContext task retained a source checkout path'
+  }
+
+  $database = Join-Path $dataDirectory 'powercontext.db'
+  if (!(Test-Path -LiteralPath $database -PathType Leaf)) {
+    throw 'personal service did not create its SQLite database'
+  }
+  $header = [Text.Encoding]::ASCII.GetString([IO.File]::ReadAllBytes($database), 0, 16)
+  Assert-Equal -Name 'personal service SQLite header' -Actual $header -Expected "SQLite format 3$([char]0)"
+
+  $uninstall = Invoke-Server -Binary $archiveBinary -Arguments @('server', 'uninstall', '--data-dir', $dataDirectory)
+  Assert-Equal -Name 'uninstall registration' -Actual $uninstall.registration -Expected 'not_installed'
+  Wait-Unreachable -Endpoint $endpoint
+  $postUninstall = Invoke-Server -Binary $archiveBinary -Arguments @('server', 'status', '--data-dir', $dataDirectory)
+  Assert-Equal -Name 'post-uninstall registration' -Actual $postUninstall.registration -Expected 'not_installed'
+
+  & schtasks.exe /Query /TN $taskName /XML 2>&1 | Out-Null
+  if ($LASTEXITCODE -eq 0) {
+    throw 'fixed PowerContext task remains after uninstall'
+  }
+} finally {
+  if ($archiveBinary -and (Test-Path -LiteralPath $archiveBinary -PathType Leaf) -and $dataDirectory) {
+    & $archiveBinary server uninstall --data-dir $dataDirectory 2>&1 | Out-Null
+  }
+  if (Test-Path -LiteralPath $workRoot) {
+    Remove-Item -LiteralPath $workRoot -Recurse -Force
+  }
+}

--- a/test/release/windows-archive-consumer.ps1
+++ b/test/release/windows-archive-consumer.ps1
@@ -86,6 +86,29 @@ function Wait-Unreachable {
   throw "PowerContext remained live at $Endpoint after uninstall"
 }
 
+function Wait-ArchiveProcessExit {
+  param([Parameter(Mandatory)][string]$Binary)
+
+  $expected = [IO.Path]::GetFullPath($Binary)
+  $deadline = [DateTime]::UtcNow.AddSeconds(30)
+  do {
+    $running = @(
+      Get-Process -Name powercontext -ErrorAction SilentlyContinue | Where-Object {
+        try {
+          [string]::Equals([IO.Path]::GetFullPath($_.Path), $expected, [StringComparison]::OrdinalIgnoreCase)
+        } catch {
+          $false
+        }
+      }
+    )
+    if ($running.Count -eq 0) {
+      return
+    }
+    Start-Sleep -Milliseconds 250
+  } while ([DateTime]::UtcNow -lt $deadline)
+  throw 'archived PowerContext process remained after uninstall'
+}
+
 function Get-FreeLoopbackPort {
   $listener = [Net.Sockets.TcpListener]::new([Net.IPAddress]::Loopback, 0)
   try {
@@ -218,6 +241,7 @@ try {
 
   $uninstall = Invoke-Server -Binary $archiveBinary -Arguments @('server', 'uninstall', '--data-dir', $dataDirectory)
   Assert-Equal -Name 'uninstall registration' -Actual $uninstall.registration -Expected 'not_installed'
+  Wait-ArchiveProcessExit -Binary $archiveBinary
   Wait-Unreachable -Endpoint $endpoint
   $postUninstall = Invoke-Server -Binary $archiveBinary -Arguments @('server', 'status', '--data-dir', $dataDirectory)
   Assert-Equal -Name 'post-uninstall registration' -Actual $postUninstall.registration -Expected 'not_installed'
@@ -229,6 +253,7 @@ try {
 } finally {
   if ($archiveBinary -and (Test-Path -LiteralPath $archiveBinary -PathType Leaf) -and $dataDirectory) {
     & $archiveBinary server uninstall --data-dir $dataDirectory 2>&1 | Out-Null
+    Wait-ArchiveProcessExit -Binary $archiveBinary
   }
   if (Test-Path -LiteralPath $workRoot) {
     Remove-Item -LiteralPath $workRoot -Recurse -Force

--- a/tools/release/archive.go
+++ b/tools/release/archive.go
@@ -76,7 +76,7 @@ func archiveTree(root, output string, timestamp time.Time) (returnErr error) {
 			header.Name += "/"
 			header.Mode = 0o755
 		} else if info.Mode().IsRegular() {
-			header.Mode = normalizedFileMode(info.Mode())
+			header.Mode = releaseArchiveFileMode(relative, info.Mode())
 		}
 		header.ModTime = timestamp
 		header.AccessTime = time.Time{}
@@ -111,4 +111,14 @@ func normalizedFileMode(mode os.FileMode) int64 {
 		return 0o755
 	}
 	return 0o644
+}
+
+func releaseArchiveFileMode(path string, mode os.FileMode) int64 {
+	if filepath.Base(filepath.Dir(path)) == "bin" {
+		switch filepath.Base(path) {
+		case "powercontext", "powercontext.exe":
+			return 0o755
+		}
+	}
+	return normalizedFileMode(mode)
 }

--- a/tools/release/main_test.go
+++ b/tools/release/main_test.go
@@ -840,7 +840,7 @@ func TestArchiveTreeIsDeterministic(t *testing.T) {
 	}
 }
 
-func TestReleaseArchiveKeepsExecutablePathsAndModes(t *testing.T) {
+func TestReleaseArchiveKeepsStableExecutablePathAndMode(t *testing.T) {
 	parent := t.TempDir()
 	root := filepath.Join(parent, "powercontext-1.2.3-linux-amd64")
 	bin := filepath.Join(root, "bin")

--- a/tools/release/main_test.go
+++ b/tools/release/main_test.go
@@ -840,15 +840,17 @@ func TestArchiveTreeIsDeterministic(t *testing.T) {
 	}
 }
 
-func TestReleaseArchiveKeepsStableExecutablePathAndMode(t *testing.T) {
+func TestReleaseArchiveKeepsExecutablePathsAndModes(t *testing.T) {
 	parent := t.TempDir()
 	root := filepath.Join(parent, "powercontext-1.2.3-linux-amd64")
-	binary := filepath.Join(root, "bin", "powercontext")
-	if err := os.MkdirAll(filepath.Dir(binary), 0o755); err != nil {
+	bin := filepath.Join(root, "bin")
+	if err := os.MkdirAll(bin, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(binary, []byte("binary"), 0o755); err != nil {
-		t.Fatal(err)
+	for _, name := range []string{"powercontext", "powercontext.exe"} {
+		if err := os.WriteFile(filepath.Join(bin, name), []byte("binary"), 0o644); err != nil {
+			t.Fatal(err)
+		}
 	}
 	archive := filepath.Join(parent, "release.tar.gz")
 	if err := archiveTree(root, archive, time.Unix(0, 0).UTC()); err != nil {
@@ -873,7 +875,7 @@ func TestReleaseArchiveKeepsStableExecutablePathAndMode(t *testing.T) {
 		}
 	}()
 	reader := tar.NewReader(compressed)
-	found := false
+	found := map[string]bool{"powercontext": false, "powercontext.exe": false}
 	for {
 		header, err := reader.Next()
 		if errors.Is(err, io.EOF) {
@@ -882,15 +884,39 @@ func TestReleaseArchiveKeepsStableExecutablePathAndMode(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if strings.HasSuffix(header.Name, "/bin/powercontext") {
-			found = true
+		name := filepath.Base(header.Name)
+		_, expected := found[name]
+		if strings.HasSuffix(header.Name, "/bin/"+name) && expected {
+			found[name] = true
 			if header.Mode&0o111 == 0 {
-				t.Fatalf("packaged binary mode = %#o", header.Mode)
+				t.Fatalf("packaged binary %q mode = %#o", name, header.Mode)
 			}
 		}
 	}
-	if !found {
-		t.Fatal("release archive does not contain bin/powercontext")
+	for name, present := range found {
+		if !present {
+			t.Fatalf("release archive does not contain bin/%s", name)
+		}
+	}
+}
+
+func TestStageReleaseUsesWindowsExecutablePath(t *testing.T) {
+	repository := filepath.Clean(filepath.Join("..", ".."))
+	root := filepath.Join(t.TempDir(), "powercontext-1.2.3-windows-amd64")
+	binary := filepath.Join(t.TempDir(), "powercontext.exe")
+	if err := os.WriteFile(binary, []byte("binary"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := stageRelease(repository, root, packageOptions{Binary: binary}, binaryFacts{GOOS: "windows"}); err != nil {
+		t.Fatal(err)
+	}
+	packaged := filepath.Join(root, filepath.FromSlash(releaseBinaryPath("windows")))
+	info, err := os.Stat(packaged)
+	if err != nil || !info.Mode().IsRegular() {
+		t.Fatalf("Windows release binary %q is unavailable: %v", packaged, err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "bin", "powercontext")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("Windows release retained extensionless binary: %v", err)
 	}
 }
 

--- a/tools/release/package.go
+++ b/tools/release/package.go
@@ -146,11 +146,16 @@ func packageRelease(options packageOptions) (packageResult, error) {
 		return packageResult{}, err
 	}
 	target := facts.GOOS + "-" + facts.GOARCH
-	if _, ok := assets.Tokenizers.Assets[target]; !ok {
-		return packageResult{}, fmt.Errorf("unsupported release target %q", target)
-	}
-	if _, ok := assets.ONNXRuntime.Assets[target]; !ok {
-		return packageResult{}, fmt.Errorf("unsupported release target %q", target)
+	// The Windows standard edition embeds sqlite-vec and has no Full native
+	// asset dependency. All existing targets and every Full release remain
+	// constrained by the native asset manifest.
+	if options.Edition == "full" || target != "windows-amd64" {
+		if _, ok := assets.Tokenizers.Assets[target]; !ok {
+			return packageResult{}, fmt.Errorf("unsupported release target %q", target)
+		}
+		if _, ok := assets.ONNXRuntime.Assets[target]; !ok {
+			return packageResult{}, fmt.Errorf("unsupported release target %q", target)
+		}
 	}
 
 	outputDirectory, err := filepath.Abs(options.Output)
@@ -336,9 +341,17 @@ func newBuildManifest(
 		BuildDate: buildTime.Format(time.RFC3339), GoVersion: facts.Info.GoVersion,
 		Target: facts.GOOS + "-" + facts.GOARCH, CGOEnabled: facts.CGOEnabled == "1",
 		BuildTags: slices.Clone(facts.BuildTags), Oracle: oracle,
-		Binary:       fileRecord{Path: "bin/powercontext", SHA256: facts.BinaryHash, Size: facts.BinaryBytes},
+		Binary:       fileRecord{Path: releaseBinaryPath(facts.GOOS), SHA256: facts.BinaryHash, Size: facts.BinaryBytes},
 		NativeAssets: nativeRecords,
 	}
+}
+
+func releaseBinaryPath(goos string) string {
+	name := "powercontext"
+	if goos == "windows" {
+		name += ".exe"
+	}
+	return "bin/" + name
 }
 
 func validatePackageOptions(options packageOptions) (time.Time, error) {
@@ -422,7 +435,7 @@ func stageRelease(repository, root string, options packageOptions, facts binaryF
 			return err
 		}
 	}
-	if err := copyRegularFile(options.Binary, filepath.Join(root, "bin", "powercontext"), 0o755); err != nil {
+	if err := copyRegularFile(options.Binary, filepath.Join(root, filepath.FromSlash(releaseBinaryPath(facts.GOOS))), 0o755); err != nil {
 		return err
 	}
 	for _, pair := range [][2]string{

--- a/tools/release/workflow_test.go
+++ b/tools/release/workflow_test.go
@@ -243,9 +243,13 @@ func TestContinuousIntegrationPreservesPythonTopologyAndGoAssurance(t *testing.T
 			"go test -json -race -shuffle=on -count=25",
 		},
 		"windows-contract.yml": {
-			"name: Windows contract checkout", "runs-on: windows-2025", "timeout-minutes: 10",
+			"name: Windows contract checkout", "runs-on: windows-2025", "timeout-minutes: 20",
 			"Verify LF attributes and frozen fixture hashes", "Get-FileHash -Algorithm SHA256",
 			"git check-attr eol", "git diff --exit-code",
+			"Stage locked SQLite headers for Windows archive consumption",
+			"go-sqlite3@v1.14.33\\sqlite3-binding.h", "CGO_CPPFLAGS",
+			"Install the pinned SBOM generator for Windows archive consumption",
+			"Verify Windows release archive personal server lifecycle",
 		},
 		"e2e-harness.yml": {
 			"name: E2E harness", "validate:", "acceptance:", "database: [sqlite]",
@@ -1476,7 +1480,7 @@ func TestWindowsContractExercisesTargetedGoRegressions(t *testing.T) {
 	if !ok {
 		t.Fatal("windows-contract.yml has no windows-contract job")
 	}
-	setupIndex, apiTestIndex, executorTestIndex := -1, -1, -1
+	setupIndex, apiTestIndex, executorTestIndex, headerIndex, syftIndex, archiveConsumerIndex := -1, -1, -1, -1, -1, -1
 	for index, step := range job.Steps {
 		switch step.Name {
 		case "Set up the Go environment":
@@ -1491,14 +1495,31 @@ func TestWindowsContractExercisesTargetedGoRegressions(t *testing.T) {
 			if strings.TrimSpace(step.Run) == "go test -count=1 ./internal/personalsvchost/windows" {
 				executorTestIndex = index
 			}
+		case "Stage locked SQLite headers for Windows archive consumption":
+			if strings.Contains(step.Run, "go-sqlite3@v1.14.33\\sqlite3-binding.h") {
+				headerIndex = index
+			}
+		case "Install the pinned SBOM generator for Windows archive consumption":
+			if strings.Contains(step.Run, "github.com/anchore/syft/cmd/syft") {
+				syftIndex = index
+			}
+		case "Verify Windows release archive personal server lifecycle":
+			if strings.Contains(step.Run, "windows-archive-consumer.ps1") &&
+				strings.Contains(step.Run, "POWERCONTEXT_WINDOWS_RELEASE_CONSUMER_SYFT") {
+				archiveConsumerIndex = index
+			}
 		}
 	}
-	if setupIndex < 0 || apiTestIndex <= setupIndex || executorTestIndex <= apiTestIndex {
+	if setupIndex < 0 || apiTestIndex <= setupIndex || executorTestIndex <= apiTestIndex ||
+		headerIndex <= executorTestIndex || syftIndex <= headerIndex || archiveConsumerIndex <= syftIndex {
 		t.Fatalf(
-			"Windows targeted Go steps = setup %d, API %d, executor %d, want ordered setup and regression tests",
+			"Windows targeted steps = setup %d, API %d, executor %d, header %d, Syft %d, archive consumer %d, want ordered setup and regression tests",
 			setupIndex,
 			apiTestIndex,
 			executorTestIndex,
+			headerIndex,
+			syftIndex,
+			archiveConsumerIndex,
 		)
 	}
 }
@@ -1512,6 +1533,7 @@ func TestFrozenTextAssetsDeclareLFCheckout(t *testing.T) {
 		"openapi/powercontext.yaml",
 		"artifact/memory/prompts/conversation.txt",
 		"artifact/memory/prompts/extraction.schema.json",
+		"test/release/windows-archive-consumer.ps1",
 		"evaluation/tests/contract/fixtures/swebench_pro_public_v2.jsonl",
 		"api/v1/oas_client_gen.go",
 		"test/conformance/target-delta.json",


### PR DESCRIPTION
## Summary
- package a SQLite-only windows-amd64 standard archive with in/powercontext.exe and a matching manifest record
- run the extracted binary through the fixed Windows Task Scheduler lifecycle: install, health, SQLite verification, status, uninstall, and cleanup
- wait at the Windows CLI boundary for an owned asynchronous service to become live before declaring install success

## Boundaries
- Windows Task Scheduler only
- SQLite only
- no new or restored external agent
- Linux systemd, macOS LaunchAgent, seekDB, and OceanBase remain out of scope

## Validation
- go test -count=1 ./tools/release
- go test -count=1 ./internal/cli ./internal/personalsvc ./internal/personalsvchost/windows
- go test -race -count=1 ./internal/cli
- go vet ./internal/cli ./tools/release
- golangci-lint run ./internal/cli ./tools/release
- ctionlint

Local Windows release-consumer execution reached a real listening Server and valid SQLite database, but the host cannot complete loopback TCP handshakes even with proxy bypass. The new windows-2025 workflow step is therefore the required final native-network proof.