### PR TITLE
feat(inference): support Anthropic workload base URL

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -623,7 +623,13 @@ source / artifact / trigger / inference
   errors, `String`/`GoString`, and structured logs. Verify valid independent
   generation, embedding, and rerank settings; generation-backed rerank
   overrides; orphaned or malformed overrides; and redaction in every rendered
-  configuration representation.
+  configuration representation. When a provider supports only selected
+  workload fields, gate each field independently instead of rejecting or
+  accepting the workload object as a whole. Verify the supported field through
+  the exact provider request and keep unsupported sibling fields in the typed,
+  redacted refusal path before transport. When native and gateway routes use
+  different credentials or capabilities, include route ownership and auth mode
+  in that field-support matrix.
 - When an exported portable native-manager contract stores an injected
   boundary or validated plan, reject zero-value or manually formed invalid
   values with an existing typed redacted error before invoking the native

--- a/internal/modelprovider/anthropic.go
+++ b/internal/modelprovider/anthropic.go
@@ -17,6 +17,8 @@ package modelprovider
 import (
 	"context"
 	"errors"
+	"fmt"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"strings"
@@ -46,6 +48,30 @@ type AnthropicConfig struct {
 	HTTPClient *http.Client
 	Headers    http.Header
 	Query      url.Values
+}
+
+func (c AnthropicConfig) String() string   { return c.redactedString() }
+func (c AnthropicConfig) GoString() string { return c.redactedString() }
+
+func (c AnthropicConfig) LogValue() slog.Value {
+	return slog.GroupValue(
+		slog.Bool("api_key_configured", strings.TrimSpace(c.APIKey) != ""),
+		slog.Bool("base_url_configured", strings.TrimSpace(c.BaseURL) != ""),
+		slog.Bool("auth_mode_configured", c.AuthMode != 0),
+		slog.Bool("http_client_configured", c.HTTPClient != nil),
+		slog.Bool("headers_configured", len(c.Headers) > 0),
+		slog.Int("header_count", len(c.Headers)),
+		slog.Bool("query_configured", len(c.Query) > 0),
+		slog.Int("query_count", len(c.Query)),
+	)
+}
+
+func (c AnthropicConfig) redactedString() string {
+	return fmt.Sprintf(
+		"{APIKeyConfigured:%t BaseURLConfigured:%t AuthModeConfigured:%t HTTPClientConfigured:%t HeadersConfigured:%t HeaderCount:%d QueryConfigured:%t QueryCount:%d}",
+		strings.TrimSpace(c.APIKey) != "", strings.TrimSpace(c.BaseURL) != "", c.AuthMode != 0,
+		c.HTTPClient != nil, len(c.Headers) > 0, len(c.Headers), len(c.Query) > 0, len(c.Query),
+	)
 }
 
 type AnthropicTextModel struct {

--- a/internal/modelprovider/anthropic_test.go
+++ b/internal/modelprovider/anthropic_test.go
@@ -19,8 +19,11 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
+	"net/url"
 	"slices"
 	"strings"
 	"sync"
@@ -29,11 +32,43 @@ import (
 	"github.com/ob-labs/powercontext-go/inference"
 )
 
+func TestAnthropicConfigRepresentationsAreRedacted(t *testing.T) {
+	config := AnthropicConfig{
+		APIKey:  "private-api-key",
+		BaseURL: "https://private-provider.test/custom/",
+		Headers: http.Header{"X-Private": []string{"private-header"}},
+		Query:   url.Values{"private-query": []string{"private-query-value"}},
+	}
+	display := fmt.Sprintf("%v", config)
+	goDisplay := fmt.Sprintf("%#v", config)
+	var logged bytes.Buffer
+	slog.New(slog.NewTextHandler(&logged, nil)).Info("anthropic", "config", config)
+	if !strings.Contains(display, "APIKeyConfigured:true") || !strings.Contains(display, "HeaderCount:1") ||
+		!strings.Contains(goDisplay, "BaseURLConfigured:true") || !strings.Contains(goDisplay, "QueryCount:1") {
+		t.Fatalf("Anthropic configuration display lost redacted state: %q / %q", display, goDisplay)
+	}
+	if output := logged.String(); !strings.Contains(output, "config.api_key_configured=true") ||
+		!strings.Contains(output, "config.header_count=1") || !strings.Contains(output, "config.query_count=1") {
+		t.Fatalf("Anthropic configuration log lost redacted state: %q", output)
+	}
+	representations := []string{display, goDisplay, logged.String()}
+	for _, secret := range []string{
+		"private-api-key", "private-provider", "private-header", "private-query", "private-query-value",
+	} {
+		for _, representation := range representations {
+			if strings.Contains(representation, secret) {
+				t.Fatalf("Anthropic configuration leaked %q in %q", secret, representation)
+			}
+		}
+	}
+}
+
 type capturedAnthropicRequest struct {
 	path          string
 	apiKey        string
 	authorization string
 	version       string
+	headers       http.Header
 	body          map[string]any
 }
 
@@ -59,6 +94,7 @@ func (f *anthropicFake) RoundTrip(request *http.Request) (*http.Response, error)
 		apiKey:        request.Header.Get("X-Api-Key"),
 		authorization: request.Header.Get("Authorization"),
 		version:       request.Header.Get("Anthropic-Version"),
+		headers:       request.Header.Clone(),
 		body:          body,
 	})
 	status := http.StatusOK
@@ -92,6 +128,34 @@ func (f *anthropicFake) Requests() []capturedAnthropicRequest {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return slices.Clone(f.requests)
+}
+
+func TestAnthropicConfigDoesNotRetainMutableHeadersOrQuery(t *testing.T) {
+	fake := &anthropicFake{responses: []any{anthropicResponse("msg_1", "ok", 1, 1)}}
+	headers := http.Header{"X-Workload": []string{"original-header"}}
+	query := url.Values{"workload": []string{"original-query"}}
+	route, err := Resolve("anthropic:claude-test", Generation)
+	if err != nil {
+		t.Fatal(err)
+	}
+	model, err := NewAnthropicTextModel(route, AnthropicConfig{
+		APIKey: "test-key", BaseURL: "https://provider.test/custom/", HTTPClient: fake.Client(),
+		Headers: headers, Query: query,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	headers.Set("X-Workload", "mutated-header")
+	query.Set("workload", "mutated-query")
+	if _, err := model.Complete(t.Context(), textRequestForProviderTest(t)); err != nil {
+		t.Fatal(err)
+	}
+
+	requests := fake.Requests()
+	if len(requests) != 1 || requests[0].path != "/custom/v1/messages?workload=original-query" ||
+		requests[0].headers.Get("X-Workload") != "original-header" {
+		t.Fatalf("Anthropic request retained caller mutation: %#v", requests)
+	}
 }
 
 func TestAnthropicMatchesFrozenPromptedOutputWireConversation(t *testing.T) {

--- a/internal/modelprovider/factory.go
+++ b/internal/modelprovider/factory.go
@@ -151,8 +151,8 @@ func (f *Factory) TextModel(modelID string) (inference.TextModel, error) {
 	return f.textModel(modelID, WorkloadConfig{})
 }
 
-// TextModelWithWorkload builds an OpenAI-compatible text client with a
-// workload-local endpoint, headers, and request settings.
+// TextModelWithWorkload builds a text client with supported workload-local
+// endpoint, header, and request-setting overrides.
 func (f *Factory) TextModelWithWorkload(modelID string, workload WorkloadConfig) (inference.TextModel, error) {
 	return f.textModel(modelID, workload)
 }
@@ -172,8 +172,11 @@ func (f *Factory) textModel(modelID string, workload WorkloadConfig) (inference.
 	if err := validateProviderModel(route); err != nil {
 		return nil, err
 	}
-	if clonedWorkload.hasOverrides() && route.protocol != ProtocolOpenAIChat && route.protocol != ProtocolOpenAIResponses {
-		return nil, inference.NewConfigurationError("workload-provider", "workload overrides require OpenAI-compatible model routes")
+	openAIWorkload := route.protocol == ProtocolOpenAIChat || route.protocol == ProtocolOpenAIResponses
+	anthropicBaseURLOnly := route.protocol == ProtocolAnthropic && !route.gateway && clonedWorkload.BaseURL != "" &&
+		len(clonedWorkload.Headers) == 0 && len(clonedWorkload.ModelSettings) == 0
+	if clonedWorkload.hasOverrides() && !openAIWorkload && !anthropicBaseURLOnly {
+		return nil, inference.NewConfigurationError("workload-provider", "workload override is not supported for model route")
 	}
 	switch route.protocol {
 	case ProtocolOpenAIChat, ProtocolOpenAIResponses:
@@ -187,6 +190,9 @@ func (f *Factory) textModel(modelID string, workload WorkloadConfig) (inference.
 		config, configErr := f.anthropicConfig(route)
 		if configErr != nil {
 			return nil, configErr
+		}
+		if clonedWorkload.BaseURL != "" {
+			config.BaseURL = clonedWorkload.BaseURL
 		}
 		return NewAnthropicTextModel(route, config)
 	case ProtocolGroq, ProtocolXAI, ProtocolMistral, ProtocolHuggingFace:

--- a/internal/modelprovider/factory_workload_test.go
+++ b/internal/modelprovider/factory_workload_test.go
@@ -15,13 +15,69 @@
 package modelprovider
 
 import (
+	json "encoding/json/v2"
 	"errors"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
 	"github.com/ob-labs/powercontext-go/inference"
 )
+
+func TestFactoryAnthropicWorkloadBaseURLUsesEnvironmentAPIKey(t *testing.T) {
+	type requestDetails struct {
+		method        string
+		path          string
+		apiKey        string
+		authorization string
+	}
+	requests := make(chan requestDetails, 4)
+	provider := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		requests <- requestDetails{
+			method:        request.Method,
+			path:          request.URL.Path,
+			apiKey:        request.Header.Get("X-Api-Key"),
+			authorization: request.Header.Get("Authorization"),
+		}
+		response.Header().Set("Content-Type", "application/json")
+		encoded, err := json.Marshal(anthropicResponse("msg_1", "ok", 1, 1))
+		if err != nil {
+			t.Errorf("encode Anthropic response: %v", err)
+			return
+		}
+		if _, err := response.Write(encoded); err != nil {
+			t.Errorf("write Anthropic response: %v", err)
+		}
+	}))
+	t.Cleanup(provider.Close)
+
+	factory, err := NewFactory(MilestoneB, testEnvironment{
+		"ANTHROPIC_API_KEY":  "environment-key",
+		"ANTHROPIC_BASE_URL": "http://127.0.0.1:1",
+	}.lookup, provider.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+	workload := WorkloadConfig{BaseURL: provider.URL + "/custom-anthropic/"}
+	model, err := factory.TextModelWithWorkload("anthropic:claude-test", workload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	workload.BaseURL = "http://127.0.0.1:2/mutated/"
+	if _, err := model.Complete(t.Context(), textRequestForProviderTest(t)); err != nil {
+		t.Fatal(err)
+	}
+
+	request := <-requests
+	if request.method != http.MethodPost || request.path != "/custom-anthropic/v1/messages" ||
+		request.apiKey != "environment-key" || request.authorization != "" {
+		t.Fatalf("Anthropic request = %#v", request)
+	}
+	if len(requests) != 0 {
+		t.Fatalf("unexpected additional Anthropic requests = %d", len(requests))
+	}
+}
 
 func TestFactoryAppliesWorkloadOverridesWithoutRetainingCallerState(t *testing.T) {
 	fake := &openAIFake{responses: []any{chatResponse("chat_1", `{"value":"stable"}`, 1, 1)}}
@@ -69,35 +125,54 @@ func TestFactoryAppliesWorkloadOverridesWithoutRetainingCallerState(t *testing.T
 	}
 }
 
-func TestFactoryRejectsWorkloadOverrideForNonOpenAIProviderBeforeRequest(t *testing.T) {
-	factory, err := NewFactory(MilestoneB, testEnvironment{"ANTHROPIC_API_KEY": "test-key"}.lookup, nil)
+func TestFactoryRejectsUnsupportedNonOpenAIWorkloadOverrides(t *testing.T) {
+	factory, err := NewFactory(MilestoneB, testEnvironment{
+		"ANTHROPIC_API_KEY":            "test-key",
+		"PYDANTIC_AI_GATEWAY_API_KEY":  "private-bearer",
+		"PYDANTIC_AI_GATEWAY_BASE_URL": "https://gateway-provider.test/proxy",
+	}.lookup, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	workload := WorkloadConfig{
-		BaseURL: "https://private-provider.test/v1",
-		Headers: http.Header{"Authorization": []string{"private-secret"}},
-	}
 	for _, factoryCall := range []struct {
-		name string
-		call func() error
+		name    string
+		call    func() error
+		secrets []string
 	}{
-		{name: "text", call: func() error {
-			_, callErr := factory.TextModelWithWorkload("anthropic:claude-test", workload)
+		{name: "Anthropic headers", call: func() error {
+			_, callErr := factory.TextModelWithWorkload("anthropic:claude-test", WorkloadConfig{
+				Headers: http.Header{"Authorization": []string{"private-secret"}},
+			})
 			return callErr
-		}},
-		{name: "embedding", call: func() error {
-			_, callErr := factory.EmbeddingTransportWithWorkload("google:gemini-embedding-001", workload)
+		}, secrets: []string{"private-secret", "test-key"}},
+		{name: "Anthropic model settings", call: func() error {
+			_, callErr := factory.TextModelWithWorkload("anthropic:claude-test", WorkloadConfig{
+				ModelSettings: map[string]any{"top_p": "private-setting"},
+			})
 			return callErr
-		}},
+		}, secrets: []string{"private-setting", "test-key"}},
+		{name: "Anthropic gateway base URL", call: func() error {
+			_, callErr := factory.TextModelWithWorkload(
+				"gateway/anthropic:claude-test",
+				WorkloadConfig{BaseURL: "https://private-provider.test/v1"},
+			)
+			return callErr
+		}, secrets: []string{"private-provider", "private-bearer", "gateway-provider"}},
+		{name: "Google embedding base URL", call: func() error {
+			_, callErr := factory.EmbeddingTransportWithWorkload(
+				"google:gemini-embedding-001",
+				WorkloadConfig{BaseURL: "https://private-provider.test/v1"},
+			)
+			return callErr
+		}, secrets: []string{"private-provider", "test-key"}},
 	} {
 		t.Run(factoryCall.name, func(t *testing.T) {
 			err := factoryCall.call()
-			var configuration *inference.ConfigurationError
-			if !errors.As(err, &configuration) || configuration.Code() != "workload-provider" {
+			configuration, ok := errors.AsType[*inference.ConfigurationError](err)
+			if !ok || configuration.Code() != "workload-provider" {
 				t.Fatalf("error = %v", err)
 			}
-			for _, secret := range []string{"private-provider", "private-secret"} {
+			for _, secret := range factoryCall.secrets {
 				if strings.Contains(err.Error(), secret) {
 					t.Fatalf("error leaked %q: %v", secret, err)
 				}

--- a/server/dependencies_workload_test.go
+++ b/server/dependencies_workload_test.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"sync"
 	"testing"
 	"time"
@@ -29,6 +30,67 @@ import (
 	"github.com/ob-labs/powercontext-go/artifact/memory"
 	"github.com/ob-labs/powercontext-go/inference"
 )
+
+func TestAssembleDependenciesRoutesAnthropicBaseURLToGenerationReadiness(t *testing.T) {
+	type requestDetails struct {
+		method        string
+		path          string
+		apiKey        string
+		authorization string
+	}
+	requests := make(chan requestDetails, 4)
+	provider := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		requests <- requestDetails{
+			method:        request.Method,
+			path:          request.URL.Path,
+			apiKey:        request.Header.Get("X-Api-Key"),
+			authorization: request.Header.Get("Authorization"),
+		}
+		response.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(response).Encode(map[string]any{
+			"id": "probe", "type": "message", "role": "assistant", "model": "claude-test",
+			"content":     []any{map[string]any{"type": "text", "text": "ok"}},
+			"stop_reason": "end_turn", "stop_sequence": nil,
+			"usage": map[string]any{"input_tokens": 1, "output_tokens": 1},
+		}); err != nil {
+			t.Errorf("encode Anthropic response: %v", err)
+		}
+	}))
+	t.Cleanup(provider.Close)
+	t.Setenv("ANTHROPIC_API_KEY", "environment-key")
+	t.Setenv("ANTHROPIC_BASE_URL", "http://127.0.0.1:1")
+
+	config, err := DefaultConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	config.Inference.GenerationModel = "anthropic:claude-test"
+	config.Inference.Generation = &InferenceWorkloadConfig{BaseURL: provider.URL + "/custom-anthropic/"}
+	if err := config.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	assembled, err := assembleDependencies(
+		config, Dependencies{HTTPClient: provider.Client()}, noop.NewTracerProvider(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if assembled.generationReadiness == nil {
+		t.Fatal("configured Anthropic generation model did not produce a readiness operation")
+	}
+	if err := assembled.generationReadiness(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+
+	request := <-requests
+	if request.method != http.MethodPost || request.path != "/custom-anthropic/v1/messages" ||
+		request.apiKey != "environment-key" || request.authorization != "" {
+		t.Fatalf("Anthropic readiness request = %#v", request)
+	}
+	if len(requests) != 0 {
+		t.Fatalf("unexpected additional Anthropic readiness requests = %d", len(requests))
+	}
+}
 
 func TestAssembleDependenciesRoutesOpenAIWorkloadOverrides(t *testing.T) {
 	t.Setenv("OPENAI_API_KEY", "test-key")

--- a/server/dependencies_workload_test.go
+++ b/server/dependencies_workload_test.go
@@ -66,8 +66,8 @@ func TestAssembleDependenciesRoutesAnthropicBaseURLToGenerationReadiness(t *test
 	}
 	config.Inference.GenerationModel = "anthropic:claude-test"
 	config.Inference.Generation = &InferenceWorkloadConfig{BaseURL: provider.URL + "/custom-anthropic/"}
-	if err := config.Validate(); err != nil {
-		t.Fatal(err)
+	if validationErr := config.Validate(); validationErr != nil {
+		t.Fatal(validationErr)
 	}
 	assembled, err := assembleDependencies(
 		config, Dependencies{HTTPClient: provider.Client()}, noop.NewTracerProvider(),


### PR DESCRIPTION
## Summary
- allow a BaseURL-only workload override for native non-gateway nthropic:* generation
- keep ANTHROPIC_API_KEY authentication, reject workload headers/settings and gateway Anthropic overrides before transport
- redact Anthropic configuration representation and isolate mutable caller inputs

## Security boundary
gateway/anthropic:* overrides remain refused before gateway credentials are read, preventing bearer credentials from crossing to a workload-supplied host.

## Validation
- focused modelprovider red/green, race, vet, pinned lint and independent review
- real HTTP factory and server readiness tests intentionally remain active

## CI requirement
The local Windows host cannot connect to same-process loopback listeners and cannot execute the SQLite server test reliably. The PR's Linux CI is the required exact-Head execution proof; local tests were not skipped or weakened.